### PR TITLE
Raise coverage to 100%

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -22,8 +22,8 @@ jobs:
         run: |
           uv pip install --system pytest pytest-cov coverage
           if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
-          pytest --cov=flywheel --cov-report=xml --cov-report=term --maxfail=1 --disable-warnings -q
-          coverage report --fail-under=80
+          pytest --cov=flywheel --cov-report=xml --cov-report=term --maxfail=1 --disable-warnings -q --cov-fail-under=100
+          coverage report --fail-under=100
 
       - name: JavaScript Tests
         if: matrix.language == 'javascript'

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 80
+        target: 100
         threshold: 0
     patch:
       default:

--- a/tests/test_patch_coverage.py
+++ b/tests/test_patch_coverage.py
@@ -1,5 +1,6 @@
 import textwrap
 
+import requests
 import responses
 
 from flywheel.repocrawler import RepoCrawler
@@ -21,3 +22,92 @@ def test_badge_fallback():
     crawler = RepoCrawler([])
     pct = crawler._badge_patch_percent("foo/bar", "main")
     assert pct == 95.0
+
+
+def test_badge_patch_network_error(monkeypatch):
+    class ErrSession:
+        def __init__(self):
+            self.headers = {}
+
+        def get(self, *a, **kw):
+            raise requests.RequestException("boom")
+
+    crawler = RepoCrawler([], session=ErrSession())
+    assert crawler._badge_patch_percent("foo/bar", "main") is None
+
+
+def test_patch_coverage_network_fallback(monkeypatch):
+    class ErrSession:
+        def __init__(self):
+            self.headers = {}
+
+        def get(self, *a, **kw):
+            raise requests.RequestException("fail")
+
+    crawler = RepoCrawler([], session=ErrSession())
+    monkeypatch.setattr(crawler, "_badge_patch_percent", lambda *a: 88.0)
+    assert crawler._patch_coverage_from_codecov("foo/bar", "main") == 88.0
+
+
+def test_patch_coverage_json_error(monkeypatch):
+    class BadResp:
+        status_code = 200
+
+        def json(self):
+            raise ValueError("bad")
+
+    class Sess:
+        def __init__(self):
+            self.headers = {}
+
+        def get(self, *a, **kw):
+            return BadResp()
+
+    crawler = RepoCrawler([], session=Sess())
+    monkeypatch.setattr(crawler, "_badge_patch_percent", lambda *a: 77.0)
+    assert crawler._patch_coverage_from_codecov("foo/bar", "main") == 77.0
+
+
+def test_patch_coverage_with_token(monkeypatch):
+    data = {"totals": {"patch": {"coverage": 99}}}
+
+    class Sess:
+        def __init__(self):
+            self.headers = {}
+
+        def get(self, url, headers=None, timeout=10):
+            assert headers.get("Authorization") == "Bearer token123"
+
+            class Resp:
+                status_code = 200
+
+                def json(self_inner):
+                    return data
+
+            return Resp()
+
+    monkeypatch.setenv("CODECOV_TOKEN", "token123")
+    crawler = RepoCrawler([], session=Sess())
+    assert crawler._patch_coverage_from_codecov("foo/bar", "main") == 99.0
+
+
+def test_patch_coverage_compare_success():
+    class Sess:
+        def __init__(self):
+            self.headers = {}
+
+        def get(self, url, headers=None, timeout=10):
+            class Resp:
+                def __init__(self, status, data=None):
+                    self.status_code = status
+                    self._data = data
+
+                def json(self):
+                    return self._data or {}
+
+            if "totals" in url:
+                return Resp(500)
+            return Resp(200, {"totals": {"patch": {"coverage": 66}}})
+
+    crawler = RepoCrawler([], session=Sess())
+    assert crawler._patch_coverage_from_codecov("foo/bar", "main") == 66.0


### PR DESCRIPTION
## Summary
- add tests to cover error paths in `RepoCrawler`
- enforce 100% coverage in CI and Codecov

## Testing
- `pre-commit run --all-files`
- `pytest --cov=flywheel --cov-report=term-missing --cov-fail-under=100`

------
https://chatgpt.com/codex/tasks/task_e_6870415aed90832f971e053839b13da3