### PR TITLE
Add trunk status to repo summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ flywheel crawl futuroptimist/flywheel futuroptimist/axel --output docs/repo-feat
 Append `@branch` to any repo to crawl a non-default branch, e.g. `owner/name@dev`.
 Pass `--token YOURTOKEN` or set `GITHUB_TOKEN` to avoid API rate limits.
 The `Update Repo Feature Summary` workflow commits `docs/repo-feature-summary.md` to `main` after each merge.
-The summary records the short SHA of the latest commit and the name of each repository's default branch.
+The summary records the short SHA of the latest commit, the name of each repository's default branch, and whether the latest commit passed CI on that branch.
 
 ### Auditing dev tooling
 

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -4,18 +4,18 @@ This table tracks which flywheel features each related repository has adopted.
 
 <!-- spellchecker: disable -->
 ## Basics
-| Repo | Branch | Commit |
-| ---- | ------ | ------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `2020985` |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `540fb42` |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `441852f` |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `186b68d` |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `1467519` |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `d6c8d6a` |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | `37db08f` |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | `179d186` |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | `b9a888c` |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | main | `d763d35` |
+| Repo | Branch | Commit | Trunk |
+| ---- | ------ | ------ | ----- |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `e501bda` | ❌ |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `540fb42` | ❌ |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `441852f` | ✅ |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `186b68d` | ✅ |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `1467519` | ✅ |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `d6c8d6a` | ✅ |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | `37db08f` | ❌ |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | `179d186` | ❌ |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | `b9a888c` | ❌ |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | main | `2a9a989` | ❌ |
 
 ## Coverage & Installer
 | Repo | Coverage | Patch | Installer |
@@ -45,4 +45,4 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ✅ | 5 | ✅ | ✅ | ✅ | ✅ |
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ | ✅ | 4 | ✅ | ❌ | ❌ | ✅ |
 
-Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time.
+Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time. The Trunk column indicates whether CI is green for that commit.

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -146,6 +146,7 @@ def test_generate_summary_installer_variants(monkeypatch):
         installer="uv",
         latest_commit="cafec0d",
         workflow_count=1,
+        trunk_green=True,
     )
     info_partial = info_uv.__class__(
         **{**info_uv.__dict__, "name": "demo/partial", "installer": "partial"}
@@ -172,6 +173,7 @@ def test_generate_summary_other_installer(monkeypatch):
         installer="poetry",
         latest_commit="1234567",
         workflow_count=1,
+        trunk_green=True,
     )
     crawler = rc.RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
@@ -194,15 +196,16 @@ def test_summary_column_order(monkeypatch):
         installer="uv",
         latest_commit="abcdef0",
         workflow_count=1,
+        trunk_green=True,
     )
     crawler = rc.RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
     summary = crawler.generate_summary()
-    assert "| Repo | Branch | Commit |" in summary
+    assert "| Repo | Branch | Commit | Trunk |" in summary
     assert "| Repo | Coverage | Patch | Installer |" in summary
     assert "| Repo | License | CI | Workflows |" in summary
     lines = summary.splitlines()
-    idx = lines.index("| Repo | Branch | Commit |")
+    idx = lines.index("| Repo | Branch | Commit | Trunk |")
     row = lines[idx + 2]
     assert "`abcdef0`" in row
 
@@ -230,6 +233,7 @@ def test_generate_summary_with_patch(monkeypatch):
         installer="uv",
         latest_commit="abcdef1",
         workflow_count=1,
+        trunk_green=False,
     )
     crawler = rc.RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -202,6 +202,7 @@ def test_generate_summary_no_patch(monkeypatch):
         installer="uv",
         latest_commit="123cafe",
         workflow_count=1,
+        trunk_green=None,
     )
     crawler = RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])

--- a/tests/test_summary_generation.py
+++ b/tests/test_summary_generation.py
@@ -13,6 +13,7 @@ def test_summary_generation(monkeypatch):
     monkeypatch.setattr(crawler, "_fetch_file", lambda *a, **kw: "")
     monkeypatch.setattr(crawler, "_list_workflows", lambda *a, **kw: set())
     monkeypatch.setattr(crawler, "_latest_commit", lambda *a, **kw: "deadbee")
+    monkeypatch.setattr(crawler, "_branch_green", lambda *a, **kw: True)
     monkeypatch.setattr(crawler, "_detect_installer", lambda *a, **kw: "uv")
     monkeypatch.setattr(crawler, "_has_file", lambda *a, **kw: True)
 


### PR DESCRIPTION
## Summary
- detect CI status for default branch commits
- include new "Trunk" column in repo summary tables
- document new column in README
- handle `.yaml` workflows

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_687c77585928832fb5b4cdf263131cf0