### PR TITLE
chore: allow Playwright in spellcheck

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -10,6 +10,7 @@ JS
 LLM
 NEWREPO
 OpenAI
+Playwright
 PRD
 Prettier
 PyPI


### PR DESCRIPTION
## Summary
- include Playwright in spellcheck dictionary

## Testing
- `pyspelling -c .spellcheck.yaml --verbose`
- `pytest -q`
- `npm test -- --coverage` *(fails: tests were interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_688ffb8a189c832fbe9e132f9e9cec67