### PR TITLE
Add GitHub token option to RepoCrawler

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -82,3 +82,4 @@ uv
 venv
 brightgreen
 SHA
+YOURTOKEN

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Create a Markdown table showing which flywheel files each repo uses:
 ```bash
 flywheel crawl futuroptimist/flywheel futuroptimist/axel --output docs/repo-feature-summary.md
 ```
+Pass `--token YOURTOKEN` or set `GITHUB_TOKEN` to avoid API rate limits.
 The table in `docs/repo-feature-summary.md` is automatically refreshed after each commit via GitHub Actions.
 The summary now records the short SHA of the latest commit and the name of each repository's default branch.
 

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -2,15 +2,17 @@
 
 This table tracks which flywheel features each related repository has adopted.
 
+<!-- spellcheck-disable -->
 | Repo | Branch | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
 | ---- | ------ | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 112a49d |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | 97d105b |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | eccea81 |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | 2f4cdde |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | d65d648 |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ef45c45 |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ac58b74 |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | 7de9b86 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | bd2e736 |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | b9f666f |
 | [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | main | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | 1ee6938 |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | 763ac09 |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ❌ | pip | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | b54c6b0 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 30fd08e |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | bda6390 |
+<!-- spellcheck-enable -->
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv highlights repos using uv for faster installs. Coverage percentages are parsed from their badges where available. The commit column shows the short SHA of the latest default branch commit at crawl time.

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -2,7 +2,6 @@
 
 This table tracks which flywheel features each related repository has adopted.
 
-<!-- spellcheck-disable -->
 | Repo | Branch | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
 | ---- | ------ | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ef45c45 |
@@ -13,6 +12,5 @@ This table tracks which flywheel features each related repository has adopted.
 | [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | main | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | 1ee6938 |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 30fd08e |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | bda6390 |
-<!-- spellcheck-enable -->
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv highlights repos using uv for faster installs. Coverage percentages are parsed from their badges where available. The commit column shows the short SHA of the latest default branch commit at crawl time.

--- a/flywheel/__main__.py
+++ b/flywheel/__main__.py
@@ -96,7 +96,7 @@ def prompt(args: argparse.Namespace) -> None:
 
 
 def crawl(args: argparse.Namespace) -> None:
-    crawler = RepoCrawler(args.repos)
+    crawler = RepoCrawler(args.repos, token=args.token)
     md = crawler.generate_summary()
     Path(args.output).write_text(md)
 
@@ -146,6 +146,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--output",
         default="docs/repo-feature-summary.md",
         help="output markdown path",
+    )
+    p_crawl.add_argument(
+        "--token",
+        help="GitHub token for authenticated API calls",
+        default=None,
     )
     p_crawl.set_defaults(func=crawl)
 

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass
 from typing import Iterable, List, Optional
@@ -28,10 +29,16 @@ class RepoCrawler:
     """Check remote GitHub repos for standard flywheel features."""
 
     def __init__(
-        self, repos: Iterable[str], session: Optional[requests.Session] = None
+        self,
+        repos: Iterable[str],
+        session: Optional[requests.Session] = None,
+        token: Optional[str] = None,
     ) -> None:
         self.repos = list(repos)
         self.session = session or requests.Session()
+        tok = token or os.environ.get("GITHUB_TOKEN")
+        if tok:
+            self.session.headers.update({"Authorization": f"Bearer {tok}"})
 
     def _fetch_file(
         self,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,7 +24,7 @@ def test_main_crawl(monkeypatch, tmp_path):
     out = tmp_path / "sum.md"
 
     class DummyCrawler:
-        def __init__(self, repos):
+        def __init__(self, repos, token=None):
             self.repos = repos
 
         def generate_summary(self):

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -8,6 +8,7 @@ import flywheel.repocrawler as rc  # noqa: E402
 class DummySession:
     def __init__(self, files):
         self.files = files
+        self.headers = {}
 
     def get(self, url, **kwargs):
         class Resp:
@@ -66,3 +67,9 @@ def test_parse_coverage_no_match():
     crawler = rc.RepoCrawler([])
     result = crawler._parse_coverage("nothing here")
     assert result is None
+
+
+def test_init_with_token():
+    session = DummySession({})
+    rc.RepoCrawler(["foo/bar"], session=session, token="abc123")
+    assert session.headers.get("Authorization") == "Bearer abc123"


### PR DESCRIPTION
## Summary
- support authenticated API calls in RepoCrawler
- expose `--token` argument for the `crawl` CLI
- document the new option in the README
- update repo summary table
- cover token logic in tests
- fix spellcheck errors by ignoring table output

## Testing
- `/root/.pyenv/versions/3.12.10/bin/pre-commit run --files .wordlist.txt docs/repo-feature-summary.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a24b29614832fa2e907911c5fa59f