### PR TITLE
Fix coverage retrieval in repo crawler

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -6,12 +6,12 @@ This table tracks which flywheel features each related repository has adopted.
 ## Basics
 | Repo | Branch | Commit |
 | ---- | ------ | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `5674541` |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `5f05345` |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `540fb42` |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `b0c308a` |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `441852f` |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `186b68d` |
 | [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `4647f4f` |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `4d11689` |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `d6c8d6a` |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | `37db08f` |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | `179d186` |
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | `b9a888c` |
@@ -20,14 +20,14 @@ This table tracks which flywheel features each related repository has adopted.
 ## Coverage & Installer
 | Repo | Coverage | Patch | Installer |
 | ---- | -------- | ----- | --------- |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ❌ | — | 🚀 uv |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ❌ | — | 🚀 uv |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ❌ | — | 🚀 uv |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ❌ | — | 🚀 uv |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ❌ | — | pip |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | — | 🔶 partial |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | — | 🚀 uv |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ❌ | — | 🚀 uv |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (100%) | — | 🚀 uv |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | 🚀 uv |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | 🚀 uv |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (99%) | — | 🚀 uv |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | pip |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (100%) | — | 🔶 partial |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ (100%) | — | 🚀 uv |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | ❌ | — | pip |
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ❌ | — | 🚀 uv |
 


### PR DESCRIPTION
## Summary
- parse overall coverage from Codecov badges if API call fails
- update `docs/repo-feature-summary.md` using revised crawler

## Testing
- `pre-commit run --files docs/repo-feature-summary.md flywheel/repocrawler.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b4b2b8244832f9d48b0e86c79fbaf