### PR TITLE
Fix spellcheck config

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -83,3 +83,6 @@ venv
 brightgreen
 SHA
 YOURTOKEN
+
+htmlcontent
+installable

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -5,7 +5,7 @@ This table tracks which flywheel features each related repository has adopted.
 <!-- spellchecker: disable -->
 | Repo | Branch | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
 | ---- | ------ | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `9b1710d` |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `6267db3` |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (unknown) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | `ac58b74` |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | pip | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | `7de9b86` |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bd2e736` |


### PR DESCRIPTION
## Summary
- configure `.spellcheck.yaml` to use `en_US`
- allow `htmlcontent` and `installable` in spellchecker wordlist

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_686af7c651a4832f89b6dd6f8e13c587