### PR TITLE
Fix end-of-file and PAT issue

### DIFF
--- a/.github/workflows/04-update-summary.yml
+++ b/.github/workflows/04-update-summary.yml
@@ -27,6 +27,10 @@ jobs:
           pre-commit run --files docs/repo-feature-summary.md || true
           git add docs/repo-feature-summary.md
           pre-commit run --files docs/repo-feature-summary.md
+      - name: Set up PAT
+        run: git remote set-url origin https://$TOKEN@github.com/futuroptimist/flywheel.git
+        env:
+          TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - name: Commit changes
         run: |
           git config user.name github-actions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,5 @@ repos:
           - requests
           - Flask
           - responses
+          - trimesh
         pass_filenames: false

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -103,3 +103,5 @@ repurpose
 config
 PRs
 changelogs
+STLs
+sugarkube

--- a/README.md
+++ b/README.md
@@ -104,6 +104,26 @@ Verify that a repository contains the expected CI workflows and config files:
 flywheel audit path/to/repo
 ```
 
+### Viewing the 3D flywheel
+
+Run the bundled Flask app to explore the CAD models:
+
+```bash
+python webapp/app.py
+```
+
+Visit `http://localhost:42165` and watch the wheel spin in your browser.
+
+### Verifying CAD fit
+
+Run a quick check to ensure the STLs match their SCAD sources:
+
+```bash
+python -m flywheel.fit
+```
+
+If no assertions fail, the printed message confirms the parts align correctly.
+
 ## Values
 
 We aim for a positive-sum, empathetic community. The flywheel embraces regenerative and open-source principles to keep energy cycling back into every project.

--- a/flywheel/fit.py
+++ b/flywheel/fit.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Dict, Tuple
+
+import trimesh
+
+_DEF_RE = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*([0-9.]+);")
+
+
+def parse_scad_vars(path: Path) -> Dict[str, float]:
+    """Return variable assignments parsed from a SCAD file."""
+    vars: Dict[str, float] = {}
+    for line in Path(path).read_text().splitlines():
+        m = _DEF_RE.match(line.strip())
+        if m:
+            vars[m.group(1)] = float(m.group(2))
+    return vars
+
+
+def _dims(stl_path: Path) -> Tuple[float, float, float]:
+    """Return (x, y, z) dimensions of the STL mesh."""
+    mesh = trimesh.load_mesh(stl_path)
+    bounds = mesh.bounds
+    diff = bounds[1] - bounds[0]
+    return float(diff[0]), float(diff[1]), float(diff[2])
+
+
+def verify_fit(
+    scad_dir: Path = Path("cad"),
+    stl_dir: Path = Path("stl"),
+) -> bool:
+    """Check that CAD parameters align across parts and match exported STLs."""
+    adapter = parse_scad_vars(scad_dir / "adapter.scad")
+    shaft = parse_scad_vars(scad_dir / "shaft.scad")
+    wheel = parse_scad_vars(scad_dir / "flywheel.scad")
+    stand = parse_scad_vars(scad_dir / "stand.scad")
+
+    # Basic parameter relationships
+    assert shaft["shaft_diameter"] == adapter["shaft_diameter"]
+    assert wheel["shaft_diameter"] >= shaft["shaft_diameter"]
+    assert stand["bearing_outer_d"] > shaft["shaft_diameter"]
+
+    tol = 0.1
+
+    shaft_dims = _dims(stl_dir / "shaft.stl")
+    assert abs(shaft_dims[2] - shaft["shaft_length"]) < tol
+    assert any(abs(d - shaft["shaft_diameter"]) < tol for d in shaft_dims[:2])
+
+    wheel_dims = _dims(stl_dir / "flywheel.stl")
+    assert abs(wheel_dims[0] - 2 * wheel["radius"]) < 1.0
+    assert abs(wheel_dims[2] - wheel["height"]) < tol
+
+    adapter_dims = _dims(stl_dir / "adapter.stl")
+    assert abs(adapter_dims[0] - adapter["outer_diameter"]) < 1.0
+    assert abs(adapter_dims[2] - adapter["length"]) < tol
+
+    stand_dims = _dims(stl_dir / "stand.stl")
+    expected_z = (
+        stand["post_height"]
+        + stand["base_thickness"]
+        + stand["bearing_outer_d"] / 2  # noqa: E501
+    )
+    assert abs(stand_dims[0] - stand["base_length"]) < tol
+    assert abs(stand_dims[1] - stand["base_width"]) < tol
+    assert abs(stand_dims[2] - expected_z) < 1.0
+
+    return True
+
+
+if __name__ == "__main__":
+    verify_fit()
+    print("All parts fit together.")

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -1,0 +1,118 @@
+import runpy
+import types
+from pathlib import Path
+
+import flywheel.fit as ff
+
+REPO = Path(__file__).resolve().parents[1]
+CAD_DIR = REPO / "cad"
+STL_DIR = REPO / "stl"
+
+
+def test_parse_scad_vars(tmp_path):
+    scad = tmp_path / "part.scad"
+    scad.write_text("radius = 5;\nheight = 2;")
+    vars = ff.parse_scad_vars(scad)
+    assert vars == {"radius": 5.0, "height": 2.0}
+
+
+def test_verify_fit(tmp_path, monkeypatch):
+    assert ff.verify_fit(CAD_DIR, STL_DIR)
+
+
+def test_ensure_obj_models_mock(monkeypatch, tmp_path):
+    import shutil
+    import subprocess
+    import sys
+
+    import webapp.app as webapp_module
+
+    models = tmp_path / "models"
+    models.mkdir()
+    webapp_module.MODEL_DIR = models
+    webapp_module.SCAD_DIR = CAD_DIR
+
+    class DummyMesh:
+        def export(self, path, file_type="obj"):
+            Path(path).write_text("ok")
+
+    def fake_load(path, file_type=None):
+        return DummyMesh()
+
+    def fake_run(cmd, check):
+        Path(cmd[2]).write_text("stl")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "trimesh",
+        types.SimpleNamespace(load_mesh=fake_load),
+    )
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(shutil, "which", lambda x: "/usr/bin/openscad")
+
+    webapp_module.ensure_obj_models()
+    scad_names = [p.stem for p in CAD_DIR.glob("*.scad")]
+    obj_names = [p.stem for p in models.glob("*.obj")]
+    assert set(scad_names) <= set(obj_names)
+
+
+def test_ensure_obj_models_no_openscad(monkeypatch, tmp_path):
+    import shutil
+
+    import webapp.app as webapp_module
+
+    webapp_module.MODEL_DIR = tmp_path / "models"
+    webapp_module.SCAD_DIR = CAD_DIR
+    monkeypatch.setattr(shutil, "which", lambda x: None)
+    webapp_module.ensure_obj_models()
+    assert list(webapp_module.MODEL_DIR.glob("*.obj")) == []
+
+
+def test_ensure_obj_models_exception(monkeypatch, tmp_path):
+    import shutil
+    import subprocess
+
+    import webapp.app as webapp_module
+
+    webapp_module.MODEL_DIR = tmp_path / "models"
+    webapp_module.SCAD_DIR = CAD_DIR
+    monkeypatch.setattr(shutil, "which", lambda x: "/usr/bin/openscad")
+
+    def fail_run(cmd, check):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(subprocess, "run", fail_run)
+    webapp_module.ensure_obj_models()
+    assert list(webapp_module.MODEL_DIR.glob("*.obj")) == []
+
+
+def test_models_route(tmp_path):
+    from webapp import app as webapp_module
+
+    webapp_module.MODEL_DIR = tmp_path
+    f = tmp_path / "dummy.obj"
+    f.write_text("ok")
+    client = webapp_module.app.test_client()
+    resp = client.get(f"/models/{f.name}")
+    assert resp.status_code == 200
+
+
+def test_main_entry(monkeypatch):
+    called = {}
+
+    def fake_run(self, debug, port):
+        called["port"] = port
+
+    monkeypatch.setattr("flask.app.Flask.run", fake_run)
+    runpy.run_module("webapp.app", run_name="__main__")
+    assert called.get("port") == 42165
+
+
+def test_fit_module_main(monkeypatch):
+    import sys
+    from io import StringIO
+
+    buf = StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    runpy.run_module("flywheel.fit", run_name="__main__")
+    assert "All parts fit together." in buf.getvalue()


### PR DESCRIPTION
## Summary
- add PAT step to update-summary workflow so pushes succeed
- document how to spin up the Flask 3D viewer and check CAD/STL fit
- implement fit verification helper with tests
- allow `sugarkube` term in spellcheck

## Testing
- `pre-commit run --files README.md docs/repo-feature-summary.md .wordlist.txt`
- `pyspelling -c .spellcheck.yaml`
- `pytest -q`
- `pytest --cov=flywheel --cov=webapp -q`


------
https://chatgpt.com/codex/tasks/task_e_6875fd32791c832fa806f8c19345d4c7