### PR TITLE
Fix docs workflow env and exclude .venv

### DIFF
--- a/.github/workflows/03-docs.yml
+++ b/.github/workflows/03-docs.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: astral-sh/setup-uv@v1
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
       - run: |
           uv pip install --system linkchecker
           linkchecker README.md docs/ || true

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist/
 .DS_Store
 coverage/
 dictionary.dic
+.venv/

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -79,3 +79,4 @@ dir
 pio
 testbed
 uv
+venv

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -4,7 +4,7 @@ This table tracks which flywheel features each related repository has adopted.
 
 | Repo | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
 | ---- | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- |
-| [futuroptimist/flywheel](https://github.com/futuroptimist/flywheel) | ✅ (20%) | pip | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [futuroptimist/flywheel](https://github.com/futuroptimist/flywheel) | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ |

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -2,9 +2,9 @@
 set -e
 
 # python checks
-flake8 .
-isort --check-only .
-black --check .
+flake8 . --exclude=.venv
+isort --check-only . --skip .venv
+black --check . --exclude ".venv/"
 
 # js checks
 if [ -f package.json ]; then


### PR DESCRIPTION
## Summary
- add Python setup step in docs workflow so `linkchecker` installs properly
- exclude `.venv/` from version control and ignore it in lint checks
- allow `venv` in spellcheck wordlist

## Testing
- `pre-commit run --files $(git ls-files)`

------
https://chatgpt.com/codex/tasks/task_e_6869aec5a150832fac695cffb25c2b64