### PR TITLE
Add repo crawler CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - CodeQL workflow for security scanning
 - Style guides for Python and JavaScript
 - Example code and templates
-- Python CLI with subcommands `init`, `update`, `audit`, and `prompt` that prompts interactively unless `--yes` is used
+- Python CLI with subcommands `init`, `update`, `audit`, `prompt`, and `crawl` that prompts interactively unless `--yes` is used
 - [AGENTS.md](AGENTS.md) detailing included LLM assistants
 - [llms.txt](llms.txt) with quick context for AI helpers
 - [CLAUDE.md](CLAUDE.md) summarizing Anthropic guidance

--- a/docs/patch-plan.md
+++ b/docs/patch-plan.md
@@ -4,7 +4,7 @@ This patch extends the flywheel template with a Python CLI and agent hook.
 
 ## Code
 - new `flywheel` package exposing a `flywheel` command with subcommands
-  `init`, `update`, `audit`, and `prompt`.
+  `init`, `update`, `audit`, `prompt`, and `crawl`.
 - `--save-dev` option copies ESLint/Prettier configs, CI workflows,
   DEPENDABOT settings and release scripts into a target repository.
 - added minimal `.eslintrc.json` and `.prettierrc` used as templates.

--- a/flywheel/__main__.py
+++ b/flywheel/__main__.py
@@ -2,6 +2,8 @@ import argparse
 import shutil
 from pathlib import Path
 
+from .repocrawler import RepoCrawler
+
 ROOT = Path(__file__).resolve().parent.parent
 
 WORKFLOW_FILES = [
@@ -93,6 +95,12 @@ def prompt(args: argparse.Namespace) -> None:
     print(PROMPT_TMPL.format(snippet=snippet))
 
 
+def crawl(args: argparse.Namespace) -> None:
+    crawler = RepoCrawler(args.repos)
+    md = crawler.generate_summary()
+    Path(args.output).write_text(md)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="flywheel")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -131,6 +139,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="repository path",
     )
     p_prompt.set_defaults(func=prompt)
+
+    p_crawl = sub.add_parser("crawl", help="generate repo feature summary")
+    p_crawl.add_argument("repos", nargs="+", help="repos in owner/name form")
+    p_crawl.add_argument(
+        "--output",
+        default="docs/repo-feature-summary.md",
+        help="output markdown path",
+    )
+    p_crawl.set_defaults(func=crawl)
 
     return parser
 

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -1,0 +1,118 @@
+"""Utilities to crawl GitHub repositories for flywheel features."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+import requests
+
+
+@dataclass
+class RepoInfo:
+    name: str
+    coverage: Optional[str]
+    has_license: bool
+    has_ci: bool
+    has_agents: bool
+    has_coc: bool
+    has_contributing: bool
+    has_precommit: bool
+
+
+class RepoCrawler:
+    """Check remote GitHub repos for standard flywheel features."""
+
+    def __init__(
+        self, repos: Iterable[str], session: Optional[requests.Session] = None
+    ) -> None:
+        self.repos = list(repos)
+        self.session = session or requests.Session()
+
+    def _fetch_file(self, repo: str, path: str) -> Optional[str]:
+        for branch in ("main", "master"):
+            base = "https://raw.githubusercontent.com/"
+            url = f"{base}{repo}/{branch}/{path}"
+            resp = self.session.get(url)
+            if resp.status_code == 200:
+                return resp.text
+        return None
+
+    def _has_file(self, repo: str, path: str) -> bool:
+        return self._fetch_file(repo, path) is not None
+
+    def _parse_coverage(self, readme: Optional[str]) -> Optional[str]:
+        if not readme:
+            return None
+        match = re.search(r"(\d{1,3})%", readme)
+        if match:
+            return f"{match.group(1)}%"
+        if "coverage" in readme.lower():
+            return "unknown"
+        return None
+
+    def _check_repo(self, repo: str) -> RepoInfo:
+        readme = self._fetch_file(repo, "README.md")
+        coverage = self._parse_coverage(readme)
+        return RepoInfo(
+            name=repo,
+            coverage=coverage,
+            has_license=self._has_file(repo, "LICENSE"),
+            has_ci=self._has_file(
+                repo,
+                ".github/workflows/01-lint-format.yml",
+            ),
+            has_agents=self._has_file(repo, "AGENTS.md"),
+            has_coc=self._has_file(repo, "CODE_OF_CONDUCT.md"),
+            has_contributing=self._has_file(repo, "CONTRIBUTING.md"),
+            has_precommit=self._has_file(repo, ".pre-commit-config.yaml"),
+        )
+
+    def crawl(self) -> List[RepoInfo]:
+        return [self._check_repo(r) for r in self.repos]
+
+    def generate_summary(self) -> str:
+        repos = self.crawl()
+        header = (
+            "| Repo | Coverage | License | CI | AGENTS.md | "
+            "Code of Conduct | Contributing | Pre-commit |"
+        )
+        sep = (
+            "| ---- | -------- | ------- | -- | --------- | "
+            "--------------- | ------------ | ---------- |"
+        )
+        lines = [
+            "# Repo Feature Summary",
+            "",
+            (
+                "This table tracks which flywheel features each related "
+                "repository has adopted."
+            ),
+            "",
+            header,
+            sep,
+        ]
+        for info in repos:
+            coverage = "❌"
+            if info.coverage:
+                coverage = f"✅ ({info.coverage})"
+            repo_link = f"[{info.name}](https://github.com/{info.name})"
+            row = "| {} | {} | {} | {} | {} | {} | {} | {} |".format(
+                repo_link,
+                coverage,
+                "✅" if info.has_license else "❌",
+                "✅" if info.has_ci else "❌",
+                "✅" if info.has_agents else "❌",
+                "✅" if info.has_coc else "❌",
+                "✅" if info.has_contributing else "❌",
+                "✅" if info.has_precommit else "❌",
+            )
+            lines.append(row)
+        lines.append("")
+        lines.append(
+            "Legend: ✅ indicates the repo has adopted that feature from "
+            "flywheel. Coverage percentages are parsed from their badges "
+            "where available."
+        )
+        return "\n".join(lines)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,7 +9,7 @@ def test_build_parser_commands():
     parser = fm.build_parser()
     sub = parser._subparsers._group_actions[0]
     cmds = set(sub.choices.keys())
-    assert {"init", "update", "audit", "prompt"} <= cmds
+    assert {"init", "update", "audit", "prompt", "crawl"} <= cmds
 
 
 def test_main_audit(capsys, tmp_path):
@@ -18,3 +18,18 @@ def test_main_audit(capsys, tmp_path):
     fm.main(["audit", str(repo)])
     out = capsys.readouterr().out
     assert "TODO" in out
+
+
+def test_main_crawl(monkeypatch, tmp_path):
+    out = tmp_path / "sum.md"
+
+    class DummyCrawler:
+        def __init__(self, repos):
+            self.repos = repos
+
+        def generate_summary(self):
+            return "report"
+
+    monkeypatch.setattr(fm, "RepoCrawler", DummyCrawler)
+    fm.main(["crawl", "foo/bar", "--output", str(out)])
+    assert out.read_text() == "report"

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+import flywheel.repocrawler as rc  # noqa: E402
+
+
+class DummySession:
+    def __init__(self, files):
+        self.files = files
+
+    def get(self, url):
+        class Resp:
+            def __init__(self, text, status):
+                self.text = text
+                self.status_code = status
+
+        path = url.split("raw.githubusercontent.com/")[-1]
+        if path in self.files:
+            return Resp(self.files[path], 200)
+        return Resp("", 404)
+
+
+def test_generate_summary():
+    files = {
+        "foo/bar/main/README.md": "100% coverage",
+        "foo/bar/main/LICENSE": "",
+        "foo/bar/main/.github/workflows/01-lint-format.yml": "",
+        "foo/bar/main/AGENTS.md": "",
+        "foo/bar/main/CODE_OF_CONDUCT.md": "",
+        "foo/bar/main/CONTRIBUTING.md": "",
+        "foo/bar/main/.pre-commit-config.yaml": "",
+    }
+    session = DummySession(files)
+    crawler = rc.RepoCrawler(["foo/bar"], session=session)
+    out = crawler.generate_summary()
+    assert "100%" in out
+    assert "foo/bar" in out


### PR DESCRIPTION
## Summary
- create `flywheel/repocrawler.py` to scan GitHub repos for standard flywheel files
- expose new `crawl` subcommand in the CLI
- document the new command in README and patch plan
- test repo crawler and CLI entry points

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68699b0962b4832fb6a18911907fc32e