### PR TITLE
Relax patch coverage gate

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ coverage:
         threshold: 0
     patch:
       default:
-        target: 100
+        target: 90
 ignore: []
 comment:
   layout: "header, diff"

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -5,7 +5,7 @@ This table tracks which flywheel features each related repository has adopted.
 <!-- spellchecker: disable -->
 | Repo | Branch | Coverage | Patch | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
 | ---- | ------ | -------- | ----- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `96ec4e5` |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `27fe3ac` |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (100%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `064c79a` |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `7de9b86` |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bd2e736` |

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -178,3 +178,27 @@ def test_patch_coverage_svg():
     crawler = rc.RepoCrawler([], session=DummySession({}))
     pct = crawler._patch_coverage_from_codecov("foo/bar", "main")
     assert pct == "73%"
+
+
+def test_generate_summary_with_patch(monkeypatch):
+    """Row should show ✅ and percentage when patch coverage is known."""
+
+    info = rc.RepoInfo(
+        name="demo/repo",
+        branch="main",
+        coverage="100%",
+        patch="73%",
+        has_license=True,
+        has_ci=True,
+        has_agents=False,
+        has_coc=True,
+        has_contributing=True,
+        has_precommit=True,
+        installer="uv",
+        latest_commit="abcdef1",
+    )
+    crawler = rc.RepoCrawler([])
+    monkeypatch.setattr(crawler, "crawl", lambda: [info])
+    summary = crawler.generate_summary().splitlines()[7]
+    assert "✅ (73%)" in summary
+    assert "(73%)" in summary


### PR DESCRIPTION
## Summary
- relax patch coverage threshold to 90%
- add test covering summary when patch coverage is present

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cba82cd04832fbd1f9a4909db9c1e