### PR TITLE
docs: auto-generate prompt docs summary

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -129,3 +129,5 @@ TODO
 DSPACE's
 explainers
 NSW
+RepoCrawler
+py

--- a/dict/prompt-doc-repos.txt
+++ b/dict/prompt-doc-repos.txt
@@ -1,0 +1,2 @@
+futuroptimist/flywheel
+democratizedspace/dspace@v3

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -1,0 +1,16 @@
+# Prompt Docs Summary
+
+This index is auto-generated with [scripts/update_prompt_docs_summary.py](../scripts/update_prompt_docs_summary.py)
+using RepoCrawler to discover prompt documents across repositories.
+
+| Repo                                                                    | Document                                                                                                              | Title                          |
+|-------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|--------------------------------|
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-cad.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cad.md)                 | Codex CAD Prompt               |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-ci-fix.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md)           | Codex CI-Failure Fix Prompt    |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-physics.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-physics.md)         | Codex Physics Explainer Prompt |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-spellcheck.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-spellcheck.md)   | Codex Spellcheck Prompt        |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md)                         | Flywheel Codex Prompt          |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | [prompts-codex.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md)   | Codex Prompts                  |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | [prompts-quests.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md) | Quest Prompts                  |
+
+_Updated automatically: 2025-08-02_

--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -1,0 +1,27 @@
+---
+title: 'Codex Spellcheck Prompt'
+slug: 'prompts-codex-spellcheck'
+---
+
+# Codex Spellcheck Prompt
+
+Use this prompt to automatically find and fix spelling mistakes in Markdown documentation before opening a pull request.
+
+```
+SYSTEM:
+You are an automated contributor for the Flywheel repository.
+Check all Markdown files for spelling errors using `pyspelling -c .spellcheck.yaml`.
+Add unknown but legitimate words to `dict/allow.txt`.
+Follow the conventions in AGENTS.md and ensure all other checks pass with `bash scripts/checks.sh`.
+
+USER:
+1. Run the spellcheck command and inspect the results.
+2. Correct misspellings or update `dict/allow.txt` as needed.
+3. Re-run `pyspelling` until it reports no errors.
+4. Commit the changes with a concise message and open a pull request.
+
+OUTPUT:
+A pull request URL that summarizes the fixes and shows passing check results.
+```
+
+Copy this block whenever you want Codex to clean up spelling across the docs.

--- a/scripts/update_prompt_docs_summary.py
+++ b/scripts/update_prompt_docs_summary.py
@@ -1,0 +1,101 @@
+"""Generate prompt docs summary using RepoCrawler."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import date
+from pathlib import Path
+from typing import List
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tabulate import tabulate  # noqa: E402
+
+from flywheel.repocrawler import RepoCrawler  # noqa: E402
+
+
+def load_repos(path: Path) -> List[str]:
+    lines = path.read_text().splitlines()
+    return [line.strip() for line in lines if line.strip()]
+
+
+def extract_title(text: str) -> str:
+    lines = text.splitlines()
+    if lines and lines[0].strip() == "---":
+        for line in lines[1:]:
+            if line.strip() == "---":
+                break
+            if line.lower().startswith("title:"):
+                return line.split(":", 1)[1].strip().strip("'\"")
+    for line in lines:
+        if line.startswith("#"):
+            return line.lstrip("#").strip()
+    return ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repos-from", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--token")
+    args = parser.parse_args()
+
+    repos = load_repos(args.repos_from)
+    crawler = RepoCrawler(repos, token=args.token)
+    infos = crawler.crawl()
+
+    rows: list[list[str]] = []
+
+    # Include prompt docs from the local repository (first entry)
+    local_repo = repos[0].split("@")[0]
+    docs_dir = Path(__file__).resolve().parents[1] / "docs"
+    for path in sorted(docs_dir.glob("prompts-*.md")):
+        text = path.read_text()
+        title = extract_title(text)
+        repo_link = f"**[{local_repo}](https://github.com/{local_repo})**"
+        file_name = path.name
+        doc_link = (
+            f"[{file_name}](https://github.com/{local_repo}/blob/main/docs/"
+            f"{file_name})"
+        )
+        rows.append([repo_link, doc_link, title])
+
+    # Add prompt docs from remote repositories (skip local repo)
+    for info in infos[1:]:
+        files = crawler._list_files(info.name, info.branch)
+        for path in files:
+            if "prompts-" in path and path.endswith(".md"):
+                text = crawler._fetch_file(info.name, path, info.branch) or ""
+                title = extract_title(text)
+                repo_link = f"[{info.name}](https://github.com/{info.name})"
+                file_name = path.split("/")[-1]
+                doc_link = (
+                    f"[{file_name}](https://github.com/{info.name}/blob/"
+                    f"{info.branch}/{path})"
+                )
+                rows.append([repo_link, doc_link, title])
+
+    table = tabulate(
+        rows,
+        headers=["Repo", "Document", "Title"],
+        tablefmt="github",
+    )
+    lines = [
+        "# Prompt Docs Summary",
+        "",
+        "This index is auto-generated with "
+        "[scripts/update_prompt_docs_summary.py]"
+        "(../scripts/update_prompt_docs_summary.py)",
+        "using RepoCrawler to discover prompt documents across repositories.",
+        "",
+        table,
+        "",
+        f"_Updated automatically: {date.today()}_",
+        "",
+    ]
+    args.out.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- include local prompt docs when generating summary and update summary index
- add Codex spellcheck prompt and allow proper nouns in dictionary

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_688dc6acc4b8832f9fbd3629072b8704