### PR TITLE
Fix spellcheck for commit hashes

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -81,3 +81,4 @@ testbed
 uv
 venv
 brightgreen
+SHA

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -4,13 +4,13 @@ This table tracks which flywheel features each related repository has adopted.
 
 | Repo | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
 | ---- | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | f1ed3a3 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | 30c1bda |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | eccea81 |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | 2f4cdde |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | d65d648 |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | 1ee6938 |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | 763ac09 |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | b54c6b0 |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `f1ed3a3` |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | `30c1bda` |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | `eccea81` |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | `2f4cdde` |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | `d65d648` |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | `1ee6938` |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | `763ac09` |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | `b54c6b0` |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv highlights repos using uv for faster installs. Coverage percentages are parsed from their badges where available. The commit column shows the short SHA of the latest main branch commit at crawl time.

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -4,13 +4,13 @@ This table tracks which flywheel features each related repository has adopted.
 
 | Repo | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
 | ---- | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `f1ed3a3` |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | `30c1bda` |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | `eccea81` |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | `2f4cdde` |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | `d65d648` |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | `1ee6938` |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | `763ac09` |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | `b54c6b0` |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | eba35f5 |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | 0a664fa |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | eccea81 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | 2f4cdde |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | d65d648 |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | 1ee6938 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | 763ac09 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | b54c6b0 |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv highlights repos using uv for faster installs. Coverage percentages are parsed from their badges where available. The commit column shows the short SHA of the latest main branch commit at crawl time.


### PR DESCRIPTION
## Summary
- ignore commit hashes by quoting them
- allow `SHA` in spelling wordlist

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_6869bfbd0ee0832f9dc8d8c4c65e9a34