### PR TITLE
Improve audit coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ Pass `--token YOURTOKEN` or set `GITHUB_TOKEN` to avoid API rate limits.
 The table in `docs/repo-feature-summary.md` is automatically refreshed after each commit via GitHub Actions.
 The summary now records the short SHA of the latest commit and the name of each repository's default branch.
 
+### Auditing dev tooling
+
+Verify that a repository contains the expected CI workflows and config files:
+
+```bash
+flywheel audit path/to/repo
+```
+
 ## Values
 
 We aim for a positive-sum, empathetic community. The flywheel embraces regenerative and open-source principles to keep energy cycling back into every project.

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -6,11 +6,11 @@ This table tracks which flywheel features each related repository has adopted.
 ## Basics
 | Repo | Branch | Commit |
 | ---- | ------ | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `6698ae0` |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `55e79dc` |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `3eb7ec7` |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `2da14d3` |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `2f860ed` |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `7873d3e` |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `5f4452a` |
 | [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `72a2032` |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | `25cd2c6` |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | `64d265f` |
@@ -23,7 +23,7 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | 🔶 partial |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (93%) | — | pip |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | pip |
 | [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (78%) | — | pip |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | 🚀 uv |

--- a/flywheel/__main__.py
+++ b/flywheel/__main__.py
@@ -41,6 +41,19 @@ def inject_dev(target: Path) -> None:
         copy_file(ROOT / rel, target / rel)
 
 
+def audit_repo(target: Path) -> None:
+    missing = []
+    for rel in WORKFLOW_FILES + OTHER_FILES:
+        if not (target / rel).exists():
+            missing.append(rel)
+    if missing:
+        print("Missing dev tooling files:")
+        for rel in missing:
+            print(f" - {rel}")
+    else:
+        print("All dev tooling files present.")
+
+
 def prompt_bool(question: str, default: bool) -> bool:
     suffix = "Y/n" if default else "y/N"
     resp = input(f"{question} [{suffix}]: ").strip().lower()
@@ -129,7 +142,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_audit = sub.add_parser("audit", help="check for missing tooling")
     p_audit.add_argument("path", help="repository path")
-    p_audit.set_defaults(func=lambda a: print("TODO: audit not implemented"))
+    p_audit.set_defaults(func=lambda a: audit_repo(Path(a.path)))
 
     p_prompt = sub.add_parser("prompt", help="generate Codex prompt")
     p_prompt.add_argument(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,7 +17,16 @@ def test_main_audit(capsys, tmp_path):
     repo.mkdir()
     fm.main(["audit", str(repo)])
     out = capsys.readouterr().out
-    assert "TODO" in out
+    assert "Missing dev tooling files" in out
+
+
+def test_main_audit_all_present(capsys, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    fm.inject_dev(repo)
+    fm.main(["audit", str(repo)])
+    out = capsys.readouterr().out
+    assert "All dev tooling files present." in out
 
 
 def test_main_crawl(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- update README instructions for verifying dev tooling
- add a simple `audit_repo` helper and connect CLI
- test that the audit command reports success when files exist

## Testing
- `pre-commit run --all-files`
- `pytest --cov=flywheel --cov-report=term --cov-fail-under=100 -q`

------
https://chatgpt.com/codex/tasks/task_e_68749fc787a0832fba6f814cc7ca3a75