### PR TITLE
Add CI fix prompt docs

### DIFF
--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -1,0 +1,109 @@
+---
+title: 'Codex CI-Failure Fix Prompt'
+slug:  'prompts-codex-ci-fix'
+---
+
+# OpenAI Codex CI-Failure Fix Prompt
+
+Use this prompt whenever a GitHub Actions run in *any* repository fails and you want Codex to diagnose and repair the problem automatically.
+**Human set-up steps (do these *before* switching ChatGPT into “Code” mode):**
+
+1. Open the failed job in GitHub Actions, copy the page URL, and **paste it on the first line** of your ChatGPT message.
+2. Press <kbd>Enter</kbd> twice so that exactly **two blank lines** follow the URL.
+3. Copy the entire code-block below (starting with `SYSTEM:`) and paste it *after* the blank lines.
+4. Send the message and wait for Codex to return a pull-request link that fixes the failure.
+
+```text
+SYSTEM:
+You are an automated contributor for the target repository.
+Given a link to a failed GitHub Actions job, fetch the logs, infer the root-cause, and create a minimal, well-tested pull request that makes the workflow green again.
+
+Constraints:
+* Do **not** break existing functionality.
+* Follow the repository’s style guidelines and commit-lint rules.
+* If the failure involves flaky tests, stabilise them or mark them with an agreed-upon tag.
+* Always run the project’s full test / lint / type-check suite locally (or in CI) before proposing the PR.
+* If a new tool or dependency is required, update lock-files and documentation.
+* Add or update **unit tests** *and* **integration tests** to reproduce and prove the fix.
+* Provide a concise changelog entry.
+
+USER:
+1. Read the failure logs and locate the first real error.
+2. Explain (in the pull-request body) *why* the failure occurred.
+3. Commit the necessary code, configuration, or documentation changes.
+4. Push to a branch named `codex/ci-fix/<short-description>`.
+5. Open a pull request that – once merged – makes the default branch CI-green.
+6. After merge, post a follow-up comment on this prompt with lessons learned so we can refine it.
+
+OUTPUT:
+A GitHub pull request URL. The PR must include:
+* A human-readable summary of the root cause and the implemented fix.
+* Evidence that **all** checks are now passing (`✔️`).
+* Links to any new or updated tests.
+Copy this block verbatim whenever you want Codex to repair a failing workflow run. After each successful run, refine the instructions in this file so the next run is even smoother.
+```
+
+### Why this mirrors the existing pattern
+* Front-matter (`title`, `slug`) and the narrative structure match *prompts-codex.md* in **DSPACE** so that docs render consistently.
+* Codex best-practice constraints follow the official “Introducing Codex” guidance on AGENTS.md-driven projects.
+* The SYSTEM/USER/OUTPUT triad aligns with the format OpenAI recommends for deterministic agent prompts.
+
+---
+
+## 2 – Add a column to `docs/repo-feature-summary.md`
+
+### a) Patch
+
+```diff
+-| Docs | Changelog | Codex Prompts |
++| Docs | Changelog | Codex Prompts | **CI-Fix Prompt** |
+@@
+-| ✅  | ✅ | prompts-codex.md |
++| ✅  | ✅ | prompts-codex.md | prompts-codex-ci-fix.md |
+```
+### b) Why a separate column?
+Keeping each Codex prompt in its own table cell lets Flywheel’s propagation script iterate over *.md prompt files programmatically (e.g., via glob) without special-casing names, mirroring suggestions in GitHub’s table-syntax guide and enabling easy alignment tweaking with extended Markdown rules.
+
+## 3 – Committing & propagating
+Create the file above at docs/prompts-codex-ci-fix.md.
+
+Apply the table patch (or edit manually; don’t forget the pipe alignment).
+
+Run pnpm docs:build (or your docs generator) to ensure no broken links.
+
+Push and open a PR in flywheel; once merged, downstream repos can import the new prompt automatically through Flywheel’s existing propagation workflow.
+
+If you later need to reference the prompt programmatically, its slug (prompts-codex-ci-fix) will generate /docs/prompts-codex-ci-fix at build time.
+
+## 4 – Further reading & references
+OpenAI Codex overview and prompt design basics
+Medium
+
+How Codex consumes AGENTS.md files for repo-specific context
+GitHub
+
+Community discussion on AGENTS.md placement
+OpenAI Community
+
+Example of an AGENTS.md template (independent guide)
+Agents.md Guide for OpenAI Codex
+
+GitHub Docs – workflow syntax & contexts (useful for diagnosing CI)
+GitHub Docs
+
+StackOverflow Q&A on retrieving workflow-run URLs programmatically
+Stack Overflow
+
+GitHub Community thread on exposing run URLs inside jobs
+GitHub
+
+Markdown Guide – extended table syntax
+CommonMark Discussion
+
+Escaping pipes in Markdown tables
+Stack Overflow
+
+GitHub Copilot/Codex CLI repository (official prompt-handling conventions)
+GitHub
+
+Feel free to tweak wording or constraints as you see fit, but the file above is production-ready and follows the same conventions already used in your DSPACE documentation.

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -45,4 +45,9 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ✅ | 6 | ✅ | ✅ | ✅ | ✅ |
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ | ✅ | 5 | ✅ | ❌ | ❌ | ✅ |
 
+## Docs & Prompts
+| Docs | Changelog | Codex Prompts | **CI-Fix Prompt** |
+| ---- | --------- | ------------- | ----------------- |
+| ✅  | ✅ | prompts-codex.md | prompts-codex-ci-fix.md |
+
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time. The Trunk column indicates whether CI is green for that commit.

--- a/docs/repo-feature-summary.md.jinja
+++ b/docs/repo-feature-summary.md.jinja
@@ -21,3 +21,8 @@ This table tracks which flywheel features each related repository has adopted.
 | ---- | ------- | -- | --------- | --------- | --------------- | ------------ | ---------- |
 {% for row in policy_rows %}{{ row }}
 {% endfor %}
+
+## Docs & Prompts
+| Docs | Changelog | Codex Prompts | **CI-Fix Prompt** |
+| ---- | --------- | ------------- | ----------------- |
+| ✅  | ✅ | prompts-codex.md | prompts-codex-ci-fix.md |


### PR DESCRIPTION
## Summary
- document new Codex CI-Failure Fix prompt
- extend `repo-feature-summary` tables to list the prompt file

The `docs` link checker failed because `docs/repo-feature-summary.md` referenced a missing `prompts-codex-ci-fix.md`. Adding the prompt file and updating the Jinja template resolves the broken link.

## Testing
- `pre-commit run --files docs/prompts-codex-ci-fix.md docs/repo-feature-summary.md docs/repo-feature-summary.md.jinja`
- `pytest -q`
- `npm test -- --coverage`
- `npm --prefix docs-site run build`


------
https://chatgpt.com/codex/tasks/task_e_688839e7c93c832fb076e8e4b46b9ee3