### PR TITLE
docs: suggest prompt docs for related repos

### DIFF
--- a/dict/prompt-doc-repos.txt
+++ b/dict/prompt-doc-repos.txt
@@ -1,2 +1,10 @@
 futuroptimist/flywheel
 democratizedspace/dspace@v3
+futuroptimist/axel
+futuroptimist/f2clipboard
+futuroptimist/futuroptimist
+futuroptimist/gabriel
+futuroptimist/sigma
+futuroptimist/sugarkube
+futuroptimist/token.place
+futuroptimist/wove

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -1,16 +1,32 @@
 # Prompt Docs Summary
 
-This index is auto-generated with [scripts/update_prompt_docs_summary.py](../scripts/update_prompt_docs_summary.py)
+This index is auto-generated with
+[scripts/update_prompt_docs_summary.py]
+(../scripts/update_prompt_docs_summary.py)
 using RepoCrawler to discover prompt documents across repositories.
 
-| Repo                                                                    | Document                                                                                                              | Title                          |
-|-------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|--------------------------------|
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-cad.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cad.md)                 | Codex CAD Prompt               |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-ci-fix.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md)           | Codex CI-Failure Fix Prompt    |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-physics.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-physics.md)         | Codex Physics Explainer Prompt |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-spellcheck.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-spellcheck.md)   | Codex Spellcheck Prompt        |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md)                         | Flywheel Codex Prompt          |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | [prompts-codex.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md)   | Codex Prompts                  |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | [prompts-quests.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md) | Quest Prompts                  |
+| Repo                                                                    | Document                                                                                                                    | Title                           |
+|-------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|---------------------------------|
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-cad.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cad.md)                       | Codex CAD Prompt                |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-ci-fix.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md)                 | Codex CI-Failure Fix Prompt     |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-physics.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-physics.md)               | Codex Physics Explainer Prompt  |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-spellcheck.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-spellcheck.md)         | Codex Spellcheck Prompt         |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex-suggested-docs.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-suggested-docs.md) | Create Prompt Docs Across Repos |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | [prompts-codex.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md)                               | Flywheel Codex Prompt           |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | [prompts-codex.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md)         | Codex Prompts                   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | [prompts-quests.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md)       | Quest Prompts                   |
 
-_Updated automatically: 2025-08-02_
+## Suggested Prompt Docs
+
+| Repo                                                                          | Suggested Doc           | Purpose                                                            |
+|-------------------------------------------------------------------------------|-------------------------|--------------------------------------------------------------------|
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | prompts-synergy.md      | Centralize prompts for cross-repo coordination via the Synergy Bot |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard)     | prompts-clipboard.md    | Describe prompts for clipboard automation and sharing              |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | prompts-organization.md | Capture prompts for organizational workflows and profile updates   |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | prompts-gabriel.md      | Document prompts guiding Gabriel integrations                      |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | prompts-design.md       | Collect prompts for collaborative design sessions                  |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)         | prompts-devops.md       | Provide prompts for deployment and infrastructure tasks            |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     | prompts-market.md       | Outline prompts for token marketplace operations                   |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove)                   | prompts-weaving.md      | Detail prompts for weaving simulations and planning                |
+
+_Updated automatically: 2025-08-03_

--- a/docs/prompts-codex-suggested-docs.md
+++ b/docs/prompts-codex-suggested-docs.md
@@ -1,0 +1,136 @@
+---
+title: 'Create Prompt Docs Across Repos'
+slug: 'prompts-codex-suggested-docs'
+---
+
+# Cross-Repo Prompt Doc Creator
+
+Use the following self-contained prompts in Codex to scaffold prompt documentation for Futuroptimist repositories. Copy the block for the repository you want to update into a fresh Codex session.
+
+## futuroptimist/axel
+
+```
+SYSTEM: You are an automated contributor that works in Git repositories and follows their conventions.
+
+USER:
+1. Clone https://github.com/futuroptimist/axel.git and checkout the default branch.
+2. Create docs/prompts-synergy.md with a level-1 heading "Prompts Synergy".
+3. Insert the placeholder sentence: "Centralize prompts for cross-repo coordination via the Synergy Bot."
+4. Run formatting and tests if available (`pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`).
+5. Commit with message `docs: add prompt doc skeleton` and open a pull request titled `docs: add prompt doc skeleton`.
+
+OUTPUT:
+Return the URL of the pull request.
+```
+
+## futuroptimist/f2clipboard
+
+```
+SYSTEM: You are an automated contributor that works in Git repositories and follows their conventions.
+
+USER:
+1. Clone https://github.com/futuroptimist/f2clipboard.git and checkout the default branch.
+2. Create docs/prompts-clipboard.md with a level-1 heading "Prompts Clipboard".
+3. Insert the placeholder sentence: "Describe prompts for clipboard automation and sharing."
+4. Run formatting and tests if available (`pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`).
+5. Commit with message `docs: add prompt doc skeleton` and open a pull request titled `docs: add prompt doc skeleton`.
+
+OUTPUT:
+Return the URL of the pull request.
+```
+
+## futuroptimist/futuroptimist
+
+```
+SYSTEM: You are an automated contributor that works in Git repositories and follows their conventions.
+
+USER:
+1. Clone https://github.com/futuroptimist/futuroptimist.git and checkout the default branch.
+2. Create docs/prompts-organization.md with a level-1 heading "Prompts Organization".
+3. Insert the placeholder sentence: "Capture prompts for organizational workflows and profile updates."
+4. Run formatting and tests if available (`pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`).
+5. Commit with message `docs: add prompt doc skeleton` and open a pull request titled `docs: add prompt doc skeleton`.
+
+OUTPUT:
+Return the URL of the pull request.
+```
+
+## futuroptimist/gabriel
+
+```
+SYSTEM: You are an automated contributor that works in Git repositories and follows their conventions.
+
+USER:
+1. Clone https://github.com/futuroptimist/gabriel.git and checkout the default branch.
+2. Create docs/prompts-gabriel.md with a level-1 heading "Prompts Gabriel".
+3. Insert the placeholder sentence: "Document prompts guiding Gabriel integrations."
+4. Run formatting and tests if available (`pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`).
+5. Commit with message `docs: add prompt doc skeleton` and open a pull request titled `docs: add prompt doc skeleton`.
+
+OUTPUT:
+Return the URL of the pull request.
+```
+
+## futuroptimist/sigma
+
+```
+SYSTEM: You are an automated contributor that works in Git repositories and follows their conventions.
+
+USER:
+1. Clone https://github.com/futuroptimist/sigma.git and checkout the default branch.
+2. Create docs/prompts-design.md with a level-1 heading "Prompts Design".
+3. Insert the placeholder sentence: "Collect prompts for collaborative design sessions."
+4. Run formatting and tests if available (`pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`).
+5. Commit with message `docs: add prompt doc skeleton` and open a pull request titled `docs: add prompt doc skeleton`.
+
+OUTPUT:
+Return the URL of the pull request.
+```
+
+## futuroptimist/sugarkube
+
+```
+SYSTEM: You are an automated contributor that works in Git repositories and follows their conventions.
+
+USER:
+1. Clone https://github.com/futuroptimist/sugarkube.git and checkout the default branch.
+2. Create docs/prompts-devops.md with a level-1 heading "Prompts Devops".
+3. Insert the placeholder sentence: "Provide prompts for deployment and infrastructure tasks."
+4. Run formatting and tests if available (`pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`).
+5. Commit with message `docs: add prompt doc skeleton` and open a pull request titled `docs: add prompt doc skeleton`.
+
+OUTPUT:
+Return the URL of the pull request.
+```
+
+## futuroptimist/token.place
+
+```
+SYSTEM: You are an automated contributor that works in Git repositories and follows their conventions.
+
+USER:
+1. Clone https://github.com/futuroptimist/token.place.git and checkout the default branch.
+2. Create docs/prompts-market.md with a level-1 heading "Prompts Market".
+3. Insert the placeholder sentence: "Outline prompts for token marketplace operations."
+4. Run formatting and tests if available (`pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`).
+5. Commit with message `docs: add prompt doc skeleton` and open a pull request titled `docs: add prompt doc skeleton`.
+
+OUTPUT:
+Return the URL of the pull request.
+```
+
+## futuroptimist/wove
+
+```
+SYSTEM: You are an automated contributor that works in Git repositories and follows their conventions.
+
+USER:
+1. Clone https://github.com/futuroptimist/wove.git and checkout the default branch.
+2. Create docs/prompts-weaving.md with a level-1 heading "Prompts Weaving".
+3. Insert the placeholder sentence: "Detail prompts for weaving simulations and planning."
+4. Run formatting and tests if available (`pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`).
+5. Commit with message `docs: add prompt doc skeleton` and open a pull request titled `docs: add prompt doc skeleton`.
+
+OUTPUT:
+Return the URL of the pull request.
+```


### PR DESCRIPTION
## Summary
- sort repository list used to crawl prompt docs
- restructure suggested prompt doc prompt into per-repo sections
- regenerate prompt docs summary with sorted suggestions

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`
- `bash scripts/checks.sh` *(terminated early by dev server)*


------
https://chatgpt.com/codex/tasks/task_e_688ef16e59a0832f9722d5a06ee60e19