### PR TITLE
Fix spellcheck failures in docs workflow

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -2,15 +2,17 @@
 
 This table tracks which flywheel features each related repository has adopted.
 
+<!-- spellchecker: disable -->
 | Repo | Branch | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
 | ---- | ------ | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 4cf793d |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ac58b74 |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | 7de9b86 |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | bd2e736 |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | b9f666f |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | main | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | 1ee6938 |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 30fd08e |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | bda6390 |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `4cf793d` |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | `ac58b74` |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | `7de9b86` |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bd2e736` |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | `b9f666f` |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | main | ❌ | pip | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | `1ee6938` |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `30fd08e` |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bda6390` |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv highlights repos using uv for faster installs. Coverage percentages are parsed from their badges where available. The commit column shows the short SHA of the latest default branch commit at crawl time.
+<!-- spellchecker: enable -->

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -5,7 +5,7 @@ This table tracks which flywheel features each related repository has adopted.
 <!-- spellchecker: disable -->
 | Repo | Branch | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
 | ---- | ------ | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `4cf793d` |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `008593e` |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | `ac58b74` |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | `7de9b86` |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bd2e736` |
@@ -15,4 +15,3 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bda6390` |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv highlights repos using uv for faster installs. Coverage percentages are parsed from their badges where available. The commit column shows the short SHA of the latest default branch commit at crawl time.
-<!-- spellchecker: enable -->

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -172,6 +172,7 @@ class RepoCrawler:
                 "repository has adopted."
             ),
             "",
+            "<!-- spellchecker: disable -->",
             header,
             sep,
         ]
@@ -182,6 +183,7 @@ class RepoCrawler:
             repo_link = f"[{info.name}](https://github.com/{info.name})"
             if idx == 0:
                 repo_link = f"**{repo_link}**"
+            commit = f"`{info.latest_commit}`" if info.latest_commit else "n/a"
             row = "| {} | {} | {} | {} | {} | {} | {} | {} | ".format(
                 repo_link,
                 info.branch,
@@ -194,7 +196,7 @@ class RepoCrawler:
             ) + "{} | {} | {} |".format(
                 "✅" if info.has_contributing else "❌",
                 "✅" if info.has_precommit else "❌",
-                info.latest_commit or "n/a",
+                commit,
             )
             lines.append(row)
         lines.append("")


### PR DESCRIPTION
## Summary
- insert spellcheck disable marker in repo summary
- wrap commit SHAs in backticks
- emit HTML comment in generator and wrap commit numbers

## Testing
- `pre-commit run --files flywheel/repocrawler.py`
- `pytest -q`
- `pyspelling --config spellcheck.yaml`


------
https://chatgpt.com/codex/tasks/task_e_686a2d6b6780832f826dc2c9c42ecf0f