### PR TITLE
Fix coverage parsing fallback

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -6,28 +6,28 @@ This table tracks which flywheel features each related repository has adopted.
 ## Basics
 | Repo | Branch | Commit |
 | ---- | ------ | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `5674541` |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `5f05345` |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `540fb42` |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `b0c308a` |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `441852f` |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `186b68d` |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `4647f4f` |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `4d11689` |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `1467519` |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `d6c8d6a` |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | `37db08f` |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | `179d186` |
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | `b9a888c` |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | main | `65e5c5e` |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | main | `d763d35` |
 
 ## Coverage & Installer
 | Repo | Coverage | Patch | Installer |
 | ---- | -------- | ----- | --------- |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ❌ | — | 🚀 uv |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ❌ | — | 🚀 uv |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ❌ | — | 🚀 uv |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ❌ | — | 🚀 uv |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ❌ | — | pip |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | — | 🔶 partial |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | — | 🚀 uv |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ❌ | — | 🚀 uv |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (100%) | — | 🚀 uv |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | 🚀 uv |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | 🚀 uv |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (99%) | — | 🚀 uv |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | pip |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (100%) | — | 🔶 partial |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ (100%) | — | 🚀 uv |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | ❌ | — | pip |
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ❌ | — | 🚀 uv |
 
@@ -38,7 +38,7 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ✅ |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ✅ |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ | ✅ | 6 | ✅ | ✅ | ✅ | ✅ |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ | ✅ | 2 | ✅ | ✅ | ❌ | ✅ |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ | ✅ | 2 | ✅ | ✅ | ✅ | ✅ |
 | [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ❌ |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ✅ |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ✅ |

--- a/tests/test_coverage_errors.py
+++ b/tests/test_coverage_errors.py
@@ -52,7 +52,7 @@ def test_patch_coverage_token_and_errors(monkeypatch):
     monkeypatch.setenv("CODECOV_TOKEN", "abc")
     monkeypatch.setattr(crawler, "_badge_patch_percent", lambda *a, **kw: 42.0)
     pct = crawler._patch_coverage_from_codecov("foo/bar", "main")
-    assert pct is None
+    assert pct == 42.0
     assert sess.calls[0][1]["Authorization"] == "Bearer abc"
 
 

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -210,7 +210,7 @@ def test_summary_column_order(monkeypatch):
 def test_patch_coverage_svg():
     crawler = rc.RepoCrawler([], session=DummySession({}))
     pct = crawler._patch_coverage_from_codecov("foo/bar", "main")
-    assert pct is None
+    assert pct == 95.0
 
 
 def test_generate_summary_with_patch(monkeypatch):

--- a/tests/test_total_coverage.py
+++ b/tests/test_total_coverage.py
@@ -1,0 +1,53 @@
+import requests
+import responses
+
+from flywheel.repocrawler import RepoCrawler
+
+
+@responses.activate
+def test_badge_total_success():
+    svg = "<svg>98%</svg>"
+    responses.add(
+        responses.GET,
+        "https://codecov.io/gh/foo/bar/branch/main/graph/badge.svg",
+        body=svg,
+        status=200,
+    )
+    c = RepoCrawler([])
+    assert c._badge_total_percent("foo/bar", "main") == "98%"
+
+
+@responses.activate
+def test_project_coverage_badge_fallback():
+    responses.add(
+        responses.GET,
+        "https://codecov.io/api/gh/foo/bar",
+        status=404,
+    )
+    responses.add(
+        responses.GET,
+        "https://codecov.io/gh/foo/bar/branch/main/graph/badge.svg",
+        body="<svg>88%</svg>",
+        status=200,
+    )
+    c = RepoCrawler([])
+    assert c._project_coverage_from_codecov("foo/bar", "main") == "88%"
+
+
+def test_project_coverage_badge_error(monkeypatch):
+    c = RepoCrawler([])
+
+    def boom(*a, **kw):
+        raise ValueError("fail")
+
+    monkeypatch.setattr(c, "_badge_total_percent", boom)
+
+    class Sess:
+        def __init__(self):
+            self.headers = {}
+
+        def get(self, *a, **kw):
+            raise requests.RequestException("err")
+
+    c.session = Sess()
+    assert c._project_coverage_from_codecov("foo/bar", "main") is None


### PR DESCRIPTION
## Summary
- fallback to parsing Codecov badge SVGs when API calls fail
- update repo feature summary with latest commit hashes

## Testing
- `pre-commit run --files docs/repo-feature-summary.md`
- `pytest --cov=flywheel --cov-report=term --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_687b4b2b8244832f9d48b0e86c79fbaf