### PR TITLE
Increase repocrawler coverage to 100%

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -20,9 +20,10 @@ jobs:
           python-version: '3.x'
       - if: matrix.language == 'python'
         run: |
-          uv pip install --system pytest pytest-cov
+          uv pip install --system pytest pytest-cov coverage
           if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
           pytest --cov=flywheel --cov-report=xml --cov-report=term --maxfail=1 --disable-warnings -q
+          coverage report --fail-under=100
 
       - name: JavaScript Tests
         if: matrix.language == 'javascript'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.1
+ignore: []
+comment:
+  layout: "header, diff"

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -1,0 +1,89 @@
+from flywheel.repocrawler import RepoCrawler
+
+
+class DummyResp:
+    def __init__(self, status, text="", json_data=None):
+        self.status_code = status
+        self.text = text
+        self._json = json_data
+
+    def json(self):
+        if isinstance(self._json, Exception):
+            raise self._json
+        return self._json
+
+
+def make_session(mapping):
+    class Sess:
+        def __init__(self):
+            self.headers = {}
+
+        def get(self, url, *_, **__):
+            for key, resp in mapping.items():
+                if key in url:
+                    return resp() if callable(resp) else resp
+            return DummyResp(404)
+
+    return Sess()
+
+
+def test_fetch_file_branch_fallback():
+    sess = make_session({"main/file.txt": DummyResp(200, "hello")})
+    crawler = RepoCrawler([], session=sess)
+    assert crawler._fetch_file("demo/repo", "file.txt", "dev") == "hello"
+
+
+def test_default_branch_errors():
+    sess = make_session({"/repos/demo/repo": DummyResp(500)})
+    crawler = RepoCrawler([], session=sess)
+    assert crawler._default_branch("demo/repo") == "main"
+
+    sess = make_session(
+        {
+            "/repos/demo/repo": DummyResp(200, json_data=ValueError("boom")),
+        }
+    )
+    crawler = RepoCrawler([], session=sess)
+    assert crawler._default_branch("demo/repo") == "main"
+
+
+def test_latest_commit_error():
+    sess = make_session({"/commits?per_page=1": DummyResp(200, json_data={})})
+    crawler = RepoCrawler([], session=sess)
+    assert crawler._latest_commit("demo/repo", "main") is None
+
+
+def test_latest_commit_non_200():
+    sess = make_session({"/commits?per_page=1": DummyResp(404)})
+    crawler = RepoCrawler([], session=sess)
+    assert crawler._latest_commit("demo/repo", "main") is None
+
+
+def test_list_workflows_error():
+    sess = make_session(
+        {
+            "/contents/.github/workflows": DummyResp(
+                200,
+                json_data=ValueError("bad"),
+            ),
+        }
+    )
+    crawler = RepoCrawler([], session=sess)
+    assert crawler._list_workflows("demo/repo", "main") == set()
+
+
+def test_list_workflows_non_200():
+    sess = make_session({"/contents/.github/workflows": DummyResp(404)})
+    crawler = RepoCrawler([], session=sess)
+    assert crawler._list_workflows("demo/repo", "main") == set()
+
+
+def test_coverage_from_codecov_no_match():
+    sess = make_session({"codecov": DummyResp(200, "<svg></svg>")})
+    crawler = RepoCrawler([], session=sess)
+    assert crawler._coverage_from_codecov("demo/repo", "main") is None
+
+
+def test_has_ci_false():
+    crawler = RepoCrawler([])
+    assert crawler._has_ci({"deploy.yml"}) is False


### PR DESCRIPTION
## Summary
- add focused tests hitting error branches in `repocrawler`
- gate coverage in CI and require 100%
- prohibit future Codecov ignores

## Testing
- `pre-commit run --files tests/test_repocrawler_extra.py .github/workflows/02-tests.yml codecov.yml`
- `pytest --cov=flywheel -q`

------
https://chatgpt.com/codex/tasks/task_e_686b5632f930832f845675d6b79cf9fe