### PR TITLE
Improve RepoCrawler with token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ flywheel crawl futuroptimist/flywheel futuroptimist/axel --output docs/repo-feat
 ```
 The table in `docs/repo-feature-summary.md` is automatically refreshed after each commit via GitHub Actions.
 The summary now records the short SHA of the latest commit and the name of each repository's default branch.
+Set the `GITHUB_TOKEN` environment variable or pass `--token YOURTOKEN` to avoid GitHub API rate limits.
 
 ## Values
 

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -4,13 +4,13 @@ This table tracks which flywheel features each related repository has adopted.
 
 | Repo | Branch | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
 | ---- | ------ | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 112a49d |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | 97d105b |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | eccea81 |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | 2f4cdde |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | d65d648 |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ef45c45 |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ac58b74 |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | 7de9b86 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | bd2e736 |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | b9f666f |
 | [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | main | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | 1ee6938 |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | 763ac09 |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | b54c6b0 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 30fd08e |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | bda6390 |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv highlights repos using uv for faster installs. Coverage percentages are parsed from their badges where available. The commit column shows the short SHA of the latest default branch commit at crawl time.

--- a/flywheel/__main__.py
+++ b/flywheel/__main__.py
@@ -96,7 +96,7 @@ def prompt(args: argparse.Namespace) -> None:
 
 
 def crawl(args: argparse.Namespace) -> None:
-    crawler = RepoCrawler(args.repos)
+    crawler = RepoCrawler(args.repos, token=args.token)
     md = crawler.generate_summary()
     Path(args.output).write_text(md)
 
@@ -146,6 +146,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--output",
         default="docs/repo-feature-summary.md",
         help="output markdown path",
+    )
+    p_crawl.add_argument(
+        "--token",
+        help="GitHub token for authenticated requests",
     )
     p_crawl.set_defaults(func=crawl)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,7 +24,7 @@ def test_main_crawl(monkeypatch, tmp_path):
     out = tmp_path / "sum.md"
 
     class DummyCrawler:
-        def __init__(self, repos):
+        def __init__(self, repos, token=None):
             self.repos = repos
 
         def generate_summary(self):


### PR DESCRIPTION
## Summary
- allow passing a GitHub token to `RepoCrawler`
- expose `--token` option on CLI
- document token usage in README
- regenerate repo feature summary
- adjust test stub for new param

## Testing
- `pre-commit run --files flywheel/repocrawler.py flywheel/__main__.py README.md tests/test_main.py docs/repo-feature-summary.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a24b29614832fa2e907911c5fa59f