### PR TITLE
Add workflow count to repo crawler

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -8,17 +8,38 @@ This table tracks which flywheel features each related repository has adopted.
 | ---- | ------ | ------ |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `784114b` |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `3eb7ec7` |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `27ba24a` |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `2f860ed` |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `7873d3e` |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `72a2032` |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | `25cd2c6` |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | `64d265f` |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | `f4b8cbc` |
 
 ## Coverage & Installer
 | Repo | Coverage | Patch | Installer |
 | ---- | -------- | ----- | --------- |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (20%) | — | 🔶 partial |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | 🚀 uv |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | 🚀 uv |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | 🔶 partial |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (93%) | — | pip |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (78%) | — | pip |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ (100%) | — | 🚀 uv |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | 🚀 uv |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ❌ | — | pip |
 
 ## Policies & Automation
 | Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
 | ---- | ------- | -- | --------- | --------- | --------------- | ------------ | ---------- |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ | ✅ | 7 | ✅ | ✅ | ✅ | ✅ |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ | ✅ | 1 | ✅ | ✅ | ✅ | ✅ |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ | ✅ | 2 | ✅ | ✅ | ✅ | ✅ |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ | ✅ | 6 | ✅ | ✅ | ✅ | ✅ |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ | ✅ | 2 | ✅ | ✅ | ❌ | ✅ |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ❌ |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ✅ |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ✅ |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ❌ | ❌ | 0 | ✅ | ❌ | ❌ | ❌ |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time.

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -3,16 +3,22 @@
 This table tracks which flywheel features each related repository has adopted.
 
 <!-- spellchecker: disable -->
-| Repo | Branch | Coverage | Patch | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
-| ---- | ------ | -------- | ----- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | ✅ (20%) | — | 🔶 partial | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `ba3631b` |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `3eb7ec7` |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `35a85fe` |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | ✅ (100%) | — | 🔶 partial | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `a0b9448` |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | ✅ (93%) | — | pip | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | `7873d3e` |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | ✅ (78%) | — | pip | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | `72a2032` |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `25cd2c6` |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | ✅ (100%) | — | 🚀 uv | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | `64d265f` |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | ❌ | — | pip | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | n/a |
+## Basics
+| Repo | Branch | Commit |
+| ---- | ------ | ------ |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `784114b` |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `3eb7ec7` |
+
+## Coverage & Installer
+| Repo | Coverage | Patch | Installer |
+| ---- | -------- | ----- | --------- |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (20%) | — | 🔶 partial |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | 🚀 uv |
+
+## Policies & Automation
+| Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
+| ---- | ------- | -- | --------- | --------- | --------------- | ------------ | ---------- |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ | ✅ | 7 | ✅ | ✅ | ✅ | ✅ |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ | ✅ | 1 | ✅ | ✅ | ✅ | ✅ |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time.

--- a/docs/repo-feature-summary.md.jinja
+++ b/docs/repo-feature-summary.md.jinja
@@ -3,7 +3,21 @@
 This table tracks which flywheel features each related repository has adopted.
 
 <!-- spellchecker: disable -->
-| Repo | Branch | Coverage | Patch | Installer | License | CI | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Commit |
-| ---- | ------ | -------- | ----- | --------- | ------- | -- | --------- | --------------- | ------------ | ---------- | ------ |
-{% for row in rows %}{{ row }}
+
+## Basics
+| Repo | Branch | Commit |
+| ---- | ------ | ------ |
+{% for row in basics_rows %}{{ row }}
+{% endfor %}
+
+## Coverage & Installer
+| Repo | Coverage | Patch | Installer |
+| ---- | -------- | ----- | --------- |
+{% for row in coverage_rows %}{{ row }}
+{% endfor %}
+
+## Policies & Automation
+| Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
+| ---- | ------- | -- | --------- | --------- | --------------- | ------------ | ---------- |
+{% for row in policy_rows %}{{ row }}
 {% endfor %}

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -138,6 +138,7 @@ def test_generate_summary_installer_variants(monkeypatch):
         has_precommit=True,
         installer="uv",
         latest_commit="cafec0d",
+        workflow_count=1,
     )
     info_partial = info_uv.__class__(
         **{**info_uv.__dict__, "name": "demo/partial", "installer": "partial"}
@@ -163,15 +164,17 @@ def test_summary_column_order(monkeypatch):
         has_precommit=True,
         installer="uv",
         latest_commit="abcdef0",
+        workflow_count=1,
     )
     crawler = rc.RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
-    lines = crawler.generate_summary().splitlines()
-    header = lines[5]
-    row = lines[7]
-    expected = "| Repo | Branch | Coverage | Patch | Installer |"
-    assert header.startswith(expected)
-    assert row.count("|") >= 12
+    summary = crawler.generate_summary()
+    assert "| Repo | Branch | Commit |" in summary
+    assert "| Repo | Coverage | Patch | Installer |" in summary
+    assert "| Repo | License | CI | Workflows |" in summary
+    lines = summary.splitlines()
+    idx = lines.index("| Repo | Branch | Commit |")
+    row = lines[idx + 2]
     assert "`abcdef0`" in row
 
 
@@ -197,9 +200,12 @@ def test_generate_summary_with_patch(monkeypatch):
         has_precommit=True,
         installer="uv",
         latest_commit="abcdef1",
+        workflow_count=1,
     )
     crawler = rc.RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
-    summary = crawler.generate_summary().splitlines()[7]
-    assert "❌ (73%)" in summary
-    assert "(73%)" in summary
+    lines = crawler.generate_summary().splitlines()
+    idx = lines.index("| Repo | Coverage | Patch | Installer |")
+    row = lines[idx + 2]
+    assert "❌ (73%)" in row
+    assert "(73%)" in row

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -160,8 +160,11 @@ def test_generate_summary_no_patch(monkeypatch):
         has_precommit=True,
         installer="uv",
         latest_commit="123cafe",
+        workflow_count=1,
     )
     crawler = RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
-    table = crawler.generate_summary().splitlines()[7]
-    assert "| — |" in table
+    lines = crawler.generate_summary().splitlines()
+    idx = lines.index("| Repo | Coverage | Patch | Installer |")
+    row = lines[idx + 2]
+    assert "| — |" in row


### PR DESCRIPTION
## Summary
- track workflow_count in RepoInfo
- restructure repo summary into Basics, Coverage & Installer, and Policies tables
- record workflow counts in new Policies table
- update docs with new summary tables
- update tests for new column

## Testing
- `pre-commit run --files flywheel/repocrawler.py tests/test_repocrawler.py tests/test_repocrawler_extra.py docs/repo-feature-summary.md docs/repo-feature-summary.md.jinja`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f67009980832fb0f6236f2796475b