### PR TITLE
Add branch column in repo crawler

### DIFF
--- a/.github/workflows/04-update-summary.yml
+++ b/.github/workflows/04-update-summary.yml
@@ -1,6 +1,8 @@
 name: Update Repo Feature Summary
 on:
   push:
+    branches:
+      - main
 jobs:
   crawl:
     if: github.actor != 'github-actions[bot]'

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -2,15 +2,15 @@
 
 This table tracks which flywheel features each related repository has adopted.
 
-| Repo | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
-| ---- | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | f1ed3a3 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | 30c1bda |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | eccea81 |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | 2f4cdde |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | d65d648 |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | 1ee6938 |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | 763ac09 |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | b54c6b0 |
+| Repo | Branch | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
+| ---- | ------ | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | f1ed3a3 |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | 30c1bda |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | eccea81 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | 2f4cdde |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | d65d648 |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | 1ee6938 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | 763ac09 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | b54c6b0 |
 
-Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv highlights repos using uv for faster installs. Coverage percentages are parsed from their badges where available. The commit column shows the short SHA of the latest main branch commit at crawl time.
+Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv highlights repos using uv for faster installs. Coverage percentages are parsed from their badges where available. The commit column shows the short SHA of the latest default branch commit at crawl time.

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -20,11 +20,14 @@ class DummySession:
 
                 return json.loads(self.text)
 
+        if url.startswith("https://api.github.com/repos/"):
+            if url.endswith("/commits?per_page=1&sha=main"):
+                return Resp('[{"sha": "deadbeef"}]', 200)
+            return Resp('{"default_branch": "main"}', 200)
+
         path = url.split("raw.githubusercontent.com/")[-1]
         if path in self.files:
             return Resp(self.files[path], 200)
-        if url.startswith("https://api.github.com/repos/"):
-            return Resp('[{"sha": "deadbeef"}]', 200)
         return Resp("", 404)
 
 
@@ -43,6 +46,7 @@ def test_generate_summary():
     out = crawler.generate_summary()
     assert "100%" in out
     assert "**[foo/bar](https://github.com/foo/bar)**" in out
+    assert "main" in out
     assert "pip" in out
     assert "deadbee" in out
 


### PR DESCRIPTION
## Summary
- record each repo's default branch name when crawling
- include new Branch column in repo feature summary
- update summary update workflow to run only on main pushes
- tweak tests for branch detection

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869bdf2b0d0832fbb4595dd72300c28