### PR TITLE
feat: track codecov usage in repo crawler

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -1,6 +1,7 @@
 AES
 CLI
 CodeQL
+Codecov
 DEPENDABOT
 Dependabot
 DoS

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -18,18 +18,18 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | main | `e98ee18` | ✅ |
 
 ## Coverage & Installer
-| Repo | Coverage | Patch | Installer |
-| ---- | -------- | ----- | --------- |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | pip |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (100%) | — | 🔶 partial |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | — | 🚀 uv |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | 🚀 uv |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ (100%) | — | pip |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ (57%) | — | 🚀 uv |
+| Repo | Coverage | Patch | Codecov | Installer |
+| ---- | -------- | ----- | ------- | --------- |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (100%) | — | ✅ | 🚀 uv |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | ✅ | 🚀 uv |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | ✅ | 🚀 uv |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | ✅ | 🚀 uv |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | ✅ | pip |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (100%) | — | ✅ | 🔶 partial |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | — | ❌ | 🚀 uv |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | ✅ | 🚀 uv |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ (100%) | — | ✅ | pip |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ (57%) | — | ✅ | 🚀 uv |
 
 ## Policies & Automation
 | Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit |
@@ -59,4 +59,4 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | 0 | 0 |
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | 0 | 0 |
 
-Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time. The Trunk column indicates whether CI is green for that commit. Dark Patterns and Bright Patterns list counts of suspicious or positive code snippets detected.
+Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. Coverage percentages are parsed from their badges where available. Codecov shows ✅ when a Codecov config or badge is present. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses. The commit column shows the short SHA of the latest default branch commit at crawl time. The Trunk column indicates whether CI is green for that commit. Dark Patterns and Bright Patterns list counts of suspicious or positive code snippets detected.

--- a/scripts/update_repo_feature_summary.py
+++ b/scripts/update_repo_feature_summary.py
@@ -30,7 +30,7 @@ def main() -> None:
     infos = crawler.crawl()
 
     basics = [["Repo", "Branch", "Commit"]]
-    coverage = [["Repo", "Coverage", "Patch", "Installer"]]
+    coverage = [["Repo", "Coverage", "Patch", "Codecov", "Installer"]]
     policy = [
         [
             "Repo",
@@ -63,7 +63,8 @@ def main() -> None:
 
         inst_map = {"uv": "🚀 uv", "partial": "🔶 partial"}
         inst = inst_map.get(info.installer, info.installer)
-        coverage.append([link, cov, patch, inst])
+        codecov = "✅" if info.uses_codecov else "❌"
+        coverage.append([link, cov, patch, codecov, inst])
 
         policy.append(
             [
@@ -100,8 +101,9 @@ def main() -> None:
     lines.append(
         "Legend: ✅ indicates the repo has adopted that feature from flywheel. "
         "🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip. "
-        "Coverage percentages are parsed from Codecov when available. Patch "
-        "shows ✅ when diff coverage is at least 90% and ❌ otherwise. The "
+        "Coverage percentages are parsed from Codecov when available. Codecov "
+        "shows ✅ when a Codecov config or badge is present. Patch shows ✅ "
+        "when diff coverage is at least 90% and ❌ otherwise. The "
         "commit column shows the short SHA of the latest default branch "
         "commit at crawl time."
     )

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -193,6 +193,7 @@ def test_generate_summary_no_patch(monkeypatch):
         branch="main",
         coverage="100%",
         patch_percent=None,
+        uses_codecov=True,
         has_license=True,
         has_ci=True,
         has_agents=False,
@@ -207,7 +208,7 @@ def test_generate_summary_no_patch(monkeypatch):
     crawler = RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
     lines = crawler.generate_summary().splitlines()
-    idx = lines.index("| Repo | Coverage | Patch | Installer |")
+    idx = lines.index("| Repo | Coverage | Patch | Codecov | Installer |")
     row = lines[idx + 2]
     assert "| — |" in row
 

--- a/tests/test_summary_generation.py
+++ b/tests/test_summary_generation.py
@@ -18,6 +18,7 @@ def test_summary_generation(monkeypatch):
     monkeypatch.setattr(crawler, "_has_file", lambda *a, **kw: True)
 
     summary = crawler.generate_summary()
+    assert "| Repo | Coverage | Patch | Codecov | Installer |" in summary
     assert "(95%)" in summary
     assert "—" not in summary
     assert "| Repo | Dark Patterns | Bright Patterns |" in summary


### PR DESCRIPTION
## Summary
- detect Codecov configuration in RepoCrawler and expose a `uses_codecov` flag
- record Codecov usage in repo feature summary generation
- document Codecov presence for related repos
- add tests for Codecov detection and allow-list "Codecov" for spellchecking

## Testing
- `pre-commit run --all-files`
- `pytest -q --cov=flywheel --cov-report=term`
- `npm test -- --coverage`
- `python -m flywheel.fit`


------
https://chatgpt.com/codex/tasks/task_e_688dd023af2c832f8b975117a6ab072e