### PR TITLE
Fix patch coverage retrieval

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -6,15 +6,15 @@ This table tracks which flywheel features each related repository has adopted.
 ## Basics
 | Repo | Branch | Commit |
 | ---- | ------ | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `4a0a7e7` |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `f32fe53` |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `3eb7ec7` |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `2da14d3` |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `2f860ed` |
 | [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `5f4452a` |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `c9cb08b` |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `4c4a860` |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | `25cd2c6` |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | `64d265f` |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | `d9db0fa` |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | `9438883` |
 
 ## Coverage & Installer
 | Repo | Coverage | Patch | Installer |
@@ -23,8 +23,8 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | 🔶 partial |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | pip |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (82%) | — | pip |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | ❌ (0%) | pip |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (99%) | — | pip |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | ❌ | — | pip |
@@ -40,6 +40,6 @@ This table tracks which flywheel features each related repository has adopted.
 | [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ❌ |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ✅ |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ✅ |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ❌ | 0 | ✅ | ❌ | ❌ | ❌ |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ✅ | 2 | ✅ | ✅ | ✅ | ✅ |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time.

--- a/tests/test_coverage_errors.py
+++ b/tests/test_coverage_errors.py
@@ -47,6 +47,11 @@ def test_patch_coverage_token_and_errors(monkeypatch):
 
     sess = Sess()
     crawler = RepoCrawler([], session=sess)
+    monkeypatch.setattr(
+        crawler,
+        "_recent_commits",
+        lambda *a, **kw: ["h", "b"],
+    )
     monkeypatch.setenv("CODECOV_TOKEN", "abc")
     monkeypatch.setattr(crawler, "_badge_patch_percent", lambda *a, **kw: 42.0)
     pct = crawler._patch_coverage_from_codecov("foo/bar", "main")
@@ -73,6 +78,11 @@ def test_patch_coverage_compare_on_error(monkeypatch):
                 return Resp()
 
     crawler = RepoCrawler([], session=Sess())
+    monkeypatch.setattr(
+        crawler,
+        "_recent_commits",
+        lambda *a, **kw: ["h", "b"],
+    )
     pct = crawler._patch_coverage_from_codecov("foo/bar", "main")
     assert pct == 77.0
 
@@ -97,4 +107,9 @@ def test_patch_coverage_compare_request_exception(monkeypatch):
 
     crawler = RepoCrawler([], session=Sess())
     monkeypatch.setattr(crawler, "_badge_patch_percent", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        crawler,
+        "_recent_commits",
+        lambda *a, **kw: [],
+    )
     assert crawler._patch_coverage_from_codecov("foo/bar", "main") is None

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -24,6 +24,8 @@ class DummySession:
         if url.startswith("https://api.github.com/repos/"):
             if url.endswith("/commits?per_page=1&sha=main"):
                 return Resp('[{"sha": "deadbeef"}]', 200)
+            if url.endswith("/commits?per_page=2&sha=main"):
+                return Resp('[{"sha": "cafecafe"}, {"sha": "deadbeef"}]', 200)
             if "/contents/.github/workflows" in url:
                 import json
 


### PR DESCRIPTION
## Summary
- fetch latest commit SHAs via `_recent_commits`
- query Codecov compare endpoint with real SHAs
- fall back to `HEAD~1`/`HEAD` when commit history is unavailable
- update tests for new helper

## Testing
- `pre-commit run --files flywheel/repocrawler.py tests/test_coverage_errors.py tests/test_repocrawler.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874ae8e143c832f9ae98bc8c7a27ac1