### PR TITLE
Add unified LLM instructions

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -72,3 +72,4 @@ YAML
 solarpunk
 Futuroptimist's
 LLMs
+Anthropic

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,9 @@
 # \U0001F916 AGENTS
 
 This project uses several lightweight LLM assistants to keep the flywheel spinning.
+See [llms.txt](llms.txt) for a quick orientation summary and [CLAUDE.md](CLAUDE.md)
+for Anthropic-specific coding guidance. Broader Codex behavior rules live in
+[CUSTOM_INSTRUCTIONS.md](CUSTOM_INSTRUCTIONS.md).
 
 ## Code Linter Agent
 - **When:** every PR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# Claude Integration
+
+This file summarizes best practices from [Anthropic's "Claude Code Best Practices"](https://www.anthropic.com/engineering/claude-code-best-practices).
+It complements [`AGENTS.md`](AGENTS.md) and [`llms.txt`](llms.txt) by focusing on guidance
+specific to the Claude model family.
+
+## Key Points
+- Keep prompts concise and provide explicit context.
+- Prefer deterministic functions with clear input and output formats.
+- Use code comments to explain non-obvious logic.
+- Validate model output before acting on it.
+
+For broader assistant behavior, see [CUSTOM_INSTRUCTIONS.md](CUSTOM_INSTRUCTIONS.md).

--- a/CUSTOM_INSTRUCTIONS.md
+++ b/CUSTOM_INSTRUCTIONS.md
@@ -5,34 +5,34 @@ This file expands on [`AGENTS.md`](AGENTS.md), [`llms.txt`](llms.txt) and
 flywheel turning smoothly.
 
 ## 1. Project Discovery
-1. **Bootstrapping**  
+1. **Bootstrapping**
    - On cloning/opening a repo, immediately locate and parse:
      - `AGENTS.md`
      - `README.md`
      - Any project-specific docs (e.g. `QUESTS/`, `docs/`).
    - Infer the repo’s **primary goal**, architecture, language(s), and key modules before any changes.
 
-2. **Clarify Missing Docs**  
+2. **Clarify Missing Docs**
    - If **no** `AGENTS.md` exists, ask:
-     > "What agent-oriented workflows or LLM-driven interactions would you like documented here?"  
+     > "What agent-oriented workflows or LLM-driven interactions would you like documented here?"
    - If the **README** is sparse, prompt for:
      - Installation steps
      - Usage examples
      - Contribution guidelines
 
 ## 2. Documentation Ownership
-1. **AGENTS.md**  
+1. **AGENTS.md**
    - Keep it in sync with the code:
      - Update descriptions when new agents or prompt templates appear.
      - Add usage examples or CLI flags.
      - Fix typos and broken links.
-2. **README.md**  
+2. **README.md**
    - Ensure it has:
      - Project badges (CI, coverage, PyPI/npm, license).
      - A clear "Getting Started" section.
      - Links to AGENTS.md and any "How to Contribute" guides.
 
-3. **In-Code Prompts**  
+3. **In-Code Prompts**
    - Search for LLM prompts in code (e.g. `PROMPT = """…"""`).
    - Standardize formatting:
      - A short **purpose** header
@@ -41,31 +41,31 @@ flywheel turning smoothly.
    - Where appropriate, wrap prompts in helper functions to DRY-up repetition.
 
 ## 3. Code Quality & Quick Wins
-1. **Low-hanging Fruit**  
+1. **Low-hanging Fruit**
    - Run linters/formatters (e.g. `black`, `eslint`) and apply safe fixes.
    - Remove unused imports, dead code, or console/debug statements.
    - Fix any broken examples in docs or source comments.
-2. **Basic Tests**  
+2. **Basic Tests**
    - If no tests exist for a core module, generate a minimal test stub.
    - Where coverage is >0% but <50%, highlight modules lacking tests.
 
 ## 4. Cross-Project Synergies
-1. **Shared Utilities**  
+1. **Shared Utilities**
    - Spot duplicate logic (e.g. config loading, authentication) across repos:
      - Propose extraction into a common package (e.g. `@futuroptimist/common`).
-2. **Consistent Templates**  
+2. **Consistent Templates**
    - Use the same PR, issue, and commit message templates in all projects.
    - Harmonize code style and tooling (e.g. the same ESLint/Prettier or Flake8/black config).
 
 ## 5. Quest & Flywheel Enhancement (dspace-specific)
-1. **Tech-Tree Gaps**  
+1. **Tech-Tree Gaps**
    - Parse existing quests and their prerequisites.
    - Suggest 1–2 new quests that naturally follow each completed branch.
-2. **Automated Quest Scaffolding**  
+2. **Automated Quest Scaffolding**
    - Add or improve an "`npm run generate-quest`" (or equivalent) to scaffold:
      - Metadata (title, description, requirements)
      - Placeholder code/tests
-3. **Prompt-Driven Quest Creation**  
+3. **Prompt-Driven Quest Creation**
    - Enhance any in-repo prompts so Codex can, on command, "Create a new quest called X that requires Y and teaches Z."
 
 ## 6. Continuous Feedback Loop

--- a/CUSTOM_INSTRUCTIONS.md
+++ b/CUSTOM_INSTRUCTIONS.md
@@ -1,0 +1,80 @@
+# Codex Assistant Rules
+
+This file expands on [`AGENTS.md`](AGENTS.md), [`llms.txt`](llms.txt) and
+[`CLAUDE.md`](CLAUDE.md). Any LLM can refine these standards to keep the
+flywheel turning smoothly.
+
+## 1. Project Discovery
+1. **Bootstrapping**  
+   - On cloning/opening a repo, immediately locate and parse:
+     - `AGENTS.md`
+     - `README.md`
+     - Any project-specific docs (e.g. `QUESTS/`, `docs/`).
+   - Infer the repo’s **primary goal**, architecture, language(s), and key modules before any changes.
+
+2. **Clarify Missing Docs**  
+   - If **no** `AGENTS.md` exists, ask:
+     > "What agent-oriented workflows or LLM-driven interactions would you like documented here?"  
+   - If the **README** is sparse, prompt for:
+     - Installation steps
+     - Usage examples
+     - Contribution guidelines
+
+## 2. Documentation Ownership
+1. **AGENTS.md**  
+   - Keep it in sync with the code:
+     - Update descriptions when new agents or prompt templates appear.
+     - Add usage examples or CLI flags.
+     - Fix typos and broken links.
+2. **README.md**  
+   - Ensure it has:
+     - Project badges (CI, coverage, PyPI/npm, license).
+     - A clear "Getting Started" section.
+     - Links to AGENTS.md and any "How to Contribute" guides.
+
+3. **In-Code Prompts**  
+   - Search for LLM prompts in code (e.g. `PROMPT = """…"""`).
+   - Standardize formatting:
+     - A short **purpose** header
+     - A **context** section with relevant code snippets
+     - A **request** section at the bottom
+   - Where appropriate, wrap prompts in helper functions to DRY-up repetition.
+
+## 3. Code Quality & Quick Wins
+1. **Low-hanging Fruit**  
+   - Run linters/formatters (e.g. `black`, `eslint`) and apply safe fixes.
+   - Remove unused imports, dead code, or console/debug statements.
+   - Fix any broken examples in docs or source comments.
+2. **Basic Tests**  
+   - If no tests exist for a core module, generate a minimal test stub.
+   - Where coverage is >0% but <50%, highlight modules lacking tests.
+
+## 4. Cross-Project Synergies
+1. **Shared Utilities**  
+   - Spot duplicate logic (e.g. config loading, authentication) across repos:
+     - Propose extraction into a common package (e.g. `@futuroptimist/common`).
+2. **Consistent Templates**  
+   - Use the same PR, issue, and commit message templates in all projects.
+   - Harmonize code style and tooling (e.g. the same ESLint/Prettier or Flake8/black config).
+
+## 5. Quest & Flywheel Enhancement (dspace-specific)
+1. **Tech-Tree Gaps**  
+   - Parse existing quests and their prerequisites.
+   - Suggest 1–2 new quests that naturally follow each completed branch.
+2. **Automated Quest Scaffolding**  
+   - Add or improve an "`npm run generate-quest`" (or equivalent) to scaffold:
+     - Metadata (title, description, requirements)
+     - Placeholder code/tests
+3. **Prompt-Driven Quest Creation**  
+   - Enhance any in-repo prompts so Codex can, on command, "Create a new quest called X that requires Y and teaches Z."
+
+## 6. Continuous Feedback Loop
+- **On every push**:
+  1. Re-scan for new or changed prompts/docs.
+  2. Check for new low-hanging documentation or lint fixes.
+  3. Propose a small "doc/code hygiene" PR alongside any feature work.
+- **Always err on the side of small, incremental improvements** rather than big rewrites or new deps.
+
+---
+
+> \U0001F527 **Tip:** If you ever feel stuck, revisit the project’s README goals and the “flywheel” concept—every little doc or prompt tweak should help the next contributor onboard faster and push the wheel a bit further.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 - Python CLI with subcommands `init`, `update`, `audit`, and `prompt` that prompts interactively unless `--yes` is used
 - [AGENTS.md](AGENTS.md) detailing included LLM assistants
 - [llms.txt](llms.txt) with quick context for AI helpers
+- [CLAUDE.md](CLAUDE.md) summarizing Anthropic guidance
+- [CUSTOM_INSTRUCTIONS.md](CUSTOM_INSTRUCTIONS.md) for Codex rules
   and a [runbook.yml](runbook.yml) checklist for repo setup
 - Axel integration guide in `docs/axel-integration.md`
 - token.place roadmap in `docs/tokenplace-roadmap.md`

--- a/docs/futuroptimist-integration.md
+++ b/docs/futuroptimist-integration.md
@@ -1,12 +1,12 @@
 # Futuroptimist Synergy
 
-[futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) hosts video scripts, helper utilities and a complete test suite for a solarpunk YouTube channel. The repository uses `llms.txt` and `AGENTS.md` to keep AI assistants aligned with its workflow. It also includes a 3‑D heat‑map generator that visualizes lines of code changed per day.
+[futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) hosts video scripts, helper utilities and a complete test suite for a solarpunk YouTube channel. The repository uses `llms.txt`, `AGENTS.md` and `CLAUDE.md` to keep AI assistants aligned with its workflow. It also includes a 3‑D heat‑map generator that visualizes lines of code changed per day.
 
 This document collects lessons Flywheel can borrow and suggests improvements for Futuroptimist.
 
 ## Lessons for Flywheel
 
-- **Orientation file** – Maintaining a short `llms.txt` alongside `AGENTS.md` helps LLMs understand tone and context. Flywheel adopters should consider adding a similar file after running `./scripts/setup.sh`.
+- **Orientation file** – Maintaining a short `llms.txt` alongside `AGENTS.md` and `CLAUDE.md` helps LLMs understand tone and context. Flywheel adopters should consider adding similar docs and extending them with `CUSTOM_INSTRUCTIONS.md` after running `./scripts/setup.sh`.
 - **Structured metadata** – Each video script lives in a dated folder with a `metadata.json` file validated by JSON Schema.
 - **Automation helpers** – The Makefile creates virtualenvs, fetches subtitles and scaffolds new script folders with one command.
 - **Cross-platform** – Make targets run on both Unix and Windows.

--- a/llms.txt
+++ b/llms.txt
@@ -9,4 +9,6 @@ Commit messages should be descriptive; every change feeds the public knowledge b
 - Install hooks with `pre-commit install` and run `pre-commit run --all-files` before pushing.
 - Tests live in `tests/` and run with `pytest`.
 
-See AGENTS.md for built-in assistants and docs/ for integration guides.
+See AGENTS.md for built-in assistants, [CLAUDE.md](CLAUDE.md) for
+Anthropic-style best practices, and [CUSTOM_INSTRUCTIONS.md](CUSTOM_INSTRUCTIONS.md)
+for Codex behavior rules. Additional integration guides live in `docs/`.


### PR DESCRIPTION
## Summary
- capture Codex custom instructions in `CUSTOM_INSTRUCTIONS.md`
- create `CLAUDE.md` for Anthropic best practices
- cross-link AGENTS, llms.txt, CLAUDE and custom instructions
- reference new docs from README and Futuroptimist guide

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68677b319eec832f9a737d0837e71e27