### PR TITLE
feat: track codecov usage in repo crawler

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -1,6 +1,7 @@
 AES
 CLI
 CodeQL
+Codecov
 DEPENDABOT
 Dependabot
 DoS

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -18,18 +18,18 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | main | `e98ee18` | ✅ |
 
 ## Coverage & Installer
-| Repo | Coverage | Patch | Installer |
-| ---- | -------- | ----- | --------- |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | pip |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (100%) | — | 🔶 partial |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | — | 🚀 uv |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ (100%) | — | pip |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ (57%) | — | 🚀 uv |
+| Repo | Coverage | Patch | Codecov | Installer |
+| ---- | -------- | ----- | ------- | --------- |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (100%) | — | ✅ | 🚀 uv |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | ✅ | 🚀 uv |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | ✅ | 🚀 uv |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | ✅ | 🚀 uv |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | ✅ | pip |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (100%) | — | ✅ | 🔶 partial |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | — | ❌ | 🚀 uv |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | ✅ | 🚀 uv |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ (100%) | — | ✅ | pip |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ (57%) | — | ✅ | 🚀 uv |
 
 ## Policies & Automation
 | Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
@@ -59,4 +59,4 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | 0 | 0 |
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | 0 | 0 |
 
-Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time. The Trunk column indicates whether CI is green for that commit. Dark Patterns and Bright Patterns list counts of suspicious or positive code snippets detected.
+Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Codecov shows ✅ when a Codecov config or badge is present. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time. The Trunk column indicates whether CI is green for that commit. Dark Patterns and Bright Patterns list counts of suspicious or positive code snippets detected.

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -21,6 +21,7 @@ class RepoInfo:
     branch: str
     coverage: Optional[str]
     patch_percent: Optional[float]
+    uses_codecov: bool
     has_license: bool
     has_ci: bool
     has_agents: bool
@@ -500,10 +501,30 @@ class RepoCrawler:
             return pct
         return None
 
+    def _uses_codecov(
+        self,
+        repo: str,
+        branch: str,
+        readme: Optional[str],
+    ) -> bool:
+        """Return True if Codecov appears to be configured."""
+        if readme and "codecov.io" in readme:
+            return True
+        for name in (
+            "codecov.yml",
+            "codecov.yaml",
+            ".codecov.yml",
+            ".codecov.yaml",
+        ):
+            if self._has_file(repo, name, branch):
+                return True
+        return False
+
     def _check_repo(self, repo: str) -> RepoInfo:
         branch = self._branch_overrides.get(repo) or self._default_branch(repo)
         readme = self._fetch_file(repo, "README.md", branch)
         coverage = self._parse_coverage(readme, repo, branch)
+        uses_codecov = self._uses_codecov(repo, branch, readme)
         patch_cov = self._patch_coverage_from_codecov(repo, branch)
         workflow_files = self._list_workflows(repo, branch)
         workflow_count = len(workflow_files)
@@ -550,6 +571,7 @@ class RepoCrawler:
             branch=branch,
             coverage=coverage,
             patch_percent=patch_cov,
+            uses_codecov=uses_codecov,
             has_license=self._has_file(repo, "LICENSE", branch),
             has_ci=self._has_ci(workflow_files),
             has_agents=self._has_file(repo, "AGENTS.md", branch),
@@ -589,8 +611,8 @@ class RepoCrawler:
         lines.extend(["## Basics", basics_header, basics_sep])
         basics_rows = []
 
-        coverage_header = "| Repo | Coverage | Patch | Installer |"
-        coverage_sep = "| ---- | -------- | ----- | --------- |"
+        coverage_header = "| Repo | Coverage | Patch | Codecov | Installer |"
+        coverage_sep = "| ---- | -------- | ----- | ------- | --------- |"
         coverage_rows = []
 
         policy_header = (
@@ -636,11 +658,13 @@ class RepoCrawler:
             basics_rows.append(
                 f"| {repo_link} | {info.branch} | {commit} | {trunk} |"  # noqa: E501
             )
+            codecov = "✅" if info.uses_codecov else "❌"
             coverage_rows.append(
-                "| {} | {} | {} | {} |".format(
+                "| {} | {} | {} | {} | {} |".format(
                     repo_link,
                     coverage,
                     patch,
+                    codecov,
                     inst,
                 )
             )
@@ -695,7 +719,8 @@ class RepoCrawler:
             "flywheel. 🚀 uv means only uv was found. "
             "🔶 partial signals a mix of uv and pip. "
             "Coverage percentages are parsed from their badges where "
-            "available. Patch shows ✅ when diff coverage is at least 90% "
+            "available. Codecov shows ✅ when a Codecov config or badge is "
+            "present. Patch shows ✅ when diff coverage is at least 90% "
             "and ❌ otherwise, with the percentage in parentheses. "
             "The commit column shows the short SHA of the latest default "
             "branch commit at crawl time. The Trunk column indicates "

--- a/scripts/update_repo_feature_summary.py
+++ b/scripts/update_repo_feature_summary.py
@@ -30,7 +30,7 @@ def main() -> None:
     infos = crawler.crawl()
 
     basics = [["Repo", "Branch", "Commit"]]
-    coverage = [["Repo", "Coverage", "Patch", "Installer"]]
+    coverage = [["Repo", "Coverage", "Patch", "Codecov", "Installer"]]
     policy = [
         [
             "Repo",
@@ -63,7 +63,8 @@ def main() -> None:
 
         inst_map = {"uv": "🚀 uv", "partial": "🔶 partial"}
         inst = inst_map.get(info.installer, info.installer)
-        coverage.append([link, cov, patch, inst])
+        codecov = "✅" if info.uses_codecov else "❌"
+        coverage.append([link, cov, patch, codecov, inst])
 
         policy.append(
             [
@@ -100,8 +101,9 @@ def main() -> None:
     lines.append(
         "Legend: ✅ indicates the repo has adopted that feature from flywheel. "
         "🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. "
-        "Coverage percentages are parsed from Codecov when available. Patch "
-        "shows ✅ when diff coverage is at least 90% and ❌ otherwise. The "
+        "Coverage percentages are parsed from Codecov when available. Codecov "
+        "shows ✅ when a Codecov config or badge is present. Patch shows ✅ "
+        "when diff coverage is at least 90% and ❌ otherwise. The "
         "commit column shows the short SHA of the latest default branch "
         "commit at crawl time."
     )

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -109,6 +109,19 @@ def test_parse_coverage_codecov():
     assert result == "95%"
 
 
+def test_uses_codecov_from_readme():
+    sess = DummySession({})
+    crawler = rc.RepoCrawler([], session=sess)
+    readme = "See https://codecov.io/gh/foo/bar for coverage"
+    assert crawler._uses_codecov("foo/bar", "main", readme) is True
+
+
+def test_uses_codecov_false():
+    sess = DummySession({})
+    crawler = rc.RepoCrawler([], session=sess)
+    assert crawler._uses_codecov("foo/bar", "main", "no badge") is False
+
+
 def test_init_with_token():
     session = DummySession({})
     rc.RepoCrawler(["foo/bar"], session=session, token="abc123")

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -138,6 +138,7 @@ def test_generate_summary_installer_variants(monkeypatch):
         branch="main",
         coverage="100%",
         patch_percent=None,
+        uses_codecov=True,
         has_license=True,
         has_ci=True,
         has_agents=False,
@@ -165,6 +166,7 @@ def test_generate_summary_other_installer(monkeypatch):
         branch="main",
         coverage="80%",
         patch_percent=None,
+        uses_codecov=True,
         has_license=True,
         has_ci=True,
         has_agents=True,
@@ -188,6 +190,7 @@ def test_summary_column_order(monkeypatch):
         branch="main",
         coverage="100%",
         patch_percent=None,
+        uses_codecov=True,
         has_license=True,
         has_ci=True,
         has_agents=True,
@@ -203,7 +206,7 @@ def test_summary_column_order(monkeypatch):
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
     summary = crawler.generate_summary()
     assert "| Repo | Branch | Commit | Trunk |" in summary
-    assert "| Repo | Coverage | Patch | Installer |" in summary
+    assert "| Repo | Coverage | Patch | Codecov | Installer |" in summary
     assert "| Repo | License | CI | Workflows |" in summary
     assert "| Repo | Dark Patterns | Bright Patterns |" in summary
     lines = summary.splitlines()
@@ -226,6 +229,7 @@ def test_generate_summary_with_patch(monkeypatch):
         branch="main",
         coverage="100%",
         patch_percent=73.0,
+        uses_codecov=True,
         has_license=True,
         has_ci=True,
         has_agents=False,
@@ -240,7 +244,7 @@ def test_generate_summary_with_patch(monkeypatch):
     crawler = rc.RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
     lines = crawler.generate_summary().splitlines()
-    idx = lines.index("| Repo | Coverage | Patch | Installer |")
+    idx = lines.index("| Repo | Coverage | Patch | Codecov | Installer |")
     row = lines[idx + 2]
     assert "❌ (73%)" in row
     assert "(73%)" in row

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -193,6 +193,7 @@ def test_generate_summary_no_patch(monkeypatch):
         branch="main",
         coverage="100%",
         patch_percent=None,
+        uses_codecov=True,
         has_license=True,
         has_ci=True,
         has_agents=False,
@@ -207,7 +208,7 @@ def test_generate_summary_no_patch(monkeypatch):
     crawler = RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
     lines = crawler.generate_summary().splitlines()
-    idx = lines.index("| Repo | Coverage | Patch | Installer |")
+    idx = lines.index("| Repo | Coverage | Patch | Codecov | Installer |")
     row = lines[idx + 2]
     assert "| — |" in row
 

--- a/tests/test_summary_generation.py
+++ b/tests/test_summary_generation.py
@@ -18,6 +18,7 @@ def test_summary_generation(monkeypatch):
     monkeypatch.setattr(crawler, "_has_file", lambda *a, **kw: True)
 
     summary = crawler.generate_summary()
+    assert "| Repo | Coverage | Patch | Codecov | Installer |" in summary
     assert "(95%)" in summary
     assert "—" not in summary
     assert "| Repo | Dark Patterns | Bright Patterns |" in summary


### PR DESCRIPTION
## Summary
- detect Codecov configuration in RepoCrawler and expose a `uses_codecov` flag
- record Codecov usage in repo feature summary generation
- document Codecov presence for related repos

## Testing
- `SKIP=run-checks pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`
- `bash scripts/checks.sh` *(partially, exits after running JS tests and viewer server)*

------
https://chatgpt.com/codex/tasks/task_e_688dd023af2c832f8b975117a6ab072e