### PR TITLE
Improve RepoCrawler resiliency

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -5,12 +5,12 @@ This table tracks which flywheel features each related repository has adopted.
 <!-- spellchecker: disable -->
 | Repo | Branch | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
 | ---- | ------ | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `d663139` |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `6bf56f9` |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `064c79a` |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `7de9b86` |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bd2e736` |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (93%) | pip | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | `458ec12` |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | ✅ (78%) | pip | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | `6a30373` |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (93%) | pip | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | `715addf` |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | ✅ (78%) | pip | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | `b87f446` |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `30fd08e` |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bda6390` |
 


### PR DESCRIPTION
## Summary
- handle network errors in RepoCrawler
- test that RepoCrawler gracefully handles request failures

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c57cee608832fa760a3b628741470