### PR TITLE
feat: track codecov usage in repo summaries

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -18,18 +18,18 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | main | `e98ee18` | n/a |
 
 ## Coverage & Installer
-| Repo | Coverage | Patch | Installer |
-| ---- | -------- | ----- | --------- |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | pip |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (100%) | — | 🔶 partial |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ (100%) | — | pip |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ (57%) | — | 🚀 uv |
+| Repo | Coverage | Patch | Codecov | Installer |
+| ---- | -------- | ----- | ------- | --------- |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (100%) | — | ✅ | 🚀 uv |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | ✅ | 🚀 uv |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | ❌ | 🚀 uv |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | ❌ | 🚀 uv |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | ✅ | pip |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (100%) | — | ✅ | 🔶 partial |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ (100%) | — | ❌ | 🚀 uv |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | ❌ | 🚀 uv |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ (100%) | — | ❌ | pip |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ (57%) | — | ✅ | 🚀 uv |
 
 ## Policies & Automation
 | Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
@@ -59,4 +59,4 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | 0 | 0 |
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | 0 | 0 |
 
-Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time. The Trunk column indicates whether CI is green for that commit. Dark Patterns and Bright Patterns list counts of suspicious or positive code snippets detected.
+Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. Codecov shows ✅ when a Codecov config is present. The commit column shows the short SHA of the latest default branch commit at crawl time. The Trunk column indicates whether CI is green for that commit. Dark Patterns and Bright Patterns list counts of suspicious or positive code snippets detected.

--- a/docs/repo-feature-summary.md.jinja
+++ b/docs/repo-feature-summary.md.jinja
@@ -11,8 +11,8 @@ This table tracks which flywheel features each related repository has adopted.
 {% endfor %}
 
 ## Coverage & Installer
-| Repo | Coverage | Patch | Installer |
-| ---- | -------- | ----- | --------- |
+| Repo | Coverage | Patch | Codecov | Installer |
+| ---- | -------- | ----- | ------- | --------- |
 {% for row in coverage_rows %}{{ row }}
 {% endfor %}
 

--- a/scripts/update_repo_feature_summary.py
+++ b/scripts/update_repo_feature_summary.py
@@ -30,7 +30,7 @@ def main() -> None:
     infos = crawler.crawl()
 
     basics = [["Repo", "Branch", "Commit"]]
-    coverage = [["Repo", "Coverage", "Patch", "Installer"]]
+    coverage = [["Repo", "Coverage", "Patch", "Codecov", "Installer"]]
     policy = [
         [
             "Repo",
@@ -63,7 +63,9 @@ def main() -> None:
 
         inst_map = {"uv": "🚀 uv", "partial": "🔶 partial"}
         inst = inst_map.get(info.installer, info.installer)
-        coverage.append([link, cov, patch, inst])
+        coverage.append(
+            [link, cov, patch, "✅" if info.uses_codecov else "❌", inst]
+        )  # noqa: E501
 
         policy.append(
             [
@@ -101,9 +103,10 @@ def main() -> None:
         "Legend: ✅ indicates the repo has adopted that feature from flywheel. "
         "🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. "
         "Coverage percentages are parsed from Codecov when available. Patch "
-        "shows ✅ when diff coverage is at least 90% and ❌ otherwise. The "
-        "commit column shows the short SHA of the latest default branch "
-        "commit at crawl time."
+        "shows ✅ when diff coverage is at least 90% and ❌ otherwise. "
+        "Codecov shows ✅ when a Codecov config is present. The commit "
+        "column shows the short SHA of the latest default branch commit at "
+        "crawl time."
     )
     lines.append(
         f"_Updated automatically: {date.today()}_",

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -138,6 +138,7 @@ def test_generate_summary_installer_variants(monkeypatch):
         branch="main",
         coverage="100%",
         patch_percent=None,
+        uses_codecov=True,
         has_license=True,
         has_ci=True,
         has_agents=False,
@@ -165,6 +166,7 @@ def test_generate_summary_other_installer(monkeypatch):
         branch="main",
         coverage="80%",
         patch_percent=None,
+        uses_codecov=True,
         has_license=True,
         has_ci=True,
         has_agents=True,
@@ -188,6 +190,7 @@ def test_summary_column_order(monkeypatch):
         branch="main",
         coverage="100%",
         patch_percent=None,
+        uses_codecov=True,
         has_license=True,
         has_ci=True,
         has_agents=True,
@@ -203,7 +206,7 @@ def test_summary_column_order(monkeypatch):
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
     summary = crawler.generate_summary()
     assert "| Repo | Branch | Commit | Trunk |" in summary
-    assert "| Repo | Coverage | Patch | Installer |" in summary
+    assert "| Repo | Coverage | Patch | Codecov | Installer |" in summary
     assert "| Repo | License | CI | Workflows |" in summary
     assert "| Repo | Dark Patterns | Bright Patterns |" in summary
     lines = summary.splitlines()
@@ -226,6 +229,7 @@ def test_generate_summary_with_patch(monkeypatch):
         branch="main",
         coverage="100%",
         patch_percent=73.0,
+        uses_codecov=True,
         has_license=True,
         has_ci=True,
         has_agents=False,
@@ -240,7 +244,7 @@ def test_generate_summary_with_patch(monkeypatch):
     crawler = rc.RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
     lines = crawler.generate_summary().splitlines()
-    idx = lines.index("| Repo | Coverage | Patch | Installer |")
+    idx = lines.index("| Repo | Coverage | Patch | Codecov | Installer |")
     row = lines[idx + 2]
     assert "❌ (73%)" in row
     assert "(73%)" in row

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -193,6 +193,7 @@ def test_generate_summary_no_patch(monkeypatch):
         branch="main",
         coverage="100%",
         patch_percent=None,
+        uses_codecov=True,
         has_license=True,
         has_ci=True,
         has_agents=False,
@@ -207,7 +208,7 @@ def test_generate_summary_no_patch(monkeypatch):
     crawler = RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
     lines = crawler.generate_summary().splitlines()
-    idx = lines.index("| Repo | Coverage | Patch | Installer |")
+    idx = lines.index("| Repo | Coverage | Patch | Codecov | Installer |")
     row = lines[idx + 2]
     assert "| — |" in row
 


### PR DESCRIPTION
## Summary
- track Codecov config presence in `RepoCrawler` and doc generation
- document Codecov usage in repo feature summary tables
- update tests for new `Codecov` column

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`
- `bash scripts/checks.sh` *(fails: bandit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dc700e6a0832f9cbdef365415508a