### PR TITLE
Fix docs workflow with pinned spellcheck

### DIFF
--- a/.github/workflows/03-docs.yml
+++ b/.github/workflows/03-docs.yml
@@ -9,9 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: rojopolis/spellcheck-github-actions@v0
+
+      # Ensure dictionaries are present
+      - name: Install aspell dictionaries
+        run: sudo apt-get update && sudo apt-get install -y aspell aspell-en
+
+      - name: Spell check markdown & docs
+        uses: rojopolis/spellcheck-github-actions@0.35.0
         with:
-          config_path: spellcheck.yaml
+          config_path: .spellcheck.yaml
+        # If you prefer non-blocking:
+        # continue-on-error: true
   linkcheck:
     runs-on: ubuntu-latest
     steps:

--- a/.spellcheck.yaml
+++ b/.spellcheck.yaml
@@ -8,10 +8,9 @@ matrix:
       wordlists:
         - .wordlist.txt
     aspell:
-      lang: en
-      d: en_US
+      lang: en_US
     pipeline:
-      - pyspelling.filters.markdown:
+      - pyspelling.filters.markdown
       - pyspelling.filters.html:
           comments: false
           ignores:

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -18,7 +18,7 @@ fi
 pytest -q
 
 # docs checks
-if command -v pyspelling >/dev/null 2>&1 && [ -f spellcheck.yaml ]; then
-  pyspelling -c spellcheck.yaml || true
+if command -v pyspelling >/dev/null 2>&1 && [ -f .spellcheck.yaml ]; then
+  pyspelling -c .spellcheck.yaml || true
 fi
 linkchecker README.md docs/ || true


### PR DESCRIPTION
## Summary
- use `.spellcheck.yaml` with correct YAML
- install aspell dictionaries in CI and pin spellcheck action
- update `scripts/checks.sh` for new config name

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_686a2d6b6780832f826dc2c9c42ecf0f