### PR TITLE
Fix spellcheck by ignoring commit SHAs

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -4,13 +4,13 @@ This table tracks which flywheel features each related repository has adopted.
 
 | Repo | Branch | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
 | ---- | ------ | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 00f63c5 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ac58b74 |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | 7de9b86 |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | bd2e736 |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | b9f666f |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | main | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | 1ee6938 |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 30fd08e |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | bda6390 |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | [`53f58a8`](https://github.com/futuroptimist/flywheel/commit/53f58a8) |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | [`ac58b74`](https://github.com/futuroptimist/axel/commit/ac58b74) |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | [`7de9b86`](https://github.com/futuroptimist/gabriel/commit/7de9b86) |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | [`bd2e736`](https://github.com/futuroptimist/futuroptimist/commit/bd2e736) |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | [`b9f666f`](https://github.com/futuroptimist/token.place/commit/b9f666f) |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | main | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | [`1ee6938`](https://github.com/democratizedspace/dspace/commit/1ee6938) |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | [`30fd08e`](https://github.com/futuroptimist/f2clipboard/commit/30fd08e) |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | [`bda6390`](https://github.com/futuroptimist/sigma/commit/bda6390) |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv highlights repos using uv for faster installs. Coverage percentages are parsed from their badges where available. The commit column shows the short SHA of the latest default branch commit at crawl time.

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -4,7 +4,7 @@ This table tracks which flywheel features each related repository has adopted.
 
 | Repo | Branch | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
 | ---- | ------ | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | [`53f58a8`](https://github.com/futuroptimist/flywheel/commit/53f58a8) |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | [`008593e`](https://github.com/futuroptimist/flywheel/commit/008593e) |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | [`ac58b74`](https://github.com/futuroptimist/axel/commit/ac58b74) |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | [`7de9b86`](https://github.com/futuroptimist/gabriel/commit/7de9b86) |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | [`bd2e736`](https://github.com/futuroptimist/futuroptimist/commit/bd2e736) |

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -182,6 +182,13 @@ class RepoCrawler:
             repo_link = f"[{info.name}](https://github.com/{info.name})"
             if idx == 0:
                 repo_link = f"**{repo_link}**"
+            commit = (
+                f"[`{info.latest_commit}`]("
+                f"https://github.com/{info.name}/commit/"
+                f"{info.latest_commit})"
+                if info.latest_commit
+                else "n/a"
+            )
             row = "| {} | {} | {} | {} | {} | {} | {} | {} | ".format(
                 repo_link,
                 info.branch,
@@ -194,7 +201,7 @@ class RepoCrawler:
             ) + "{} | {} | {} |".format(
                 "✅" if info.has_contributing else "❌",
                 "✅" if info.has_precommit else "❌",
-                info.latest_commit or "n/a",
+                commit,
             )
             lines.append(row)
         lines.append("")

--- a/spellcheck.yaml
+++ b/spellcheck.yaml
@@ -4,6 +4,11 @@ matrix:
     sources:
       - README.md
       - docs/**/*.md
+    defaults:
+      pipeline:
+        - pyspelling.filters.markdown
+        - name: pyspelling.filters.html
+          ignores: [code]
     dictionary:
       wordlists:
         - .wordlist.txt


### PR DESCRIPTION
## Summary
- ignore code when spellchecking markdown
- show commit SHAs as inline links in repo summary
- regenerate repo-feature-summary

## Testing
- `pre-commit run --files flywheel/repocrawler.py spellcheck.yaml docs/repo-feature-summary.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a2ae5e7a8832f973599ea24f5b326