### PR TITLE
Add local environment doc and values section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - [AGENTS.md](AGENTS.md) detailing included LLM assistants
 - Axel integration guide in `docs/axel-integration.md`
 - token.place roadmap in `docs/tokenplace-roadmap.md`
+- local environment guide in `docs/local-environments.md`
 - token.place features in `docs/tokenplace-features.md`
 - token.place PRD in `docs/tokenplace-PRD.md`
 
@@ -64,6 +65,10 @@ Invoke the prompt agent to get repo-aware suggestions:
 ```bash
 flywheel prompt
 ```
+
+## Values
+
+We aim for a positive-sum, empathetic community. The flywheel embraces regenerative and open-source principles to keep energy cycling back into every project.
 
 ## Related Projects
 

--- a/docs/best_practices_overview.md
+++ b/docs/best_practices_overview.md
@@ -1,3 +1,9 @@
 # Best Practices Overview
 
 This documentation outlines recommended workflows, CI setup, and guidelines to keep your project healthy.
+
+## Energy Across Dimensions
+
+- **Code conventions** ensure consistent style. See `docs/styleguides`.
+- **Local environments** keep personal tweaks in `.local` as described in `docs/local-environments.md`.
+- **Positive-sum values** guide our decisions. We favor regenerative, empathetic, and open-source approaches.

--- a/docs/local-environments.md
+++ b/docs/local-environments.md
@@ -1,0 +1,13 @@
+# Local Environment Configuration
+
+Flywheel can scaffold a `.local` directory that stores personal settings such as API keys or editor preferences. Anything in this folder is git‑ignored so each contributor can keep private customisations while sharing the rest of the repo.
+
+To generate it, run:
+
+```bash
+./scripts/setup.sh YOURNAME YOURREPO
+```
+
+The script creates a `.local` folder and adds typical config templates. You can extend these files for other projects without affecting version control.
+
+This keeps personal energy flowing into your workflow without leaking private information.


### PR DESCRIPTION
## Summary
- document `.local` setup for per-user config
- outline energy practices in best practices doc
- mention value system and local environment guide in README

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68644b5ab058832faa112915a9961e80