### PR TITLE
Increase coverage to 100%

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -22,8 +22,8 @@ jobs:
         run: |
           uv pip install --system pytest pytest-cov coverage
           if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
-          pytest --cov=flywheel --cov-report=xml --cov-report=term --maxfail=1 --disable-warnings -q
-          coverage report --fail-under=80
+          pytest --cov=flywheel --cov-report=xml --cov-report=term --maxfail=1 --disable-warnings -q --cov-fail-under=100
+          coverage report --fail-under=100
 
       - name: JavaScript Tests
         if: matrix.language == 'javascript'

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 80
+        target: 100
         threshold: 0
     patch:
       default:

--- a/tests/test_coverage_errors.py
+++ b/tests/test_coverage_errors.py
@@ -18,3 +18,83 @@ def test_handles_shields_timeout(monkeypatch):
         "main",
     )
     assert pct == "unknown"
+
+
+def test_badge_patch_percent_request_error(monkeypatch):
+    class Sess:
+        def __init__(self):
+            self.headers = {}
+
+        def get(self, *a, **kw):
+            raise requests.RequestException("boom")
+
+    crawler = RepoCrawler([], session=Sess())
+    assert crawler._badge_patch_percent("foo/bar", "main") is None
+
+
+def test_patch_coverage_token_and_errors(monkeypatch):
+    class Sess:
+        def __init__(self):
+            self.headers = {}
+            self.calls = []
+
+        def get(self, url, **kw):
+            self.calls.append((url, kw.get("headers")))
+            if "totals" in url:
+                raise requests.RequestException("fail")
+            if "compare" in url:
+                raise ValueError("bad")
+
+    sess = Sess()
+    crawler = RepoCrawler([], session=sess)
+    monkeypatch.setenv("CODECOV_TOKEN", "abc")
+    monkeypatch.setattr(crawler, "_badge_patch_percent", lambda *a, **kw: 42.0)
+    pct = crawler._patch_coverage_from_codecov("foo/bar", "main")
+    assert pct == 42.0
+    assert sess.calls[0][1]["Authorization"] == "Bearer abc"
+
+
+def test_patch_coverage_compare_on_error(monkeypatch):
+    class Sess:
+        def __init__(self):
+            self.headers = {}
+
+        def get(self, url, **kw):
+            if "totals" in url:
+                raise ValueError("bad json")
+            if "compare" in url:
+
+                class Resp:
+                    status_code = 200
+
+                    def json(self):
+                        return {"totals": {"patch": {"coverage": 77}}}
+
+                return Resp()
+
+    crawler = RepoCrawler([], session=Sess())
+    pct = crawler._patch_coverage_from_codecov("foo/bar", "main")
+    assert pct == 77.0
+
+
+def test_patch_coverage_compare_request_exception(monkeypatch):
+    class Sess:
+        def __init__(self):
+            self.headers = {}
+
+        def get(self, url, **kw):
+            if "totals" in url:
+
+                class Resp:
+                    status_code = 404
+
+                    def json(self):
+                        return {}
+
+                return Resp()
+            if "compare" in url:
+                raise requests.RequestException("boom")
+
+    crawler = RepoCrawler([], session=Sess())
+    monkeypatch.setattr(crawler, "_badge_patch_percent", lambda *a, **kw: None)
+    assert crawler._patch_coverage_from_codecov("foo/bar", "main") is None


### PR DESCRIPTION
## Summary
- add tests for error paths in `repocrawler`
- enforce 100% coverage in workflow and Codecov config

## Testing
- `pre-commit run --all-files`
- `pytest --cov=flywheel --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_6870415aed90832f971e053839b13da3