### PR TITLE
Improve repo crawler with commit data

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Create a Markdown table showing which flywheel files each repo uses:
 flywheel crawl futuroptimist/flywheel futuroptimist/axel --output docs/repo-feature-summary.md
 ```
 The table in `docs/repo-feature-summary.md` is automatically refreshed after each commit via GitHub Actions.
+The summary now records the short SHA of the latest commit crawled for each repository.
 
 ## Values
 

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -8,7 +8,7 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | 30c1bda |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | eccea81 |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | 2f4cdde |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | 28fcdee |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | d65d648 |
 | [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | 1ee6938 |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | 763ac09 |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | b54c6b0 |

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -2,15 +2,15 @@
 
 This table tracks which flywheel features each related repository has adopted.
 
-| Repo | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
-| ---- | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Repo | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
+| ---- | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 372b95d |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | 30c1bda |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | eccea81 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | 2f4cdde |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | 28fcdee |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | 1ee6938 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | 763ac09 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | b54c6b0 |
 
-Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv highlights repos using uv for faster installs. Coverage percentages are parsed from their badges where available.
+Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv highlights repos using uv for faster installs. Coverage percentages are parsed from their badges where available. The commit column shows the short SHA of the latest main branch commit at crawl time.

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -9,15 +9,22 @@ class DummySession:
     def __init__(self, files):
         self.files = files
 
-    def get(self, url):
+    def get(self, url, **kwargs):
         class Resp:
             def __init__(self, text, status):
                 self.text = text
                 self.status_code = status
 
+            def json(self):
+                import json
+
+                return json.loads(self.text)
+
         path = url.split("raw.githubusercontent.com/")[-1]
         if path in self.files:
             return Resp(self.files[path], 200)
+        if url.startswith("https://api.github.com/repos/"):
+            return Resp('[{"sha": "deadbeef"}]', 200)
         return Resp("", 404)
 
 
@@ -37,6 +44,7 @@ def test_generate_summary():
     assert "100%" in out
     assert "**[foo/bar](https://github.com/foo/bar)**" in out
     assert "pip" in out
+    assert "deadbee" in out
 
 
 def test_parse_coverage_none():


### PR DESCRIPTION
## Summary
- track latest commit SHA when crawling repos
- update repo feature summary
- document the commit column in README
- adjust tests for new metadata

## Testing
- `pre-commit run --files flywheel/repocrawler.py tests/test_repocrawler.py docs/repo-feature-summary.md README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869ba241ed8832fa8c43fde1db9a61d