### PR TITLE
feat: add three.js flywheel demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Create a Markdown table showing which flywheel files each repo uses:
 ```bash
 flywheel crawl --repos-file docs/repo_list.txt --output docs/repo-feature-summary.md
 ```
+
 Append `@branch` to any repo to crawl a non-default branch, e.g. `owner/name@dev`. Lines in `docs/repo_list.txt` are combined with any repos passed on the command line.
 Pass `--token YOURTOKEN` or set `GITHUB_TOKEN` to avoid API rate limits.
 The `Update Repo Feature Summary` workflow commits `docs/repo-feature-summary.md` to `main` after each merge.
@@ -124,6 +125,7 @@ Clone a set of repos and generate Markdown reports:
 ```bash
 python -m flywheel.agents.scanner
 ```
+
 Reports are written to `reports/`.
 
 ### Viewing the 3D flywheel
@@ -135,6 +137,8 @@ python webapp/app.py
 ```
 
 Visit `http://localhost:42165` and watch the wheel spin in your browser.
+
+Alternatively, open `viewer/threejs.html` for a standalone Three.js demo that loads the STL parts and shows simple ball bearings.
 
 ### Verifying CAD fit
 

--- a/docs/web-viewer.md
+++ b/docs/web-viewer.md
@@ -19,6 +19,10 @@ python webapp/app.py
 
 Visit [http://localhost:5000](http://localhost:5000) and select a model. Drag the mouse to rotate and scroll to zoom.
 
+## Three.js Demo
+
+Open `viewer/threejs.html` directly in your browser to spin the STL-based flywheel. The script uses Three.js's `STLLoader` and adds simple animated spheres as ball bearings.
+
 ## User Journeys
 
 - **Rotate:** left-click and drag on the canvas.

--- a/viewer/threejs.html
+++ b/viewer/threejs.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Flywheel Three.js Demo</title>
+    <style>
+      body {
+        margin: 0;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <script type="module" src="threejs.js"></script>
+  </body>
+</html>

--- a/viewer/threejs.js
+++ b/viewer/threejs.js
@@ -1,0 +1,82 @@
+/* eslint-env browser */
+import * as THREE from 'https://unpkg.com/three@0.162.0/build/three.module.js';
+import { OrbitControls } from 'https://unpkg.com/three@0.162.0/examples/jsm/controls/OrbitControls.js';
+import { STLLoader } from 'https://unpkg.com/three@0.162.0/examples/jsm/loaders/STLLoader.js';
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x202020);
+
+const camera = new THREE.PerspectiveCamera(
+  45,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  1000
+);
+camera.position.set(0, -120, 60);
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+const controls = new OrbitControls(camera, renderer.domElement);
+
+const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1.0);
+scene.add(light);
+
+const loader = new STLLoader();
+let wheelGroup;
+
+function loadMesh(path, color) {
+  return new Promise((resolve) => {
+    loader.load(path, (geometry) => {
+      geometry.center();
+      geometry.computeBoundingSphere();
+      const material = new THREE.MeshStandardMaterial({ color });
+      const mesh = new THREE.Mesh(geometry, material);
+      resolve(mesh);
+    });
+  });
+}
+
+Promise.all([
+  loadMesh('../stl/flywheel.stl', 0x777777),
+  loadMesh('../stl/shaft.stl', 0x333333),
+]).then(([wheel, shaft]) => {
+  wheelGroup = new THREE.Group();
+  wheelGroup.add(wheel);
+  scene.add(wheelGroup);
+  scene.add(shaft);
+  addBearings(wheel.geometry.boundingSphere.radius - 2);
+  animate();
+});
+
+function addBearings(radius) {
+  const balls = new THREE.Group();
+  const ballGeo = new THREE.SphereGeometry(2, 32, 32);
+  const ballMat = new THREE.MeshStandardMaterial({ color: 0xffffff });
+  const count = 12;
+  for (let i = 0; i < count; i += 1) {
+    const angle = (i / count) * Math.PI * 2;
+    const x = Math.cos(angle) * radius;
+    const y = Math.sin(angle) * radius;
+    const ball = new THREE.Mesh(ballGeo, ballMat);
+    ball.position.set(x, y, 0);
+    balls.add(ball);
+  }
+  wheelGroup.add(balls);
+}
+
+function animate() {
+  requestAnimationFrame(animate);
+  if (wheelGroup) {
+    wheelGroup.rotation.z += 0.01;
+  }
+  controls.update();
+  renderer.render(scene, camera);
+}
+
+window.addEventListener('resize', () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+});


### PR DESCRIPTION
## Summary
- add Three.js example that loads STL flywheel parts and ball bearings
- document new demo in README and web-viewer guide

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_688ee4e0cb88832fa0375b569e0ef362