### PR TITLE
Add wove to repo crawler list

### DIFF
--- a/.github/workflows/04-update-summary.yml
+++ b/.github/workflows/04-update-summary.yml
@@ -21,7 +21,7 @@ jobs:
           uv pip install --system pre-commit
       - name: Generate summary
         run: |
-          python -m flywheel crawl futuroptimist/flywheel futuroptimist/axel futuroptimist/gabriel futuroptimist/futuroptimist futuroptimist/token.place democratizedspace/dspace@v3 futuroptimist/f2clipboard futuroptimist/sigma --output docs/repo-feature-summary.md
+          python -m flywheel crawl futuroptimist/flywheel futuroptimist/axel futuroptimist/gabriel futuroptimist/futuroptimist futuroptimist/token.place democratizedspace/dspace@v3 futuroptimist/f2clipboard futuroptimist/sigma futuroptimist/wove --output docs/repo-feature-summary.md
       - name: Run pre-commit
         run: |
           pre-commit run --files docs/repo-feature-summary.md || true

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -5,13 +5,14 @@ This table tracks which flywheel features each related repository has adopted.
 <!-- spellchecker: disable -->
 | Repo | Branch | Coverage | Patch | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
 | ---- | ------ | -------- | ----- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `b053a1f` |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `064c79a` |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `35105a6` |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `fc84a64` |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (93%) | — | pip | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | `715addf` |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | ✅ (78%) | — | pip | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | `b87f446` |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `d68f830` |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `3eb7ec7` |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `35a85fe` |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | — | 🔶 partial | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `d5dff5e` |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (93%) | — | pip | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | `7873d3e` |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | ✅ (78%) | — | pip | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | `72a2032` |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `25cd2c6` |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `64d265f` |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | ❌ | — | pip | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | n/a |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time.

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -8,7 +8,7 @@ This table tracks which flywheel features each related repository has adopted.
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `d68f830` |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `3eb7ec7` |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `35a85fe` |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | — | 🔶 partial | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `d5dff5e` |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | — | 🔶 partial | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `a0b9448` |
 | [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (93%) | — | pip | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | `7873d3e` |
 | [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | ✅ (78%) | — | pip | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | `72a2032` |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `25cd2c6` |


### PR DESCRIPTION
## Summary
- include future `wove` repo in crawling workflow
- regenerate repo feature summary table
- clean up end-of-file newline in docs

## Testing
- `pytest -q`
- `python -m pre_commit run --files docs/repo-feature-summary.md .github/workflows/04-update-summary.yml`

------
https://chatgpt.com/codex/tasks/task_e_686f4b661594832fb7a29e538dab09a3