### PR TITLE
fix: install Playwright browsers before tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "format:check": "echo skip",
     "jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "playwright": "playwright test",
-    "test": "npm run jest -- && npm run playwright",
-    "playwright:install": "playwright install",
+    "playwright:install": "playwright install --with-deps",
+    "test": "npm run playwright:install && npm run jest -- && npm run playwright",
     "docs:dev": "npm --prefix docs-site run dev"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- ensure `npm test` installs required Playwright browsers

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`


------
https://chatgpt.com/codex/tasks/task_e_688ffb1ba8ac832f879f1d0d5b2fa920