### PR TITLE
Fix typos config parsing error

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -106,7 +106,7 @@ extend-words = [
   "PRs",
   "changelogs",
   "STLs",
-  "sugarkube",
+  "sugarkube"
 ]
 
 [files]


### PR DESCRIPTION
## Summary
- remove trailing comma in `.typos.toml`

## Testing
- `pre-commit run --files .typos.toml`

------
https://chatgpt.com/codex/tasks/task_e_6878adfa2470832faf65b5c3e5289424