### PR TITLE
Add bright pattern detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 - CodeQL workflow for security scanning
 - Style guides for Python and JavaScript
 - Detailed best practice explanations in `docs/best_practices_catalog.md`
+- Dark pattern guidance in `docs/dark-patterns.md`
+- Bright pattern catalog in `docs/bright-patterns.md`
 - Fast Python installs powered by [uv](https://github.com/astral-sh/uv)
 - Example code and templates
 - Python CLI with subcommands `init`, `update`, `audit`, `prompt`, and `crawl` that prompts interactively unless `--yes` is used

--- a/docs/best_practices_catalog.md
+++ b/docs/best_practices_catalog.md
@@ -117,6 +117,14 @@ Each section covers three points:
 
 **Maintenance:** Review these documents periodically. Agents should flag outdated links or wording.
 
+## Respecting Users
+
+**Why:** Avoid manipulative design choices that erode trust.
+
+**How it works:** The [dark-patterns guide](dark-patterns.md) outlines common traps and the "bright" alternatives we encourage. A companion [bright-patterns guide](bright-patterns.md) lists pro-user design elements. The repo crawler scans each repository for suspicious dark patterns and for positive bright patterns, recording the counts in `docs/repo-feature-summary.md`.
+
+**Maintenance:** Update the pattern list and scanning heuristics as new anti-patterns emerge. Keep this catalog and the guide in sync.
+
 ## Maintaining This Catalog
 
 - Add a new section whenever a best practice is added to the repository.

--- a/docs/bright-patterns.md
+++ b/docs/bright-patterns.md
@@ -1,0 +1,19 @@
+# Bright Patterns
+
+This catalog lists design choices that respect user autonomy and well-being. They are the positive counterparts to the dark patterns described in [dark-patterns.md](dark-patterns.md).
+
+| Bright pattern | Why it's helpful |
+| -------------- | ---------------- |
+| Transparent labeling | Users know exactly what each action will do and can make informed decisions. |
+| Easy opt-out | Subscriptions and data collection can be declined or cancelled in a single step. |
+| Upfront pricing | All fees are disclosed early so there are no payment surprises. |
+| Respectful privacy choices | Users can opt out of tracking or share only the data they want. |
+| Simple account deletion | Leaving a service is as easy as joining. |
+| Neutral language | Decline options avoid guilt-tripping or coercive wording. |
+| Clearly labeled ads | Promotional content is unmistakable so it doesn't mislead. |
+| Straightforward navigation | Buttons and links do exactly what they say. |
+| Dismissible reminders | Notifications can be permanently turned off. |
+| Plain language questions | No trick phrasing or double negatives. |
+| Explicit order confirmation | Nothing is added to a cart or order without clear consent. |
+
+Use these bright patterns to build trust and foster positive engagement.

--- a/docs/dark-patterns.md
+++ b/docs/dark-patterns.md
@@ -1,0 +1,25 @@
+# Dark Patterns and Bright Patterns
+
+This guide catalogs user-hostile design tactics, explains why they are problematic, and offers "bright pattern" alternatives that respect the user's agency. See [bright-patterns.md](bright-patterns.md) for a dedicated catalog of pro-user practices. The repo crawler counts potential dark patterns across related projects and records the results in `docs/repo-feature-summary.md`.
+
+## Why avoid dark patterns?
+
+Manipulative interfaces erode trust and may even violate privacy or consumer protection laws. Sustainable communities grow when contributors feel respected and in control of their data.
+
+## Catalog
+
+| Dark pattern | Why it's harmful | Bright pattern |
+| ------------ | ---------------- | -------------- |
+| **Bait and switch** | Promising one thing but delivering another confuses users. | Be transparent about outcomes and label actions clearly. |
+| **Forced continuity** | Making subscriptions hard to cancel traps users. | Provide an easy, single-step opt-out path. |
+| **Hidden costs** | Surprises at checkout feel deceptive. | Display full pricing upfront, including fees. |
+| **Privacy Zuckering** | Coercing users to share more data than necessary violates consent. | Offer clear privacy choices and respect opt-outs. |
+| **Roach Motel** | Easy to sign up, hard to leave. | Allow account deletion without hoops. |
+| **Confirmshaming** | Guilt-tripping language pressures users. | Use neutral copy for decline options. |
+| **Disguised ads** | Ads that look like native content mislead readers. | Clearly label promotional material. |
+| **Misdirection** | Visual tricks nudge clicks toward unintended actions. | Use straightforward navigation and button labels. |
+| **Nagging** | Persistent pop-ups or notifications wear users down. | Provide respectful reminders that can be dismissed permanently. |
+| **Trick questions** | Ambiguous wording leads to wrong choices. | Write plain-language questions with unambiguous answers. |
+| **Sneak into basket** | Adding items to a cart without consent exploits inattentive users. | Require explicit confirmation before modifying orders. |
+
+For additional guidance, see [best_practices_catalog.md](best_practices_catalog.md).

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -45,4 +45,19 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ✅ | 6 | ✅ | ✅ | ✅ | ✅ |
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ | ✅ | 5 | ✅ | ❌ | ❌ | ✅ |
 
+## Dark & Bright Pattern Scan
+| Repo | Dark Patterns | Bright Patterns |
+| ---- | ------------- | --------------- |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | 0 | 0 |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | 0 | 0 |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | 0 | 0 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | 0 | 0 |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | 0 | 0 |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | 0 | 0 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | 0 | 0 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | 0 | 0 |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | 0 | 0 |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | 0 | 0 |
+
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time. The Trunk column indicates whether CI is green for that commit.
+Dark Patterns and Bright Patterns list counts of suspicious or positive snippets detected during the scan.

--- a/tests/test_pattern_detection.py
+++ b/tests/test_pattern_detection.py
@@ -1,0 +1,70 @@
+import flywheel.repocrawler as rc
+
+
+def test_dark_bright_detection(monkeypatch):
+    crawler = rc.RepoCrawler([])
+    monkeypatch.setattr(
+        crawler,
+        "_list_files",
+        lambda repo, branch: ["index.js", "README.md"],
+    )
+    monkeypatch.setattr(
+        crawler,
+        "_fetch_file",
+        lambda repo, path, branch: (
+            "onbeforeunload" if path == "index.js" else "delete account"
+        ),
+    )
+    assert crawler._detect_dark_patterns("foo/bar", "main") == 1
+    assert crawler._detect_bright_patterns("foo/bar", "main") == 1
+
+
+def test_pattern_detection_skips(monkeypatch):
+    crawler = rc.RepoCrawler([])
+    monkeypatch.setattr(
+        crawler,
+        "_list_files",
+        lambda repo, branch: ["image.png", "script.js"],
+    )
+
+    def fetch(repo, path, branch):
+        if path == "script.js":
+            return "unsubscribe"
+        return None
+
+    monkeypatch.setattr(crawler, "_fetch_file", fetch)
+    assert crawler._detect_dark_patterns("foo/bar", "main") == 0
+    assert crawler._detect_bright_patterns("foo/bar", "main") == 1
+
+
+def test_list_files_errors(monkeypatch):
+    crawler = rc.RepoCrawler([])
+
+    class DummySession:
+        def get(self, url, **kwargs):
+            raise rc.requests.RequestException
+
+    crawler.session = DummySession()
+    assert crawler._list_files("foo/bar", "main") == []
+
+    class Resp:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            raise ValueError
+
+    class BadSession:
+        def get(self, url, **kwargs):
+            return Resp()
+
+    crawler.session = BadSession()
+    assert crawler._list_files("foo/bar", "main") == []
+
+
+def test_continue_on_empty(monkeypatch):
+    crawler = rc.RepoCrawler([])
+    monkeypatch.setattr(crawler, "_list_files", lambda r, b: ["script.js"])
+    monkeypatch.setattr(crawler, "_fetch_file", lambda r, p, b: None)
+    assert crawler._detect_dark_patterns("foo/bar", "main") == 0
+    assert crawler._detect_bright_patterns("foo/bar", "main") == 0

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -74,6 +74,7 @@ def test_generate_summary():
     assert "main" in out
     assert "pip" in out
     assert "deadbee" in out
+    assert "| Repo | Dark Patterns | Bright Patterns |" in out
 
 
 def test_parse_coverage_none():
@@ -204,6 +205,7 @@ def test_summary_column_order(monkeypatch):
     assert "| Repo | Branch | Commit | Trunk |" in summary
     assert "| Repo | Coverage | Patch | Installer |" in summary
     assert "| Repo | License | CI | Workflows |" in summary
+    assert "| Repo | Dark Patterns | Bright Patterns |" in summary
     lines = summary.splitlines()
     idx = lines.index("| Repo | Branch | Commit | Trunk |")
     row = lines[idx + 2]

--- a/tests/test_summary_generation.py
+++ b/tests/test_summary_generation.py
@@ -20,3 +20,4 @@ def test_summary_generation(monkeypatch):
     summary = crawler.generate_summary()
     assert "(95%)" in summary
     assert "—" not in summary
+    assert "| Repo | Dark Patterns | Bright Patterns |" in summary


### PR DESCRIPTION
## Summary
- document pro-user bright patterns
- expand best practices with bright pattern guide
- update feature summary table with dark and bright counts
- detect bright patterns in RepoCrawler
- test new summary column
- add coverage tests for bright pattern detection

## Testing
- `pre-commit run --all-files`
- `pytest --cov=flywheel --cov-report=term --cov-report=xml --maxfail=1 --disable-warnings -q --cov-fail-under=100`
- `npm test -- --coverage`
- `bash scripts/checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_68893f129ecc832f951c4de595b625d8