### PR TITLE
Fix trunk status detection in repo crawler

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -6,16 +6,16 @@ This table tracks which flywheel features each related repository has adopted.
 ## Basics
 | Repo | Branch | Commit | Trunk |
 | ---- | ------ | ------ | ----- |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `98b1831` | ✅ |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `8cc14e4` | n/a |
 | [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `e7829e7` | ✅ |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `277d494` | ✅ |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `7b5c1b5` | ❌ |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `7b5c1b5` | ✅ |
 | [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `a8abe86` | ✅ |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `f893ef4` | ❌ |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | `df004e4` | ✅ |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | `c501f49` | ✅ |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | `8da1955` | n/a |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | main | n/a | n/a |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `1c8954b` | n/a |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | `df004e4` | n/a |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | `c501f49` | n/a |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | `8da1955` | ✅ |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | main | `e98ee18` | n/a |
 
 ## Coverage & Installer
 | Repo | Coverage | Patch | Installer |
@@ -29,7 +29,7 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | 🚀 uv |
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ (100%) | — | pip |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ (57%) | — | 🔶 partial |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ (57%) | — | 🚀 uv |
 
 ## Policies & Automation
 | Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
@@ -43,7 +43,7 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ✅ |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ |
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ✅ | 6 | ✅ | ✅ | ✅ | ✅ |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ | ❌ | 0 | ✅ | ❌ | ❌ | ✅ |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ | ✅ | 5 | ✅ | ❌ | ❌ | ✅ |
 
 ## Dark & Bright Pattern Scan
 | Repo | Dark Patterns | Bright Patterns |

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -304,7 +304,7 @@ def test_branch_green_no_status_treated_as_pass():
         }
     )
     crawler = RepoCrawler([], session=sess)
-    assert crawler._branch_green("demo/repo", "main", "nosh") is True
+    assert crawler._branch_green("demo/repo", "main", "nosh") is None
 
 
 def test_branch_green_actions_bad_json_fallback():


### PR DESCRIPTION
## Summary
- improve trunk status detection in `RepoCrawler` by checking commit status first and scanning recent workflow runs
- treat pending or missing statuses as unknown
- update repo summary table accordingly
- adjust tests for new behavior

## Testing
- `pre-commit run --files flywheel/repocrawler.py docs/repo-feature-summary.md` *(fails: AssertionError in tests)*
- `pre-commit run --files flywheel/repocrawler.py docs/repo-feature-summary.md` *(failures resolved)*
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a867a09a8832f812c9039ea74633a