### PR TITLE
Switch workflows to uv

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           npm install --no-audit --no-fund
           npx playwright install --with-deps
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
           npm test -- --coverage --coverageReporters=lcov
 
       # --- Upload coverage only if the matching report exists ---

--- a/docs/best_practices_catalog.md
+++ b/docs/best_practices_catalog.md
@@ -86,4 +86,3 @@ Each section covers three points:
 - Keep links to other docs (README, AGENTS, style guides) current.
 - LLM agents should scan for config changes on each push and propose updates here.
 - Humans can open small PRs to clarify steps or fix typos.
-

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -19,7 +19,7 @@ This table tracks which flywheel features each related repository has adopted.
 ## Coverage & Installer
 | Repo | Coverage | Patch | Installer |
 | ---- | -------- | ----- | --------- |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (20%) | — | 🔶 partial |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (20%) | — | 🚀 uv |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | 🔶 partial |

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -6,25 +6,25 @@ This table tracks which flywheel features each related repository has adopted.
 ## Basics
 | Repo | Branch | Commit |
 | ---- | ------ | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `4a0a7e7` |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `258e24b` |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `3eb7ec7` |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `2da14d3` |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `2f860ed` |
 | [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `5f4452a` |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `c9cb08b` |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `ce6f28f` |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | `25cd2c6` |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | `64d265f` |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | `d9db0fa` |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | `9438883` |
 
 ## Coverage & Installer
 | Repo | Coverage | Patch | Installer |
 | ---- | -------- | ----- | --------- |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (20%) | — | 🚀 uv |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (20%) | — | 🔶 partial |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | 🔶 partial |
 | [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | pip |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (82%) | — | pip |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (92%) | — | pip |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | ❌ | — | pip |
@@ -40,6 +40,6 @@ This table tracks which flywheel features each related repository has adopted.
 | [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ❌ |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ✅ |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ✅ |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ❌ | 0 | ✅ | ❌ | ❌ | ❌ |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ✅ | 2 | ✅ | ✅ | ✅ | ✅ |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time.


### PR DESCRIPTION
## Summary
- use `uv` pip install in JS test workflow
- show `uv` installer for flywheel in repo summary
- fix missing newline

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_6874af641724832fb00b404ea7260cad