### PR TITLE
docs: suggest prompt docs for related repos

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -3,14 +3,27 @@
 This index is auto-generated with [scripts/update_prompt_docs_summary.py](../scripts/update_prompt_docs_summary.py)
 using RepoCrawler to discover prompt documents across repositories.
 
-| Repo                                                                    | Document                                                                                                              | Title                          |
-|-------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|--------------------------------|
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-cad.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cad.md)                 | Codex CAD Prompt               |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-ci-fix.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md)           | Codex CI-Failure Fix Prompt    |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-physics.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-physics.md)         | Codex Physics Explainer Prompt |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-spellcheck.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-spellcheck.md)   | Codex Spellcheck Prompt        |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md)                         | Flywheel Codex Prompt          |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | [prompts-codex.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md)   | Codex Prompts                  |
+| Repo                                                                    | Document                                                            | Title                          |
+|-------------------------------------------------------------------------|--------------------------------------------------------------------|--------------------------------|
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-cad.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cad.md)               | Codex CAD Prompt               |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-ci-fix.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md)         | Codex CI-Failure Fix Prompt    |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-physics.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-physics.md)       | Codex Physics Explainer Prompt |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-spellcheck.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-spellcheck.md) | Codex Spellcheck Prompt        |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md)                       | Flywheel Codex Prompt          |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | [prompts-codex.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md) | Codex Prompts                  |
 | [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | [prompts-quests.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md) | Quest Prompts                  |
 
-_Updated automatically: 2025-08-02_
+## Suggested Prompt Docs
+
+| Repo                                                                          | Suggested Doc           | Purpose                                              |
+|-------------------------------------------------------------------------------|-------------------------|------------------------------------------------------|
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | prompts-synergy.md      | Centralize prompts for cross-repo coordination via the Synergy Bot |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | prompts-gabriel.md      | Document prompts guiding Gabriel integrations        |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | prompts-organization.md | Capture prompts for organizational workflows and profile updates |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     | prompts-market.md       | Outline prompts for token marketplace operations     |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard)     | prompts-clipboard.md    | Describe prompts for clipboard automation and sharing |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | prompts-design.md       | Collect prompts for collaborative design sessions    |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove)                   | prompts-weaving.md      | Detail prompts for weaving simulations and planning  |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)         | prompts-devops.md       | Provide prompts for deployment and infrastructure tasks |
+
+_Updated automatically: 2025-08-03_


### PR DESCRIPTION
## Summary
- add suggested prompt-doc mappings for related repositories
- show a "Suggested Prompt Docs" section in the prompt docs summary

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_688ef16e59a0832f9722d5a06ee60e19