### PR TITLE
Fix trunk CI status detection

### DIFF
--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -251,30 +251,114 @@ def test_recent_commits_request_exception():
     assert crawler._recent_commits("demo/repo", "main") == []
 
 
-def test_branch_green_success():
+@pytest.mark.parametrize("conclusion", ["success", "neutral", "skipped"])
+def test_branch_green_actions_pass(conclusion):
     sess = make_session(
         {
+            "/actions/runs": DummyResp(
+                200,
+                json_data={"workflow_runs": [{"conclusion": conclusion}]},
+            )
+        }
+    )
+    crawler = RepoCrawler([], session=sess)
+    assert crawler._branch_green("demo/repo", "main", "dead") is True
+
+
+@pytest.mark.parametrize("conclusion", ["failure", "timed_out", "cancelled"])
+def test_branch_green_actions_fail(conclusion):
+    sess = make_session(
+        {
+            "/actions/runs": DummyResp(
+                200,
+                json_data={"workflow_runs": [{"conclusion": conclusion}]},
+            )
+        }
+    )
+    crawler = RepoCrawler([], session=sess)
+    assert crawler._branch_green("demo/repo", "main", "dead") is False
+
+
+def test_branch_green_fallback_success():
+    sess = make_session(
+        {
+            "/actions/runs": DummyResp(200, json_data={"workflow_runs": []}),
             "/commits/cafe/status": DummyResp(
                 200,
                 json_data={"state": "success"},
-            )
+            ),
         }
     )
     crawler = RepoCrawler([], session=sess)
-    assert crawler._branch_green("demo/repo", "cafe") is True
+    assert crawler._branch_green("demo/repo", "main", "cafe") is True
 
 
-def test_branch_green_failure():
+def test_branch_green_no_status_treated_as_pass():
     sess = make_session(
         {
+            "/actions/runs": DummyResp(200, json_data={"workflow_runs": []}),
+            "/commits/nosh/status": DummyResp(
+                200,
+                json_data={"state": "no_status"},
+            ),
+        }
+    )
+    crawler = RepoCrawler([], session=sess)
+    assert crawler._branch_green("demo/repo", "main", "nosh") is True
+
+
+def test_branch_green_actions_bad_json_fallback():
+    """Invalid workflow run JSON should fall back to commit status."""
+    sess = make_session(
+        {
+            "/actions/runs": DummyResp(200, json_data=ValueError("boom")),
+            "/commits/cafe/status": DummyResp(
+                200,
+                json_data={"state": "success"},
+            ),
+        }
+    )
+    crawler = RepoCrawler([], session=sess)
+    assert crawler._branch_green("demo/repo", "main", "cafe") is True
+
+
+def test_branch_green_failure_fallback():
+    sess = make_session(
+        {
+            "/actions/runs": DummyResp(200, json_data={"workflow_runs": []}),
             "/commits/dead/status": DummyResp(
                 200,
                 json_data={"state": "failure"},
-            )
+            ),
         }
     )
     crawler = RepoCrawler([], session=sess)
-    assert crawler._branch_green("demo/repo", "dead") is False
+    assert crawler._branch_green("demo/repo", "main", "dead") is False
+
+
+def test_branch_green_status_bad_json():
+    sess = make_session(
+        {
+            "/actions/runs": DummyResp(200, json_data={"workflow_runs": []}),
+            "/commits/bad/status": DummyResp(
+                200,
+                json_data=ValueError("boom"),
+            ),
+        }
+    )
+    crawler = RepoCrawler([], session=sess)
+    assert crawler._branch_green("demo/repo", "main", "bad") is None
+
+
+def test_branch_green_status_non_200():
+    sess = make_session(
+        {
+            "/actions/runs": DummyResp(200, json_data={"workflow_runs": []}),
+            "/commits/miss/status": DummyResp(404),
+        }
+    )
+    crawler = RepoCrawler([], session=sess)
+    assert crawler._branch_green("demo/repo", "main", "miss") is None
 
 
 def test_branch_green_request_exception():
@@ -286,31 +370,9 @@ def test_branch_green_request_exception():
             raise requests.RequestException("boom")
 
     crawler = RepoCrawler([], session=ErrSession())
-    assert crawler._branch_green("demo/repo", "dead") is None
+    assert crawler._branch_green("demo/repo", "main", "dead") is None
 
 
 def test_branch_green_no_sha():
     crawler = RepoCrawler([])
-    assert crawler._branch_green("demo/repo", "") is None
-
-
-def test_branch_green_bad_json():
-    sess = make_session(
-        {"/commits/bad/status": DummyResp(200, json_data=ValueError("boom"))}
-    )
-    crawler = RepoCrawler([], session=sess)
-    assert crawler._branch_green("demo/repo", "bad") is None
-
-
-def test_branch_green_non_200():
-    sess = make_session({"/commits/miss/status": DummyResp(404)})
-    crawler = RepoCrawler([], session=sess)
-    assert crawler._branch_green("demo/repo", "miss") is None
-
-
-def test_branch_green_no_state():
-    sess = make_session(
-        {"/commits/nothing/status": DummyResp(200, json_data={})}
-    )  # noqa: E501
-    crawler = RepoCrawler([], session=sess)
-    assert crawler._branch_green("demo/repo", "nothing") is None
+    assert crawler._branch_green("demo/repo", "main", "") is None


### PR DESCRIPTION
## Summary
- improve `_branch_green` to check latest workflow run first, falling back to commit status
- update caller logic
- expand unit tests for various workflow-run conclusions
- add tests for bad JSON and non-200 responses to ensure full coverage

## Testing
- `pre-commit run --all-files`
- `pytest --cov=flywheel --cov-report=term --cov-report=xml --maxfail=1 --disable-warnings -q --cov-fail-under=100`


------
https://chatgpt.com/codex/tasks/task_e_68882590da38832face94965ac0f789a