### PR TITLE
Add trunk green status to repo summary

### DIFF
--- a/docs/repo-feature-summary.md.jinja
+++ b/docs/repo-feature-summary.md.jinja
@@ -17,7 +17,7 @@ This table tracks which flywheel features each related repository has adopted.
 {% endfor %}
 
 ## Policies & Automation
-| Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
-| ---- | ------- | -- | --------- | --------- | --------------- | ------------ | ---------- |
+| Repo | License | CI | Trunk | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
+| ---- | ------- | -- | ----- | --------- | --------- | --------------- | ------------ | ---------- |
 {% for row in policy_rows %}{{ row }}
 {% endfor %}

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -146,6 +146,7 @@ def test_generate_summary_installer_variants(monkeypatch):
         installer="uv",
         latest_commit="cafec0d",
         workflow_count=1,
+        trunk_green=True,
     )
     info_partial = info_uv.__class__(
         **{**info_uv.__dict__, "name": "demo/partial", "installer": "partial"}
@@ -172,6 +173,7 @@ def test_generate_summary_other_installer(monkeypatch):
         installer="poetry",
         latest_commit="1234567",
         workflow_count=1,
+        trunk_green=True,
     )
     crawler = rc.RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
@@ -194,13 +196,14 @@ def test_summary_column_order(monkeypatch):
         installer="uv",
         latest_commit="abcdef0",
         workflow_count=1,
+        trunk_green=True,
     )
     crawler = rc.RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
     summary = crawler.generate_summary()
     assert "| Repo | Branch | Commit |" in summary
     assert "| Repo | Coverage | Patch | Installer |" in summary
-    assert "| Repo | License | CI | Workflows |" in summary
+    assert "| Repo | License | CI | Trunk | Workflows |" in summary
     lines = summary.splitlines()
     idx = lines.index("| Repo | Branch | Commit |")
     row = lines[idx + 2]
@@ -230,6 +233,7 @@ def test_generate_summary_with_patch(monkeypatch):
         installer="uv",
         latest_commit="abcdef1",
         workflow_count=1,
+        trunk_green=False,
     )
     crawler = rc.RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])

--- a/tests/test_summary_generation.py
+++ b/tests/test_summary_generation.py
@@ -13,6 +13,7 @@ def test_summary_generation(monkeypatch):
     monkeypatch.setattr(crawler, "_fetch_file", lambda *a, **kw: "")
     monkeypatch.setattr(crawler, "_list_workflows", lambda *a, **kw: set())
     monkeypatch.setattr(crawler, "_latest_commit", lambda *a, **kw: "deadbee")
+    monkeypatch.setattr(crawler, "_trunk_green", lambda *a, **kw: True)
     monkeypatch.setattr(crawler, "_detect_installer", lambda *a, **kw: "uv")
     monkeypatch.setattr(crawler, "_has_file", lambda *a, **kw: True)
 


### PR DESCRIPTION
## Summary
- detect `uv pip` usage correctly
- track trunk build status when crawling repositories
- display trunk status in the policies table
- update docs and tests for new column

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_687c77585928832fb5b4cdf263131cf0