### PR TITLE
Fix typos config formatting

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,113 +1,113 @@
 [default]
-extend-words = [
-  "AES",
-  "CLI",
-  "CodeQL",
-  "DEPENDABOT",
-  "Dependabot",
-  "DoS",
-  "ESLint",
-  "JS",
-  "LLM",
-  "NEWREPO",
-  "OpenAI",
-  "PRD",
-  "Prettier",
-  "PyPI",
-  "README",
-  "RSA",
-  "YOURNAME",
-  "auth",
-  "axel",
-  "axel's",
-  "backend",
-  "cd",
-  "cli",
-  "configs",
-  "dev",
-  "dspace",
-  "eslint",
-  "eslintrc",
-  "frictionless",
-  "futuroptimist",
-  "Gabriel",
-  "github",
-  "https",
-  "idempotency",
-  "img",
-  "init",
-  "io",
-  "isort",
-  "json",
-  "js",
-  "macOS",
-  "md",
-  "npm",
-  "pipx",
-  "pre",
-  "prettierrc",
-  "release-drafter",
-  "repo",
-  "repo_manager",
-  "repos",
-  "roadmap",
-  "subcommands",
-  "subprocess",
-  "token.place",
-  "tokenplace",
-  "txt",
-  "wasm",
-  "yml",
-  "yourorg",
-  "YOURREPO",
-  "styleguides",
-  "customizations",
-  "gabriel",
-  "heatmap",
-  "llms",
-  "onboarding",
-  "runbook",
-  "Runbook",
-  "subcommand",
-  "virtualenvs",
-  "Makefile",
-  "YAML",
-  "solarpunk",
-  "Futuroptimist's",
-  "LLMs",
-  "Anthropic",
-  "democratizedspace",
-  "CLIs",
-  "dir",
-  "pio",
-  "testbed",
-  "uv",
-  "venv",
-  "brightgreen",
-  "SHA",
-  "YOURTOKEN",
-  "htmlcontent",
-  "installable",
-  "OpenSCAD",
-  "LaTeX",
-  "tfrac",
-  "frac",
-  "PETG",
-  "explainer",
-  "PLA",
-  "STL",
-  "retightened",
-  "http",
-  "localhost",
-  "dropdown",
-  "IRL",
-  "repurpose",
-  "config",
-  "PRs",
-  "changelogs",
-  "STLs",
-  "sugarkube",
-]
+
+[default.extend-words]
+AES = "AES"
+CLI = "CLI"
+CodeQL = "CodeQL"
+DEPENDABOT = "DEPENDABOT"
+Dependabot = "Dependabot"
+DoS = "DoS"
+ESLint = "ESLint"
+JS = "JS"
+LLM = "LLM"
+NEWREPO = "NEWREPO"
+OpenAI = "OpenAI"
+PRD = "PRD"
+Prettier = "Prettier"
+PyPI = "PyPI"
+README = "README"
+RSA = "RSA"
+YOURNAME = "YOURNAME"
+auth = "auth"
+axel = "axel"
+"axel's" = "axel's"
+backend = "backend"
+cd = "cd"
+cli = "cli"
+configs = "configs"
+dev = "dev"
+dspace = "dspace"
+eslint = "eslint"
+eslintrc = "eslintrc"
+frictionless = "frictionless"
+futuroptimist = "futuroptimist"
+Gabriel = "Gabriel"
+github = "github"
+https = "https"
+idempotency = "idempotency"
+img = "img"
+init = "init"
+io = "io"
+isort = "isort"
+json = "json"
+js = "js"
+macOS = "macOS"
+md = "md"
+npm = "npm"
+pipx = "pipx"
+pre = "pre"
+prettierrc = "prettierrc"
+"release-drafter" = "release-drafter"
+repo = "repo"
+repo_manager = "repo_manager"
+repos = "repos"
+roadmap = "roadmap"
+subcommands = "subcommands"
+subprocess = "subprocess"
+"token.place" = "token.place"
+tokenplace = "tokenplace"
+txt = "txt"
+wasm = "wasm"
+yml = "yml"
+yourorg = "yourorg"
+YOURREPO = "YOURREPO"
+styleguides = "styleguides"
+customizations = "customizations"
+gabriel = "gabriel"
+heatmap = "heatmap"
+llms = "llms"
+onboarding = "onboarding"
+runbook = "runbook"
+Runbook = "Runbook"
+subcommand = "subcommand"
+virtualenvs = "virtualenvs"
+Makefile = "Makefile"
+YAML = "YAML"
+solarpunk = "solarpunk"
+"Futuroptimist's" = "Futuroptimist's"
+LLMs = "LLMs"
+Anthropic = "Anthropic"
+democratizedspace = "democratizedspace"
+CLIs = "CLIs"
+dir = "dir"
+pio = "pio"
+testbed = "testbed"
+uv = "uv"
+venv = "venv"
+brightgreen = "brightgreen"
+SHA = "SHA"
+YOURTOKEN = "YOURTOKEN"
+htmlcontent = "htmlcontent"
+installable = "installable"
+OpenSCAD = "OpenSCAD"
+LaTeX = "LaTeX"
+tfrac = "tfrac"
+frac = "frac"
+PETG = "PETG"
+explainer = "explainer"
+PLA = "PLA"
+STL = "STL"
+retightened = "retightened"
+http = "http"
+localhost = "localhost"
+dropdown = "dropdown"
+IRL = "IRL"
+repurpose = "repurpose"
+config = "config"
+PRs = "PRs"
+changelogs = "changelogs"
+STLs = "STLs"
+sugarkube = "sugarkube"
 
 [files]
-extend-exclude=["*.lock","*.svg"]
+extend-exclude = ["*.lock", "*.svg"]


### PR DESCRIPTION
## Summary
- use table syntax for `default.extend-words` in `.typos.toml`

## Testing
- `pre-commit run --all-files`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68774bda903c832fa53789c626e2da30