### PR TITLE
feat: add security scan table

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,43 @@
+name: Security Scan
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - uses: astral-sh/setup-uv@v1
+      - name: Install deps
+        run: |
+          uv pip install --system -r requirements.txt
+          uv pip install --system pre-commit
+      - name: Rebuild summary
+        run: |
+          python -m flywheel crawl --repos-file docs/repo_list.txt --output docs/repo-feature-summary.md
+          node scripts/security-scan.mjs --repos-from docs/repo_list.txt --out docs/repo-feature-summary.md
+      - name: Run pre-commit
+        run: |
+          pre-commit run --files docs/repo-feature-summary.md || true
+          git add docs/repo-feature-summary.md
+          pre-commit run --files docs/repo-feature-summary.md
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "chore: update security scan"
+          title: "chore: update security scan"
+          body: "Nightly security & dependency health scan"
+          branch: security-scan

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -31,6 +31,21 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ (100%) | — | ✅ | pip | 2025-07-29 |
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ (57%) | — | ✅ | 🚀 uv | 2025-08-03 |
 
+
+## Security & Dependency Health
+| Repo | Dependabot | Secret-Scanning | CodeQL | Snyk (badge) |
+| ---- | ---------- | --------------- | ------ | ------------ |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ❌ | ❌ | ❌ | ❌ |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ❌ | ❌ | ❌ | ❌ |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ❌ | ❌ | ❌ | ❌ |
+
 ## Policies & Automation
 | Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Last-Updated (UTC) |
 | ---- | ------- | -- | --------- | --------- | --------------- | ------------ | ---------- | ----------------- |

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "playwright": "playwright test",
     "playwright:install": "playwright install --with-deps",
+    "coverage": "npm run jest -- --coverage",
     "test": "npm run playwright:install && npm run jest -- && npm run playwright",
     "docs:dev": "npm --prefix docs-site run dev"
   },

--- a/scripts/security-scan.mjs
+++ b/scripts/security-scan.mjs
@@ -1,0 +1,85 @@
+import fs from 'fs/promises';
+
+function headers(token) {
+  const h = { 'User-Agent': 'flywheel-security-scan', Accept: 'application/vnd.github+json' };
+  if (token) h.Authorization = `token ${token}`;
+  return { headers: h };
+}
+
+export async function scanRepo(repo, branch = 'main', token = null, fetchImpl = fetch) {
+  const opts = headers(token);
+  const depUrl = `https://api.github.com/repos/${repo}/contents/.github/dependabot.yml?ref=${branch}`;
+  const depResp = await fetchImpl(depUrl, opts).catch(() => ({ ok: false }));
+  const dependabot = depResp.ok;
+
+  const secUrl = `https://api.github.com/repos/${repo}/secret-scanning/alerts?per_page=1`;
+  const secResp = await fetchImpl(secUrl, opts).catch(() => ({ status: 404 }));
+  const secret = secResp.status === 200;
+
+  const readmeUrl = `https://api.github.com/repos/${repo}/readme?ref=${branch}`;
+  const readmeResp = await fetchImpl(readmeUrl, opts).catch(() => ({ ok: false }));
+  let readme = '';
+  if (readmeResp.ok) {
+    const json = await readmeResp.json();
+    const enc = json.encoding || 'base64';
+    readme = Buffer.from(json.content || '', enc).toString();
+  }
+  const codeql = /codeql/i.test(readme);
+  const snyk = /snyk/i.test(readme);
+
+  return { repo, dependabot, secret, codeql, snyk };
+}
+
+function mark(flag) {
+  return flag ? '✅' : '❌';
+}
+
+export function renderTable(results) {
+  const header = '| Repo | Dependabot | Secret-Scanning | CodeQL | Snyk (badge) |';
+  const sep = '| ---- | ---------- | --------------- | ------ | ------------ |';
+  const rows = results.map((r, idx) => {
+    const link = `[${r.repo}](https://github.com/${r.repo})`;
+    const repoLink = idx === 0 ? `**${link}**` : link;
+    return `| ${repoLink} | ${mark(r.dependabot)} | ${mark(r.secret)} | ${mark(r.codeql)} | ${mark(r.snyk)} |`;
+  });
+  return [header, sep, ...rows].join('\n');
+}
+
+export async function updateDoc(path, table) {
+  const text = await fs.readFile(path, 'utf8');
+  const lines = text.split('\n');
+  const secHeader = '## Security & Dependency Health';
+  const covIndex = lines.findIndex((l) => l.startsWith('## Coverage & Installer'));
+  if (covIndex === -1) throw new Error('Coverage section not found');
+  const nextSection = lines.findIndex((l, i) => i > covIndex && l.startsWith('## '));
+  const insertAt = nextSection === -1 ? lines.length : nextSection;
+  const secIndex = lines.findIndex((l) => l.startsWith(secHeader));
+  if (secIndex !== -1) {
+    const end = lines.findIndex((l, i) => i > secIndex && l.startsWith('## '));
+    const sliceEnd = end === -1 ? lines.length : end;
+    lines.splice(secIndex, sliceEnd - secIndex, secHeader, table, '');
+  } else {
+    lines.splice(insertAt, 0, '', secHeader, table, '');
+  }
+  await fs.writeFile(path, lines.join('\n'));
+}
+
+export async function run(args = process.argv.slice(2)) {
+  const reposFrom = args[args.indexOf('--repos-from') + 1];
+  const out = args[args.indexOf('--out') + 1];
+  const tokenIdx = args.indexOf('--token');
+  const token = tokenIdx !== -1 ? args[tokenIdx + 1] : process.env.GITHUB_TOKEN;
+  const list = (await fs.readFile(reposFrom, 'utf8')).split(/\r?\n/).filter(Boolean);
+  const results = [];
+  for (const entry of list) {
+    const [repo, branch = 'main'] = entry.split('@');
+    results.push(await scanRepo(repo, branch, token));
+  }
+  const table = renderTable(results);
+  await updateDoc(out, table);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run();
+}
+

--- a/tests/security-scan.test.js
+++ b/tests/security-scan.test.js
@@ -1,0 +1,61 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { jest } from '@jest/globals';
+import { scanRepo, renderTable, updateDoc, run } from '../scripts/security-scan.mjs';
+
+test('scanRepo detects features from API responses', async () => {
+  const readme = Buffer.from('![CodeQL](a)\n![snyk](b)').toString('base64');
+  const fetchMock = jest.fn()
+    .mockResolvedValueOnce({ ok: true })
+    .mockResolvedValueOnce({ status: 200 })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ content: readme, encoding: 'base64' }) });
+  const res = await scanRepo('owner/repo', 'main', null, fetchMock);
+  expect(res).toEqual({ repo: 'owner/repo', dependabot: true, secret: true, codeql: true, snyk: true });
+});
+
+test('scanRepo handles missing features', async () => {
+  const fetchMock = jest.fn()
+    .mockResolvedValueOnce({ ok: false })
+    .mockResolvedValueOnce({ status: 404 })
+    .mockResolvedValueOnce({ ok: false });
+  const res = await scanRepo('owner/repo', 'main', null, fetchMock);
+  expect(res).toEqual({ repo: 'owner/repo', dependabot: false, secret: false, codeql: false, snyk: false });
+});
+
+test('renderTable and updateDoc insert section', async () => {
+  const table = renderTable([
+    { repo: 'owner/repo', dependabot: true, secret: false, codeql: true, snyk: false }
+  ]);
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'scan-'));
+  const file = path.join(tmp, 'summary.md');
+  await fs.writeFile(file, '# Repo Feature Summary\n\n## Coverage & Installer\n| c | d |\n\n## Policies & Automation\n');
+  await updateDoc(file, table);
+  const text1 = await fs.readFile(file, 'utf8');
+  expect(text1).toMatch('## Security & Dependency Health');
+  expect(text1).toMatch('\| Repo \| Dependabot');
+  // run again to ensure replacement path
+  await updateDoc(file, table);
+  const text2 = await fs.readFile(file, 'utf8');
+  expect(text2.match(/Security & Dependency Health/g).length).toBe(1);
+});
+
+test('run integrates scanning and updating', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'scan-'));
+  const repos = path.join(tmp, 'repos.txt');
+  await fs.writeFile(repos, 'owner/repo');
+  const file = path.join(tmp, 'summary.md');
+  await fs.writeFile(file, '# Repo Feature Summary\n\n## Coverage & Installer\n| c | d |\n\n## Policies & Automation\n');
+  const readme = Buffer.from('CodeQL badge\nSnyk badge').toString('base64');
+  const mockFetch = jest.fn()
+    .mockResolvedValueOnce({ ok: true })
+    .mockResolvedValueOnce({ status: 200 })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ content: readme, encoding: 'base64' }) });
+  const origFetch = global.fetch;
+  global.fetch = mockFetch;
+  await run(['--repos-from', repos, '--out', file]);
+  global.fetch = origFetch;
+  const text = await fs.readFile(file, 'utf8');
+  expect(text).toMatch('CodeQL');
+});
+


### PR DESCRIPTION
## Summary
- track Dependabot, secret scanning, CodeQL, and Snyk badges across repos
- add nightly workflow to refresh repo feature summary
- cover new security scan helper with tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`
- `npm run coverage`
- `npm run lint`
- `./bin/act -j security-scan` *(fails: Couldn't get a valid docker connection)*
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68903e47d080832fa7d36c6d91d15a87