### PR TITLE
Add additional CLI and coverage tests

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -5,7 +5,7 @@ This table tracks which flywheel features each related repository has adopted.
 <!-- spellchecker: disable -->
 | Repo | Branch | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
 | ---- | ------ | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `75d1cd0` |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `efe0238` |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `064c79a` |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `7de9b86` |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bd2e736` |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,3 +56,14 @@ def test_prompt_no_readme(tmp_path):
         check=True,
     )
     assert "No README found." in result.stdout
+
+
+def test_cli_help():
+    result = subprocess.run(
+        [sys.executable, "-m", "flywheel", "--help"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "init" in result.stdout
+    assert "crawl" in result.stdout

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -120,3 +120,13 @@ def test_network_exceptions_handled():
     assert c._latest_commit("demo/repo", "main") is None
     assert c._list_workflows("demo/repo", "main") == set()
     assert c._coverage_from_codecov("demo/repo", "main") is None
+
+
+def test_parse_coverage_codecov_fallback(monkeypatch):
+    crawler = RepoCrawler([])
+
+    monkeypatch.setattr(crawler, "_coverage_from_codecov", lambda *a: None)
+
+    readme = "![Coverage](https://codecov.io/gh/foo/bar/branch/main/badge.svg)"
+    result = crawler._parse_coverage(readme, "foo/bar", "main")
+    assert result == "unknown"


### PR DESCRIPTION
## Summary
- test CLI `--help` output for subcommands
- ensure coverage parsing falls back to `unknown` when Codecov badge unavailable

## Testing
- `python -m pre_commit run --all-files`
- `pytest -q --cov=flywheel --cov-report=term`

------
https://chatgpt.com/codex/tasks/task_e_686c59cb06f8832f900cbf37da9655d3