### PR TITLE
Switch to uv and enhance RepoCrawler

### DIFF
--- a/.github/workflows/01-lint-format.yml
+++ b/.github/workflows/01-lint-format.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: '3.x'
       - name: Install Py Lint Tools
         if: matrix.language == 'python'
-        run: uv pip install flake8 black isort
+        run: uv pip install --system flake8 black isort
       - name: Run Python Linters
         if: matrix.language == 'python'
         run: |

--- a/.github/workflows/01-lint-format.yml
+++ b/.github/workflows/01-lint-format.yml
@@ -9,6 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup uv
+        if: matrix.language == 'python'
+        uses: astral-sh/setup-uv@v1
+
       - name: Setup Python
         if: matrix.language == 'python'
         uses: actions/setup-python@v4
@@ -16,7 +20,7 @@ jobs:
           python-version: '3.x'
       - name: Install Py Lint Tools
         if: matrix.language == 'python'
-        run: pip install flake8 black isort
+        run: uv pip install flake8 black isort
       - name: Run Python Linters
         if: matrix.language == 'python'
         run: |

--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -20,8 +20,8 @@ jobs:
           python-version: '3.x'
       - if: matrix.language == 'python'
         run: |
-          uv pip install pytest
-          if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
+          uv pip install --system pytest
+          if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
           pytest --maxfail=1 --disable-warnings -q
 
       - name: JavaScript Tests

--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -9,6 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup uv
+        if: matrix.language == 'python'
+        uses: astral-sh/setup-uv@v1
+
       - name: Python Tests
         if: matrix.language == 'python'
         uses: actions/setup-python@v4
@@ -16,8 +20,8 @@ jobs:
           python-version: '3.x'
       - if: matrix.language == 'python'
         run: |
-          pip install pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          uv pip install pytest
+          if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
           pytest --maxfail=1 --disable-warnings -q
 
       - name: JavaScript Tests

--- a/.github/workflows/03-docs.yml
+++ b/.github/workflows/03-docs.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: astral-sh/setup-uv@v1
       - run: |
-          pip install linkchecker
+          uv pip install linkchecker
           linkchecker README.md docs/ || true

--- a/.github/workflows/03-docs.yml
+++ b/.github/workflows/03-docs.yml
@@ -18,5 +18,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: astral-sh/setup-uv@v1
       - run: |
-          uv pip install linkchecker
+          uv pip install --system linkchecker
           linkchecker README.md docs/ || true

--- a/.github/workflows/04-update-summary.yml
+++ b/.github/workflows/04-update-summary.yml
@@ -17,8 +17,8 @@ jobs:
         uses: astral-sh/setup-uv@v1
       - name: Install dependencies
         run: |
-          uv pip install -r requirements.txt
-          uv pip install pre-commit
+          uv pip install --system -r requirements.txt
+          uv pip install --system pre-commit
       - name: Generate summary
         run: |
           python -m flywheel crawl futuroptimist/flywheel futuroptimist/axel futuroptimist/gabriel futuroptimist/futuroptimist futuroptimist/token.place democratizedspace/dspace futuroptimist/f2clipboard futuroptimist/sigma --output docs/repo-feature-summary.md

--- a/.github/workflows/04-update-summary.yml
+++ b/.github/workflows/04-update-summary.yml
@@ -13,10 +13,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v1
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
-          pip install pre-commit
+          uv pip install -r requirements.txt
+          uv pip install pre-commit
       - name: Generate summary
         run: |
           python -m flywheel crawl futuroptimist/flywheel futuroptimist/axel futuroptimist/gabriel futuroptimist/futuroptimist futuroptimist/token.place democratizedspace/dspace futuroptimist/f2clipboard futuroptimist/sigma --output docs/repo-feature-summary.md

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -78,3 +78,4 @@ CLIs
 dir
 pio
 testbed
+uv

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ git add .
 git commit -m "chore: initialize flywheel"
 
 # Install uv and pre-commit hooks
-curl -Ls https://astral.sh/uv/install | sh
+curl -Ls https://astral.sh/uv/install.sh | sh
+uv venv
 uv pip install pre-commit
 pre-commit install
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - DEPENDABOT for automated dependency updates
 - CodeQL workflow for security scanning
 - Style guides for Python and JavaScript
+- Fast Python installs powered by [uv](https://github.com/astral-sh/uv)
 - Example code and templates
 - Python CLI with subcommands `init`, `update`, `audit`, `prompt`, and `crawl` that prompts interactively unless `--yes` is used
 - [AGENTS.md](AGENTS.md) detailing included LLM assistants
@@ -51,8 +52,9 @@ cd NEWREPO
 git add .
 git commit -m "chore: initialize flywheel"
 
-# Install pre-commit hooks
-pip install pre-commit
+# Install uv and pre-commit hooks
+curl -Ls https://astral.sh/uv/install | sh
+uv pip install pre-commit
 pre-commit install
 
 # Run checks before committing

--- a/docs/best_practices_overview.md
+++ b/docs/best_practices_overview.md
@@ -6,4 +6,5 @@ This documentation outlines recommended workflows, CI setup, and guidelines to k
 
 - **Code conventions** ensure consistent style. See the style guides in `docs/styleguides`.
 - **Local environments** keep personal tweaks in `.local` as described in `docs/local-environments.md`.
+- **Use uv** for Python dependency management to dramatically speed up installs.
 - **Positive-sum values** guide our decisions. We favor regenerative, empathetic, and open-source approaches.

--- a/docs/f2clipboard-integration.md
+++ b/docs/f2clipboard-integration.md
@@ -15,7 +15,7 @@ Clone the tool and run it alongside Flywheel:
 ```bash
 git clone https://github.com/futuroptimist/f2clipboard
 cd f2clipboard
-pip install -e .
+uv pip install -e .
 python -m f2clipboard --dir ../flywheel --pattern "*.md"
 ```
 

--- a/docs/f2clipboard-integration.md
+++ b/docs/f2clipboard-integration.md
@@ -15,6 +15,7 @@ Clone the tool and run it alongside Flywheel:
 ```bash
 git clone https://github.com/futuroptimist/f2clipboard
 cd f2clipboard
+uv venv
 uv pip install -e .
 python -m f2clipboard --dir ../flywheel --pattern "*.md"
 ```

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -2,15 +2,9 @@
 
 This table tracks which flywheel features each related repository has adopted.
 
-| Repo | Coverage | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
-| ---- | -------- | ------- | -- | --------- | --------------- | ------------ | ---------- |
-| [futuroptimist/flywheel](https://github.com/futuroptimist/flywheel) | ✅ (20%) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (unknown) | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (unknown) | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (unknown) | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Repo | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
+| ---- | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- |
+| [futuroptimist/flywheel](https://github.com/futuroptimist/flywheel) | ✅ (20%) | pip | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
 
-Legend: ✅ indicates the repo has adopted that feature from flywheel. Coverage percentages are parsed from their badges where available.
+Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv highlights repos using uv for faster installs. Coverage percentages are parsed from their badges where available.

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -6,5 +6,11 @@ This table tracks which flywheel features each related repository has adopted.
 | ---- | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- |
 | [futuroptimist/flywheel](https://github.com/futuroptimist/flywheel) | ✅ (20%) | pip | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (unknown) | pip | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv highlights repos using uv for faster installs. Coverage percentages are parsed from their badges where available.

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -36,3 +36,4 @@ def test_generate_summary():
     out = crawler.generate_summary()
     assert "100%" in out
     assert "foo/bar" in out
+    assert "pip" in out


### PR DESCRIPTION
## Summary
- use uv for faster installs in CI workflows and docs
- document uv setup in README and best practices
- update f2clipboard integration guide to use uv
- detect whether repos use uv vs pip when crawling
- test new installer detection

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869a779f170832fad68808ac7d41b34