### PR TITLE
Add nightly STL export workflow

### DIFF
--- a/.github/workflows/export-stl.yml
+++ b/.github/workflows/export-stl.yml
@@ -1,0 +1,29 @@
+name: Export SCAD to STL
+on:
+  schedule:
+    - cron: '15 5 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install OpenSCAD
+        run: sudo apt-get update && sudo apt-get install -y openscad
+      - name: Generate STL files
+        run: |
+          ./scripts/build_stl.sh
+      - name: Commit STL models
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add stl/**/*.stl || true
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update STL models"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - Gabriel integration in `docs/gabriel-integration.md`
 - Sigma integration in `docs/sigma-integration.md`
 - Web viewer instructions in `docs/web-viewer.md`
+- Nightly STL exports live in `stl/` for quick preview on GitHub
 - Flywheel construction guide in `docs/flywheel-construction.md` with CAD files in `cad/`
   including `stand.scad`, `shaft.scad`, and `adapter.scad`. Assembly details live in `docs/flywheel-stand.md`, clamp instructions in `docs/flywheel-adapter.md`, and physics in `docs/flywheel-physics.md`
 

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -6,7 +6,7 @@ This table tracks which flywheel features each related repository has adopted.
 ## Basics
 | Repo | Branch | Commit |
 | ---- | ------ | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `b518646` |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `5b7ba57` |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `3eb7ec7` |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `2da14d3` |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `2f860ed` |

--- a/docs/web-viewer.md
+++ b/docs/web-viewer.md
@@ -3,6 +3,9 @@
 This repo includes a tiny Flask application that renders OBJ models generated from the SCAD files in `cad/`.
 
 A GitHub Actions workflow automatically converts the SCAD files to OBJ using `openscad` and commits them to `webapp/static/models/`.
+Another workflow runs nightly to export the same SCAD sources to `stl/`. GitHub
+renders `.stl` files with a built‑in 3D viewer so you can quickly inspect the
+geometry right in the browser.
 
 ## Running Locally
 

--- a/scripts/build_stl.sh
+++ b/scripts/build_stl.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCAD_DIR="${SCAD_DIR:-cad}"
+STL_DIR="${STL_DIR:-stl}"
+
+mkdir -p "$STL_DIR"
+
+while IFS= read -r -d '' scad; do
+  rel="${scad#$SCAD_DIR/}"
+  stl="$STL_DIR/${rel%.scad}.stl"
+  mkdir -p "$(dirname "$stl")"
+  if [ -f "$stl" ] && [ "$stl" -nt "$scad" ]; then
+    echo "[INFO] Skipping $scad; STL up to date"
+    continue
+  fi
+  echo "[INFO] Exporting $scad -> $stl"
+  openscad -o "$stl" "$scad"
+done < <(find "$SCAD_DIR" -name '*.scad' -print0)

--- a/stl/adapter.stl
+++ b/stl/adapter.stl
@@ -1,0 +1,2494 @@
+solid OpenSCAD_Model
+  facet normal 0.406745 0.913542 -0
+    outer loop
+      vertex 6 10.3923 0
+      vertex 3.7082 11.4127 20
+      vertex 6 10.3923 20
+    endloop
+  endfacet
+  facet normal 0.406745 0.913542 0
+    outer loop
+      vertex 3.7082 11.4127 20
+      vertex 6 10.3923 0
+      vertex 3.7082 11.4127 0
+    endloop
+  endfacet
+  facet normal 0.951049 0.30904 0
+    outer loop
+      vertex 10.9625 4.88084 20
+      vertex 11.5 3.22672 10
+      vertex 10.9625 4.88084 0
+    endloop
+  endfacet
+  facet normal 0.951048 0.309044 -7.16943e-07
+    outer loop
+      vertex 11.7378 2.49494 20
+      vertex 11.5 3.22672 10
+      vertex 10.9625 4.88084 20
+    endloop
+  endfacet
+  facet normal 0.951045 0.309053 0
+    outer loop
+      vertex 11.5 3.22672 10
+      vertex 11.7378 2.49494 20
+      vertex 11.7378 2.49494 10
+    endloop
+  endfacet
+  facet normal 0.951049 0.30904 0
+    outer loop
+      vertex 10.9625 4.88084 0
+      vertex 11.5 3.22672 10
+      vertex 11.5 3.22672 0
+    endloop
+  endfacet
+  facet normal 0.994523 0.104517 0
+    outer loop
+      vertex 12 0 20
+      vertex 11.7378 2.49494 10
+      vertex 11.7378 2.49494 20
+    endloop
+  endfacet
+  facet normal 0.994523 0.104517 0
+    outer loop
+      vertex 11.7378 2.49494 10
+      vertex 12 0 20
+      vertex 12 0 10
+    endloop
+  endfacet
+  facet normal 0.866032 0.499988 0
+    outer loop
+      vertex 10.9625 4.88084 20
+      vertex 9.7082 7.05342 0
+      vertex 9.7082 7.05342 20
+    endloop
+  endfacet
+  facet normal 0.866032 0.499988 0
+    outer loop
+      vertex 9.7082 7.05342 0
+      vertex 10.9625 4.88084 20
+      vertex 10.9625 4.88084 0
+    endloop
+  endfacet
+  facet normal 0.951037 -0.309076 0
+    outer loop
+      vertex 11.7378 -2.49494 20
+      vertex 11.497 -3.23589 11.3262
+      vertex 11.7378 -2.49494 10.9775
+    endloop
+  endfacet
+  facet normal 0.951054 -0.309025 -4.82829e-06
+    outer loop
+      vertex 11.7378 -2.49494 20
+      vertex 11.1361 -4.3466 11.646
+      vertex 11.497 -3.23589 11.3262
+    endloop
+  endfacet
+  facet normal 0.951048 -0.309044 -1.92387e-07
+    outer loop
+      vertex 10.9625 -4.88084 20
+      vertex 11.1361 -4.3466 11.646
+      vertex 11.7378 -2.49494 20
+    endloop
+  endfacet
+  facet normal 0.951049 -0.309041 0
+    outer loop
+      vertex 11.1361 -4.3466 11.646
+      vertex 10.9625 -4.88084 20
+      vertex 10.9625 -4.88084 11.7371
+    endloop
+  endfacet
+  facet normal 0.950431 -0.310937 0
+    outer loop
+      vertex 11.497 -3.23589 8.67375
+      vertex 11.5 -3.22672 0
+      vertex 11.5 -3.22672 8.67807
+    endloop
+  endfacet
+  facet normal 0.951054 -0.309024 2.23795e-06
+    outer loop
+      vertex 11.1361 -4.3466 8.35403
+      vertex 11.5 -3.22672 0
+      vertex 11.497 -3.23589 8.67375
+    endloop
+  endfacet
+  facet normal 0.951049 -0.309041 -2.56664e-07
+    outer loop
+      vertex 10.9625 -4.88084 8.26293
+      vertex 11.5 -3.22672 0
+      vertex 11.1361 -4.3466 8.35403
+    endloop
+  endfacet
+  facet normal 0.951049 -0.30904 0
+    outer loop
+      vertex 11.5 -3.22672 0
+      vertex 10.9625 -4.88084 8.26293
+      vertex 10.9625 -4.88084 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.65418 -1.62695 0
+      vertex 11.5 -3.22672 0
+      vertex 10.9625 -4.88084 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.5 -3.22672 0
+      vertex 4 0 0
+      vertex 11.5 3.22672 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.65418 -1.62695 0
+      vertex 10.9625 -4.88084 0
+      vertex 9.7082 -7.05342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.91259 0.831646 0
+      vertex 11.5 3.22672 0
+      vertex 4 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.23607 -2.35114 0
+      vertex 9.7082 -7.05342 0
+      vertex 8.02957 -8.91774 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.65418 1.62695 0
+      vertex 11.5 3.22672 0
+      vertex 3.91259 0.831646 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.67652 -2.97258 0
+      vertex 8.02957 -8.91774 0
+      vertex 6 -10.3923 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.5 3.22672 0
+      vertex 3.65418 1.62695 0
+      vertex 10.9625 4.88084 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.9625 4.88084 0
+      vertex 3.65418 1.62695 0
+      vertex 9.7082 7.05342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.5 -3.22672 0
+      vertex 3.91259 -0.831646 0
+      vertex 4 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2 -3.4641 0
+      vertex 6 -10.3923 0
+      vertex 3.7082 -11.4127 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.5 -3.22672 0
+      vertex 3.65418 -1.62695 0
+      vertex 3.91259 -0.831646 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.7082 -7.05342 0
+      vertex 3.23607 -2.35114 0
+      vertex 3.65418 -1.62695 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.02957 -8.91774 0
+      vertex 2.67652 -2.97258 0
+      vertex 3.23607 -2.35114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6 -10.3923 0
+      vertex 2 -3.4641 0
+      vertex 2.67652 -2.97258 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.23607 -3.80423 0
+      vertex 3.7082 -11.4127 0
+      vertex 1.25434 -11.9343 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.7082 -11.4127 0
+      vertex 1.23607 -3.80423 0
+      vertex 2 -3.4641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.25434 -11.9343 0
+      vertex 0.418114 -3.97809 0
+      vertex 1.23607 -3.80423 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.25434 -11.9343 0
+      vertex -0.418114 -3.97809 0
+      vertex 0.418114 -3.97809 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.25434 -11.9343 0
+      vertex -0.418114 -3.97809 0
+      vertex 1.25434 -11.9343 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.418114 -3.97809 0
+      vertex -1.25434 -11.9343 0
+      vertex -1.23607 -3.80423 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.7082 -11.4127 0
+      vertex -1.23607 -3.80423 0
+      vertex -1.25434 -11.9343 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.23607 -3.80423 0
+      vertex -3.7082 -11.4127 0
+      vertex -2 -3.4641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6 -10.3923 0
+      vertex -2 -3.4641 0
+      vertex -3.7082 -11.4127 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -2 -3.4641 0
+      vertex -6 -10.3923 0
+      vertex -2.67652 -2.97258 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.02957 -8.91774 0
+      vertex -2.67652 -2.97258 0
+      vertex -6 -10.3923 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -2.67652 -2.97258 0
+      vertex -8.02957 -8.91774 0
+      vertex -3.23607 -2.35114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.7082 -7.05342 0
+      vertex -3.23607 -2.35114 0
+      vertex -8.02957 -8.91774 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -3.23607 -2.35114 0
+      vertex -9.7082 -7.05342 0
+      vertex -3.65418 -1.62695 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.23607 2.35114 0
+      vertex 9.7082 7.05342 0
+      vertex 3.65418 1.62695 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 9.7082 7.05342 0
+      vertex 3.23607 2.35114 0
+      vertex 8.02957 8.91774 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.67652 2.97258 0
+      vertex 8.02957 8.91774 0
+      vertex 3.23607 2.35114 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 8.02957 8.91774 0
+      vertex 2.67652 2.97258 0
+      vertex 6 10.3923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2 3.4641 0
+      vertex 6 10.3923 0
+      vertex 2.67652 2.97258 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 6 10.3923 0
+      vertex 2 3.4641 0
+      vertex 3.7082 11.4127 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.23607 3.80423 0
+      vertex 3.7082 11.4127 0
+      vertex 2 3.4641 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 3.7082 11.4127 0
+      vertex 1.23607 3.80423 0
+      vertex 1.25434 11.9343 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.418114 3.97809 0
+      vertex 1.25434 11.9343 0
+      vertex 1.23607 3.80423 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.418114 3.97809 0
+      vertex 1.25434 11.9343 0
+      vertex 0.418114 3.97809 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.25434 11.9343 0
+      vertex -0.418114 3.97809 0
+      vertex -1.23607 3.80423 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.418114 3.97809 0
+      vertex -1.25434 11.9343 0
+      vertex 1.25434 11.9343 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.7082 11.4127 0
+      vertex -1.23607 3.80423 0
+      vertex -2 3.4641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6 10.3923 0
+      vertex -2 3.4641 0
+      vertex -2.67652 2.97258 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.02957 8.91774 0
+      vertex -2.67652 2.97258 0
+      vertex -3.23607 2.35114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.7082 7.05342 0
+      vertex -3.23607 2.35114 0
+      vertex -3.65418 1.62695 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.23607 3.80423 0
+      vertex -3.7082 11.4127 0
+      vertex -1.25434 11.9343 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9625 4.88084 0
+      vertex -3.65418 1.62695 0
+      vertex -3.91259 0.831646 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7378 2.49494 0
+      vertex -3.91259 0.831646 0
+      vertex -4 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9625 -4.88084 0
+      vertex -3.65418 -1.62695 0
+      vertex -9.7082 -7.05342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2 3.4641 0
+      vertex -6 10.3923 0
+      vertex -3.7082 11.4127 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -3.65418 -1.62695 0
+      vertex -10.9625 -4.88084 0
+      vertex -3.91259 -0.831646 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.67652 2.97258 0
+      vertex -8.02957 8.91774 0
+      vertex -6 10.3923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7378 -2.49494 0
+      vertex -3.91259 -0.831646 0
+      vertex -10.9625 -4.88084 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.23607 2.35114 0
+      vertex -9.7082 7.05342 0
+      vertex -8.02957 8.91774 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -3.91259 -0.831646 0
+      vertex -11.7378 -2.49494 0
+      vertex -4 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.65418 1.62695 0
+      vertex -10.9625 4.88084 0
+      vertex -9.7082 7.05342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12 0 0
+      vertex -4 0 0
+      vertex -11.7378 -2.49494 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.91259 0.831646 0
+      vertex -11.7378 2.49494 0
+      vertex -10.9625 4.88084 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4 0 0
+      vertex -12 0 0
+      vertex -11.7378 2.49494 0
+    endloop
+  endfacet
+  facet normal 0.207918 -0.978146 0
+    outer loop
+      vertex 1.25434 -11.9343 0
+      vertex 3.7082 -11.4127 20
+      vertex 1.25434 -11.9343 20
+    endloop
+  endfacet
+  facet normal 0.207918 -0.978146 0
+    outer loop
+      vertex 3.7082 -11.4127 20
+      vertex 1.25434 -11.9343 0
+      vertex 3.7082 -11.4127 0
+    endloop
+  endfacet
+  facet normal 0.743147 0.669128 0
+    outer loop
+      vertex 9.7082 7.05342 20
+      vertex 8.02957 8.91774 0
+      vertex 8.02957 8.91774 20
+    endloop
+  endfacet
+  facet normal 0.743147 0.669128 0
+    outer loop
+      vertex 8.02957 8.91774 0
+      vertex 9.7082 7.05342 20
+      vertex 9.7082 7.05342 0
+    endloop
+  endfacet
+  facet normal 0.743151 -0.669123 -1.95051e-06
+    outer loop
+      vertex 8.02957 -8.91774 0
+      vertex 9.7082 -7.05342 8.02708
+      vertex 9.29079 -7.51701 8.12997
+    endloop
+  endfacet
+  facet normal 0.743143 -0.669132 8.55848e-07
+    outer loop
+      vertex 8.02957 -8.91774 0
+      vertex 9.29079 -7.51701 8.12997
+      vertex 8.86387 -7.99115 8.35403
+    endloop
+  endfacet
+  facet normal 0.743146 -0.66913 2.61422e-07
+    outer loop
+      vertex 8.02957 -8.91774 0
+      vertex 8.86387 -7.99115 8.35403
+      vertex 8.50298 -8.39196 8.67375
+    endloop
+  endfacet
+  facet normal 0.743149 -0.669125 -1.8368e-07
+    outer loop
+      vertex 8.02957 -8.91774 0
+      vertex 8.50298 -8.39196 8.67375
+      vertex 8.22909 -8.69615 9.07055
+    endloop
+  endfacet
+  facet normal 0.743143 -0.669133 1.5689e-07
+    outer loop
+      vertex 8.02957 -8.91774 0
+      vertex 8.22909 -8.69615 9.07055
+      vertex 8.05812 -8.88603 9.52137
+    endloop
+  endfacet
+  facet normal 0.743147 -0.669128 0
+    outer loop
+      vertex 9.7082 -7.05342 8.02708
+      vertex 8.02957 -8.91774 0
+      vertex 9.7082 -7.05342 0
+    endloop
+  endfacet
+  facet normal 0.743166 -0.669107 0
+    outer loop
+      vertex 8.02957 -8.91774 0
+      vertex 8.05812 -8.88603 9.52137
+      vertex 8.02957 -8.91774 9.75649
+    endloop
+  endfacet
+  facet normal 0.743147 -0.669128 0
+    outer loop
+      vertex 8.02957 -8.91774 20
+      vertex 9.7082 -7.05342 11.9729
+      vertex 9.7082 -7.05342 20
+    endloop
+  endfacet
+  facet normal 0.743151 -0.669123 1.9505e-06
+    outer loop
+      vertex 9.7082 -7.05342 11.9729
+      vertex 8.02957 -8.91774 20
+      vertex 9.29079 -7.51701 11.87
+    endloop
+  endfacet
+  facet normal 0.743143 -0.669132 -8.55863e-07
+    outer loop
+      vertex 9.29079 -7.51701 11.87
+      vertex 8.02957 -8.91774 20
+      vertex 8.86387 -7.99115 11.646
+    endloop
+  endfacet
+  facet normal 0.743146 -0.66913 -2.61418e-07
+    outer loop
+      vertex 8.86387 -7.99115 11.646
+      vertex 8.02957 -8.91774 20
+      vertex 8.50298 -8.39196 11.3262
+    endloop
+  endfacet
+  facet normal 0.743149 -0.669125 1.83679e-07
+    outer loop
+      vertex 8.50298 -8.39196 11.3262
+      vertex 8.02957 -8.91774 20
+      vertex 8.22909 -8.69615 10.9294
+    endloop
+  endfacet
+  facet normal 0.743143 -0.669133 -1.5689e-07
+    outer loop
+      vertex 8.22909 -8.69615 10.9294
+      vertex 8.02957 -8.91774 20
+      vertex 8.05812 -8.88603 10.4786
+    endloop
+  endfacet
+  facet normal 0.743166 -0.669107 0
+    outer loop
+      vertex 8.05812 -8.88603 10.4786
+      vertex 8.02957 -8.91774 20
+      vertex 8.02957 -8.91774 10.2435
+    endloop
+  endfacet
+  facet normal -0.951048 -0.309044 0
+    outer loop
+      vertex -10.9625 -4.88084 0
+      vertex -11.7378 -2.49494 20
+      vertex -11.7378 -2.49494 0
+    endloop
+  endfacet
+  facet normal -0.951048 -0.309044 0
+    outer loop
+      vertex -11.7378 -2.49494 20
+      vertex -10.9625 -4.88084 0
+      vertex -10.9625 -4.88084 20
+    endloop
+  endfacet
+  facet normal 0.866056 -0.499947 0
+    outer loop
+      vertex 10.9625 -4.88084 20
+      vertex 10.7092 -5.31963 11.87
+      vertex 10.9625 -4.88084 11.7371
+    endloop
+  endfacet
+  facet normal 0.866043 -0.499969 1.54193e-06
+    outer loop
+      vertex 10.9625 -4.88084 20
+      vertex 10.2411 -6.13047 11.9854
+      vertex 10.7092 -5.31963 11.87
+    endloop
+  endfacet
+  facet normal 0.866032 -0.499988 5.55543e-06
+    outer loop
+      vertex 9.7082 -7.05342 20
+      vertex 10.2411 -6.13047 11.9854
+      vertex 10.9625 -4.88084 20
+    endloop
+  endfacet
+  facet normal 0.866014 -0.500019 7.74859e-07
+    outer loop
+      vertex 10.2411 -6.13047 11.9854
+      vertex 9.7082 -7.05342 20
+      vertex 9.75893 -6.96557 11.9854
+    endloop
+  endfacet
+  facet normal 0.865984 -0.500072 0
+    outer loop
+      vertex 9.75893 -6.96557 11.9854
+      vertex 9.7082 -7.05342 20
+      vertex 9.7082 -7.05342 11.9729
+    endloop
+  endfacet
+  facet normal 0.866056 -0.499947 0
+    outer loop
+      vertex 10.7092 -5.31963 8.12997
+      vertex 10.9625 -4.88084 0
+      vertex 10.9625 -4.88084 8.26293
+    endloop
+  endfacet
+  facet normal 0.866043 -0.499969 -1.54194e-06
+    outer loop
+      vertex 10.2411 -6.13047 8.01458
+      vertex 10.9625 -4.88084 0
+      vertex 10.7092 -5.31963 8.12997
+    endloop
+  endfacet
+  facet normal 0.866014 -0.500019 -7.74861e-07
+    outer loop
+      vertex 9.7082 -7.05342 0
+      vertex 10.2411 -6.13047 8.01458
+      vertex 9.75893 -6.96557 8.01458
+    endloop
+  endfacet
+  facet normal 0.865984 -0.500072 0
+    outer loop
+      vertex 9.7082 -7.05342 0
+      vertex 9.75893 -6.96557 8.01458
+      vertex 9.7082 -7.05342 8.02708
+    endloop
+  endfacet
+  facet normal 0.866032 -0.499988 -5.55545e-06
+    outer loop
+      vertex 10.2411 -6.13047 8.01458
+      vertex 9.7082 -7.05342 0
+      vertex 10.9625 -4.88084 0
+    endloop
+  endfacet
+  facet normal -0.406745 0.913542 0
+    outer loop
+      vertex -3.7082 11.4127 0
+      vertex -6 10.3923 20
+      vertex -3.7082 11.4127 20
+    endloop
+  endfacet
+  facet normal -0.406745 0.913542 0
+    outer loop
+      vertex -6 10.3923 20
+      vertex -3.7082 11.4127 0
+      vertex -6 10.3923 0
+    endloop
+  endfacet
+  facet normal -0.587783 0.809019 0
+    outer loop
+      vertex -6 10.3923 0
+      vertex -8.02957 8.91774 20
+      vertex -6 10.3923 20
+    endloop
+  endfacet
+  facet normal -0.587783 0.809019 0
+    outer loop
+      vertex -8.02957 8.91774 20
+      vertex -6 10.3923 0
+      vertex -8.02957 8.91774 0
+    endloop
+  endfacet
+  facet normal -0.743147 0.669128 0
+    outer loop
+      vertex -9.7082 7.05342 0
+      vertex -8.02957 8.91774 20
+      vertex -8.02957 8.91774 0
+    endloop
+  endfacet
+  facet normal -0.743147 0.669128 0
+    outer loop
+      vertex -8.02957 8.91774 20
+      vertex -9.7082 7.05342 0
+      vertex -9.7082 7.05342 20
+    endloop
+  endfacet
+  facet normal -0.866032 0.499988 0
+    outer loop
+      vertex -10.9625 4.88084 0
+      vertex -9.7082 7.05342 20
+      vertex -9.7082 7.05342 0
+    endloop
+  endfacet
+  facet normal -0.866032 0.499988 0
+    outer loop
+      vertex -9.7082 7.05342 20
+      vertex -10.9625 4.88084 0
+      vertex -10.9625 4.88084 20
+    endloop
+  endfacet
+  facet normal 0.587783 -0.809019 0
+    outer loop
+      vertex 6 -10.3923 20
+      vertex 8.02957 -8.91774 10.2435
+      vertex 8.02957 -8.91774 20
+    endloop
+  endfacet
+  facet normal 0.587758 -0.809037 -7.83051e-06
+    outer loop
+      vertex 6 -10.3923 20
+      vertex 8 -8.93922 10
+      vertex 8.02957 -8.91774 10.2435
+    endloop
+  endfacet
+  facet normal 0.587784 -0.809018 0
+    outer loop
+      vertex 6 -10.3923 0
+      vertex 8 -8.93922 10
+      vertex 6 -10.3923 20
+    endloop
+  endfacet
+  facet normal 0.587758 -0.809037 7.83031e-06
+    outer loop
+      vertex 8 -8.93922 10
+      vertex 6 -10.3923 0
+      vertex 8.02957 -8.91774 9.75649
+    endloop
+  endfacet
+  facet normal 0.587783 -0.809019 0
+    outer loop
+      vertex 8.02957 -8.91774 9.75649
+      vertex 6 -10.3923 0
+      vertex 8.02957 -8.91774 0
+    endloop
+  endfacet
+  facet normal 0.207918 0.978146 -0
+    outer loop
+      vertex 3.7082 11.4127 0
+      vertex 1.25434 11.9343 20
+      vertex 3.7082 11.4127 20
+    endloop
+  endfacet
+  facet normal 0.207918 0.978146 0
+    outer loop
+      vertex 1.25434 11.9343 20
+      vertex 3.7082 11.4127 0
+      vertex 1.25434 11.9343 0
+    endloop
+  endfacet
+  facet normal -0.994523 -0.104517 0
+    outer loop
+      vertex -11.7378 -2.49494 0
+      vertex -12 0 20
+      vertex -12 0 0
+    endloop
+  endfacet
+  facet normal -0.994523 -0.104517 0
+    outer loop
+      vertex -12 0 20
+      vertex -11.7378 -2.49494 0
+      vertex -11.7378 -2.49494 20
+    endloop
+  endfacet
+  facet normal 0.994525 -0.104498 0
+    outer loop
+      vertex 12 0 20
+      vertex 11.9419 -0.552945 10.4786
+      vertex 12 0 10
+    endloop
+  endfacet
+  facet normal 0.99452 -0.104545 2.72976e-06
+    outer loop
+      vertex 12 0 20
+      vertex 11.7709 -2.17963 10.9294
+      vertex 11.9419 -0.552945 10.4786
+    endloop
+  endfacet
+  facet normal 0.994523 -0.104517 -4.03283e-06
+    outer loop
+      vertex 11.7378 -2.49494 20
+      vertex 11.7709 -2.17963 10.9294
+      vertex 12 0 20
+    endloop
+  endfacet
+  facet normal 0.994535 -0.104402 0
+    outer loop
+      vertex 11.7709 -2.17963 10.9294
+      vertex 11.7378 -2.49494 20
+      vertex 11.7378 -2.49494 10.9775
+    endloop
+  endfacet
+  facet normal -0.866032 -0.499988 0
+    outer loop
+      vertex -9.7082 -7.05342 0
+      vertex -10.9625 -4.88084 20
+      vertex -10.9625 -4.88084 0
+    endloop
+  endfacet
+  facet normal -0.866032 -0.499988 0
+    outer loop
+      vertex -10.9625 -4.88084 20
+      vertex -9.7082 -7.05342 0
+      vertex -9.7082 -7.05342 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4 0 20
+      vertex 12 0 20
+      vertex 11.7378 2.49494 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.91259 0.831646 20
+      vertex 11.7378 2.49494 20
+      vertex 10.9625 4.88084 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12 0 20
+      vertex 4 0 20
+      vertex 11.7378 -2.49494 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.65418 1.62695 20
+      vertex 10.9625 4.88084 20
+      vertex 9.7082 7.05342 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.91259 -0.831646 20
+      vertex 11.7378 -2.49494 20
+      vertex 4 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.23607 2.35114 20
+      vertex 9.7082 7.05342 20
+      vertex 8.02957 8.91774 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7378 -2.49494 20
+      vertex 3.91259 -0.831646 20
+      vertex 10.9625 -4.88084 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.67652 2.97258 20
+      vertex 8.02957 8.91774 20
+      vertex 6 10.3923 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.65418 -1.62695 20
+      vertex 10.9625 -4.88084 20
+      vertex 3.91259 -0.831646 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9625 -4.88084 20
+      vertex 3.65418 -1.62695 20
+      vertex 9.7082 -7.05342 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7378 2.49494 20
+      vertex 3.91259 0.831646 20
+      vertex 4 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2 3.4641 20
+      vertex 6 10.3923 20
+      vertex 3.7082 11.4127 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9625 4.88084 20
+      vertex 3.65418 1.62695 20
+      vertex 3.91259 0.831646 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.7082 7.05342 20
+      vertex 3.23607 2.35114 20
+      vertex 3.65418 1.62695 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.02957 8.91774 20
+      vertex 2.67652 2.97258 20
+      vertex 3.23607 2.35114 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 10.3923 20
+      vertex 2 3.4641 20
+      vertex 2.67652 2.97258 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.23607 3.80423 20
+      vertex 3.7082 11.4127 20
+      vertex 1.25434 11.9343 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.7082 11.4127 20
+      vertex 1.23607 3.80423 20
+      vertex 2 3.4641 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.25434 11.9343 20
+      vertex 0.418114 3.97809 20
+      vertex 1.23607 3.80423 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.25434 11.9343 20
+      vertex -0.418114 3.97809 20
+      vertex 0.418114 3.97809 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.25434 11.9343 20
+      vertex -0.418114 3.97809 20
+      vertex 1.25434 11.9343 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.418114 3.97809 20
+      vertex -1.25434 11.9343 20
+      vertex -1.23607 3.80423 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3.7082 11.4127 20
+      vertex -1.23607 3.80423 20
+      vertex -1.25434 11.9343 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.23607 3.80423 20
+      vertex -3.7082 11.4127 20
+      vertex -2 3.4641 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -6 10.3923 20
+      vertex -2 3.4641 20
+      vertex -3.7082 11.4127 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2 3.4641 20
+      vertex -6 10.3923 20
+      vertex -2.67652 2.97258 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -8.02957 8.91774 20
+      vertex -2.67652 2.97258 20
+      vertex -6 10.3923 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.67652 2.97258 20
+      vertex -8.02957 8.91774 20
+      vertex -3.23607 2.35114 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.7082 7.05342 20
+      vertex -3.23607 2.35114 20
+      vertex -8.02957 8.91774 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.23607 2.35114 20
+      vertex -9.7082 7.05342 20
+      vertex -3.65418 1.62695 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.23607 -2.35114 20
+      vertex 9.7082 -7.05342 20
+      vertex 3.65418 -1.62695 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.7082 -7.05342 20
+      vertex 3.23607 -2.35114 20
+      vertex 8.02957 -8.91774 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.67652 -2.97258 20
+      vertex 8.02957 -8.91774 20
+      vertex 3.23607 -2.35114 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.02957 -8.91774 20
+      vertex 2.67652 -2.97258 20
+      vertex 6 -10.3923 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2 -3.4641 20
+      vertex 6 -10.3923 20
+      vertex 2.67652 -2.97258 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 -10.3923 20
+      vertex 2 -3.4641 20
+      vertex 3.7082 -11.4127 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.23607 -3.80423 20
+      vertex 3.7082 -11.4127 20
+      vertex 2 -3.4641 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.7082 -11.4127 20
+      vertex 1.23607 -3.80423 20
+      vertex 1.25434 -11.9343 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.418114 -3.97809 20
+      vertex 1.25434 -11.9343 20
+      vertex 1.23607 -3.80423 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.418114 -3.97809 20
+      vertex 1.25434 -11.9343 20
+      vertex 0.418114 -3.97809 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.25434 -11.9343 20
+      vertex -0.418114 -3.97809 20
+      vertex -1.23607 -3.80423 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.418114 -3.97809 20
+      vertex -1.25434 -11.9343 20
+      vertex 1.25434 -11.9343 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.7082 -11.4127 20
+      vertex -1.23607 -3.80423 20
+      vertex -2 -3.4641 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6 -10.3923 20
+      vertex -2 -3.4641 20
+      vertex -2.67652 -2.97258 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.02957 -8.91774 20
+      vertex -2.67652 -2.97258 20
+      vertex -3.23607 -2.35114 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.7082 -7.05342 20
+      vertex -3.23607 -2.35114 20
+      vertex -3.65418 -1.62695 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.23607 -3.80423 20
+      vertex -3.7082 -11.4127 20
+      vertex -1.25434 -11.9343 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9625 -4.88084 20
+      vertex -3.65418 -1.62695 20
+      vertex -3.91259 -0.831646 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7378 -2.49494 20
+      vertex -3.91259 -0.831646 20
+      vertex -4 0 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.9625 4.88084 20
+      vertex -3.65418 1.62695 20
+      vertex -9.7082 7.05342 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2 -3.4641 20
+      vertex -6 -10.3923 20
+      vertex -3.7082 -11.4127 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.65418 1.62695 20
+      vertex -10.9625 4.88084 20
+      vertex -3.91259 0.831646 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.67652 -2.97258 20
+      vertex -8.02957 -8.91774 20
+      vertex -6 -10.3923 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.7378 2.49494 20
+      vertex -3.91259 0.831646 20
+      vertex -10.9625 4.88084 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.23607 -2.35114 20
+      vertex -9.7082 -7.05342 20
+      vertex -8.02957 -8.91774 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.91259 0.831646 20
+      vertex -11.7378 2.49494 20
+      vertex -4 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.65418 -1.62695 20
+      vertex -10.9625 -4.88084 20
+      vertex -9.7082 -7.05342 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12 0 20
+      vertex -4 0 20
+      vertex -11.7378 2.49494 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.91259 -0.831646 20
+      vertex -11.7378 -2.49494 20
+      vertex -10.9625 -4.88084 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4 0 20
+      vertex -12 0 20
+      vertex -11.7378 -2.49494 20
+    endloop
+  endfacet
+  facet normal -0.587783 -0.809019 0
+    outer loop
+      vertex -8.02957 -8.91774 0
+      vertex -6 -10.3923 20
+      vertex -8.02957 -8.91774 20
+    endloop
+  endfacet
+  facet normal -0.587783 -0.809019 -0
+    outer loop
+      vertex -6 -10.3923 20
+      vertex -8.02957 -8.91774 0
+      vertex -6 -10.3923 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 1.25434 11.9343 0
+      vertex -1.25434 11.9343 20
+      vertex 1.25434 11.9343 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.25434 11.9343 20
+      vertex 1.25434 11.9343 0
+      vertex -1.25434 11.9343 0
+    endloop
+  endfacet
+  facet normal -0.951048 0.309044 0
+    outer loop
+      vertex -11.7378 2.49494 0
+      vertex -10.9625 4.88084 20
+      vertex -10.9625 4.88084 0
+    endloop
+  endfacet
+  facet normal -0.951048 0.309044 0
+    outer loop
+      vertex -10.9625 4.88084 20
+      vertex -11.7378 2.49494 0
+      vertex -11.7378 2.49494 20
+    endloop
+  endfacet
+  facet normal 0.406745 -0.913542 0
+    outer loop
+      vertex 3.7082 -11.4127 0
+      vertex 6 -10.3923 20
+      vertex 3.7082 -11.4127 20
+    endloop
+  endfacet
+  facet normal 0.406745 -0.913542 0
+    outer loop
+      vertex 6 -10.3923 20
+      vertex 3.7082 -11.4127 0
+      vertex 6 -10.3923 0
+    endloop
+  endfacet
+  facet normal 0.587783 0.809019 -0
+    outer loop
+      vertex 8.02957 8.91774 0
+      vertex 6 10.3923 20
+      vertex 8.02957 8.91774 20
+    endloop
+  endfacet
+  facet normal 0.587783 0.809019 0
+    outer loop
+      vertex 6 10.3923 20
+      vertex 8.02957 8.91774 0
+      vertex 6 10.3923 0
+    endloop
+  endfacet
+  facet normal -0.994523 0.104517 0
+    outer loop
+      vertex -12 0 0
+      vertex -11.7378 2.49494 20
+      vertex -11.7378 2.49494 0
+    endloop
+  endfacet
+  facet normal -0.994523 0.104517 0
+    outer loop
+      vertex -11.7378 2.49494 20
+      vertex -12 0 0
+      vertex -12 0 20
+    endloop
+  endfacet
+  facet normal -0.207918 0.978146 0
+    outer loop
+      vertex -1.25434 11.9343 0
+      vertex -3.7082 11.4127 20
+      vertex -1.25434 11.9343 20
+    endloop
+  endfacet
+  facet normal -0.207918 0.978146 0
+    outer loop
+      vertex -3.7082 11.4127 20
+      vertex -1.25434 11.9343 0
+      vertex -3.7082 11.4127 0
+    endloop
+  endfacet
+  facet normal -0.743147 -0.669128 0
+    outer loop
+      vertex -8.02957 -8.91774 0
+      vertex -9.7082 -7.05342 20
+      vertex -9.7082 -7.05342 0
+    endloop
+  endfacet
+  facet normal -0.743147 -0.669128 0
+    outer loop
+      vertex -9.7082 -7.05342 20
+      vertex -8.02957 -8.91774 0
+      vertex -8.02957 -8.91774 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.25434 -11.9343 0
+      vertex 1.25434 -11.9343 20
+      vertex -1.25434 -11.9343 20
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 1.25434 -11.9343 20
+      vertex -1.25434 -11.9343 0
+      vertex 1.25434 -11.9343 0
+    endloop
+  endfacet
+  facet normal -0.207918 -0.978146 0
+    outer loop
+      vertex -3.7082 -11.4127 0
+      vertex -1.25434 -11.9343 20
+      vertex -3.7082 -11.4127 20
+    endloop
+  endfacet
+  facet normal -0.207918 -0.978146 -0
+    outer loop
+      vertex -1.25434 -11.9343 20
+      vertex -3.7082 -11.4127 0
+      vertex -1.25434 -11.9343 0
+    endloop
+  endfacet
+  facet normal -0.406745 -0.913542 0
+    outer loop
+      vertex -6 -10.3923 0
+      vertex -3.7082 -11.4127 20
+      vertex -6 -10.3923 20
+    endloop
+  endfacet
+  facet normal -0.406745 -0.913542 -0
+    outer loop
+      vertex -3.7082 -11.4127 20
+      vertex -6 -10.3923 0
+      vertex -3.7082 -11.4127 0
+    endloop
+  endfacet
+  facet normal 0.743143 0.669133 0
+    outer loop
+      vertex -2.67652 -2.97258 20
+      vertex -3.23607 -2.35114 0
+      vertex -3.23607 -2.35114 20
+    endloop
+  endfacet
+  facet normal 0.743143 0.669133 0
+    outer loop
+      vertex -3.23607 -2.35114 0
+      vertex -2.67652 -2.97258 20
+      vertex -2.67652 -2.97258 0
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309017 0
+    outer loop
+      vertex 3.91259 0.831646 0
+      vertex 3.65418 1.62695 20
+      vertex 3.65418 1.62695 0
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309017 0
+    outer loop
+      vertex 3.65418 1.62695 20
+      vertex 3.91259 0.831646 0
+      vertex 3.91259 0.831646 20
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104529 0
+    outer loop
+      vertex 4 0 0
+      vertex 3.91259 0.831646 20
+      vertex 3.91259 0.831646 0
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104529 0
+    outer loop
+      vertex 3.91259 0.831646 20
+      vertex 4 0 0
+      vertex 4 0 20
+    endloop
+  endfacet
+  facet normal -0.866026 -0.499999 0
+    outer loop
+      vertex 3.65418 1.62695 0
+      vertex 3.23607 2.35114 20
+      vertex 3.23607 2.35114 0
+    endloop
+  endfacet
+  facet normal -0.866026 -0.499999 0
+    outer loop
+      vertex 3.23607 2.35114 20
+      vertex 3.65418 1.62695 0
+      vertex 3.65418 1.62695 20
+    endloop
+  endfacet
+  facet normal -0.587785 -0.809017 0
+    outer loop
+      vertex 2 3.4641 0
+      vertex 2.67652 2.97258 20
+      vertex 2 3.4641 20
+    endloop
+  endfacet
+  facet normal -0.587785 -0.809017 -0
+    outer loop
+      vertex 2.67652 2.97258 20
+      vertex 2 3.4641 0
+      vertex 2.67652 2.97258 0
+    endloop
+  endfacet
+  facet normal -0.587785 0.809017 0
+    outer loop
+      vertex 2.67652 -2.97258 0
+      vertex 2 -3.4641 20
+      vertex 2.67652 -2.97258 20
+    endloop
+  endfacet
+  facet normal -0.587785 0.809017 0
+    outer loop
+      vertex 2 -3.4641 20
+      vertex 2.67652 -2.97258 0
+      vertex 2 -3.4641 0
+    endloop
+  endfacet
+  facet normal 0.406743 0.913543 -0
+    outer loop
+      vertex -1.23607 -3.80423 0
+      vertex -2 -3.4641 20
+      vertex -1.23607 -3.80423 20
+    endloop
+  endfacet
+  facet normal 0.406743 0.913543 0
+    outer loop
+      vertex -2 -3.4641 20
+      vertex -1.23607 -3.80423 0
+      vertex -2 -3.4641 0
+    endloop
+  endfacet
+  facet normal -0.994522 0.104529 0
+    outer loop
+      vertex 3.91259 -0.831646 0
+      vertex 4 0 20
+      vertex 4 0 0
+    endloop
+  endfacet
+  facet normal -0.994522 0.104529 0
+    outer loop
+      vertex 4 0 20
+      vertex 3.91259 -0.831646 0
+      vertex 3.91259 -0.831646 20
+    endloop
+  endfacet
+  facet normal -0.743143 -0.669133 0
+    outer loop
+      vertex 3.23607 2.35114 0
+      vertex 2.67652 2.97258 20
+      vertex 2.67652 2.97258 0
+    endloop
+  endfacet
+  facet normal -0.743143 -0.669133 0
+    outer loop
+      vertex 2.67652 2.97258 20
+      vertex 3.23607 2.35114 0
+      vertex 3.23607 2.35114 20
+    endloop
+  endfacet
+  facet normal 0.207909 0.978148 -0
+    outer loop
+      vertex -0.418114 -3.97809 0
+      vertex -1.23607 -3.80423 20
+      vertex -0.418114 -3.97809 20
+    endloop
+  endfacet
+  facet normal 0.207909 0.978148 0
+    outer loop
+      vertex -1.23607 -3.80423 20
+      vertex -0.418114 -3.97809 0
+      vertex -1.23607 -3.80423 0
+    endloop
+  endfacet
+  facet normal 0.207909 -0.978148 0
+    outer loop
+      vertex -1.23607 3.80423 0
+      vertex -0.418114 3.97809 20
+      vertex -1.23607 3.80423 20
+    endloop
+  endfacet
+  facet normal 0.207909 -0.978148 0
+    outer loop
+      vertex -0.418114 3.97809 20
+      vertex -1.23607 3.80423 0
+      vertex -0.418114 3.97809 0
+    endloop
+  endfacet
+  facet normal 0.743143 -0.669133 0
+    outer loop
+      vertex -3.23607 2.35114 20
+      vertex -2.67652 2.97258 0
+      vertex -2.67652 2.97258 20
+    endloop
+  endfacet
+  facet normal 0.743143 -0.669133 0
+    outer loop
+      vertex -2.67652 2.97258 0
+      vertex -3.23607 2.35114 20
+      vertex -3.23607 2.35114 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.418114 3.97809 0
+      vertex 0.418114 3.97809 20
+      vertex -0.418114 3.97809 20
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 0.418114 3.97809 20
+      vertex -0.418114 3.97809 0
+      vertex 0.418114 3.97809 0
+    endloop
+  endfacet
+  facet normal -0.951056 0.309017 0
+    outer loop
+      vertex 3.65418 -1.62695 0
+      vertex 3.91259 -0.831646 20
+      vertex 3.91259 -0.831646 0
+    endloop
+  endfacet
+  facet normal -0.951056 0.309017 0
+    outer loop
+      vertex 3.91259 -0.831646 20
+      vertex 3.65418 -1.62695 0
+      vertex 3.65418 -1.62695 20
+    endloop
+  endfacet
+  facet normal -0.406743 0.913543 0
+    outer loop
+      vertex 2 -3.4641 0
+      vertex 1.23607 -3.80423 20
+      vertex 2 -3.4641 20
+    endloop
+  endfacet
+  facet normal -0.406743 0.913543 0
+    outer loop
+      vertex 1.23607 -3.80423 20
+      vertex 2 -3.4641 0
+      vertex 1.23607 -3.80423 0
+    endloop
+  endfacet
+  facet normal 0.587785 0.809017 -0
+    outer loop
+      vertex -2 -3.4641 0
+      vertex -2.67652 -2.97258 20
+      vertex -2 -3.4641 20
+    endloop
+  endfacet
+  facet normal 0.587785 0.809017 0
+    outer loop
+      vertex -2.67652 -2.97258 20
+      vertex -2 -3.4641 0
+      vertex -2.67652 -2.97258 0
+    endloop
+  endfacet
+  facet normal 0.951056 -0.309017 0
+    outer loop
+      vertex -3.91259 0.831646 20
+      vertex -3.65418 1.62695 0
+      vertex -3.65418 1.62695 20
+    endloop
+  endfacet
+  facet normal 0.951056 -0.309017 0
+    outer loop
+      vertex -3.65418 1.62695 0
+      vertex -3.91259 0.831646 20
+      vertex -3.91259 0.831646 0
+    endloop
+  endfacet
+  facet normal 0.587785 -0.809017 0
+    outer loop
+      vertex -2.67652 2.97258 0
+      vertex -2 3.4641 20
+      vertex -2.67652 2.97258 20
+    endloop
+  endfacet
+  facet normal 0.587785 -0.809017 0
+    outer loop
+      vertex -2 3.4641 20
+      vertex -2.67652 2.97258 0
+      vertex -2 3.4641 0
+    endloop
+  endfacet
+  facet normal 0.951056 0.309017 0
+    outer loop
+      vertex -3.65418 -1.62695 20
+      vertex -3.91259 -0.831646 0
+      vertex -3.91259 -0.831646 20
+    endloop
+  endfacet
+  facet normal 0.951056 0.309017 0
+    outer loop
+      vertex -3.91259 -0.831646 0
+      vertex -3.65418 -1.62695 20
+      vertex -3.65418 -1.62695 0
+    endloop
+  endfacet
+  facet normal 0.406743 -0.913543 0
+    outer loop
+      vertex -2 3.4641 0
+      vertex -1.23607 3.80423 20
+      vertex -2 3.4641 20
+    endloop
+  endfacet
+  facet normal 0.406743 -0.913543 0
+    outer loop
+      vertex -1.23607 3.80423 20
+      vertex -2 3.4641 0
+      vertex -1.23607 3.80423 0
+    endloop
+  endfacet
+  facet normal -0.207909 0.978148 0
+    outer loop
+      vertex 1.23607 -3.80423 0
+      vertex 0.418114 -3.97809 20
+      vertex 1.23607 -3.80423 20
+    endloop
+  endfacet
+  facet normal -0.207909 0.978148 0
+    outer loop
+      vertex 0.418114 -3.97809 20
+      vertex 1.23607 -3.80423 0
+      vertex 0.418114 -3.97809 0
+    endloop
+  endfacet
+  facet normal 0.994522 0.104529 0
+    outer loop
+      vertex -3.91259 -0.831646 20
+      vertex -4 0 0
+      vertex -4 0 20
+    endloop
+  endfacet
+  facet normal 0.994522 0.104529 0
+    outer loop
+      vertex -4 0 0
+      vertex -3.91259 -0.831646 20
+      vertex -3.91259 -0.831646 0
+    endloop
+  endfacet
+  facet normal 0.866026 0.499999 0
+    outer loop
+      vertex -3.23607 -2.35114 20
+      vertex -3.65418 -1.62695 0
+      vertex -3.65418 -1.62695 20
+    endloop
+  endfacet
+  facet normal 0.866026 0.499999 0
+    outer loop
+      vertex -3.65418 -1.62695 0
+      vertex -3.23607 -2.35114 20
+      vertex -3.23607 -2.35114 0
+    endloop
+  endfacet
+  facet normal 0.866026 -0.499999 0
+    outer loop
+      vertex -3.65418 1.62695 20
+      vertex -3.23607 2.35114 0
+      vertex -3.23607 2.35114 20
+    endloop
+  endfacet
+  facet normal 0.866026 -0.499999 0
+    outer loop
+      vertex -3.23607 2.35114 0
+      vertex -3.65418 1.62695 20
+      vertex -3.65418 1.62695 0
+    endloop
+  endfacet
+  facet normal -0.866026 0.499999 0
+    outer loop
+      vertex 3.23607 -2.35114 0
+      vertex 3.65418 -1.62695 20
+      vertex 3.65418 -1.62695 0
+    endloop
+  endfacet
+  facet normal -0.866026 0.499999 0
+    outer loop
+      vertex 3.65418 -1.62695 20
+      vertex 3.23607 -2.35114 0
+      vertex 3.23607 -2.35114 20
+    endloop
+  endfacet
+  facet normal -0.406743 -0.913543 0
+    outer loop
+      vertex 1.23607 3.80423 0
+      vertex 2 3.4641 20
+      vertex 1.23607 3.80423 20
+    endloop
+  endfacet
+  facet normal -0.406743 -0.913543 -0
+    outer loop
+      vertex 2 3.4641 20
+      vertex 1.23607 3.80423 0
+      vertex 2 3.4641 0
+    endloop
+  endfacet
+  facet normal -0.207909 -0.978148 0
+    outer loop
+      vertex 0.418114 3.97809 0
+      vertex 1.23607 3.80423 20
+      vertex 0.418114 3.97809 20
+    endloop
+  endfacet
+  facet normal -0.207909 -0.978148 -0
+    outer loop
+      vertex 1.23607 3.80423 20
+      vertex 0.418114 3.97809 0
+      vertex 1.23607 3.80423 0
+    endloop
+  endfacet
+  facet normal -0.743143 0.669133 0
+    outer loop
+      vertex 2.67652 -2.97258 0
+      vertex 3.23607 -2.35114 20
+      vertex 3.23607 -2.35114 0
+    endloop
+  endfacet
+  facet normal -0.743143 0.669133 0
+    outer loop
+      vertex 3.23607 -2.35114 20
+      vertex 2.67652 -2.97258 0
+      vertex 2.67652 -2.97258 20
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 0.418114 -3.97809 0
+      vertex -0.418114 -3.97809 20
+      vertex 0.418114 -3.97809 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.418114 -3.97809 20
+      vertex 0.418114 -3.97809 0
+      vertex -0.418114 -3.97809 0
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104529 0
+    outer loop
+      vertex -4 0 20
+      vertex -3.91259 0.831646 0
+      vertex -3.91259 0.831646 20
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104529 0
+    outer loop
+      vertex -3.91259 0.831646 0
+      vertex -4 0 20
+      vertex -4 0 0
+    endloop
+  endfacet
+  facet normal 0.822985 0 0.568063
+    outer loop
+      vertex 8.22909 0 9.07055
+      vertex 8.50298 -8.39196 8.67375
+      vertex 8.50298 0 8.67375
+    endloop
+  endfacet
+  facet normal 0.822985 0 0.568063
+    outer loop
+      vertex 8.50298 -8.39196 8.67375
+      vertex 8.22909 0 9.07055
+      vertex 8.22909 -8.69615 9.07055
+    endloop
+  endfacet
+  facet normal -0.934993 0 -0.354667
+    outer loop
+      vertex 11.9419 -0.552945 10.4786
+      vertex 11.7709 0 10.9294
+      vertex 11.9419 0 10.4786
+    endloop
+  endfacet
+  facet normal -0.934993 -0 -0.354667
+    outer loop
+      vertex 11.7709 0 10.9294
+      vertex 11.9419 -0.552945 10.4786
+      vertex 11.7709 -2.17963 10.9294
+    endloop
+  endfacet
+  facet normal -0.992712 -0 -0.120511
+    outer loop
+      vertex 11.9419 0 10.4786
+      vertex 12 0 10
+      vertex 11.9419 -0.552945 10.4786
+    endloop
+  endfacet
+  facet normal 0.935013 0 -0.354612
+    outer loop
+      vertex 8.22909 -8.69615 10.9294
+      vertex 8.05812 0 10.4786
+      vertex 8.22909 0 10.9294
+    endloop
+  endfacet
+  facet normal 0.935013 0 -0.354612
+    outer loop
+      vertex 8.05812 0 10.4786
+      vertex 8.22909 -8.69615 10.9294
+      vertex 8.05812 -8.88603 10.4786
+    endloop
+  endfacet
+  facet normal -0.464732 0 0.885451
+    outer loop
+      vertex 10.7092 0 8.12997
+      vertex 11.1361 -4.3466 8.35403
+      vertex 11.1361 0 8.35403
+    endloop
+  endfacet
+  facet normal -0.464732 0 0.885451
+    outer loop
+      vertex 10.7092 -5.31963 8.12997
+      vertex 11.1361 -4.3466 8.35403
+      vertex 10.7092 0 8.12997
+    endloop
+  endfacet
+  facet normal -0.464899 9.3193e-05 0.885364
+    outer loop
+      vertex 11.1361 -4.3466 8.35403
+      vertex 10.7092 -5.31963 8.12997
+      vertex 10.9625 -4.88084 8.26293
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.75893 0 11.9854
+      vertex 10.2411 -6.13047 11.9854
+      vertex 9.75893 -6.96557 11.9854
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.2411 -6.13047 11.9854
+      vertex 9.75893 0 11.9854
+      vertex 10.2411 0 11.9854
+    endloop
+  endfacet
+  facet normal -0.663112 0 0.748521
+    outer loop
+      vertex 11.1361 0 8.35403
+      vertex 11.497 -3.23589 8.67375
+      vertex 11.497 0 8.67375
+    endloop
+  endfacet
+  facet normal -0.663112 0 0.748521
+    outer loop
+      vertex 11.497 -3.23589 8.67375
+      vertex 11.1361 0 8.35403
+      vertex 11.1361 -4.3466 8.35403
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.75893 0 8.01458
+      vertex 10.2411 -6.13047 8.01458
+      vertex 10.2411 0 8.01458
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.2411 -6.13047 8.01458
+      vertex 9.75893 0 8.01458
+      vertex 9.75893 -6.96557 8.01458
+    endloop
+  endfacet
+  facet normal 0.464618 0 -0.885511
+    outer loop
+      vertex 8.86387 0 11.646
+      vertex 9.29079 -7.51701 11.87
+      vertex 8.86387 -7.99115 11.646
+    endloop
+  endfacet
+  facet normal 0.464618 0 -0.885511
+    outer loop
+      vertex 9.29079 -7.51701 11.87
+      vertex 8.86387 0 11.646
+      vertex 9.29079 0 11.87
+    endloop
+  endfacet
+  facet normal 0.464715 0 0.88546
+    outer loop
+      vertex 8.86387 0 8.35403
+      vertex 9.29079 -7.51701 8.12997
+      vertex 9.29079 0 8.12997
+    endloop
+  endfacet
+  facet normal 0.464715 0 0.88546
+    outer loop
+      vertex 9.29079 -7.51701 8.12997
+      vertex 8.86387 0 8.35403
+      vertex 8.86387 -7.99115 8.35403
+    endloop
+  endfacet
+  facet normal -0.464523 -6.27314e-05 -0.885561
+    outer loop
+      vertex 10.7092 -5.31963 11.87
+      vertex 11.1361 -4.3466 11.646
+      vertex 10.9625 -4.88084 11.7371
+    endloop
+  endfacet
+  facet normal -0.464635 0 -0.885502
+    outer loop
+      vertex 11.1361 -4.3466 11.646
+      vertex 10.7092 -5.31963 11.87
+      vertex 10.7092 0 11.87
+    endloop
+  endfacet
+  facet normal -0.464635 0 -0.885502
+    outer loop
+      vertex 11.1361 -4.3466 11.646
+      vertex 10.7092 0 11.87
+      vertex 11.1361 0 11.646
+    endloop
+  endfacet
+  facet normal 0.663122 0 0.748511
+    outer loop
+      vertex 8.50298 0 8.67375
+      vertex 8.86387 -7.99115 8.35403
+      vertex 8.86387 0 8.35403
+    endloop
+  endfacet
+  facet normal 0.663122 0 0.748511
+    outer loop
+      vertex 8.86387 -7.99115 8.35403
+      vertex 8.50298 0 8.67375
+      vertex 8.50298 -8.39196 8.67375
+    endloop
+  endfacet
+  facet normal -0.239362 -0 -0.97093
+    outer loop
+      vertex 10.2411 0 11.9854
+      vertex 10.7092 -5.31963 11.87
+      vertex 10.2411 -6.13047 11.9854
+    endloop
+  endfacet
+  facet normal -0.239362 0 -0.97093
+    outer loop
+      vertex 10.7092 -5.31963 11.87
+      vertex 10.2411 0 11.9854
+      vertex 10.7092 0 11.87
+    endloop
+  endfacet
+  facet normal 0.663215 0 -0.748429
+    outer loop
+      vertex 8.50298 0 11.3262
+      vertex 8.86387 -7.99115 11.646
+      vertex 8.50298 -8.39196 11.3262
+    endloop
+  endfacet
+  facet normal 0.663215 0 -0.748429
+    outer loop
+      vertex 8.86387 -7.99115 11.646
+      vertex 8.50298 0 11.3262
+      vertex 8.86387 0 11.646
+    endloop
+  endfacet
+  facet normal 0.935019 0 0.354599
+    outer loop
+      vertex 8.05812 0 9.52137
+      vertex 8.22909 -8.69615 9.07055
+      vertex 8.22909 0 9.07055
+    endloop
+  endfacet
+  facet normal 0.935019 0 0.354599
+    outer loop
+      vertex 8.22909 -8.69615 9.07055
+      vertex 8.05812 0 9.52137
+      vertex 8.05812 -8.88603 9.52137
+    endloop
+  endfacet
+  facet normal 0.992708 0 0.120544
+    outer loop
+      vertex 8 0 10
+      vertex 8.05812 -8.88603 9.52137
+      vertex 8.05812 0 9.52137
+    endloop
+  endfacet
+  facet normal 0.992708 1.35807e-07 0.120542
+    outer loop
+      vertex 8 0 10
+      vertex 8.02957 -8.91774 9.75649
+      vertex 8.05812 -8.88603 9.52137
+    endloop
+  endfacet
+  facet normal 0.992708 0 0.120547
+    outer loop
+      vertex 8.02957 -8.91774 9.75649
+      vertex 8 0 10
+      vertex 8 -8.93922 10
+    endloop
+  endfacet
+  facet normal -0.239342 0 0.970935
+    outer loop
+      vertex 10.2411 0 8.01458
+      vertex 10.7092 -5.31963 8.12997
+      vertex 10.7092 0 8.12997
+    endloop
+  endfacet
+  facet normal -0.239342 0 0.970935
+    outer loop
+      vertex 10.7092 -5.31963 8.12997
+      vertex 10.2411 0 8.01458
+      vertex 10.2411 -6.13047 8.01458
+    endloop
+  endfacet
+  facet normal -0.822975 0 -0.568077
+    outer loop
+      vertex 11.7709 -2.17963 10.9294
+      vertex 11.497 0 11.3262
+      vertex 11.7709 0 10.9294
+    endloop
+  endfacet
+  facet normal -0.822417 -0.000448346 -0.568885
+    outer loop
+      vertex 11.497 -3.23589 11.3262
+      vertex 11.7709 -2.17963 10.9294
+      vertex 11.7378 -2.49494 10.9775
+    endloop
+  endfacet
+  facet normal -0.822975 0 -0.568077
+    outer loop
+      vertex 11.7709 -2.17963 10.9294
+      vertex 11.497 -3.23589 11.3262
+      vertex 11.497 0 11.3262
+    endloop
+  endfacet
+  facet normal -0.663205 -0 -0.748438
+    outer loop
+      vertex 11.1361 0 11.646
+      vertex 11.497 -3.23589 11.3262
+      vertex 11.1361 -4.3466 11.646
+    endloop
+  endfacet
+  facet normal -0.663205 0 -0.748438
+    outer loop
+      vertex 11.497 -3.23589 11.3262
+      vertex 11.1361 0 11.646
+      vertex 11.497 0 11.3262
+    endloop
+  endfacet
+  facet normal 0.239323 0 0.97094
+    outer loop
+      vertex 9.29079 0 8.12997
+      vertex 9.75893 -6.96557 8.01458
+      vertex 9.75893 0 8.01458
+    endloop
+  endfacet
+  facet normal 0.239323 -0 0.97094
+    outer loop
+      vertex 9.29079 -7.51701 8.12997
+      vertex 9.75893 -6.96557 8.01458
+      vertex 9.29079 0 8.12997
+    endloop
+  endfacet
+  facet normal 0.239486 -0.000146518 0.9709
+    outer loop
+      vertex 9.75893 -6.96557 8.01458
+      vertex 9.29079 -7.51701 8.12997
+      vertex 9.7082 -7.05342 8.02708
+    endloop
+  endfacet
+  facet normal 0.992707 0 -0.120552
+    outer loop
+      vertex 8.05812 -8.88603 10.4786
+      vertex 8 0 10
+      vertex 8.05812 0 10.4786
+    endloop
+  endfacet
+  facet normal 0.992707 -8.4916e-09 -0.120552
+    outer loop
+      vertex 8.02957 -8.91774 10.2435
+      vertex 8 0 10
+      vertex 8.05812 -8.88603 10.4786
+    endloop
+  endfacet
+  facet normal 0.992707 0 -0.120552
+    outer loop
+      vertex 8 0 10
+      vertex 8.02957 -8.91774 10.2435
+      vertex 8 -8.93922 10
+    endloop
+  endfacet
+  facet normal -0.82137 0 0.570396
+    outer loop
+      vertex 11.497 0 8.67375
+      vertex 11.5 -3.22672 8.67807
+      vertex 11.5 0 8.67807
+    endloop
+  endfacet
+  facet normal -0.82137 0 0.570396
+    outer loop
+      vertex 11.5 -3.22672 8.67807
+      vertex 11.497 0 8.67375
+      vertex 11.497 -3.23589 8.67375
+    endloop
+  endfacet
+  facet normal 0.822985 0 -0.568063
+    outer loop
+      vertex 8.50298 -8.39196 11.3262
+      vertex 8.22909 0 10.9294
+      vertex 8.50298 0 11.3262
+    endloop
+  endfacet
+  facet normal 0.822985 0 -0.568063
+    outer loop
+      vertex 8.22909 0 10.9294
+      vertex 8.50298 -8.39196 11.3262
+      vertex 8.22909 -8.69615 10.9294
+    endloop
+  endfacet
+  facet normal 0.239547 -0.000183967 -0.970885
+    outer loop
+      vertex 9.29079 -7.51701 11.87
+      vertex 9.75893 -6.96557 11.9854
+      vertex 9.7082 -7.05342 11.9729
+    endloop
+  endfacet
+  facet normal 0.239343 0 -0.970935
+    outer loop
+      vertex 9.75893 -6.96557 11.9854
+      vertex 9.29079 -7.51701 11.87
+      vertex 9.29079 0 11.87
+    endloop
+  endfacet
+  facet normal 0.239343 0 -0.970935
+    outer loop
+      vertex 9.75893 -6.96557 11.9854
+      vertex 9.29079 0 11.87
+      vertex 9.75893 0 11.9854
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 8.05812 0 9.52137
+      vertex 11.5 0 10
+      vertex 8 0 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 8.22909 0 9.07055
+      vertex 11.5 0 10
+      vertex 8.05812 0 9.52137
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 8.50298 0 8.67375
+      vertex 11.5 0 10
+      vertex 8.22909 0 9.07055
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 8.86387 0 8.35403
+      vertex 11.5 0 10
+      vertex 8.50298 0 8.67375
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 9.29079 0 8.12997
+      vertex 11.5 0 10
+      vertex 8.86387 0 8.35403
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 11.5 0 10
+      vertex 11.1361 0 8.35403
+      vertex 11.5 0 8.67807
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11.5 0 8.67807
+      vertex 11.1361 0 8.35403
+      vertex 11.497 0 8.67375
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 9.75893 0 8.01458
+      vertex 11.5 0 10
+      vertex 9.29079 0 8.12997
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11.5 0 10
+      vertex 10.7092 0 8.12997
+      vertex 11.1361 0 8.35403
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 10.2411 0 8.01458
+      vertex 11.5 0 10
+      vertex 9.75893 0 8.01458
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11.5 0 10
+      vertex 10.2411 0 8.01458
+      vertex 10.7092 0 8.12997
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11.5 0 10
+      vertex 9.75893 0 11.9854
+      vertex 9.29079 0 11.87
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 9.75893 0 11.9854
+      vertex 11.5 0 10
+      vertex 10.2411 0 11.9854
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11.5 0 10
+      vertex 9.29079 0 11.87
+      vertex 8.86387 0 11.646
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 10.2411 0 11.9854
+      vertex 11.5 0 10
+      vertex 10.7092 0 11.87
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11.5 0 10
+      vertex 8.86387 0 11.646
+      vertex 8.50298 0 11.3262
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 10.7092 0 11.87
+      vertex 11.5 0 10
+      vertex 11.1361 0 11.646
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11.5 0 10
+      vertex 8.50298 0 11.3262
+      vertex 8.22909 0 10.9294
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11.1361 0 11.646
+      vertex 11.5 0 10
+      vertex 11.497 0 11.3262
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11.5 0 10
+      vertex 8.22909 0 10.9294
+      vertex 8.05812 0 10.4786
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11.497 0 11.3262
+      vertex 11.5 0 10
+      vertex 11.7709 0 10.9294
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11.5 0 10
+      vertex 8.05812 0 10.4786
+      vertex 8 0 10
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 11.7709 0 10.9294
+      vertex 11.5 0 10
+      vertex 11.9419 0 10.4786
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 11.9419 0 10.4786
+      vertex 11.5 0 10
+      vertex 12 0 10
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.5 0 10
+      vertex 11.7378 2.49494 10
+      vertex 12 0 10
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.7378 2.49494 10
+      vertex 11.5 0 10
+      vertex 11.5 3.22672 10
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 11.5 0 8.67807
+      vertex 11.5 3.22672 10
+      vertex 11.5 0 10
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 11.5 3.22672 10
+      vertex 11.5 0 8.67807
+      vertex 11.5 3.22672 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 11.5 -3.22672 0
+      vertex 11.5 0 8.67807
+      vertex 11.5 -3.22672 8.67807
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 11.5 0 8.67807
+      vertex 11.5 -3.22672 0
+      vertex 11.5 3.22672 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/stl/flywheel.stl
+++ b/stl/flywheel.stl
@@ -1,0 +1,1682 @@
+solid OpenSCAD_Model
+  facet normal -0.40673 -0.913548 0
+    outer loop
+      vertex -25 -43.3013 0
+      vertex -15.4508 -47.5528 20
+      vertex -25 -43.3013 20
+    endloop
+  endfacet
+  facet normal -0.40673 -0.913548 -0
+    outer loop
+      vertex -15.4508 -47.5528 20
+      vertex -25 -43.3013 0
+      vertex -15.4508 -47.5528 0
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309018 0
+    outer loop
+      vertex -45.6773 -20.3368 0
+      vertex -48.9074 -10.3956 20
+      vertex -48.9074 -10.3956 0
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309018 0
+    outer loop
+      vertex -48.9074 -10.3956 20
+      vertex -45.6773 -20.3368 0
+      vertex -45.6773 -20.3368 20
+    endloop
+  endfacet
+  facet normal 0.951056 0.309018 0
+    outer loop
+      vertex 48.9074 10.3956 20
+      vertex 45.6773 20.3368 0
+      vertex 45.6773 20.3368 20
+    endloop
+  endfacet
+  facet normal 0.951056 0.309018 0
+    outer loop
+      vertex 45.6773 20.3368 0
+      vertex 48.9074 10.3956 20
+      vertex 48.9074 10.3956 0
+    endloop
+  endfacet
+  facet normal 0.994522 0.104526 0
+    outer loop
+      vertex 50 0 20
+      vertex 48.9074 10.3956 0
+      vertex 48.9074 10.3956 20
+    endloop
+  endfacet
+  facet normal 0.994522 0.104526 0
+    outer loop
+      vertex 48.9074 10.3956 0
+      vertex 50 0 20
+      vertex 50 0 0
+    endloop
+  endfacet
+  facet normal 0.866028 0.499995 0
+    outer loop
+      vertex 45.6773 20.3368 20
+      vertex 40.4509 29.3893 0
+      vertex 40.4509 29.3893 20
+    endloop
+  endfacet
+  facet normal 0.866028 0.499995 0
+    outer loop
+      vertex 40.4509 29.3893 0
+      vertex 45.6773 20.3368 20
+      vertex 45.6773 20.3368 0
+    endloop
+  endfacet
+  facet normal 0.587791 -0.809013 0
+    outer loop
+      vertex 25 -43.3013 0
+      vertex 33.4565 -37.1572 20
+      vertex 25 -43.3013 20
+    endloop
+  endfacet
+  facet normal 0.587791 -0.809013 0
+    outer loop
+      vertex 33.4565 -37.1572 20
+      vertex 25 -43.3013 0
+      vertex 33.4565 -37.1572 0
+    endloop
+  endfacet
+  facet normal 0.40673 0.913548 -0
+    outer loop
+      vertex 25 43.3013 0
+      vertex 15.4508 47.5528 20
+      vertex 25 43.3013 20
+    endloop
+  endfacet
+  facet normal 0.40673 0.913548 0
+    outer loop
+      vertex 15.4508 47.5528 20
+      vertex 25 43.3013 0
+      vertex 15.4508 47.5528 0
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104526 0
+    outer loop
+      vertex 48.9074 -10.3956 20
+      vertex 50 0 0
+      vertex 50 0 20
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104526 0
+    outer loop
+      vertex 50 0 0
+      vertex 48.9074 -10.3956 20
+      vertex 48.9074 -10.3956 0
+    endloop
+  endfacet
+  facet normal 0.743138 0.669139 0
+    outer loop
+      vertex 40.4509 29.3893 20
+      vertex 33.4565 37.1572 0
+      vertex 33.4565 37.1572 20
+    endloop
+  endfacet
+  facet normal 0.743138 0.669139 0
+    outer loop
+      vertex 33.4565 37.1572 0
+      vertex 40.4509 29.3893 20
+      vertex 40.4509 29.3893 0
+    endloop
+  endfacet
+  facet normal -0.866028 0.499995 0
+    outer loop
+      vertex -45.6773 20.3368 0
+      vertex -40.4509 29.3893 20
+      vertex -40.4509 29.3893 0
+    endloop
+  endfacet
+  facet normal -0.866028 0.499995 0
+    outer loop
+      vertex -40.4509 29.3893 20
+      vertex -45.6773 20.3368 0
+      vertex -45.6773 20.3368 20
+    endloop
+  endfacet
+  facet normal 0.743138 -0.669139 0
+    outer loop
+      vertex 33.4565 -37.1572 20
+      vertex 40.4509 -29.3893 0
+      vertex 40.4509 -29.3893 20
+    endloop
+  endfacet
+  facet normal 0.743138 -0.669139 0
+    outer loop
+      vertex 40.4509 -29.3893 0
+      vertex 33.4565 -37.1572 20
+      vertex 33.4565 -37.1572 0
+    endloop
+  endfacet
+  facet normal -0.743138 0.669139 0
+    outer loop
+      vertex -40.4509 29.3893 0
+      vertex -33.4565 37.1572 20
+      vertex -33.4565 37.1572 0
+    endloop
+  endfacet
+  facet normal -0.743138 0.669139 0
+    outer loop
+      vertex -33.4565 37.1572 20
+      vertex -40.4509 29.3893 0
+      vertex -40.4509 29.3893 20
+    endloop
+  endfacet
+  facet normal 0.866028 -0.499995 0
+    outer loop
+      vertex 40.4509 -29.3893 20
+      vertex 45.6773 -20.3368 0
+      vertex 45.6773 -20.3368 20
+    endloop
+  endfacet
+  facet normal 0.866028 -0.499995 0
+    outer loop
+      vertex 45.6773 -20.3368 0
+      vertex 40.4509 -29.3893 20
+      vertex 40.4509 -29.3893 0
+    endloop
+  endfacet
+  facet normal -0.587791 0.809013 0
+    outer loop
+      vertex -25 43.3013 0
+      vertex -33.4565 37.1572 20
+      vertex -25 43.3013 20
+    endloop
+  endfacet
+  facet normal -0.587791 0.809013 0
+    outer loop
+      vertex -33.4565 37.1572 20
+      vertex -25 43.3013 0
+      vertex -33.4565 37.1572 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5 0 20
+      vertex 50 0 20
+      vertex 48.9074 10.3956 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.89074 1.03956 20
+      vertex 48.9074 10.3956 20
+      vertex 45.6773 20.3368 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 50 0 20
+      vertex 5 0 20
+      vertex 48.9074 -10.3956 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.56773 2.03368 20
+      vertex 45.6773 20.3368 20
+      vertex 40.4509 29.3893 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.89074 -1.03956 20
+      vertex 48.9074 -10.3956 20
+      vertex 5 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.04508 2.93893 20
+      vertex 40.4509 29.3893 20
+      vertex 33.4565 37.1572 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.9074 -10.3956 20
+      vertex 4.89074 -1.03956 20
+      vertex 45.6773 -20.3368 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.34565 3.71572 20
+      vertex 33.4565 37.1572 20
+      vertex 25 43.3013 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.56773 -2.03368 20
+      vertex 45.6773 -20.3368 20
+      vertex 4.89074 -1.03956 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.5 4.33013 20
+      vertex 25 43.3013 20
+      vertex 15.4508 47.5528 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.6773 -20.3368 20
+      vertex 4.56773 -2.03368 20
+      vertex 40.4509 -29.3893 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.54508 4.75528 20
+      vertex 15.4508 47.5528 20
+      vertex 5.22642 49.7261 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.04508 -2.93893 20
+      vertex 40.4509 -29.3893 20
+      vertex 4.56773 -2.03368 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 40.4509 -29.3893 20
+      vertex 4.04508 -2.93893 20
+      vertex 33.4565 -37.1572 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.9074 10.3956 20
+      vertex 4.89074 1.03956 20
+      vertex 5 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.6773 20.3368 20
+      vertex 4.56773 2.03368 20
+      vertex 4.89074 1.03956 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 40.4509 29.3893 20
+      vertex 4.04508 2.93893 20
+      vertex 4.56773 2.03368 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.4565 37.1572 20
+      vertex 3.34565 3.71572 20
+      vertex 4.04508 2.93893 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25 43.3013 20
+      vertex 2.5 4.33013 20
+      vertex 3.34565 3.71572 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4508 47.5528 20
+      vertex 1.54508 4.75528 20
+      vertex 2.5 4.33013 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.22642 49.7261 20
+      vertex 0.522642 4.97261 20
+      vertex 1.54508 4.75528 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.22642 49.7261 20
+      vertex -0.522642 4.97261 20
+      vertex 0.522642 4.97261 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.22642 49.7261 20
+      vertex -0.522642 4.97261 20
+      vertex 5.22642 49.7261 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.522642 4.97261 20
+      vertex -5.22642 49.7261 20
+      vertex -1.54508 4.75528 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.4508 47.5528 20
+      vertex -1.54508 4.75528 20
+      vertex -5.22642 49.7261 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.54508 4.75528 20
+      vertex -15.4508 47.5528 20
+      vertex -2.5 4.33013 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -25 43.3013 20
+      vertex -2.5 4.33013 20
+      vertex -15.4508 47.5528 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.5 4.33013 20
+      vertex -25 43.3013 20
+      vertex -3.34565 3.71572 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.34565 3.71572 20
+      vertex -33.4565 37.1572 20
+      vertex -4.04508 2.93893 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -33.4565 37.1572 20
+      vertex -3.34565 3.71572 20
+      vertex -25 43.3013 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.34565 -3.71572 20
+      vertex 33.4565 -37.1572 20
+      vertex 4.04508 -2.93893 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.4565 -37.1572 20
+      vertex 3.34565 -3.71572 20
+      vertex 25 -43.3013 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.5 -4.33013 20
+      vertex 25 -43.3013 20
+      vertex 3.34565 -3.71572 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25 -43.3013 20
+      vertex 2.5 -4.33013 20
+      vertex 15.4508 -47.5528 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.54508 -4.75528 20
+      vertex 15.4508 -47.5528 20
+      vertex 2.5 -4.33013 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4508 -47.5528 20
+      vertex 1.54508 -4.75528 20
+      vertex 5.22642 -49.7261 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.522642 -4.97261 20
+      vertex 5.22642 -49.7261 20
+      vertex 1.54508 -4.75528 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.522642 -4.97261 20
+      vertex 5.22642 -49.7261 20
+      vertex 0.522642 -4.97261 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.22642 -49.7261 20
+      vertex -0.522642 -4.97261 20
+      vertex -1.54508 -4.75528 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.4508 -47.5528 20
+      vertex -1.54508 -4.75528 20
+      vertex -2.5 -4.33013 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25 -43.3013 20
+      vertex -2.5 -4.33013 20
+      vertex -3.34565 -3.71572 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.4565 -37.1572 20
+      vertex -3.34565 -3.71572 20
+      vertex -4.04508 -2.93893 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -40.4509 -29.3893 20
+      vertex -4.04508 -2.93893 20
+      vertex -4.56773 -2.03368 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -45.6773 -20.3368 20
+      vertex -4.56773 -2.03368 20
+      vertex -4.89074 -1.03956 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.522642 -4.97261 20
+      vertex -5.22642 -49.7261 20
+      vertex 5.22642 -49.7261 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.9074 -10.3956 20
+      vertex -4.89074 -1.03956 20
+      vertex -5 0 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -40.4509 29.3893 20
+      vertex -4.04508 2.93893 20
+      vertex -33.4565 37.1572 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.04508 2.93893 20
+      vertex -40.4509 29.3893 20
+      vertex -4.56773 2.03368 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.54508 -4.75528 20
+      vertex -15.4508 -47.5528 20
+      vertex -5.22642 -49.7261 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -45.6773 20.3368 20
+      vertex -4.56773 2.03368 20
+      vertex -40.4509 29.3893 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.5 -4.33013 20
+      vertex -25 -43.3013 20
+      vertex -15.4508 -47.5528 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.56773 2.03368 20
+      vertex -45.6773 20.3368 20
+      vertex -4.89074 1.03956 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.34565 -3.71572 20
+      vertex -33.4565 -37.1572 20
+      vertex -25 -43.3013 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -48.9074 10.3956 20
+      vertex -4.89074 1.03956 20
+      vertex -45.6773 20.3368 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.04508 -2.93893 20
+      vertex -40.4509 -29.3893 20
+      vertex -33.4565 -37.1572 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.89074 1.03956 20
+      vertex -48.9074 10.3956 20
+      vertex -5 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.56773 -2.03368 20
+      vertex -45.6773 -20.3368 20
+      vertex -40.4509 -29.3893 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50 0 20
+      vertex -5 0 20
+      vertex -48.9074 10.3956 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.89074 -1.03956 20
+      vertex -48.9074 -10.3956 20
+      vertex -45.6773 -20.3368 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5 0 20
+      vertex -50 0 20
+      vertex -48.9074 -10.3956 20
+    endloop
+  endfacet
+  facet normal 0.951056 -0.309018 0
+    outer loop
+      vertex 45.6773 -20.3368 20
+      vertex 48.9074 -10.3956 0
+      vertex 48.9074 -10.3956 20
+    endloop
+  endfacet
+  facet normal 0.951056 -0.309018 0
+    outer loop
+      vertex 48.9074 -10.3956 0
+      vertex 45.6773 -20.3368 20
+      vertex 45.6773 -20.3368 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 5.22642 49.7261 0
+      vertex -5.22642 49.7261 20
+      vertex 5.22642 49.7261 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5.22642 49.7261 20
+      vertex 5.22642 49.7261 0
+      vertex -5.22642 49.7261 0
+    endloop
+  endfacet
+  facet normal -0.587791 -0.809013 0
+    outer loop
+      vertex -33.4565 -37.1572 0
+      vertex -25 -43.3013 20
+      vertex -33.4565 -37.1572 20
+    endloop
+  endfacet
+  facet normal -0.587791 -0.809013 -0
+    outer loop
+      vertex -25 -43.3013 20
+      vertex -33.4565 -37.1572 0
+      vertex -25 -43.3013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 0 0
+      vertex 50 0 0
+      vertex 48.9074 -10.3956 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.89074 -1.03956 0
+      vertex 48.9074 -10.3956 0
+      vertex 45.6773 -20.3368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 50 0 0
+      vertex 5 0 0
+      vertex 48.9074 10.3956 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.56773 -2.03368 0
+      vertex 45.6773 -20.3368 0
+      vertex 40.4509 -29.3893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.89074 1.03956 0
+      vertex 48.9074 10.3956 0
+      vertex 5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.04508 -2.93893 0
+      vertex 40.4509 -29.3893 0
+      vertex 33.4565 -37.1572 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 48.9074 10.3956 0
+      vertex 4.89074 1.03956 0
+      vertex 45.6773 20.3368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.34565 -3.71572 0
+      vertex 33.4565 -37.1572 0
+      vertex 25 -43.3013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.56773 2.03368 0
+      vertex 45.6773 20.3368 0
+      vertex 4.89074 1.03956 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.5 -4.33013 0
+      vertex 25 -43.3013 0
+      vertex 15.4508 -47.5528 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 45.6773 20.3368 0
+      vertex 4.56773 2.03368 0
+      vertex 40.4509 29.3893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.54508 -4.75528 0
+      vertex 15.4508 -47.5528 0
+      vertex 5.22642 -49.7261 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.04508 2.93893 0
+      vertex 40.4509 29.3893 0
+      vertex 4.56773 2.03368 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 40.4509 29.3893 0
+      vertex 4.04508 2.93893 0
+      vertex 33.4565 37.1572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 48.9074 -10.3956 0
+      vertex 4.89074 -1.03956 0
+      vertex 5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 45.6773 -20.3368 0
+      vertex 4.56773 -2.03368 0
+      vertex 4.89074 -1.03956 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40.4509 -29.3893 0
+      vertex 4.04508 -2.93893 0
+      vertex 4.56773 -2.03368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 33.4565 -37.1572 0
+      vertex 3.34565 -3.71572 0
+      vertex 4.04508 -2.93893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25 -43.3013 0
+      vertex 2.5 -4.33013 0
+      vertex 3.34565 -3.71572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4508 -47.5528 0
+      vertex 1.54508 -4.75528 0
+      vertex 2.5 -4.33013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.22642 -49.7261 0
+      vertex 0.522642 -4.97261 0
+      vertex 1.54508 -4.75528 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.22642 -49.7261 0
+      vertex -0.522642 -4.97261 0
+      vertex 0.522642 -4.97261 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.22642 -49.7261 0
+      vertex -0.522642 -4.97261 0
+      vertex 5.22642 -49.7261 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.522642 -4.97261 0
+      vertex -5.22642 -49.7261 0
+      vertex -1.54508 -4.75528 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.4508 -47.5528 0
+      vertex -1.54508 -4.75528 0
+      vertex -5.22642 -49.7261 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.54508 -4.75528 0
+      vertex -15.4508 -47.5528 0
+      vertex -2.5 -4.33013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25 -43.3013 0
+      vertex -2.5 -4.33013 0
+      vertex -15.4508 -47.5528 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -2.5 -4.33013 0
+      vertex -25 -43.3013 0
+      vertex -3.34565 -3.71572 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -3.34565 -3.71572 0
+      vertex -33.4565 -37.1572 0
+      vertex -4.04508 -2.93893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.4565 -37.1572 0
+      vertex -3.34565 -3.71572 0
+      vertex -25 -43.3013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.34565 3.71572 0
+      vertex 33.4565 37.1572 0
+      vertex 4.04508 2.93893 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 33.4565 37.1572 0
+      vertex 3.34565 3.71572 0
+      vertex 25 43.3013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.5 4.33013 0
+      vertex 25 43.3013 0
+      vertex 3.34565 3.71572 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 25 43.3013 0
+      vertex 2.5 4.33013 0
+      vertex 15.4508 47.5528 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.54508 4.75528 0
+      vertex 15.4508 47.5528 0
+      vertex 2.5 4.33013 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.4508 47.5528 0
+      vertex 1.54508 4.75528 0
+      vertex 5.22642 49.7261 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.522642 4.97261 0
+      vertex 5.22642 49.7261 0
+      vertex 1.54508 4.75528 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.522642 4.97261 0
+      vertex 5.22642 49.7261 0
+      vertex 0.522642 4.97261 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.22642 49.7261 0
+      vertex -0.522642 4.97261 0
+      vertex -1.54508 4.75528 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.4508 47.5528 0
+      vertex -1.54508 4.75528 0
+      vertex -2.5 4.33013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25 43.3013 0
+      vertex -2.5 4.33013 0
+      vertex -3.34565 3.71572 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.4565 37.1572 0
+      vertex -3.34565 3.71572 0
+      vertex -4.04508 2.93893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -40.4509 29.3893 0
+      vertex -4.04508 2.93893 0
+      vertex -4.56773 2.03368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -45.6773 20.3368 0
+      vertex -4.56773 2.03368 0
+      vertex -4.89074 1.03956 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.522642 4.97261 0
+      vertex -5.22642 49.7261 0
+      vertex 5.22642 49.7261 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -48.9074 10.3956 0
+      vertex -4.89074 1.03956 0
+      vertex -5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -40.4509 -29.3893 0
+      vertex -4.04508 -2.93893 0
+      vertex -33.4565 -37.1572 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -4.04508 -2.93893 0
+      vertex -40.4509 -29.3893 0
+      vertex -4.56773 -2.03368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.54508 4.75528 0
+      vertex -15.4508 47.5528 0
+      vertex -5.22642 49.7261 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -45.6773 -20.3368 0
+      vertex -4.56773 -2.03368 0
+      vertex -40.4509 -29.3893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.5 4.33013 0
+      vertex -25 43.3013 0
+      vertex -15.4508 47.5528 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -4.56773 -2.03368 0
+      vertex -45.6773 -20.3368 0
+      vertex -4.89074 -1.03956 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.34565 3.71572 0
+      vertex -33.4565 37.1572 0
+      vertex -25 43.3013 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -48.9074 -10.3956 0
+      vertex -4.89074 -1.03956 0
+      vertex -45.6773 -20.3368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.04508 2.93893 0
+      vertex -40.4509 29.3893 0
+      vertex -33.4565 37.1572 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -4.89074 -1.03956 0
+      vertex -48.9074 -10.3956 0
+      vertex -5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.56773 2.03368 0
+      vertex -45.6773 20.3368 0
+      vertex -40.4509 29.3893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -50 0 0
+      vertex -5 0 0
+      vertex -48.9074 -10.3956 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.89074 1.03956 0
+      vertex -48.9074 10.3956 0
+      vertex -45.6773 20.3368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5 0 0
+      vertex -50 0 0
+      vertex -48.9074 10.3956 0
+    endloop
+  endfacet
+  facet normal -0.40673 0.913548 0
+    outer loop
+      vertex -15.4508 47.5528 0
+      vertex -25 43.3013 20
+      vertex -15.4508 47.5528 20
+    endloop
+  endfacet
+  facet normal -0.40673 0.913548 0
+    outer loop
+      vertex -25 43.3013 20
+      vertex -15.4508 47.5528 0
+      vertex -25 43.3013 0
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104526 0
+    outer loop
+      vertex -48.9074 -10.3956 0
+      vertex -50 0 20
+      vertex -50 0 0
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104526 0
+    outer loop
+      vertex -50 0 20
+      vertex -48.9074 -10.3956 0
+      vertex -48.9074 -10.3956 20
+    endloop
+  endfacet
+  facet normal -0.743138 -0.669139 0
+    outer loop
+      vertex -33.4565 -37.1572 0
+      vertex -40.4509 -29.3893 20
+      vertex -40.4509 -29.3893 0
+    endloop
+  endfacet
+  facet normal -0.743138 -0.669139 0
+    outer loop
+      vertex -40.4509 -29.3893 20
+      vertex -33.4565 -37.1572 0
+      vertex -33.4565 -37.1572 20
+    endloop
+  endfacet
+  facet normal -0.866028 -0.499995 0
+    outer loop
+      vertex -40.4509 -29.3893 0
+      vertex -45.6773 -20.3368 20
+      vertex -45.6773 -20.3368 0
+    endloop
+  endfacet
+  facet normal -0.866028 -0.499995 0
+    outer loop
+      vertex -45.6773 -20.3368 20
+      vertex -40.4509 -29.3893 0
+      vertex -40.4509 -29.3893 20
+    endloop
+  endfacet
+  facet normal 0.207915 -0.978147 0
+    outer loop
+      vertex 5.22642 -49.7261 0
+      vertex 15.4508 -47.5528 20
+      vertex 5.22642 -49.7261 20
+    endloop
+  endfacet
+  facet normal 0.207915 -0.978147 0
+    outer loop
+      vertex 15.4508 -47.5528 20
+      vertex 5.22642 -49.7261 0
+      vertex 15.4508 -47.5528 0
+    endloop
+  endfacet
+  facet normal -0.994522 0.104526 0
+    outer loop
+      vertex -50 0 0
+      vertex -48.9074 10.3956 20
+      vertex -48.9074 10.3956 0
+    endloop
+  endfacet
+  facet normal -0.994522 0.104526 0
+    outer loop
+      vertex -48.9074 10.3956 20
+      vertex -50 0 0
+      vertex -50 0 20
+    endloop
+  endfacet
+  facet normal 0.207915 0.978147 -0
+    outer loop
+      vertex 15.4508 47.5528 0
+      vertex 5.22642 49.7261 20
+      vertex 15.4508 47.5528 20
+    endloop
+  endfacet
+  facet normal 0.207915 0.978147 0
+    outer loop
+      vertex 5.22642 49.7261 20
+      vertex 15.4508 47.5528 0
+      vertex 5.22642 49.7261 0
+    endloop
+  endfacet
+  facet normal 0.587791 0.809013 -0
+    outer loop
+      vertex 33.4565 37.1572 0
+      vertex 25 43.3013 20
+      vertex 33.4565 37.1572 20
+    endloop
+  endfacet
+  facet normal 0.587791 0.809013 0
+    outer loop
+      vertex 25 43.3013 20
+      vertex 33.4565 37.1572 0
+      vertex 25 43.3013 0
+    endloop
+  endfacet
+  facet normal -0.207915 0.978147 0
+    outer loop
+      vertex -5.22642 49.7261 0
+      vertex -15.4508 47.5528 20
+      vertex -5.22642 49.7261 20
+    endloop
+  endfacet
+  facet normal -0.207915 0.978147 0
+    outer loop
+      vertex -15.4508 47.5528 20
+      vertex -5.22642 49.7261 0
+      vertex -15.4508 47.5528 0
+    endloop
+  endfacet
+  facet normal 0.40673 -0.913548 0
+    outer loop
+      vertex 15.4508 -47.5528 0
+      vertex 25 -43.3013 20
+      vertex 15.4508 -47.5528 20
+    endloop
+  endfacet
+  facet normal 0.40673 -0.913548 0
+    outer loop
+      vertex 25 -43.3013 20
+      vertex 15.4508 -47.5528 0
+      vertex 25 -43.3013 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5.22642 -49.7261 0
+      vertex 5.22642 -49.7261 20
+      vertex -5.22642 -49.7261 20
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 5.22642 -49.7261 20
+      vertex -5.22642 -49.7261 0
+      vertex 5.22642 -49.7261 0
+    endloop
+  endfacet
+  facet normal -0.207915 -0.978147 0
+    outer loop
+      vertex -15.4508 -47.5528 0
+      vertex -5.22642 -49.7261 20
+      vertex -15.4508 -47.5528 20
+    endloop
+  endfacet
+  facet normal -0.207915 -0.978147 -0
+    outer loop
+      vertex -5.22642 -49.7261 20
+      vertex -15.4508 -47.5528 0
+      vertex -5.22642 -49.7261 0
+    endloop
+  endfacet
+  facet normal -0.951056 0.309018 0
+    outer loop
+      vertex -48.9074 10.3956 0
+      vertex -45.6773 20.3368 20
+      vertex -45.6773 20.3368 0
+    endloop
+  endfacet
+  facet normal -0.951056 0.309018 0
+    outer loop
+      vertex -45.6773 20.3368 20
+      vertex -48.9074 10.3956 0
+      vertex -48.9074 10.3956 20
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309018 0
+    outer loop
+      vertex 4.89074 1.03956 0
+      vertex 4.56773 2.03368 20
+      vertex 4.56773 2.03368 0
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309018 0
+    outer loop
+      vertex 4.56773 2.03368 20
+      vertex 4.89074 1.03956 0
+      vertex 4.89074 1.03956 20
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104526 0
+    outer loop
+      vertex 5 0 0
+      vertex 4.89074 1.03956 20
+      vertex 4.89074 1.03956 0
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104526 0
+    outer loop
+      vertex 4.89074 1.03956 20
+      vertex 5 0 0
+      vertex 5 0 20
+    endloop
+  endfacet
+  facet normal -0.866024 -0.500003 0
+    outer loop
+      vertex 4.56773 2.03368 0
+      vertex 4.04508 2.93893 20
+      vertex 4.04508 2.93893 0
+    endloop
+  endfacet
+  facet normal -0.866024 -0.500003 0
+    outer loop
+      vertex 4.04508 2.93893 20
+      vertex 4.56773 2.03368 0
+      vertex 4.56773 2.03368 20
+    endloop
+  endfacet
+  facet normal 0.40673 -0.913548 0
+    outer loop
+      vertex -2.5 4.33013 0
+      vertex -1.54508 4.75528 20
+      vertex -2.5 4.33013 20
+    endloop
+  endfacet
+  facet normal 0.40673 -0.913548 0
+    outer loop
+      vertex -1.54508 4.75528 20
+      vertex -2.5 4.33013 0
+      vertex -1.54508 4.75528 0
+    endloop
+  endfacet
+  facet normal -0.951056 0.309018 0
+    outer loop
+      vertex 4.56773 -2.03368 0
+      vertex 4.89074 -1.03956 20
+      vertex 4.89074 -1.03956 0
+    endloop
+  endfacet
+  facet normal -0.951056 0.309018 0
+    outer loop
+      vertex 4.89074 -1.03956 20
+      vertex 4.56773 -2.03368 0
+      vertex 4.56773 -2.03368 20
+    endloop
+  endfacet
+  facet normal -0.994522 0.104526 0
+    outer loop
+      vertex 4.89074 -1.03956 0
+      vertex 5 0 20
+      vertex 5 0 0
+    endloop
+  endfacet
+  facet normal -0.994522 0.104526 0
+    outer loop
+      vertex 5 0 20
+      vertex 4.89074 -1.03956 0
+      vertex 4.89074 -1.03956 20
+    endloop
+  endfacet
+  facet normal -0.40673 -0.913548 0
+    outer loop
+      vertex 1.54508 4.75528 0
+      vertex 2.5 4.33013 20
+      vertex 1.54508 4.75528 20
+    endloop
+  endfacet
+  facet normal -0.40673 -0.913548 -0
+    outer loop
+      vertex 2.5 4.33013 20
+      vertex 1.54508 4.75528 0
+      vertex 2.5 4.33013 0
+    endloop
+  endfacet
+  facet normal 0.866024 -0.500003 0
+    outer loop
+      vertex -4.56773 2.03368 20
+      vertex -4.04508 2.93893 0
+      vertex -4.04508 2.93893 20
+    endloop
+  endfacet
+  facet normal 0.866024 -0.500003 0
+    outer loop
+      vertex -4.04508 2.93893 0
+      vertex -4.56773 2.03368 20
+      vertex -4.56773 2.03368 0
+    endloop
+  endfacet
+  facet normal 0.587791 -0.809013 0
+    outer loop
+      vertex -3.34565 3.71572 0
+      vertex -2.5 4.33013 20
+      vertex -3.34565 3.71572 20
+    endloop
+  endfacet
+  facet normal 0.587791 -0.809013 0
+    outer loop
+      vertex -2.5 4.33013 20
+      vertex -3.34565 3.71572 0
+      vertex -2.5 4.33013 0
+    endloop
+  endfacet
+  facet normal -0.866024 0.500003 0
+    outer loop
+      vertex 4.04508 -2.93893 0
+      vertex 4.56773 -2.03368 20
+      vertex 4.56773 -2.03368 0
+    endloop
+  endfacet
+  facet normal -0.866024 0.500003 0
+    outer loop
+      vertex 4.56773 -2.03368 20
+      vertex 4.04508 -2.93893 0
+      vertex 4.04508 -2.93893 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.522642 4.97261 0
+      vertex 0.522642 4.97261 20
+      vertex -0.522642 4.97261 20
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 0.522642 4.97261 20
+      vertex -0.522642 4.97261 0
+      vertex 0.522642 4.97261 0
+    endloop
+  endfacet
+  facet normal -0.587791 0.809013 0
+    outer loop
+      vertex 3.34565 -3.71572 0
+      vertex 2.5 -4.33013 20
+      vertex 3.34565 -3.71572 20
+    endloop
+  endfacet
+  facet normal -0.587791 0.809013 0
+    outer loop
+      vertex 2.5 -4.33013 20
+      vertex 3.34565 -3.71572 0
+      vertex 2.5 -4.33013 0
+    endloop
+  endfacet
+  facet normal -0.743142 -0.669133 0
+    outer loop
+      vertex 4.04508 2.93893 0
+      vertex 3.34565 3.71572 20
+      vertex 3.34565 3.71572 0
+    endloop
+  endfacet
+  facet normal -0.743142 -0.669133 0
+    outer loop
+      vertex 3.34565 3.71572 20
+      vertex 4.04508 2.93893 0
+      vertex 4.04508 2.93893 20
+    endloop
+  endfacet
+  facet normal 0.207915 0.978147 -0
+    outer loop
+      vertex -0.522642 -4.97261 0
+      vertex -1.54508 -4.75528 20
+      vertex -0.522642 -4.97261 20
+    endloop
+  endfacet
+  facet normal 0.207915 0.978147 0
+    outer loop
+      vertex -1.54508 -4.75528 20
+      vertex -0.522642 -4.97261 0
+      vertex -1.54508 -4.75528 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 0.522642 -4.97261 0
+      vertex -0.522642 -4.97261 20
+      vertex 0.522642 -4.97261 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.522642 -4.97261 20
+      vertex 0.522642 -4.97261 0
+      vertex -0.522642 -4.97261 0
+    endloop
+  endfacet
+  facet normal 0.951056 -0.309018 0
+    outer loop
+      vertex -4.89074 1.03956 20
+      vertex -4.56773 2.03368 0
+      vertex -4.56773 2.03368 20
+    endloop
+  endfacet
+  facet normal 0.951056 -0.309018 0
+    outer loop
+      vertex -4.56773 2.03368 0
+      vertex -4.89074 1.03956 20
+      vertex -4.89074 1.03956 0
+    endloop
+  endfacet
+  facet normal 0.207915 -0.978147 0
+    outer loop
+      vertex -1.54508 4.75528 0
+      vertex -0.522642 4.97261 20
+      vertex -1.54508 4.75528 20
+    endloop
+  endfacet
+  facet normal 0.207915 -0.978147 0
+    outer loop
+      vertex -0.522642 4.97261 20
+      vertex -1.54508 4.75528 0
+      vertex -0.522642 4.97261 0
+    endloop
+  endfacet
+  facet normal -0.207915 0.978147 0
+    outer loop
+      vertex 1.54508 -4.75528 0
+      vertex 0.522642 -4.97261 20
+      vertex 1.54508 -4.75528 20
+    endloop
+  endfacet
+  facet normal -0.207915 0.978147 0
+    outer loop
+      vertex 0.522642 -4.97261 20
+      vertex 1.54508 -4.75528 0
+      vertex 0.522642 -4.97261 0
+    endloop
+  endfacet
+  facet normal 0.866024 0.500003 0
+    outer loop
+      vertex -4.04508 -2.93893 20
+      vertex -4.56773 -2.03368 0
+      vertex -4.56773 -2.03368 20
+    endloop
+  endfacet
+  facet normal 0.866024 0.500003 0
+    outer loop
+      vertex -4.56773 -2.03368 0
+      vertex -4.04508 -2.93893 20
+      vertex -4.04508 -2.93893 0
+    endloop
+  endfacet
+  facet normal -0.40673 0.913548 0
+    outer loop
+      vertex 2.5 -4.33013 0
+      vertex 1.54508 -4.75528 20
+      vertex 2.5 -4.33013 20
+    endloop
+  endfacet
+  facet normal -0.40673 0.913548 0
+    outer loop
+      vertex 1.54508 -4.75528 20
+      vertex 2.5 -4.33013 0
+      vertex 1.54508 -4.75528 0
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104526 0
+    outer loop
+      vertex -5 0 20
+      vertex -4.89074 1.03956 0
+      vertex -4.89074 1.03956 20
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104526 0
+    outer loop
+      vertex -4.89074 1.03956 0
+      vertex -5 0 20
+      vertex -5 0 0
+    endloop
+  endfacet
+  facet normal -0.587791 -0.809013 0
+    outer loop
+      vertex 2.5 4.33013 0
+      vertex 3.34565 3.71572 20
+      vertex 2.5 4.33013 20
+    endloop
+  endfacet
+  facet normal -0.587791 -0.809013 -0
+    outer loop
+      vertex 3.34565 3.71572 20
+      vertex 2.5 4.33013 0
+      vertex 3.34565 3.71572 0
+    endloop
+  endfacet
+  facet normal -0.207915 -0.978147 0
+    outer loop
+      vertex 0.522642 4.97261 0
+      vertex 1.54508 4.75528 20
+      vertex 0.522642 4.97261 20
+    endloop
+  endfacet
+  facet normal -0.207915 -0.978147 -0
+    outer loop
+      vertex 1.54508 4.75528 20
+      vertex 0.522642 4.97261 0
+      vertex 1.54508 4.75528 0
+    endloop
+  endfacet
+  facet normal -0.743142 0.669133 0
+    outer loop
+      vertex 3.34565 -3.71572 0
+      vertex 4.04508 -2.93893 20
+      vertex 4.04508 -2.93893 0
+    endloop
+  endfacet
+  facet normal -0.743142 0.669133 0
+    outer loop
+      vertex 4.04508 -2.93893 20
+      vertex 3.34565 -3.71572 0
+      vertex 3.34565 -3.71572 20
+    endloop
+  endfacet
+  facet normal 0.994522 0.104526 0
+    outer loop
+      vertex -4.89074 -1.03956 20
+      vertex -5 0 0
+      vertex -5 0 20
+    endloop
+  endfacet
+  facet normal 0.994522 0.104526 0
+    outer loop
+      vertex -5 0 0
+      vertex -4.89074 -1.03956 20
+      vertex -4.89074 -1.03956 0
+    endloop
+  endfacet
+  facet normal 0.951056 0.309018 0
+    outer loop
+      vertex -4.56773 -2.03368 20
+      vertex -4.89074 -1.03956 0
+      vertex -4.89074 -1.03956 20
+    endloop
+  endfacet
+  facet normal 0.951056 0.309018 0
+    outer loop
+      vertex -4.89074 -1.03956 0
+      vertex -4.56773 -2.03368 20
+      vertex -4.56773 -2.03368 0
+    endloop
+  endfacet
+  facet normal 0.587791 0.809013 -0
+    outer loop
+      vertex -2.5 -4.33013 0
+      vertex -3.34565 -3.71572 20
+      vertex -2.5 -4.33013 20
+    endloop
+  endfacet
+  facet normal 0.587791 0.809013 0
+    outer loop
+      vertex -3.34565 -3.71572 20
+      vertex -2.5 -4.33013 0
+      vertex -3.34565 -3.71572 0
+    endloop
+  endfacet
+  facet normal 0.743142 0.669133 0
+    outer loop
+      vertex -3.34565 -3.71572 20
+      vertex -4.04508 -2.93893 0
+      vertex -4.04508 -2.93893 20
+    endloop
+  endfacet
+  facet normal 0.743142 0.669133 0
+    outer loop
+      vertex -4.04508 -2.93893 0
+      vertex -3.34565 -3.71572 20
+      vertex -3.34565 -3.71572 0
+    endloop
+  endfacet
+  facet normal 0.40673 0.913548 -0
+    outer loop
+      vertex -1.54508 -4.75528 0
+      vertex -2.5 -4.33013 20
+      vertex -1.54508 -4.75528 20
+    endloop
+  endfacet
+  facet normal 0.40673 0.913548 0
+    outer loop
+      vertex -2.5 -4.33013 20
+      vertex -1.54508 -4.75528 0
+      vertex -2.5 -4.33013 0
+    endloop
+  endfacet
+  facet normal 0.743142 -0.669133 0
+    outer loop
+      vertex -4.04508 2.93893 20
+      vertex -3.34565 3.71572 0
+      vertex -3.34565 3.71572 20
+    endloop
+  endfacet
+  facet normal 0.743142 -0.669133 0
+    outer loop
+      vertex -3.34565 3.71572 0
+      vertex -4.04508 2.93893 20
+      vertex -4.04508 2.93893 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/stl/shaft.stl
+++ b/stl/shaft.stl
@@ -1,0 +1,814 @@
+solid OpenSCAD_Model
+  facet normal 0.994522 0.104529 0
+    outer loop
+      vertex 4 0 150
+      vertex 3.91259 0.831647 0
+      vertex 3.91259 0.831647 150
+    endloop
+  endfacet
+  facet normal 0.994522 0.104529 0
+    outer loop
+      vertex 3.91259 0.831647 0
+      vertex 4 0 150
+      vertex 4 0 0
+    endloop
+  endfacet
+  facet normal 0.951056 0.309017 0
+    outer loop
+      vertex 3.91259 0.831647 150
+      vertex 3.65418 1.62695 0
+      vertex 3.65418 1.62695 150
+    endloop
+  endfacet
+  facet normal 0.951056 0.309017 0
+    outer loop
+      vertex 3.65418 1.62695 0
+      vertex 3.91259 0.831647 150
+      vertex 3.91259 0.831647 0
+    endloop
+  endfacet
+  facet normal 0.866026 0.499999 0
+    outer loop
+      vertex 3.65418 1.62695 150
+      vertex 3.23607 2.35114 0
+      vertex 3.23607 2.35114 150
+    endloop
+  endfacet
+  facet normal 0.866026 0.499999 0
+    outer loop
+      vertex 3.23607 2.35114 0
+      vertex 3.65418 1.62695 150
+      vertex 3.65418 1.62695 0
+    endloop
+  endfacet
+  facet normal 0.743143 0.669133 0
+    outer loop
+      vertex 3.23607 2.35114 150
+      vertex 2.67652 2.97258 0
+      vertex 2.67652 2.97258 150
+    endloop
+  endfacet
+  facet normal 0.743143 0.669133 0
+    outer loop
+      vertex 2.67652 2.97258 0
+      vertex 3.23607 2.35114 150
+      vertex 3.23607 2.35114 0
+    endloop
+  endfacet
+  facet normal 0.587785 0.809017 -0
+    outer loop
+      vertex 2.67652 2.97258 0
+      vertex 2 3.4641 150
+      vertex 2.67652 2.97258 150
+    endloop
+  endfacet
+  facet normal 0.587785 0.809017 0
+    outer loop
+      vertex 2 3.4641 150
+      vertex 2.67652 2.97258 0
+      vertex 2 3.4641 0
+    endloop
+  endfacet
+  facet normal 0.406743 0.913543 -0
+    outer loop
+      vertex 2 3.4641 0
+      vertex 1.23607 3.80423 150
+      vertex 2 3.4641 150
+    endloop
+  endfacet
+  facet normal 0.406743 0.913543 0
+    outer loop
+      vertex 1.23607 3.80423 150
+      vertex 2 3.4641 0
+      vertex 1.23607 3.80423 0
+    endloop
+  endfacet
+  facet normal 0.207909 0.978148 -0
+    outer loop
+      vertex 1.23607 3.80423 0
+      vertex 0.418114 3.97809 150
+      vertex 1.23607 3.80423 150
+    endloop
+  endfacet
+  facet normal 0.207909 0.978148 0
+    outer loop
+      vertex 0.418114 3.97809 150
+      vertex 1.23607 3.80423 0
+      vertex 0.418114 3.97809 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 0.418114 3.97809 0
+      vertex -0.418114 3.97809 150
+      vertex 0.418114 3.97809 150
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.418114 3.97809 150
+      vertex 0.418114 3.97809 0
+      vertex -0.418114 3.97809 0
+    endloop
+  endfacet
+  facet normal -0.207909 0.978148 0
+    outer loop
+      vertex -0.418114 3.97809 0
+      vertex -1.23607 3.80423 150
+      vertex -0.418114 3.97809 150
+    endloop
+  endfacet
+  facet normal -0.207909 0.978148 0
+    outer loop
+      vertex -1.23607 3.80423 150
+      vertex -0.418114 3.97809 0
+      vertex -1.23607 3.80423 0
+    endloop
+  endfacet
+  facet normal -0.406743 0.913543 0
+    outer loop
+      vertex -1.23607 3.80423 0
+      vertex -2 3.4641 150
+      vertex -1.23607 3.80423 150
+    endloop
+  endfacet
+  facet normal -0.406743 0.913543 0
+    outer loop
+      vertex -2 3.4641 150
+      vertex -1.23607 3.80423 0
+      vertex -2 3.4641 0
+    endloop
+  endfacet
+  facet normal -0.587785 0.809017 0
+    outer loop
+      vertex -2 3.4641 0
+      vertex -2.67652 2.97258 150
+      vertex -2 3.4641 150
+    endloop
+  endfacet
+  facet normal -0.587785 0.809017 0
+    outer loop
+      vertex -2.67652 2.97258 150
+      vertex -2 3.4641 0
+      vertex -2.67652 2.97258 0
+    endloop
+  endfacet
+  facet normal -0.743143 0.669133 0
+    outer loop
+      vertex -3.23607 2.35114 0
+      vertex -2.67652 2.97258 150
+      vertex -2.67652 2.97258 0
+    endloop
+  endfacet
+  facet normal -0.743143 0.669133 0
+    outer loop
+      vertex -2.67652 2.97258 150
+      vertex -3.23607 2.35114 0
+      vertex -3.23607 2.35114 150
+    endloop
+  endfacet
+  facet normal -0.866026 0.499999 0
+    outer loop
+      vertex -3.65418 1.62695 0
+      vertex -3.23607 2.35114 150
+      vertex -3.23607 2.35114 0
+    endloop
+  endfacet
+  facet normal -0.866026 0.499999 0
+    outer loop
+      vertex -3.23607 2.35114 150
+      vertex -3.65418 1.62695 0
+      vertex -3.65418 1.62695 150
+    endloop
+  endfacet
+  facet normal -0.951056 0.309017 0
+    outer loop
+      vertex -3.91259 0.831647 0
+      vertex -3.65418 1.62695 150
+      vertex -3.65418 1.62695 0
+    endloop
+  endfacet
+  facet normal -0.951056 0.309017 0
+    outer loop
+      vertex -3.65418 1.62695 150
+      vertex -3.91259 0.831647 0
+      vertex -3.91259 0.831647 150
+    endloop
+  endfacet
+  facet normal -0.994522 0.104529 0
+    outer loop
+      vertex -4 -0 0
+      vertex -3.91259 0.831647 150
+      vertex -3.91259 0.831647 0
+    endloop
+  endfacet
+  facet normal -0.994522 0.104529 0
+    outer loop
+      vertex -3.91259 0.831647 150
+      vertex -4 -0 0
+      vertex -4 -0 150
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104529 0
+    outer loop
+      vertex -3.91259 -0.831647 0
+      vertex -4 -0 150
+      vertex -4 -0 0
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104529 0
+    outer loop
+      vertex -4 -0 150
+      vertex -3.91259 -0.831647 0
+      vertex -3.91259 -0.831647 150
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309017 0
+    outer loop
+      vertex -3.65418 -1.62695 0
+      vertex -3.91259 -0.831647 150
+      vertex -3.91259 -0.831647 0
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309017 0
+    outer loop
+      vertex -3.91259 -0.831647 150
+      vertex -3.65418 -1.62695 0
+      vertex -3.65418 -1.62695 150
+    endloop
+  endfacet
+  facet normal -0.866026 -0.499999 0
+    outer loop
+      vertex -3.23607 -2.35114 0
+      vertex -3.65418 -1.62695 150
+      vertex -3.65418 -1.62695 0
+    endloop
+  endfacet
+  facet normal -0.866026 -0.499999 0
+    outer loop
+      vertex -3.65418 -1.62695 150
+      vertex -3.23607 -2.35114 0
+      vertex -3.23607 -2.35114 150
+    endloop
+  endfacet
+  facet normal -0.743143 -0.669133 0
+    outer loop
+      vertex -2.67652 -2.97258 0
+      vertex -3.23607 -2.35114 150
+      vertex -3.23607 -2.35114 0
+    endloop
+  endfacet
+  facet normal -0.743143 -0.669133 0
+    outer loop
+      vertex -3.23607 -2.35114 150
+      vertex -2.67652 -2.97258 0
+      vertex -2.67652 -2.97258 150
+    endloop
+  endfacet
+  facet normal -0.587785 -0.809017 0
+    outer loop
+      vertex -2.67652 -2.97258 0
+      vertex -2 -3.4641 150
+      vertex -2.67652 -2.97258 150
+    endloop
+  endfacet
+  facet normal -0.587785 -0.809017 -0
+    outer loop
+      vertex -2 -3.4641 150
+      vertex -2.67652 -2.97258 0
+      vertex -2 -3.4641 0
+    endloop
+  endfacet
+  facet normal -0.406743 -0.913543 0
+    outer loop
+      vertex -2 -3.4641 0
+      vertex -1.23607 -3.80423 150
+      vertex -2 -3.4641 150
+    endloop
+  endfacet
+  facet normal -0.406743 -0.913543 -0
+    outer loop
+      vertex -1.23607 -3.80423 150
+      vertex -2 -3.4641 0
+      vertex -1.23607 -3.80423 0
+    endloop
+  endfacet
+  facet normal -0.207909 -0.978148 0
+    outer loop
+      vertex -1.23607 -3.80423 0
+      vertex -0.418114 -3.97809 150
+      vertex -1.23607 -3.80423 150
+    endloop
+  endfacet
+  facet normal -0.207909 -0.978148 -0
+    outer loop
+      vertex -0.418114 -3.97809 150
+      vertex -1.23607 -3.80423 0
+      vertex -0.418114 -3.97809 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.418114 -3.97809 0
+      vertex 0.418114 -3.97809 150
+      vertex -0.418114 -3.97809 150
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 0.418114 -3.97809 150
+      vertex -0.418114 -3.97809 0
+      vertex 0.418114 -3.97809 0
+    endloop
+  endfacet
+  facet normal 0.207909 -0.978148 0
+    outer loop
+      vertex 0.418114 -3.97809 0
+      vertex 1.23607 -3.80423 150
+      vertex 0.418114 -3.97809 150
+    endloop
+  endfacet
+  facet normal 0.207909 -0.978148 0
+    outer loop
+      vertex 1.23607 -3.80423 150
+      vertex 0.418114 -3.97809 0
+      vertex 1.23607 -3.80423 0
+    endloop
+  endfacet
+  facet normal 0.406743 -0.913543 0
+    outer loop
+      vertex 1.23607 -3.80423 0
+      vertex 2 -3.4641 150
+      vertex 1.23607 -3.80423 150
+    endloop
+  endfacet
+  facet normal 0.406743 -0.913543 0
+    outer loop
+      vertex 2 -3.4641 150
+      vertex 1.23607 -3.80423 0
+      vertex 2 -3.4641 0
+    endloop
+  endfacet
+  facet normal 0.587785 -0.809017 0
+    outer loop
+      vertex 2 -3.4641 0
+      vertex 2.67652 -2.97258 150
+      vertex 2 -3.4641 150
+    endloop
+  endfacet
+  facet normal 0.587785 -0.809017 0
+    outer loop
+      vertex 2.67652 -2.97258 150
+      vertex 2 -3.4641 0
+      vertex 2.67652 -2.97258 0
+    endloop
+  endfacet
+  facet normal 0.743143 -0.669133 0
+    outer loop
+      vertex 2.67652 -2.97258 150
+      vertex 3.23607 -2.35114 0
+      vertex 3.23607 -2.35114 150
+    endloop
+  endfacet
+  facet normal 0.743143 -0.669133 0
+    outer loop
+      vertex 3.23607 -2.35114 0
+      vertex 2.67652 -2.97258 150
+      vertex 2.67652 -2.97258 0
+    endloop
+  endfacet
+  facet normal 0.866026 -0.499999 0
+    outer loop
+      vertex 3.23607 -2.35114 150
+      vertex 3.65418 -1.62695 0
+      vertex 3.65418 -1.62695 150
+    endloop
+  endfacet
+  facet normal 0.866026 -0.499999 0
+    outer loop
+      vertex 3.65418 -1.62695 0
+      vertex 3.23607 -2.35114 150
+      vertex 3.23607 -2.35114 0
+    endloop
+  endfacet
+  facet normal 0.951056 -0.309017 0
+    outer loop
+      vertex 3.65418 -1.62695 150
+      vertex 3.91259 -0.831647 0
+      vertex 3.91259 -0.831647 150
+    endloop
+  endfacet
+  facet normal 0.951056 -0.309017 0
+    outer loop
+      vertex 3.91259 -0.831647 0
+      vertex 3.65418 -1.62695 150
+      vertex 3.65418 -1.62695 0
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104529 0
+    outer loop
+      vertex 3.91259 -0.831647 150
+      vertex 4 0 0
+      vertex 4 0 150
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104529 0
+    outer loop
+      vertex 4 0 0
+      vertex 3.91259 -0.831647 150
+      vertex 3.91259 -0.831647 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.91259 -0.831647 0
+      vertex 3.91259 0.831647 0
+      vertex 4 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.65418 -1.62695 0
+      vertex 3.91259 0.831647 0
+      vertex 3.91259 -0.831647 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.65418 -1.62695 0
+      vertex 3.65418 1.62695 0
+      vertex 3.91259 0.831647 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.23607 -2.35114 0
+      vertex 3.65418 1.62695 0
+      vertex 3.65418 -1.62695 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.23607 -2.35114 0
+      vertex 3.23607 2.35114 0
+      vertex 3.65418 1.62695 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.67652 -2.97258 0
+      vertex 3.23607 2.35114 0
+      vertex 3.23607 -2.35114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.67652 -2.97258 0
+      vertex 2.67652 2.97258 0
+      vertex 3.23607 2.35114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2 -3.4641 0
+      vertex 2.67652 2.97258 0
+      vertex 2.67652 -2.97258 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2 -3.4641 0
+      vertex 2 3.4641 0
+      vertex 2.67652 2.97258 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.23607 -3.80423 0
+      vertex 2 3.4641 0
+      vertex 2 -3.4641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.23607 -3.80423 0
+      vertex 1.23607 3.80423 0
+      vertex 2 3.4641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.418114 -3.97809 0
+      vertex 1.23607 3.80423 0
+      vertex 1.23607 -3.80423 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.418114 -3.97809 0
+      vertex 0.418114 3.97809 0
+      vertex 1.23607 3.80423 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.418114 -3.97809 0
+      vertex 0.418114 3.97809 0
+      vertex 0.418114 -3.97809 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.418114 -3.97809 0
+      vertex -0.418114 3.97809 0
+      vertex 0.418114 3.97809 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.23607 -3.80423 0
+      vertex -0.418114 3.97809 0
+      vertex -0.418114 -3.97809 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.23607 -3.80423 0
+      vertex -1.23607 3.80423 0
+      vertex -0.418114 3.97809 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2 -3.4641 0
+      vertex -1.23607 3.80423 0
+      vertex -1.23607 -3.80423 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2 -3.4641 0
+      vertex -2 3.4641 0
+      vertex -1.23607 3.80423 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.67652 -2.97258 0
+      vertex -2 3.4641 0
+      vertex -2 -3.4641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.67652 -2.97258 0
+      vertex -2.67652 2.97258 0
+      vertex -2 3.4641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.23607 -2.35114 0
+      vertex -2.67652 2.97258 0
+      vertex -2.67652 -2.97258 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.23607 -2.35114 0
+      vertex -3.23607 2.35114 0
+      vertex -2.67652 2.97258 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.65418 -1.62695 0
+      vertex -3.23607 2.35114 0
+      vertex -3.23607 -2.35114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.65418 -1.62695 0
+      vertex -3.65418 1.62695 0
+      vertex -3.23607 2.35114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.91259 -0.831647 0
+      vertex -3.65418 1.62695 0
+      vertex -3.65418 -1.62695 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.91259 -0.831647 0
+      vertex -3.91259 0.831647 0
+      vertex -3.65418 1.62695 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -3.91259 0.831647 0
+      vertex -3.91259 -0.831647 0
+      vertex -4 -0 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.91259 0.831647 150
+      vertex 3.91259 -0.831647 150
+      vertex 4 0 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.65418 1.62695 150
+      vertex 3.91259 -0.831647 150
+      vertex 3.91259 0.831647 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.65418 1.62695 150
+      vertex 3.65418 -1.62695 150
+      vertex 3.91259 -0.831647 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.23607 2.35114 150
+      vertex 3.65418 -1.62695 150
+      vertex 3.65418 1.62695 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.23607 2.35114 150
+      vertex 3.23607 -2.35114 150
+      vertex 3.65418 -1.62695 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.67652 2.97258 150
+      vertex 3.23607 -2.35114 150
+      vertex 3.23607 2.35114 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.67652 2.97258 150
+      vertex 2.67652 -2.97258 150
+      vertex 3.23607 -2.35114 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2 3.4641 150
+      vertex 2.67652 -2.97258 150
+      vertex 2.67652 2.97258 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2 3.4641 150
+      vertex 2 -3.4641 150
+      vertex 2.67652 -2.97258 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.23607 3.80423 150
+      vertex 2 -3.4641 150
+      vertex 2 3.4641 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.23607 3.80423 150
+      vertex 1.23607 -3.80423 150
+      vertex 2 -3.4641 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.418114 3.97809 150
+      vertex 1.23607 -3.80423 150
+      vertex 1.23607 3.80423 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.418114 3.97809 150
+      vertex 0.418114 -3.97809 150
+      vertex 1.23607 -3.80423 150
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.418114 3.97809 150
+      vertex 0.418114 -3.97809 150
+      vertex 0.418114 3.97809 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.418114 3.97809 150
+      vertex -0.418114 -3.97809 150
+      vertex 0.418114 -3.97809 150
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.23607 3.80423 150
+      vertex -0.418114 -3.97809 150
+      vertex -0.418114 3.97809 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.23607 3.80423 150
+      vertex -1.23607 -3.80423 150
+      vertex -0.418114 -3.97809 150
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2 3.4641 150
+      vertex -1.23607 -3.80423 150
+      vertex -1.23607 3.80423 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2 3.4641 150
+      vertex -2 -3.4641 150
+      vertex -1.23607 -3.80423 150
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.67652 2.97258 150
+      vertex -2 -3.4641 150
+      vertex -2 3.4641 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.67652 2.97258 150
+      vertex -2.67652 -2.97258 150
+      vertex -2 -3.4641 150
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3.23607 2.35114 150
+      vertex -2.67652 -2.97258 150
+      vertex -2.67652 2.97258 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.23607 2.35114 150
+      vertex -3.23607 -2.35114 150
+      vertex -2.67652 -2.97258 150
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3.65418 1.62695 150
+      vertex -3.23607 -2.35114 150
+      vertex -3.23607 2.35114 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.65418 1.62695 150
+      vertex -3.65418 -1.62695 150
+      vertex -3.23607 -2.35114 150
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3.91259 0.831647 150
+      vertex -3.65418 -1.62695 150
+      vertex -3.65418 1.62695 150
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.91259 0.831647 150
+      vertex -3.91259 -0.831647 150
+      vertex -3.65418 -1.62695 150
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -3.91259 -0.831647 150
+      vertex -3.91259 0.831647 150
+      vertex -4 -0 150
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/stl/stand.stl
+++ b/stl/stand.stl
@@ -1,0 +1,926 @@
+solid OpenSCAD_Model
+  facet normal 1 0 0
+    outer loop
+      vertex 10 20 38.2511
+      vertex 10 40 59
+      vertex 10 20 57.7489
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 10 0 59
+      vertex 10 20 57.7489
+      vertex 10 40 59
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 10 8 57.7489
+      vertex 10 0 59
+      vertex 10 8 38.2511
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 10 20 57.7489
+      vertex 10 0 59
+      vertex 10 8 57.7489
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 10 40 59
+      vertex 10 20 38.2511
+      vertex 10 40 8
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 10 0 8
+      vertex 10 20 38.2511
+      vertex 10 8 38.2511
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 10 20 38.2511
+      vertex 10 0 8
+      vertex 10 40 8
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 10 0 8
+      vertex 10 8 38.2511
+      vertex 10 0 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 40 59
+      vertex 10 0 59
+      vertex 10 40 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 0 59
+      vertex 0 40 59
+      vertex 0 0 59
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 100 40 0
+      vertex 100 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 100 40 0
+      vertex 0 0 0
+      vertex 0 40 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 40 0
+      vertex 0 20 38.2511
+      vertex 0 40 59
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 38.2511
+      vertex 0 40 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 59
+      vertex 0 8 38.2511
+      vertex 0 0 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 0 20 38.2511
+      vertex 0 0 0
+      vertex 0 8 38.2511
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 20 57.7489
+      vertex 0 40 59
+      vertex 0 20 38.2511
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 59
+      vertex 0 20 57.7489
+      vertex 0 8 57.7489
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 20 57.7489
+      vertex 0 0 59
+      vertex 0 40 59
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 8 38.2511
+      vertex 0 0 59
+      vertex 0 8 57.7489
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 100 40 59
+      vertex 90 40 8
+      vertex 90 40 59
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 90 40 8
+      vertex 100 40 0
+      vertex 10 40 8
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 100 40 0
+      vertex 90 40 8
+      vertex 100 40 59
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 10 40 8
+      vertex 0 40 59
+      vertex 10 40 59
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 10 40 8
+      vertex 0 40 0
+      vertex 0 40 59
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 40 0
+      vertex 10 40 8
+      vertex 100 40 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 59
+      vertex 10 0 8
+      vertex 10 0 59
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 10 0 8
+      vertex 0 0 0
+      vertex 90 0 8
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 10 0 8
+      vertex 0 0 59
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 90 0 8
+      vertex 100 0 59
+      vertex 90 0 59
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 90 0 8
+      vertex 100 0 0
+      vertex 100 0 59
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 100 0 0
+      vertex 90 0 8
+      vertex 0 0 0
+    endloop
+  endfacet
+  facet normal 0.207903 0 0.978149
+    outer loop
+      vertex 1.60081 20 37.5384
+      vertex 3.85019 8 37.0603
+      vertex 3.85019 20 37.0603
+    endloop
+  endfacet
+  facet normal 0.207903 0 0.978149
+    outer loop
+      vertex 3.85019 8 37.0603
+      vertex 1.60081 20 37.5384
+      vertex 1.60081 8 37.5384
+    endloop
+  endfacet
+  facet normal -0.207903 0 -0.978149
+    outer loop
+      vertex 6.14981 8 58.9397
+      vertex 8.39919 20 58.4616
+      vertex 8.39919 8 58.4616
+    endloop
+  endfacet
+  facet normal -0.207903 0 -0.978149
+    outer loop
+      vertex 8.39919 20 58.4616
+      vertex 6.14981 8 58.9397
+      vertex 6.14981 20 58.9397
+    endloop
+  endfacet
+  facet normal 0.207903 0 -0.978149
+    outer loop
+      vertex 1.60081 8 58.4616
+      vertex 3.85019 20 58.9397
+      vertex 3.85019 8 58.9397
+    endloop
+  endfacet
+  facet normal 0.207903 0 -0.978149
+    outer loop
+      vertex 3.85019 20 58.9397
+      vertex 1.60081 8 58.4616
+      vertex 1.60081 20 58.4616
+    endloop
+  endfacet
+  facet normal 0.406724 0 0.913551
+    outer loop
+      vertex 0 20 38.2511
+      vertex 1.60081 8 37.5384
+      vertex 1.60081 20 37.5384
+    endloop
+  endfacet
+  facet normal 0.406724 0 0.913551
+    outer loop
+      vertex 1.60081 8 37.5384
+      vertex 0 20 38.2511
+      vertex 0 8 38.2511
+    endloop
+  endfacet
+  facet normal -0.406724 0 -0.913551
+    outer loop
+      vertex 8.39919 8 58.4616
+      vertex 10 20 57.7489
+      vertex 10 8 57.7489
+    endloop
+  endfacet
+  facet normal -0.406724 0 -0.913551
+    outer loop
+      vertex 10 20 57.7489
+      vertex 8.39919 8 58.4616
+      vertex 8.39919 20 58.4616
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.85019 8 58.9397
+      vertex 6.14981 20 58.9397
+      vertex 6.14981 8 58.9397
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 6.14981 20 58.9397
+      vertex 3.85019 8 58.9397
+      vertex 3.85019 20 58.9397
+    endloop
+  endfacet
+  facet normal 0.406724 0 -0.913551
+    outer loop
+      vertex 0 8 57.7489
+      vertex 1.60081 20 58.4616
+      vertex 1.60081 8 58.4616
+    endloop
+  endfacet
+  facet normal 0.406724 0 -0.913551
+    outer loop
+      vertex 1.60081 20 58.4616
+      vertex 0 8 57.7489
+      vertex 0 20 57.7489
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.85019 20 37.0603
+      vertex 6.14981 8 37.0603
+      vertex 6.14981 20 37.0603
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.14981 8 37.0603
+      vertex 3.85019 20 37.0603
+      vertex 3.85019 8 37.0603
+    endloop
+  endfacet
+  facet normal -0.207903 0 0.978149
+    outer loop
+      vertex 6.14981 20 37.0603
+      vertex 8.39919 8 37.5384
+      vertex 8.39919 20 37.5384
+    endloop
+  endfacet
+  facet normal -0.207903 0 0.978149
+    outer loop
+      vertex 8.39919 8 37.5384
+      vertex 6.14981 20 37.0603
+      vertex 6.14981 8 37.0603
+    endloop
+  endfacet
+  facet normal -0.406724 0 0.913551
+    outer loop
+      vertex 8.39919 20 37.5384
+      vertex 10 8 38.2511
+      vertex 10 20 38.2511
+    endloop
+  endfacet
+  facet normal -0.406724 0 0.913551
+    outer loop
+      vertex 10 8 38.2511
+      vertex 8.39919 20 37.5384
+      vertex 8.39919 8 37.5384
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 10 8 57.7489
+      vertex 6.14981 8 58.9397
+      vertex 8.39919 8 58.4616
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 6.14981 8 58.9397
+      vertex 10 8 57.7489
+      vertex 3.85019 8 58.9397
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 8 57.7489
+      vertex 3.85019 8 58.9397
+      vertex 10 8 57.7489
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.85019 8 58.9397
+      vertex 0 8 57.7489
+      vertex 1.60081 8 58.4616
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 10 8 38.2511
+      vertex 0 8 57.7489
+      vertex 10 8 57.7489
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 10 8 38.2511
+      vertex 0 8 38.2511
+      vertex 0 8 57.7489
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 6.14981 8 37.0603
+      vertex 10 8 38.2511
+      vertex 8.39919 8 37.5384
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 10 8 38.2511
+      vertex 6.14981 8 37.0603
+      vertex 0 8 38.2511
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3.85019 8 37.0603
+      vertex 0 8 38.2511
+      vertex 6.14981 8 37.0603
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 8 38.2511
+      vertex 3.85019 8 37.0603
+      vertex 1.60081 8 37.5384
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 20 57.7489
+      vertex 3.85019 20 58.9397
+      vertex 1.60081 20 58.4616
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 3.85019 20 58.9397
+      vertex 0 20 57.7489
+      vertex 6.14981 20 58.9397
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 10 20 57.7489
+      vertex 6.14981 20 58.9397
+      vertex 0 20 57.7489
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 6.14981 20 58.9397
+      vertex 10 20 57.7489
+      vertex 8.39919 20 58.4616
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 20 38.2511
+      vertex 10 20 57.7489
+      vertex 0 20 57.7489
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 20 38.2511
+      vertex 10 20 38.2511
+      vertex 10 20 57.7489
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 3.85019 20 37.0603
+      vertex 0 20 38.2511
+      vertex 1.60081 20 37.5384
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 20 38.2511
+      vertex 3.85019 20 37.0603
+      vertex 10 20 38.2511
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 6.14981 20 37.0603
+      vertex 10 20 38.2511
+      vertex 3.85019 20 37.0603
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 10 20 38.2511
+      vertex 6.14981 20 37.0603
+      vertex 8.39919 20 37.5384
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 100 20 38.2511
+      vertex 100 40 59
+      vertex 100 20 57.7489
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 100 0 59
+      vertex 100 20 57.7489
+      vertex 100 40 59
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 100 8 57.7489
+      vertex 100 0 59
+      vertex 100 8 38.2511
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 100 20 57.7489
+      vertex 100 0 59
+      vertex 100 8 57.7489
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 100 40 59
+      vertex 100 20 38.2511
+      vertex 100 40 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 100 0 0
+      vertex 100 20 38.2511
+      vertex 100 8 38.2511
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 100 20 38.2511
+      vertex 100 0 0
+      vertex 100 40 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 100 0 0
+      vertex 100 8 38.2511
+      vertex 100 0 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 90 40 59
+      vertex 100 0 59
+      vertex 100 40 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 100 0 59
+      vertex 90 40 59
+      vertex 90 0 59
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 90 40 8
+      vertex 90 20 38.2511
+      vertex 90 40 59
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 90 0 8
+      vertex 90 20 38.2511
+      vertex 90 40 8
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 90 0 59
+      vertex 90 8 38.2511
+      vertex 90 0 8
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 90 20 38.2511
+      vertex 90 0 8
+      vertex 90 8 38.2511
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 90 20 57.7489
+      vertex 90 40 59
+      vertex 90 20 38.2511
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 90 0 59
+      vertex 90 20 57.7489
+      vertex 90 8 57.7489
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 90 20 57.7489
+      vertex 90 0 59
+      vertex 90 40 59
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 90 8 38.2511
+      vertex 90 0 59
+      vertex 90 8 57.7489
+    endloop
+  endfacet
+  facet normal 0.207901 0 0.97815
+    outer loop
+      vertex 91.6008 20 37.5384
+      vertex 93.8502 8 37.0603
+      vertex 93.8502 20 37.0603
+    endloop
+  endfacet
+  facet normal 0.207901 0 0.97815
+    outer loop
+      vertex 93.8502 8 37.0603
+      vertex 91.6008 20 37.5384
+      vertex 91.6008 8 37.5384
+    endloop
+  endfacet
+  facet normal -0.207901 0 -0.97815
+    outer loop
+      vertex 96.1498 8 58.9397
+      vertex 98.3992 20 58.4616
+      vertex 98.3992 8 58.4616
+    endloop
+  endfacet
+  facet normal -0.207901 0 -0.97815
+    outer loop
+      vertex 98.3992 20 58.4616
+      vertex 96.1498 8 58.9397
+      vertex 96.1498 20 58.9397
+    endloop
+  endfacet
+  facet normal 0.207901 0 -0.97815
+    outer loop
+      vertex 91.6008 8 58.4616
+      vertex 93.8502 20 58.9397
+      vertex 93.8502 8 58.9397
+    endloop
+  endfacet
+  facet normal 0.207901 0 -0.97815
+    outer loop
+      vertex 93.8502 20 58.9397
+      vertex 91.6008 8 58.4616
+      vertex 91.6008 20 58.4616
+    endloop
+  endfacet
+  facet normal 0.406726 0 0.91355
+    outer loop
+      vertex 90 20 38.2511
+      vertex 91.6008 8 37.5384
+      vertex 91.6008 20 37.5384
+    endloop
+  endfacet
+  facet normal 0.406726 0 0.91355
+    outer loop
+      vertex 91.6008 8 37.5384
+      vertex 90 20 38.2511
+      vertex 90 8 38.2511
+    endloop
+  endfacet
+  facet normal -0.406726 0 -0.91355
+    outer loop
+      vertex 98.3992 8 58.4616
+      vertex 100 20 57.7489
+      vertex 100 8 57.7489
+    endloop
+  endfacet
+  facet normal -0.406726 0 -0.91355
+    outer loop
+      vertex 100 20 57.7489
+      vertex 98.3992 8 58.4616
+      vertex 98.3992 20 58.4616
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 93.8502 8 58.9397
+      vertex 96.1498 20 58.9397
+      vertex 96.1498 8 58.9397
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 96.1498 20 58.9397
+      vertex 93.8502 8 58.9397
+      vertex 93.8502 20 58.9397
+    endloop
+  endfacet
+  facet normal 0.406726 0 -0.91355
+    outer loop
+      vertex 90 8 57.7489
+      vertex 91.6008 20 58.4616
+      vertex 91.6008 8 58.4616
+    endloop
+  endfacet
+  facet normal 0.406726 0 -0.91355
+    outer loop
+      vertex 91.6008 20 58.4616
+      vertex 90 8 57.7489
+      vertex 90 20 57.7489
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 93.8502 20 37.0603
+      vertex 96.1498 8 37.0603
+      vertex 96.1498 20 37.0603
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 96.1498 8 37.0603
+      vertex 93.8502 20 37.0603
+      vertex 93.8502 8 37.0603
+    endloop
+  endfacet
+  facet normal -0.207901 0 0.97815
+    outer loop
+      vertex 96.1498 20 37.0603
+      vertex 98.3992 8 37.5384
+      vertex 98.3992 20 37.5384
+    endloop
+  endfacet
+  facet normal -0.207901 0 0.97815
+    outer loop
+      vertex 98.3992 8 37.5384
+      vertex 96.1498 20 37.0603
+      vertex 96.1498 8 37.0603
+    endloop
+  endfacet
+  facet normal -0.406726 0 0.91355
+    outer loop
+      vertex 98.3992 20 37.5384
+      vertex 100 8 38.2511
+      vertex 100 20 38.2511
+    endloop
+  endfacet
+  facet normal -0.406726 0 0.91355
+    outer loop
+      vertex 100 8 38.2511
+      vertex 98.3992 20 37.5384
+      vertex 98.3992 8 37.5384
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 100 8 57.7489
+      vertex 96.1498 8 58.9397
+      vertex 98.3992 8 58.4616
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 96.1498 8 58.9397
+      vertex 100 8 57.7489
+      vertex 93.8502 8 58.9397
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 90 8 57.7489
+      vertex 93.8502 8 58.9397
+      vertex 100 8 57.7489
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 93.8502 8 58.9397
+      vertex 90 8 57.7489
+      vertex 91.6008 8 58.4616
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 100 8 38.2511
+      vertex 90 8 57.7489
+      vertex 100 8 57.7489
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 100 8 38.2511
+      vertex 90 8 38.2511
+      vertex 90 8 57.7489
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 96.1498 8 37.0603
+      vertex 100 8 38.2511
+      vertex 98.3992 8 37.5384
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 100 8 38.2511
+      vertex 96.1498 8 37.0603
+      vertex 90 8 38.2511
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 93.8502 8 37.0603
+      vertex 90 8 38.2511
+      vertex 96.1498 8 37.0603
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 90 8 38.2511
+      vertex 93.8502 8 37.0603
+      vertex 91.6008 8 37.5384
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 90 20 57.7489
+      vertex 93.8502 20 58.9397
+      vertex 91.6008 20 58.4616
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 93.8502 20 58.9397
+      vertex 90 20 57.7489
+      vertex 96.1498 20 58.9397
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 100 20 57.7489
+      vertex 96.1498 20 58.9397
+      vertex 90 20 57.7489
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 96.1498 20 58.9397
+      vertex 100 20 57.7489
+      vertex 98.3992 20 58.4616
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 90 20 38.2511
+      vertex 100 20 57.7489
+      vertex 90 20 57.7489
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 90 20 38.2511
+      vertex 100 20 38.2511
+      vertex 100 20 57.7489
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 93.8502 20 37.0603
+      vertex 90 20 38.2511
+      vertex 91.6008 20 37.5384
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 90 20 38.2511
+      vertex 93.8502 20 37.0603
+      vertex 100 20 38.2511
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 96.1498 20 37.0603
+      vertex 100 20 38.2511
+      vertex 93.8502 20 37.0603
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 100 20 38.2511
+      vertex 96.1498 20 37.0603
+      vertex 98.3992 20 37.5384
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10 40 8
+      vertex 90 0 8
+      vertex 90 40 8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 90 0 8
+      vertex 10 40 8
+      vertex 10 0 8
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
## Summary
- generate STL files from SCAD sources via `scripts/build_stl.sh`
- run nightly GitHub Actions workflow to convert SCAD files to STL and commit
- document STL workflow and artifacts
- include generated STL models

## Testing
- `pre-commit run --all-files`
- `npm run jest --silent`
- `npx playwright install --with-deps`
- `npx playwright test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687047ede0f8832f885e6c0be93f6236