### PR TITLE
Add CLI with save-dev option and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,11 @@ This project uses several lightweight LLM assistants to keep the flywheel spinni
 - **When:** commits land on `main`
 - **Does:** update release notes automatically
 
+
+## Prompt Hook
+- **When:** on demand via `flywheel prompt`
+- **Does:** generate repo-specific Codex prompts from repo context
+
 ---
 
 For personalization, run `./scripts/setup.sh YOURNAME YOURREPO` after cloning.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ pre-commit install
 pre-commit run --all-files
 ```
 
+## Embedding in existing projects
+
+Apply flywheel to an existing repository:
+
+```bash
+python flywheel.py init --save-dev .
+```
+
+The `--save-dev` flag injects ESLint, Prettier, CI workflows, Dependabot, tests, and release scripts. Run `flywheel.py update --save-dev` anytime to refresh them.
+
+
 ## Related Projects
 
 - [Axel](https://github.com/futuroptimist/axel) – personal LLM accelerator that manages goals across your repositories. See `docs/axel-integration.md` for how to pair it with flywheel.

--- a/docs/patch-plan.md
+++ b/docs/patch-plan.md
@@ -1,0 +1,14 @@
+# Patch Plan
+
+This update introduces a small CLI for applying flywheel templates and new tests.
+
+## Code
+- `flywheel.py` implements `init`, `update`, `audit`, and `prompt` subcommands with a `--save-dev` flag.
+- Dev tooling templates live in `templates/dev` and include ESLint, Prettier, CI, Dependabot, and release scripts.
+
+## Tests
+- Added `tests/test_cli.py` to verify template generation and idempotency.
+
+## Documentation
+- README updated with instructions for embedding flywheel.
+- AGENTS file updated with new Prompt Hook agent.

--- a/flywheel.py
+++ b/flywheel.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Flywheel CLI for initializing repos and generating prompts."""
+import argparse
+import shutil
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent
+
+
+def copy_template(target: Path, template_dir: Path) -> None:
+    for src in template_dir.rglob("*"):
+        rel = src.relative_to(template_dir)
+        dst = target / rel
+        if src.is_dir():
+            dst.mkdir(parents=True, exist_ok=True)
+        else:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            if not dst.exists():
+                shutil.copy2(src, dst)
+
+
+def init_repo(args) -> None:
+    target = Path(args.path).resolve()
+    target.mkdir(parents=True, exist_ok=True)
+    template_dir = REPO_ROOT / "templates" / args.template
+    copy_template(target, template_dir)
+
+    if args.save_dev:
+        copy_template(target, REPO_ROOT / "templates" / "dev")
+
+
+def update_repo(args) -> None:
+    init_repo(args)
+
+
+def audit_repo(args) -> None:
+    required = [
+        ".github/workflows/ci.yml",
+        "dependabot.yml",
+    ]
+    missing = [r for r in required if not (Path(args.path) / r).exists()]
+    if missing:
+        print("Missing files: " + ", ".join(missing))
+    else:
+        print("All required files present")
+
+
+def generate_prompt(args) -> None:
+    repo = Path(args.path)
+    readme = repo / "README.md"
+    snippet = readme.read_text()[:200] if readme.exists() else ""
+    prompt = textwrap.dedent(
+        f"""
+        ## Repo Prompt
+
+        Repository path: {repo.resolve()}
+
+        README Preview:\n{snippet}
+        """
+    )
+    print(prompt.strip())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="flywheel template manager")
+    sub = parser.add_subparsers(dest="cmd")
+    base = argparse.ArgumentParser(add_help=False)
+    base.add_argument("path", nargs="?", default=".", help="target repo path")
+    base.add_argument(
+        "--save-dev",
+        action="store_true",
+        help="include ESLint, CI, tests, and release helpers",
+    )
+
+    p_init = sub.add_parser("init", parents=[base], help="initialize repo")
+    p_init.set_defaults(func=init_repo)
+
+    p_update = sub.add_parser("update", parents=[base], help="update repo")
+    p_update.set_defaults(func=update_repo)
+
+    p_audit = sub.add_parser("audit", parents=[base], help="check repo state")
+    p_audit.set_defaults(func=audit_repo)
+
+    p_prompt = sub.add_parser(
+        "prompt", parents=[base], help="generate Codex-friendly repo prompt"
+    )
+    p_prompt.set_defaults(func=generate_prompt)
+
+    args = parser.parse_args()
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return
+
+    # fmt: off
+    if (
+        sys.stdin.isatty()
+        and not args.save_dev
+        and args.cmd in {"init", "update"}
+    ):
+        ans = input("Include dev tooling (ESLint/CI etc)? [y/N] ")
+        if ans.lower().startswith("y"):
+            args.save_dev = True
+    # fmt: on
+
+    if (Path(args.path) / "package.json").exists():
+        args.template = "javascript"
+    else:
+        args.template = "python"
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/spellcheck.yaml
+++ b/spellcheck.yaml
@@ -10,6 +10,3 @@ matrix:
     aspell:
       lang: en
       d: en_US
-    dictionary:
-      wordlists:
-        - .wordlist.txt

--- a/templates/dev/.eslintrc.json
+++ b/templates/dev/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["eslint:recommended", "prettier"]
+}

--- a/templates/dev/.github/workflows/ci.yml
+++ b/templates/dev/.github/workflows/ci.yml
@@ -1,0 +1,11 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run checks
+        run: |
+          npm install
+          npm test

--- a/templates/dev/.prettierrc
+++ b/templates/dev/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/templates/dev/dependabot.yml
+++ b/templates/dev/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/templates/dev/release.sh
+++ b/templates/dev/release.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo 'Releasing...'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,35 @@
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CLI = PROJECT_ROOT / "flywheel.py"
+
+
+def run_cmd(*args, cwd):
+    result = subprocess.run(
+        [sys.executable, str(CLI), *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def test_init_idempotent(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_cmd("init", str(repo), "--save-dev", cwd=PROJECT_ROOT)
+    assert (repo / ".eslintrc.json").exists()
+    # second run should not fail and files remain
+    run_cmd("init", str(repo), "--save-dev", cwd=PROJECT_ROOT)
+    assert (repo / ".eslintrc.json").exists()
+
+
+def test_prompt(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("Hello flywheel")
+    output = run_cmd("prompt", str(repo), cwd=PROJECT_ROOT)
+    assert "Repo Prompt" in output


### PR DESCRIPTION
## Summary
- implement `flywheel.py` CLI with `init`, `update`, `audit`, `prompt`
- add dev tooling templates and new agent description
- document how to embed flywheel via CLI
- provide patch plan and end-to-end tests
- fix spellcheck config duplication

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686245f318f0832fab69b64393494c36