### PR TITLE
Fix typos config formatting

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -110,4 +110,4 @@ extend-words = [
 ]
 
 [files]
-extend-exclude=["*.lock","*.svg"]
+extend-exclude = ["*.lock", "*.svg"]


### PR DESCRIPTION
## Summary
- fix `.typos.toml` formatting so the spellcheck workflow can parse it

## Testing
- `pre-commit run --files .typos.toml`

------
https://chatgpt.com/codex/tasks/task_e_68774bda903c832fa53789c626e2da30