### PR TITLE
feat: show numeric patch coverage

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -5,13 +5,13 @@ This table tracks which flywheel features each related repository has adopted.
 <!-- spellchecker: disable -->
 | Repo | Branch | Coverage | Patch | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
 | ---- | ------ | -------- | ----- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `524d1eb` |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (100%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `064c79a` |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `7de9b86` |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bd2e736` |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (93%) | ❌ | pip | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | `715addf` |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | ✅ (78%) | ❌ | pip | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | `b87f446` |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ✅ (100%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `30fd08e` |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ✅ (100%) | ❌ | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bda6390` |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `961dd3e` |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `064c79a` |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `fb31085` |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bd2e736` |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (93%) | — | pip | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | `715addf` |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | ✅ (78%) | — | pip | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | `b87f446` |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `30fd08e` |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `bda6390` |
 
-Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. The commit column shows the short SHA of the latest default branch commit at crawl time.
+Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time.

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -139,7 +139,7 @@ def test_parse_coverage_codecov_fallback(monkeypatch):
 def test_patch_coverage_not_found():
     """404 or bad response returns None."""
 
-    sess = make_session({"flag=patch": DummyResp(404)})
+    sess = make_session({"/totals/": DummyResp(404)})
     crawler = RepoCrawler([], session=sess)
     assert crawler._patch_coverage_from_codecov("foo/bar", "main") is None
 
@@ -151,7 +151,7 @@ def test_generate_summary_no_patch(monkeypatch):
         name="demo/repo",
         branch="main",
         coverage="100%",
-        patch=None,
+        patch_percent=None,
         has_license=True,
         has_ci=True,
         has_agents=False,
@@ -164,4 +164,4 @@ def test_generate_summary_no_patch(monkeypatch):
     crawler = RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
     table = crawler.generate_summary().splitlines()[7]
-    assert "| ❌ |" in table
+    assert "| — |" in table


### PR DESCRIPTION
## Summary
- query Codecov API for patch coverage and keep percentage
- display emoji + percent in Patch column with threshold logic
- document patch coverage legend
- update tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cbdce0398832f858064efdc7406b0