### PR TITLE
Allow per-repo branch overrides for RepoCrawler

### DIFF
--- a/.github/workflows/04-update-summary.yml
+++ b/.github/workflows/04-update-summary.yml
@@ -21,7 +21,7 @@ jobs:
           uv pip install --system pre-commit
       - name: Generate summary
         run: |
-          python -m flywheel crawl futuroptimist/flywheel futuroptimist/axel futuroptimist/gabriel futuroptimist/futuroptimist futuroptimist/token.place democratizedspace/dspace futuroptimist/f2clipboard futuroptimist/sigma --output docs/repo-feature-summary.md
+          python -m flywheel crawl futuroptimist/flywheel futuroptimist/axel futuroptimist/gabriel futuroptimist/futuroptimist futuroptimist/token.place democratizedspace/dspace@v3 futuroptimist/f2clipboard futuroptimist/sigma --output docs/repo-feature-summary.md
       - name: Run pre-commit
         run: |
           pre-commit run --files docs/repo-feature-summary.md || true

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Create a Markdown table showing which flywheel files each repo uses:
 ```bash
 flywheel crawl futuroptimist/flywheel futuroptimist/axel --output docs/repo-feature-summary.md
 ```
+Append `@branch` to any repo to crawl a non-default branch, e.g. `owner/name@dev`.
 Pass `--token YOURTOKEN` or set `GITHUB_TOKEN` to avoid API rate limits.
 The table in `docs/repo-feature-summary.md` is automatically refreshed after each commit via GitHub Actions.
 The summary now records the short SHA of the latest commit and the name of each repository's default branch.

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -90,3 +90,15 @@ def test_init_with_token():
 def test_ci_detection_single_file():
     crawler = rc.RepoCrawler([])
     assert crawler._has_ci({"ci.yml"}) is True
+
+
+def test_branch_override():
+    files = {
+        "foo/bar/dev/README.md": "100% coverage",
+        "foo/bar/dev/LICENSE": "",
+        "foo/bar/dev/.github/workflows/ci.yml": "",
+    }
+    session = DummySession(files)
+    crawler = rc.RepoCrawler(["foo/bar@dev"], session=session)
+    info = crawler.crawl()[0]
+    assert info.branch == "dev"


### PR DESCRIPTION
## Summary
- support `owner/name@branch` syntax in RepoCrawler
- update workflow to crawl `dspace@v3`
- document branch override usage in README
- test branch override behavior

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b01e8bcf4832f94c69725710e7d73