### PR TITLE
Fix docs deploy workflow

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -11,21 +11,38 @@ permissions:
   pages: write
   id-token: write
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
+      - uses: actions/configure-pages@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          enablement: true
       - run: |
           cd docs-site
           npm install --no-audit --no-fund
           npm run build
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: docs-site/dist
-      - uses: actions/deploy-pages@v1
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- modernize docs site workflow with a dedicated deploy job
- update node version and actions to latest releases
- explicitly enable Pages via configure-pages action

## Testing
- `pre-commit run --files .github/workflows/docs-site.yml`
- `pip install -r requirements.txt`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881c922aef0832fb1323c0fb79a08cd