### PR TITLE
Automate repo feature summary updates

### DIFF
--- a/.github/workflows/04-update-summary.yml
+++ b/.github/workflows/04-update-summary.yml
@@ -1,0 +1,34 @@
+name: Update Repo Feature Summary
+on:
+  push:
+jobs:
+  crawl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pre-commit
+      - name: Generate summary
+        run: |
+          python -m flywheel crawl futuroptimist/flywheel futuroptimist/axel futuroptimist/gabriel futuroptimist/futuroptimist futuroptimist/token.place democratizedspace/dspace futuroptimist/f2clipboard futuroptimist/sigma --output docs/repo-feature-summary.md
+      - name: Run pre-commit
+        run: pre-commit run --files docs/repo-feature-summary.md
+      - name: Commit changes
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add docs/repo-feature-summary.md
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update repo feature summary"
+            git push
+          fi

--- a/.github/workflows/04-update-summary.yml
+++ b/.github/workflows/04-update-summary.yml
@@ -3,6 +3,7 @@ on:
   push:
 jobs:
   crawl:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -20,7 +21,10 @@ jobs:
         run: |
           python -m flywheel crawl futuroptimist/flywheel futuroptimist/axel futuroptimist/gabriel futuroptimist/futuroptimist futuroptimist/token.place democratizedspace/dspace futuroptimist/f2clipboard futuroptimist/sigma --output docs/repo-feature-summary.md
       - name: Run pre-commit
-        run: pre-commit run --files docs/repo-feature-summary.md
+        run: |
+          pre-commit run --files docs/repo-feature-summary.md || true
+          git add docs/repo-feature-summary.md
+          pre-commit run --files docs/repo-feature-summary.md
       - name: Commit changes
         run: |
           git config user.name github-actions

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Create a Markdown table showing which flywheel files each repo uses:
 ```bash
 flywheel crawl futuroptimist/flywheel futuroptimist/axel --output docs/repo-feature-summary.md
 ```
+The table in `docs/repo-feature-summary.md` is automatically refreshed after each commit via GitHub Actions.
 
 ## Values
 

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -2,14 +2,15 @@
 
 This table tracks which flywheel features each related repository has adopted.
 
-| Repo | Branch | Coverage | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
-| ---- | ------ | -------- | ------- | -- | --------- | --------------- | ------------ | ---------- |
-| [Axel](https://github.com/futuroptimist/axel) | main | ✅ (unknown) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
-| [Gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| [Futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
-| [token.place](https://github.com/futuroptimist/token.place) | main | ✅ (90%) | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ |
-| [DSPACE](https://github.com/democratizedspace/dspace) | v3 | ✅ (6%) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| [f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ✅ (100%) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| [Sigma](https://github.com/futuroptimist/sigma) | main | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Repo | Coverage | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
+| ---- | -------- | ------- | -- | --------- | --------------- | ------------ | ---------- |
+| [futuroptimist/flywheel](https://github.com/futuroptimist/flywheel) | ✅ (20%) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (unknown) | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (unknown) | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (unknown) | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. Coverage percentages are parsed from their badges where available.


### PR DESCRIPTION
## Summary
- regenerate `docs/repo-feature-summary.md` on every push
- note in README that the table is auto-updated

## Testing
- `pre-commit run --files README.md .github/workflows/04-update-summary.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869a1666c90832f90eedb78e6a56caf