### PR TITLE
feat: add codecov usage column

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -18,18 +18,18 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | main | `e98ee18` | ✅ |
 
 ## Coverage & Installer
-| Repo | Coverage | Patch | Installer |
-| ---- | -------- | ----- | --------- |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | pip |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (100%) | — | 🔶 partial |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | — | 🚀 uv |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ (100%) | — | pip |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ (57%) | — | 🚀 uv |
+| Repo | Coverage | Patch | Installer | Codecov |
+| ---- | -------- | ----- | --------- | ------- |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (100%) | — | 🚀 uv | ✅ |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | 🚀 uv | ✅ |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | 🚀 uv | ✅ |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | 🚀 uv | ✅ |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | pip | ✅ |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (100%) | — | 🔶 partial | ✅ |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | — | 🚀 uv | ❌ |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | 🚀 uv | ✅ |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ (100%) | — | pip | ✅ |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ (57%) | — | 🚀 uv | ✅ |
 
 ## Policies & Automation
 | Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
@@ -59,4 +59,4 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | 0 | 0 |
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | 0 | 0 |
 
-Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time. The Trunk column indicates whether CI is green for that commit. Dark Patterns and Bright Patterns list counts of suspicious or positive code snippets detected.
+Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. The Codecov column marks repos using Codecov for coverage reports. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time. The Trunk column indicates whether CI is green for that commit. Dark Patterns and Bright Patterns list counts of suspicious or positive code snippets detected.

--- a/scripts/update_repo_feature_summary.py
+++ b/scripts/update_repo_feature_summary.py
@@ -30,7 +30,7 @@ def main() -> None:
     infos = crawler.crawl()
 
     basics = [["Repo", "Branch", "Commit"]]
-    coverage = [["Repo", "Coverage", "Patch", "Installer"]]
+    coverage = [["Repo", "Coverage", "Patch", "Installer", "Codecov"]]
     policy = [
         [
             "Repo",
@@ -63,7 +63,15 @@ def main() -> None:
 
         inst_map = {"uv": "🚀 uv", "partial": "🔶 partial"}
         inst = inst_map.get(info.installer, info.installer)
-        coverage.append([link, cov, patch, inst])
+        coverage.append(
+            [
+                link,
+                cov,
+                patch,
+                inst,
+                "✅" if info.uses_codecov else "❌",
+            ]
+        )
 
         policy.append(
             [
@@ -80,30 +88,46 @@ def main() -> None:
 
     lines = [
         "## Basics",
-        tabulate(basics[1:], headers=basics[0], tablefmt="github"),
+        tabulate(
+            basics[1:],
+            headers=basics[0],
+            tablefmt="github",
+            maxcolwidths=[None] * len(basics[0]),
+        ),
     ]
     lines.extend(
         [
             "",
             "## Coverage & Installer",
-            tabulate(coverage[1:], headers=coverage[0], tablefmt="github"),
+            tabulate(
+                coverage[1:],
+                headers=coverage[0],
+                tablefmt="github",
+                maxcolwidths=[None] * len(coverage[0]),
+            ),
         ]
     )
     lines.extend(
         [
             "",
             "## Policies & Automation",
-            tabulate(policy[1:], headers=policy[0], tablefmt="github"),
+            tabulate(
+                policy[1:],
+                headers=policy[0],
+                tablefmt="github",
+                maxcolwidths=[None] * len(policy[0]),
+            ),
         ]
     )
     lines.append("")
     lines.append(
         "Legend: ✅ indicates the repo has adopted that feature from flywheel. "
         "🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. "
-        "Coverage percentages are parsed from Codecov when available. Patch "
-        "shows ✅ when diff coverage is at least 90% and ❌ otherwise. The "
-        "commit column shows the short SHA of the latest default branch "
-        "commit at crawl time."
+        "Coverage percentages are parsed from Codecov when available. The "
+        "Codecov column marks repos using Codecov for reporting. Patch shows "
+        "✅ when diff coverage is at least 90% and ❌ otherwise. The commit "
+        "column shows the short SHA of the latest default branch commit at "
+        "crawl time."
     )
     lines.append(
         f"_Updated automatically: {date.today()}_",

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -138,6 +138,7 @@ def test_generate_summary_installer_variants(monkeypatch):
         branch="main",
         coverage="100%",
         patch_percent=None,
+        uses_codecov=True,
         has_license=True,
         has_ci=True,
         has_agents=False,
@@ -150,7 +151,11 @@ def test_generate_summary_installer_variants(monkeypatch):
         trunk_green=True,
     )
     info_partial = info_uv.__class__(
-        **{**info_uv.__dict__, "name": "demo/partial", "installer": "partial"}
+        **{
+            **info_uv.__dict__,
+            "name": "demo/partial",
+            "installer": "partial",
+        }
     )
     crawler = rc.RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info_uv, info_partial])
@@ -165,6 +170,7 @@ def test_generate_summary_other_installer(monkeypatch):
         branch="main",
         coverage="80%",
         patch_percent=None,
+        uses_codecov=True,
         has_license=True,
         has_ci=True,
         has_agents=True,
@@ -188,6 +194,7 @@ def test_summary_column_order(monkeypatch):
         branch="main",
         coverage="100%",
         patch_percent=None,
+        uses_codecov=True,
         has_license=True,
         has_ci=True,
         has_agents=True,
@@ -203,7 +210,7 @@ def test_summary_column_order(monkeypatch):
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
     summary = crawler.generate_summary()
     assert "| Repo | Branch | Commit | Trunk |" in summary
-    assert "| Repo | Coverage | Patch | Installer |" in summary
+    assert "| Repo | Coverage | Patch | Installer | Codecov |" in summary
     assert "| Repo | License | CI | Workflows |" in summary
     assert "| Repo | Dark Patterns | Bright Patterns |" in summary
     lines = summary.splitlines()
@@ -226,6 +233,7 @@ def test_generate_summary_with_patch(monkeypatch):
         branch="main",
         coverage="100%",
         patch_percent=73.0,
+        uses_codecov=True,
         has_license=True,
         has_ci=True,
         has_agents=False,
@@ -240,7 +248,7 @@ def test_generate_summary_with_patch(monkeypatch):
     crawler = rc.RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
     lines = crawler.generate_summary().splitlines()
-    idx = lines.index("| Repo | Coverage | Patch | Installer |")
+    idx = lines.index("| Repo | Coverage | Patch | Installer | Codecov |")
     row = lines[idx + 2]
     assert "❌ (73%)" in row
     assert "(73%)" in row

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -193,6 +193,7 @@ def test_generate_summary_no_patch(monkeypatch):
         branch="main",
         coverage="100%",
         patch_percent=None,
+        uses_codecov=True,
         has_license=True,
         has_ci=True,
         has_agents=False,
@@ -207,7 +208,7 @@ def test_generate_summary_no_patch(monkeypatch):
     crawler = RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
     lines = crawler.generate_summary().splitlines()
-    idx = lines.index("| Repo | Coverage | Patch | Installer |")
+    idx = lines.index("| Repo | Coverage | Patch | Installer | Codecov |")
     row = lines[idx + 2]
     assert "| — |" in row
 


### PR DESCRIPTION
## Summary
- track Codecov usage in `RepoInfo`
- extend summary generation and scripts with new Codecov column
- document which repos report coverage via Codecov

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`
- `bash scripts/checks.sh` *(fails: bandit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dd023af2c832f8b975117a6ab072e