### PR TITLE
Highlight flywheel repo in crawler output

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/flywheel/.github/workflows/01-lint-format.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/flywheel/actions/workflows/01-lint-format.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/flywheel/.github/workflows/02-tests.yml?label=tests)](https://github.com/futuroptimist/flywheel/actions/workflows/02-tests.yml)
+[![Coverage](https://img.shields.io/badge/coverage-20%25-red)](https://github.com/futuroptimist/flywheel)
 [![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/flywheel/.github/workflows/03-docs.yml?label=docs)](https://github.com/futuroptimist/flywheel/actions/workflows/03-docs.yml)
 [![License](https://img.shields.io/github/license/futuroptimist/flywheel)](LICENSE)
 

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -4,7 +4,7 @@ This table tracks which flywheel features each related repository has adopted.
 
 | Repo | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
 | ---- | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- |
-| [futuroptimist/flywheel](https://github.com/futuroptimist/flywheel) | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ |

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -113,11 +113,13 @@ class RepoCrawler:
             header,
             sep,
         ]
-        for info in repos:
+        for idx, info in enumerate(repos):
             coverage = "❌"
             if info.coverage:
                 coverage = f"✅ ({info.coverage})"
             repo_link = f"[{info.name}](https://github.com/{info.name})"
+            if idx == 0:
+                repo_link = f"**{repo_link}**"
             row = "| {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
                 repo_link,
                 coverage,

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -35,5 +35,5 @@ def test_generate_summary():
     crawler = rc.RepoCrawler(["foo/bar"], session=session)
     out = crawler.generate_summary()
     assert "100%" in out
-    assert "foo/bar" in out
+    assert "**[foo/bar](https://github.com/foo/bar)**" in out
     assert "pip" in out


### PR DESCRIPTION
## Summary
- bold the first repository row for emphasis
- add a basic coverage badge to the README
- adjust tests for the new highlighted repo link

## Testing
- `pre-commit run --files flywheel/repocrawler.py docs/repo-feature-summary.md README.md tests/test_repocrawler.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869b3faf69c832fabde1024347a4960