### PR TITLE
feat: track security scan results

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,30 @@
+name: Security Scan
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  security-scan:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run scan
+        run: node scripts/security-scan.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: 'chore: update security scan results'
+          title: 'chore: update security scan results'
+          branch: security-scan
+          base: main
+          add-paths: docs/repo-feature-summary.md

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -31,6 +31,20 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ (100%) | — | ✅ | pip | 2025-07-29 |
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ (57%) | — | ✅ | 🚀 uv | 2025-08-03 |
 
+
+## Security & Dependency Health
+| Repo | Dependabot | Secret-Scanning | CodeQL | Snyk (badge) |
+| ---- | ---------- | --------------- | ------ | ------------ |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ❌ | ❌ | ❌ | ❌ |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ❌ | ❌ | ❌ | ❌ |
 ## Policies & Automation
 | Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Last-Updated (UTC) |
 | ---- | ------- | -- | --------- | --------- | --------------- | ------------ | ---------- | ----------------- |

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "format": "echo skip",
     "format:check": "echo skip",
     "jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
+    "coverage": "npm run jest -- --coverage",
     "playwright": "playwright test",
     "playwright:install": "playwright install --with-deps",
     "test": "npm run playwright:install && npm run jest -- && npm run playwright",

--- a/scripts/security-scan.mjs
+++ b/scripts/security-scan.mjs
@@ -1,0 +1,100 @@
+import { readFile, writeFile } from 'fs/promises';
+
+export function authHeaders() {
+  const headers = { 'User-Agent': 'flywheel-security-scan', Accept: 'application/vnd.github+json' };
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  return headers;
+}
+
+async function fetchJSON(url) {
+  const res = await fetch(url, { headers: authHeaders() });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`);
+  return res.json();
+}
+
+function badgeInReadme(readme, keyword) {
+  const lower = readme.toLowerCase();
+  return lower.includes(keyword.toLowerCase());
+}
+
+export async function scanRepo(identifier) {
+  const [repo, ref] = identifier.split('@');
+  const [owner, name] = repo.split('/');
+  const refParam = ref ? `?ref=${ref}` : '';
+
+  const dependabot = !!(await fetchJSON(`https://api.github.com/repos/${owner}/${name}/contents/.github/dependabot.yml${refParam}`));
+
+  const repoData = await fetchJSON(`https://api.github.com/repos/${owner}/${name}`);
+  const secretScanning = repoData?.security_and_analysis?.secret_scanning?.status === 'enabled';
+  const branch = ref || repoData?.default_branch || 'main';
+
+  const readmeRes = await fetch(`https://raw.githubusercontent.com/${owner}/${name}/${branch}/README.md`);
+  const readme = readmeRes.ok ? await readmeRes.text() : '';
+  const codeql = badgeInReadme(readme, 'codeql');
+  const snyk = badgeInReadme(readme, 'snyk');
+
+  return { repo: `${owner}/${name}`, dependabot, secretScanning, codeql, snyk };
+}
+
+export function renderTable(results) {
+  const header = [
+    '## Security & Dependency Health',
+    '| Repo | Dependabot | Secret-Scanning | CodeQL | Snyk (badge) |',
+    '| ---- | ---------- | --------------- | ------ | ------------ |'
+  ];
+  const fmt = (b) => (b ? '✅' : '❌');
+  const rows = results.map((r) => {
+    const link = `https://github.com/${r.repo}`;
+    const name = r.repo === 'futuroptimist/flywheel' ? `**[${r.repo}](${link})**` : `[${r.repo}](${link})`;
+    return `| ${name} | ${fmt(r.dependabot)} | ${fmt(r.secretScanning)} | ${fmt(r.codeql)} | ${fmt(r.snyk)} |`;
+  });
+  return header.concat(rows).join('\n');
+}
+
+export function updateMarkdown(existing, table) {
+  const lines = existing.split('\n');
+  const start = lines.findIndex((l) => l.startsWith('## Security & Dependency Health'));
+  if (start !== -1) {
+    let end = start + 1;
+    while (end < lines.length && !lines[end].startsWith('## ')) end++;
+    lines.splice(start, end - start, table);
+    return lines.join('\n');
+  }
+  const coverage = lines.findIndex((l) => l.startsWith('## Coverage & Installer'));
+  if (coverage !== -1) {
+    let insert = coverage + 1;
+    while (insert < lines.length && !lines[insert].startsWith('## ')) insert++;
+    lines.splice(insert, 0, '', table, '');
+    return lines.join('\n');
+  }
+  return existing + '\n\n' + table;
+}
+
+export async function main(options = {}) {
+  const listPath = options.repoListPath
+    ? new URL(options.repoListPath, import.meta.url)
+    : new URL('../docs/repo_list.txt', import.meta.url);
+  const repoList = (await readFile(listPath, 'utf8')).trim().split('\n').filter(Boolean);
+  const results = [];
+  for (const repo of repoList) {
+    try {
+      results.push(await scanRepo(repo));
+    } catch {
+      results.push({ repo: repo.split('@')[0], dependabot: false, secretScanning: false, codeql: false, snyk: false });
+    }
+  }
+  const table = renderTable(results);
+  const mdPath = options.markdownPath
+    ? new URL(options.markdownPath, import.meta.url)
+    : new URL('../docs/repo-feature-summary.md', import.meta.url);
+  const existing = await readFile(mdPath, 'utf8');
+  const updated = updateMarkdown(existing, table);
+  await writeFile(mdPath, updated);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tests/security-scan.test.mjs
+++ b/tests/security-scan.test.mjs
@@ -1,0 +1,69 @@
+import { jest } from '@jest/globals';
+import fs from 'fs';
+import { scanRepo, renderTable, updateMarkdown, authHeaders, main } from '../scripts/security-scan.mjs';
+
+describe('scanRepo', () => {
+  test('detects security features', async () => {
+    global.fetch = jest.fn()
+      // dependabot
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      // repo info
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ security_and_analysis: { secret_scanning: { status: 'enabled' } }, default_branch: 'main' }) })
+      // readme
+      .mockResolvedValueOnce({ ok: true, text: async () => '![CodeQL](badge) ![Snyk](badge)' });
+    const result = await scanRepo('owner/repo');
+    expect(result).toEqual({ repo: 'owner/repo', dependabot: true, secretScanning: true, codeql: true, snyk: true });
+  });
+
+  test('handles missing features', async () => {
+    global.fetch = jest.fn()
+      // dependabot 404
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      // repo info disabled
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ security_and_analysis: { secret_scanning: { status: 'disabled' } }, default_branch: 'main' }) })
+      // readme empty
+      .mockResolvedValueOnce({ ok: true, text: async () => '' });
+    const result = await scanRepo('owner/repo');
+    expect(result).toEqual({ repo: 'owner/repo', dependabot: false, secretScanning: false, codeql: false, snyk: false });
+  });
+});
+
+describe('renderTable & updateMarkdown', () => {
+  const sample = [
+    { repo: 'futuroptimist/flywheel', dependabot: true, secretScanning: true, codeql: true, snyk: false }
+  ];
+  test('renders table', () => {
+    const table = renderTable(sample);
+    expect(table).toContain('Security & Dependency Health');
+    expect(table).toContain('✅');
+    expect(table).toContain('❌');
+  });
+  test('inserts and replaces section', () => {
+    const table = renderTable(sample);
+    const base = '# Title\n\n## Coverage & Installer\nfoo\n\n## Policies & Automation';
+    const inserted = updateMarkdown(base, table);
+    expect(inserted).toContain(table);
+    const replaced = updateMarkdown(inserted, table.replace('❌', '✅'));
+    expect(replaced).toContain('✅');
+  });
+});
+
+test('authHeaders includes token and main writes file', async () => {
+  process.env.GITHUB_TOKEN = 'testtoken';
+  expect(authHeaders().Authorization).toBe('Bearer testtoken');
+  delete process.env.GITHUB_TOKEN;
+
+  const repoListPath = '../tests/tmp-repos.txt';
+  const mdPath = '../tests/tmp-summary.md';
+  await fs.promises.writeFile('tests/tmp-repos.txt', 'owner/repo');
+  await fs.promises.writeFile('tests/tmp-summary.md', '# Title\n\n## Coverage & Installer\nfoo');
+  global.fetch = jest.fn()
+    .mockResolvedValueOnce({ ok: false, status: 404 })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ default_branch: 'main' }) })
+    .mockResolvedValueOnce({ ok: true, text: async () => '' });
+  await main({ repoListPath, markdownPath: mdPath });
+  const updated = await fs.promises.readFile('tests/tmp-summary.md', 'utf8');
+  expect(updated).toContain('Security & Dependency Health');
+  await fs.promises.unlink('tests/tmp-repos.txt');
+  await fs.promises.unlink('tests/tmp-summary.md');
+});


### PR DESCRIPTION
## Summary
- add `security-scan.mjs` to check Dependabot, secret scanning, CodeQL, and Snyk
- publish Security & Dependency Health results in repo summary
- schedule nightly workflow to update the table via PR

## Testing
- `pre-commit run --files docs/repo-feature-summary.md scripts/security-scan.mjs tests/security-scan.test.mjs package.json .github/workflows/security-scan.yml` *(command not found)*
- `pytest -q`
- `npm run coverage`
- `npm run lint`
- `python -m flywheel.fit`
- `npm test -- --coverage`
- `act -j security-scan` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68903e47d080832fa7d36c6d91d15a87