### PR TITLE
Add CAD and physics Codex prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 > Guidance for LLM-based assistants working in the Flywheel repository. See
 > [llms.txt](llms.txt) for a quick orientation summary and
 > [CLAUDE.md](CLAUDE.md) for Anthropic-specific advice. Broader Codex behavior
-> rules live in [CUSTOM_INSTRUCTIONS.md](CUSTOM_INSTRUCTIONS.md). The baseline automation prompt is stored in [docs/prompts-codex.md](docs/prompts-codex.md).
+> rules live in [CUSTOM_INSTRUCTIONS.md](CUSTOM_INSTRUCTIONS.md). The baseline automation prompt is stored in [docs/prompts-codex.md](docs/prompts-codex.md) along with specialized prompts like [docs/prompts-codex-cad.md](docs/prompts-codex-cad.md) and [docs/prompts-codex-physics.md](docs/prompts-codex-physics.md).
 
 ## Built-in Assistants
 - **Code Linter Agent** – runs ESLint/Flake8 on every PR and suggests patches.
@@ -17,6 +17,8 @@
 - **Prompt Agent** – generates context‑aware prompts via `flywheel prompt`.
 - **Repo Scanner Agent** – clones repositories and writes Markdown reports using
   `python -m flywheel.agents.scanner`.
+- **CAD Fit Agent** – verifies SCAD and STL models align using
+  `python -m flywheel.fit` and comments on discrepancies.
 
 ## Project Structure
 - `flywheel/` – Python package with CLI commands and agent logic.
@@ -25,6 +27,8 @@
 - `scripts/` – automation helpers such as `checks.sh`.
 - `tests/` – Python and JavaScript tests.
 - `viewer/` – 3‑D assembly viewer.
+- `cad/` – OpenSCAD source files.
+- `stl/` – exported models kept in sync with `cad/`.
 
 ## Coding Conventions
 ### General
@@ -32,6 +36,8 @@
 - TypeScript with `eslint` and `prettier` for the webapp.
 - Keep functions small and name them descriptively.
 - Document complex logic with comments.
+- Regenerate STLs when modifying SCAD files and verify dimensions with
+  `python -m flywheel.fit`.
 
 ### CSS/Styling
 - Prefer Tailwind CSS for styling in `webapp/`.
@@ -44,6 +50,7 @@ Run the full test suite before committing:
 pre-commit run --all-files
 pytest -q
 npm test -- --coverage
+python -m flywheel.fit
 ```
 
 ## Pull Request Guidelines

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@
 - [CUSTOM_INSTRUCTIONS.md](CUSTOM_INSTRUCTIONS.md) for Codex rules
   and a [runbook.yml](runbook.yml) checklist for repo setup
 - Codex automation prompt in `docs/prompts-codex.md`
+- CAD update prompt in `docs/prompts-codex-cad.md`
+- Physics explainer prompt in `docs/prompts-codex-physics.md`
 - Axel integration guide in `docs/axel-integration.md`
 - DSPACE synergy doc in `docs/dspace-integration.md`
 - token.place roadmap in `docs/tokenplace-roadmap.md`

--- a/docs/dspace-integration.md
+++ b/docs/dspace-integration.md
@@ -28,3 +28,5 @@ an unchecked item from the September 1, 2025 changelog and fully implement it.
 Each run should tackle a different backlog task and then run
 `npm run test:pr` to verify code style and all tests. Reviewing this prompt helps
 align Flywheel's agents with DSPACE workflows when building shared features.
+Flywheel now provides complementary prompts like `prompts-codex-cad.md` and
+`prompts-codex-physics.md` for CAD updates and physics explainers.

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -1,0 +1,29 @@
+---
+title: 'Codex CAD Prompt'
+slug: 'prompts-codex-cad'
+---
+
+# OpenAI Codex CAD Prompt
+
+Use this prompt whenever CAD models or STL exports need updating. It mirrors the
+style of DSPACE's `prompts-codex.md` so the automation workflows stay
+consistent.
+
+```
+SYSTEM:
+You are an automated contributor for the Flywheel repository focused on 3D
+assets. Follow AGENTS.md and README.md. Ensure SCAD files export cleanly to STL
+and OBJ models. Verify the parts fit by running `python -m flywheel.fit`.
+
+USER:
+1. Look for TODO comments in `cad/*.scad` or open issues tagged `cad`.
+2. Update the SCAD geometry or regenerate STL/OBJ files if they are outdated.
+3. Run `python -m flywheel.fit` to confirm dimensions match.
+4. Commit updated models and documentation.
+
+OUTPUT:
+A pull request summarizing the CAD changes and test results.
+```
+
+Copy this block into Codex when you want the agent to refresh CAD models or
+verify that exported files match the source.

--- a/docs/prompts-codex-physics.md
+++ b/docs/prompts-codex-physics.md
@@ -1,0 +1,28 @@
+---
+title: 'Codex Physics Explainer Prompt'
+slug: 'prompts-codex-physics'
+---
+
+# OpenAI Codex Physics Explainer Prompt
+
+Use this prompt to automatically expand Flywheel's physics documentation. The
+agent pulls formulas or explanations from the codebase and updates relevant
+Markdown files.
+
+```
+SYSTEM:
+You are an automated contributor for the Flywheel repository. Focus on improving
+the physics explainers in `docs/*`. Follow AGENTS.md for style and testing
+requirements.
+
+USER:
+1. Inspect `docs/flywheel-physics.md` for gaps or TODO notes.
+2. Add clear explanations or equations where needed.
+3. Cross-reference the CAD dimensions if relevant.
+4. Run `bash scripts/checks.sh` before committing.
+
+OUTPUT:
+A pull request enhancing the physics docs with any new derivations or diagrams.
+```
+
+This keeps the physics guides fresh and consistent across updates.


### PR DESCRIPTION
## Summary
- document additional Codex prompts in AGENTS.md
- mention new prompts in README and DSPACE integration guide
- add `prompts-codex-cad.md` and `prompts-codex-physics.md`

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889bc5230f0832f8d5c65efd73ec4c8