### PR TITLE
Add sugarkube to tracked repos

### DIFF
--- a/.github/workflows/04-update-summary.yml
+++ b/.github/workflows/04-update-summary.yml
@@ -21,7 +21,7 @@ jobs:
           uv pip install --system pre-commit
       - name: Generate summary
         run: |
-          python -m flywheel crawl futuroptimist/flywheel futuroptimist/axel futuroptimist/gabriel futuroptimist/futuroptimist futuroptimist/token.place democratizedspace/dspace@v3 futuroptimist/f2clipboard futuroptimist/sigma futuroptimist/wove --output docs/repo-feature-summary.md
+          python -m flywheel crawl futuroptimist/flywheel futuroptimist/axel futuroptimist/gabriel futuroptimist/futuroptimist futuroptimist/token.place democratizedspace/dspace@v3 futuroptimist/f2clipboard futuroptimist/sigma futuroptimist/wove futuropimist/sugarkube --output docs/repo-feature-summary.md
       - name: Run pre-commit
         run: |
           pre-commit run --files docs/repo-feature-summary.md || true

--- a/README.md
+++ b/README.md
@@ -117,5 +117,6 @@ We aim for a positive-sum, empathetic community. The flywheel embraces regenerat
 - [DSPACE](https://github.com/democratizedspace/dspace) – offline-first idle simulation with maker quests. See `docs/dspace-integration.md` for quest ideas.
 - [f2clipboard](https://github.com/futuroptimist/f2clipboard) – bulk-copy utility exploring macro workflows. See `docs/f2clipboard-integration.md`.
 - [Sigma](https://github.com/futuroptimist/sigma) – ESP32 "AI pin" hardware. See `docs/sigma-integration.md`.
+- [sugarkube](https://github.com/futuroptimist/sugarkube) – accessible k3s platform for RPis with off-grid solar. See `docs/sugarkube-integration.md`.
 
 A summary of flywheel features adopted across repos lives in [docs/repo-feature-summary.md](docs/repo-feature-summary.md).

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -8,7 +8,7 @@ This table tracks which flywheel features each related repository has adopted.
 | ---- | ------ | ------ |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `84f8204` |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `3eb7ec7` |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `2da14d3` |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `f794ae6` |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `2f860ed` |
 | [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `bda1c4a` |
 | [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `8ba17a3` |

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -6,15 +6,16 @@ This table tracks which flywheel features each related repository has adopted.
 ## Basics
 | Repo | Branch | Commit |
 | ---- | ------ | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `3cbbf44` |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `84f8204` |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `3eb7ec7` |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `2da14d3` |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `2f860ed` |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `5f4452a` |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `40c0880` |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `bda1c4a` |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `8ba17a3` |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | `25cd2c6` |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | n/a |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | n/a |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | `64d265f` |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | `9438883` |
+| [futuropimist/sugarkube](https://github.com/futuropimist/sugarkube) | main | n/a |
 
 ## Coverage & Installer
 | Repo | Coverage | Patch | Installer |
@@ -23,11 +24,12 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | 🔶 partial |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | ❌ (0%) | pip |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | pip |
 | [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (100%) | — | pip |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | ❌ | — | pip |
+| [futuropimist/sugarkube](https://github.com/futuropimist/sugarkube) | ❌ | — | pip |
 
 ## Policies & Automation
 | Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
@@ -40,6 +42,7 @@ This table tracks which flywheel features each related repository has adopted.
 | [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ❌ |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ✅ |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ✅ |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ✅ | 2 | ✅ | ✅ | ✅ | ✅ |
+| [futuropimist/sugarkube](https://github.com/futuropimist/sugarkube) | ❌ | ❌ | 0 | ❌ | ❌ | ❌ | ❌ |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time.

--- a/docs/sugarkube-integration.md
+++ b/docs/sugarkube-integration.md
@@ -1,0 +1,22 @@
+# Integrating with sugarkube
+
+[sugarkube](https://github.com/futuroptimist/sugarkube) is an accessible k3s platform targeting Raspberry Pi and similar devices. It bundles off-grid solar and cellular connectivity for outage-resistant web hosting.
+
+## Why sugarkube Matters
+
+- Showcases Flywheel's tooling on infrastructure projects.
+- Provides a platform to test LLM agents in remote or offline environments.
+- Shares CI configuration and docs with this repository.
+
+## Quick start
+
+Clone the repository and explore the setup scripts:
+
+```bash
+git clone https://github.com/futuroptimist/sugarkube
+cd sugarkube
+# follow the README to provision the cluster
+```
+
+Future updates may sync agent prompts and automation between Flywheel and sugarkube for consistent deployments.
+


### PR DESCRIPTION
## Summary
- include `sugarkube` in the auto-generated repo summary
- mention the repo in README
- update workflow to crawl `sugarkube`
- document integration steps for the new repo

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_6875fcd906b8832f8bbf714fb3f755df