### PR TITLE
Add patch coverage tracking

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -3,15 +3,15 @@
 This table tracks which flywheel features each related repository has adopted.
 
 <!-- spellchecker: disable -->
-| Repo | Branch | Coverage | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
-| ---- | ------ | -------- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `6f12960` |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `064c79a` |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `7de9b86` |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bd2e736` |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (93%) | pip | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | `715addf` |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | ✅ (78%) | pip | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | `b87f446` |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `30fd08e` |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ✅ (100%) | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bda6390` |
+| Repo | Branch | Coverage | Patch | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
+| ---- | ------ | -------- | ----- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `6f12960` |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (100%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `064c79a` |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `7de9b86` |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bd2e736` |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (93%) | ❌ | pip | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | `715addf` |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | ✅ (78%) | ❌ | pip | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | `b87f446` |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ✅ (100%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `30fd08e` |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ✅ (100%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bda6390` |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. The commit column shows the short SHA of the latest default branch commit at crawl time.

--- a/docs/repo-feature-summary.md.jinja
+++ b/docs/repo-feature-summary.md.jinja
@@ -1,0 +1,9 @@
+# Repo Feature Summary
+
+This table tracks which flywheel features each related repository has adopted.
+
+<!-- spellchecker: disable -->
+| Repo | Branch | Coverage | Patch | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
+| ---- | ------ | -------- | ----- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
+{% for row in rows %}{{ row }}
+{% endfor %}

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -84,7 +84,7 @@ def test_list_workflows_non_200():
 def test_coverage_from_codecov_no_match():
     sess = make_session({"codecov": DummyResp(200, "<svg></svg>")})
     crawler = RepoCrawler([], session=sess)
-    assert crawler._coverage_from_codecov("demo/repo", "main") is None
+    assert crawler._project_coverage_from_codecov("demo/repo", "main") is None
 
 
 def test_has_ci_false():
@@ -119,13 +119,17 @@ def test_network_exceptions_handled():
     assert c._default_branch("demo/repo") == "main"
     assert c._latest_commit("demo/repo", "main") is None
     assert c._list_workflows("demo/repo", "main") == set()
-    assert c._coverage_from_codecov("demo/repo", "main") is None
+    assert c._project_coverage_from_codecov("demo/repo", "main") is None
 
 
 def test_parse_coverage_codecov_fallback(monkeypatch):
     crawler = RepoCrawler([])
 
-    monkeypatch.setattr(crawler, "_coverage_from_codecov", lambda *a: None)
+    monkeypatch.setattr(
+        crawler,
+        "_project_coverage_from_codecov",
+        lambda *a: None,
+    )
 
     readme = "![Coverage](https://codecov.io/gh/foo/bar/branch/main/badge.svg)"
     result = crawler._parse_coverage(readme, "foo/bar", "main")


### PR DESCRIPTION
## Summary
- parse Codecov patch coverage badge
- show Patch column in Repo Feature Summary table
- update RepoCrawler and tests for patch coverage

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c657d4dac832fb49a42b207f32b97