### PR TITLE
Add orientation file and runbook

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -60,3 +60,15 @@ YOURREPO
 styleguides
 customizations
 gabriel
+heatmap
+llms
+onboarding
+runbook
+Runbook
+subcommand
+virtualenvs
+Makefile
+YAML
+solarpunk
+Futuroptimist's
+LLMs

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 - Example code and templates
 - Python CLI with subcommands `init`, `update`, `audit`, and `prompt` that prompts interactively unless `--yes` is used
 - [AGENTS.md](AGENTS.md) detailing included LLM assistants
+- [llms.txt](llms.txt) with quick context for AI helpers
+  and a [runbook.yml](runbook.yml) checklist for repo setup
 - Axel integration guide in `docs/axel-integration.md`
 - token.place roadmap in `docs/tokenplace-roadmap.md`
 - local environment guide in `docs/local-environments.md`
@@ -74,3 +76,4 @@ We aim for a positive-sum, empathetic community. The flywheel embraces regenerat
 
 - [Axel](https://github.com/futuroptimist/axel) – personal LLM accelerator that manages goals across your repositories. See `docs/axel-integration.md` for how to pair it with flywheel.
 - [Gabriel](https://github.com/futuroptimist/gabriel) – "guardian angel" LLM focused on security. Its `docs/FLYWHEEL_RISK_MODEL.md` discusses how flywheel-style automation changes your threat model. See `docs/gabriel-integration.md` for ways these repositories will share tooling and evolve together.
+- [Futuroptimist](https://github.com/futuroptimist/futuroptimist) – YouTube scripts and automation experiments. See `docs/futuroptimist-integration.md` for lessons this repo borrows and improvement ideas.

--- a/docs/futuroptimist-integration.md
+++ b/docs/futuroptimist-integration.md
@@ -1,0 +1,34 @@
+# Futuroptimist Synergy
+
+[futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) hosts video scripts, helper utilities and a complete test suite for a solarpunk YouTube channel. The repository uses `llms.txt` and `AGENTS.md` to keep AI assistants aligned with its workflow. It also includes a 3‑D heat‑map generator that visualizes lines of code changed per day.
+
+This document collects lessons Flywheel can borrow and suggests improvements for Futuroptimist.
+
+## Lessons for Flywheel
+
+- **Orientation file** – Maintaining a short `llms.txt` alongside `AGENTS.md` helps LLMs understand tone and context. Flywheel adopters should consider adding a similar file after running `./scripts/setup.sh`.
+- **Structured metadata** – Each video script lives in a dated folder with a `metadata.json` file validated by JSON Schema.
+- **Automation helpers** – The Makefile creates virtualenvs, fetches subtitles and scaffolds new script folders with one command.
+- **Cross-platform** – Make targets run on both Unix and Windows.
+- **Complete tests** – Futuroptimist's test suite covers helper scripts and schema validation, reaching 100% coverage. New Flywheel templates should encourage high coverage from the start.
+- **Runbook & instructions** – A separate `RUNBOOK.md` captures the production checklist, while `INSTRUCTIONS.md` documents setup details. Keeping these distinct avoids cluttering the README.
+
+## Recommendation for Futuroptimist
+
+Futuroptimist already automates several tasks via the Makefile and nightly workflows. A dedicated Python CLI could unify these helpers under a single command and pave the way for additional tooling:
+
+```bash
+futuroptimist init               # scaffold scripts from video_ids.txt
+futuroptimist heatmap            # rebuild the 3-D contribution chart
+futuroptimist subtitles VIDEO_ID # fetch subtitles into ./subtitles
+```
+
+Packaging the CLI would make cross‑platform usage easier (mirroring `flywheel`'s own CLI) and allow other repos to reuse pieces like the heat‑map generator. The existing scripts could be refactored into a module (e.g. `futuroptimist.cli`) and tested alongside the current utilities.
+
+Beyond the core commands, a small wrapper around Flywheel's `flywheel prompt` could produce context-aware onboarding tips:
+
+```bash
+python -m futuroptimist.prompt  # surfaces # Purpose, # Context and # Request sections
+```
+
+Another idea is to convert the Markdown runbook to `runbook.yml`. A `flywheel runbook` subcommand could then parse the YAML and output the same checklist, letting Axel or other tools reason over the steps automatically.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,12 @@
+# Flywheel llms.txt
+
+This repository provides a GitHub template with CI workflows, style guides, and LLM-powered helpers.
+
+Commit messages should be descriptive; every change feeds the public knowledge base.
+
+## Development
+- Python 3.12, formatted with black and flake8 via pre-commit.
+- Install hooks with `pre-commit install` and run `pre-commit run --all-files` before pushing.
+- Tests live in `tests/` and run with `pytest`.
+
+See AGENTS.md for built-in assistants and docs/ for integration guides.

--- a/runbook.yml
+++ b/runbook.yml
@@ -1,0 +1,18 @@
+version: 1
+workflow:
+  - stage: bootstrap
+    tasks:
+      - id: clone
+        description: "Use the GitHub template and run ./scripts/setup.sh"
+      - id: install
+        description: "Install pre-commit and hooks"
+  - stage: development
+    tasks:
+      - id: lint
+        description: "Run pre-commit run --all-files"
+      - id: test
+        description: "Run pytest"
+  - stage: release
+    tasks:
+      - id: merge
+        description: "Merge to main and let Release Drafter generate notes"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+import flywheel.__main__ as fm  # noqa: E402
+
+
+def test_build_parser_commands():
+    parser = fm.build_parser()
+    sub = parser._subparsers._group_actions[0]
+    cmds = set(sub.choices.keys())
+    assert {"init", "update", "audit", "prompt"} <= cmds
+
+
+def test_main_audit(capsys, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    fm.main(["audit", str(repo)])
+    out = capsys.readouterr().out
+    assert "TODO" in out


### PR DESCRIPTION
## Summary
- add `llms.txt` orientation file with dev tips
- provide `runbook.yml` for automation
- link new docs from README
- extend test suite with CLI parser checks

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c98862e4832f83ba4894570f16f0