### PR TITLE
Add CI status helper module

### DIFF
--- a/src/ci_status.py
+++ b/src/ci_status.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import requests
+
+from .github_auth import get_github_token
+
+_ACCEPTABLE_REST_CONCLUSIONS = {
+    "success",
+    "neutral",
+    "skipped",
+    "completed",  # legacy status API
+}
+
+
+def _query_graphql(owner: str, repo: str, sha: str) -> str | None:
+    """Return GraphQL `statusCheckRollup.state` or None on error."""
+    token = get_github_token()
+    qry = """
+    query($o:String!,$r:String!,$s:String!) {
+      repository(owner:$o, name:$r) {
+        object(oid:$s) {
+          ... on Commit { statusCheckRollup { state } }
+        }
+      }
+    }"""
+    resp = requests.post(
+        "https://api.github.com/graphql",
+        json={"query": qry, "variables": {"o": owner, "r": repo, "s": sha}},
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=15,
+    )
+    if resp.ok:
+        rollup = (
+            resp.json()
+            .get("data", {})
+            .get("repository", {})
+            .get("object", {})
+            .get("statusCheckRollup")
+        )
+        return None if rollup is None else rollup["state"]
+    return None
+
+
+def _query_rest(owner: str, repo: str, sha: str) -> str | None:
+    """Return best-effort status via the Checks REST API."""
+    token = get_github_token()
+    base = "https://api.github.com/repos/"
+    url = f"{base}{owner}/{repo}/commits/{sha}/check-runs"
+    r = requests.get(
+        url,
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=15,
+    )
+    if not r.ok:
+        return None
+    runs = r.json().get("check_runs", [])
+    if not runs:  # no CI
+        return "NO_CI"
+    for run in runs:
+        concl = (run.get("conclusion") or "").lower()
+        if concl not in _ACCEPTABLE_REST_CONCLUSIONS:
+            return "FAILURE"
+    return "SUCCESS"
+
+
+def ci_state(owner: str, repo: str, sha: str) -> str:
+    """
+    Return 'green' or 'red' for the dashboard.
+    Logic order:
+      1. GraphQL rollup
+      2. REST checks fall-back
+    """
+    state = _query_graphql(owner, repo, sha)
+    if state is None:
+        state = _query_rest(owner, repo, sha)
+
+    if state in ("SUCCESS", "PENDING", "NO_CI"):
+        return "green"
+    return "red"

--- a/src/github_auth.py
+++ b/src/github_auth.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import os
+
+
+def get_github_token() -> str:
+    """Return GITHUB_TOKEN or raise RuntimeError if unset."""
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise RuntimeError("GITHUB_TOKEN environment variable not set")
+    return token

--- a/src/table_builder.py
+++ b/src/table_builder.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .ci_status import ci_state
+
+
+def trunk_cell(owner: str, repo: str, sha: str) -> str:
+    """Return emoji for Trunk column."""
+    if not sha:
+        return "n/a"
+    state = ci_state(owner, repo, sha)
+    return "✅" if state == "green" else "❌"


### PR DESCRIPTION
## Summary
- centralize CI state checks in `src/ci_status.py`
- expose a simple helper for the Trunk column in `src/table_builder.py`
- basic GitHub token utility

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_688b04d7010c832f889fcf3c32200fec