### PR TITLE
Add Codex automation prompt documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 > Guidance for LLM-based assistants working in the Flywheel repository. See
 > [llms.txt](llms.txt) for a quick orientation summary and
 > [CLAUDE.md](CLAUDE.md) for Anthropic-specific advice. Broader Codex behavior
-> rules live in [CUSTOM_INSTRUCTIONS.md](CUSTOM_INSTRUCTIONS.md).
+> rules live in [CUSTOM_INSTRUCTIONS.md](CUSTOM_INSTRUCTIONS.md). The baseline automation prompt is stored in [docs/prompts-codex.md](docs/prompts-codex.md).
 
 ## Built-in Assistants
 - **Code Linter Agent** – runs ESLint/Flake8 on every PR and suggests patches.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - [CLAUDE.md](CLAUDE.md) summarizing Anthropic guidance
 - [CUSTOM_INSTRUCTIONS.md](CUSTOM_INSTRUCTIONS.md) for Codex rules
   and a [runbook.yml](runbook.yml) checklist for repo setup
+- Codex automation prompt in `docs/prompts-codex.md`
 - Axel integration guide in `docs/axel-integration.md`
 - DSPACE synergy doc in `docs/dspace-integration.md`
 - token.place roadmap in `docs/tokenplace-roadmap.md`

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -1,0 +1,24 @@
+---
+title: 'Flywheel Codex Prompt'
+slug: 'prompts-codex'
+---
+
+# Codex Automation Prompt
+
+This document stores the baseline prompt used when instructing OpenAI Codex (or compatible agents) to contribute to the Flywheel repository. Keeping the prompt in version control lets us refine it over time and track what worked best.
+
+```
+SYSTEM:
+You are an automated contributor for the Flywheel repository. Follow the conventions in AGENTS.md and README.md. Make small, incremental improvements or tackle an open GitHub issue. Ensure pre-commit hooks, Python tests, and JavaScript tests all pass. If browser dependencies are missing, run `npx playwright install chromium` or prefix tests with `SKIP_E2E=1`.
+
+USER:
+1. Identify a straightforward improvement or bug fix from the docs or issues.
+2. Implement the change using the existing project style.
+3. Update documentation when needed.
+4. Run `bash scripts/checks.sh` before committing.
+
+OUTPUT:
+A pull request describing the change and summarizing test results.
+```
+
+Copy this entire block into Codex when you want the agent to automatically improve Flywheel. Update the instructions after each successful run so they stay relevant.


### PR DESCRIPTION
## Summary
- document baseline Codex automation instructions in `docs/prompts-codex.md`
- reference the new prompt doc from `README.md` and `AGENTS.md`

## Testing
- `npm test -- --coverage` *(fails: 5 did not run)*
- `pytest -q`
- `flake8 . --exclude=.venv`
- `isort --check-only . --skip .venv`
- `black --check . --exclude ".venv/"`
- `bandit -r flywheel -x tests,stl --severity-level medium`
- `safety check -r requirements.txt --full-report --continue-on-error`
- `linkchecker README.md docs/`

------
https://chatgpt.com/codex/tasks/task_e_688835727d4c832fbf76193b27f113f4