### PR TITLE
Fix spellcheck config for CI

### DIFF
--- a/.spellcheck.yaml
+++ b/.spellcheck.yaml
@@ -8,7 +8,8 @@ matrix:
       wordlists:
         - .wordlist.txt
     aspell:
-      lang: en_US
+      lang: en
+      d: en_US
     pipeline:
       - pyspelling.filters.markdown
       - pyspelling.filters.html:

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -5,7 +5,7 @@ This table tracks which flywheel features each related repository has adopted.
 <!-- spellchecker: disable -->
 | Repo | Branch | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
 | ---- | ------ | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `9b1710d` |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `0b685dc` |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | `ac58b74` |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | `7de9b86` |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bd2e736` |


### PR DESCRIPTION
## Summary
- **Type of change:** fix
- **Related issues:** closes #

## Checklist
- [x] Linted
- [ ] Tests added/updated
- [ ] Docs updated
- [ ] AGENTS.md updated if applicable

## Notes
Fixes CI spellcheck job by using the generic `en` language with the `en_US` dictionary.

------
https://chatgpt.com/codex/tasks/task_e_686af7c651a4832f89b6dd6f8e13c587