### PR TITLE
Fix typos config

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -106,7 +106,7 @@ extend-words = [
   "PRs",
   "changelogs",
   "STLs",
-  "sugarkube",
+  "sugarkube"
 ]
 
 [files]


### PR DESCRIPTION
## Summary
- remove trailing comma from `.typos.toml` which was breaking the spellcheck action

## Testing
- `pre-commit run trailing-whitespace --files .typos.toml`
- `pre-commit run end-of-file-fixer --files .typos.toml`
- `pre-commit run check-yaml --files .typos.toml`
- `pre-commit run codespell --files .typos.toml`
- `pre-commit run run-checks --files .typos.toml` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6878adfa2470832faf65b5c3e5289424