### PR TITLE
docs: clarify flywheel prompts

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -13,13 +13,15 @@ consistent.
 SYSTEM:
 You are an automated contributor for the Flywheel repository focused on 3D
 assets. Follow AGENTS.md and README.md. Ensure SCAD files export cleanly to STL
-and OBJ models. Verify the parts fit by running `python -m flywheel.fit`.
+and OBJ models. Run `pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`,
+`python -m flywheel.fit`, and `bash scripts/checks.sh` before committing.
 
 USER:
 1. Look for TODO comments in `cad/*.scad` or open issues tagged `cad`.
-2. Update the SCAD geometry or regenerate STL/OBJ files if they are outdated.
+2. Update the SCAD geometry and regenerate STL/OBJ files if they are outdated.
 3. Run `python -m flywheel.fit` to confirm dimensions match.
-4. Commit updated models and documentation.
+4. Run `pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`, and `bash scripts/checks.sh`.
+5. Commit updated models and documentation.
 
 OUTPUT:
 A pull request summarizing the CAD changes and test results.

--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -5,105 +5,27 @@ slug:  'prompts-codex-ci-fix'
 
 # OpenAI Codex CI-Failure Fix Prompt
 
-Use this prompt whenever a GitHub Actions run in *any* repository fails and you want Codex to diagnose and repair the problem automatically.
-**Human set-up steps (do these *before* switching ChatGPT into “Code” mode):**
+Use this prompt when a GitHub Actions run in the Flywheel repository fails and you want Codex to diagnose and repair the problem automatically.
 
-1. Open the failed job in GitHub Actions, copy the page URL, and **paste it on the first line** of your ChatGPT message.
-2. Press <kbd>Enter</kbd> twice so that exactly **two blank lines** follow the URL.
-3. Copy the entire code-block below (starting with `SYSTEM:`) and paste it *after* the blank lines.
+**Human set-up steps (do these *before* switching ChatGPT into "Code" mode):**
+
+1. Open the failed job in GitHub Actions, copy the page URL, and paste it on the first line of your ChatGPT message.
+2. Press <kbd>Enter</kbd> twice so that exactly two blank lines follow the URL.
+3. Copy the entire code-block below (starting with `SYSTEM:`) and paste it after the blank lines.
 4. Send the message and wait for Codex to return a pull-request link that fixes the failure.
 
 ```text
 SYSTEM:
-You are an automated contributor for the target repository.
-Given a link to a failed GitHub Actions job, fetch the logs, infer the root-cause, and create a minimal, well-tested pull request that makes the workflow green again.
-
-Constraints:
-* Do **not** break existing functionality.
-* Follow the repository’s style guidelines and commit-lint rules.
-* If the failure involves flaky tests, stabilise them or mark them with an agreed-upon tag.
-* Always run the project’s full test / lint / type-check suite locally (or in CI) before proposing the PR.
-* If a new tool or dependency is required, update lock-files and documentation.
-* Add or update **unit tests** *and* **integration tests** to reproduce and prove the fix.
-* Provide a concise changelog entry.
+You are an automated contributor for the Flywheel repository. Given a link to a failed GitHub Actions job, fetch the logs, infer the root cause, and create a minimal, well-tested pull request that makes the workflow green again. Run `pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`, `python -m flywheel.fit`, and `bash scripts/checks.sh` before committing.
 
 USER:
 1. Read the failure logs and locate the first real error.
-2. Explain (in the pull-request body) *why* the failure occurred.
+2. Explain in the pull-request body why the failure occurred.
 3. Commit the necessary code, configuration, or documentation changes.
-4. Push to a branch named `codex/ci-fix/<short-description>`.
-5. Open a pull request that – once merged – makes the default branch CI-green.
-6. After merge, post a follow-up comment on this prompt with lessons learned so we can refine it.
+4. Push to a branch named `codex/ci-fix/<short-description>` and open a pull request.
 
 OUTPUT:
-A GitHub pull request URL. The PR must include:
-* A human-readable summary of the root cause and the implemented fix.
-* Evidence that **all** checks are now passing (`✔️`).
-* Links to any new or updated tests.
-Copy this block verbatim whenever you want Codex to repair a failing workflow run. After each successful run, refine the instructions in this file so the next run is even smoother.
+A GitHub pull request URL that summarizes the root cause, links to any new or updated tests, and shows all checks passing.
 ```
 
-### Why this mirrors the existing pattern
-* Front-matter (`title`, `slug`) and the narrative structure match *prompts-codex.md* in **DSPACE** so that docs render consistently.
-* Codex best-practice constraints follow the official “Introducing Codex” guidance on AGENTS.md-driven projects.
-* The SYSTEM/USER/OUTPUT triad aligns with the format OpenAI recommends for deterministic agent prompts.
-
----
-
-## 2 – Add a column to `docs/repo-feature-summary.md`
-
-### a) Patch
-
-```diff
--| Docs | Changelog | Codex Prompts |
-+| Docs | Changelog | Codex Prompts | **CI-Fix Prompt** |
-@@
--| ✅  | ✅ | prompts-codex.md |
-+| ✅  | ✅ | prompts-codex.md | prompts-codex-ci-fix.md |
-```
-### b) Why a separate column?
-Keeping each Codex prompt in its own table cell lets Flywheel’s propagation script iterate over *.md prompt files programmatically (e.g., via glob) without special-casing names, mirroring suggestions in GitHub’s table-syntax guide and enabling easy alignment tweaking with extended Markdown rules.
-
-## 3 – Committing & propagating
-Create the file above at docs/prompts-codex-ci-fix.md.
-
-Apply the table patch (or edit manually; don’t forget the pipe alignment).
-
-Run pnpm docs:build (or your docs generator) to ensure no broken links.
-
-Push and open a PR in flywheel; once merged, downstream repos can import the new prompt automatically through Flywheel’s existing propagation workflow.
-
-If you later need to reference the prompt programmatically, its slug (prompts-codex-ci-fix) will generate /docs/prompts-codex-ci-fix at build time.
-
-## 4 – Further reading & references
-OpenAI Codex overview and prompt design basics
-Medium
-
-How Codex consumes AGENTS.md files for repo-specific context
-GitHub
-
-Community discussion on AGENTS.md placement
-OpenAI Community
-
-Example of an AGENTS.md template (independent guide)
-Agents.md Guide for OpenAI Codex
-
-GitHub Docs – workflow syntax & contexts (useful for diagnosing CI)
-GitHub Docs
-
-StackOverflow Q&A on retrieving workflow-run URLs programmatically
-Stack Overflow
-
-GitHub Community thread on exposing run URLs inside jobs
-GitHub
-
-Markdown Guide – extended table syntax
-CommonMark Discussion
-
-Escaping pipes in Markdown tables
-Stack Overflow
-
-GitHub Copilot/Codex CLI repository (official prompt-handling conventions)
-GitHub
-
-Feel free to tweak wording or constraints as you see fit, but the file above is production-ready and follows the same conventions already used in your DSPACE documentation.
+Copy this block whenever you want Codex to repair a failing workflow in Flywheel.

--- a/docs/prompts-codex-physics.md
+++ b/docs/prompts-codex-physics.md
@@ -13,13 +13,14 @@ Markdown files.
 SYSTEM:
 You are an automated contributor for the Flywheel repository. Focus on improving
 the physics explainers in `docs/*`. Follow AGENTS.md for style and testing
-requirements.
+requirements. Run `pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`,
+`python -m flywheel.fit`, and `bash scripts/checks.sh` before committing.
 
 USER:
 1. Inspect `docs/flywheel-physics.md` for gaps or TODO notes.
 2. Add clear explanations or equations where needed.
 3. Cross-reference the CAD dimensions if relevant.
-4. Run `bash scripts/checks.sh` before committing.
+4. Run `pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`, `python -m flywheel.fit`, and `bash scripts/checks.sh`.
 
 OUTPUT:
 A pull request enhancing the physics docs with any new derivations or diagrams.

--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -12,13 +12,15 @@ SYSTEM:
 You are an automated contributor for the Flywheel repository.
 Check all Markdown files for spelling errors using `pyspelling -c .spellcheck.yaml`.
 Add unknown but legitimate words to `dict/allow.txt`.
-Follow the conventions in AGENTS.md and ensure all other checks pass with `bash scripts/checks.sh`.
+Follow AGENTS.md and ensure `pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`,
+`python -m flywheel.fit`, and `bash scripts/checks.sh` pass.
 
 USER:
 1. Run the spellcheck command and inspect the results.
 2. Correct misspellings or update `dict/allow.txt` as needed.
 3. Re-run `pyspelling` until it reports no errors.
-4. Commit the changes with a concise message and open a pull request.
+4. Run `pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`, `python -m flywheel.fit`, and `bash scripts/checks.sh`.
+5. Commit the changes with a concise message and open a pull request.
 
 OUTPUT:
 A pull request URL that summarizes the fixes and shows passing check results.

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -9,13 +9,13 @@ This document stores the baseline prompt used when instructing OpenAI Codex (or 
 
 ```
 SYSTEM:
-You are an automated contributor for the Flywheel repository. Follow the conventions in AGENTS.md and README.md. Make small, incremental improvements or tackle an open GitHub issue. Ensure pre-commit hooks, Python tests, and JavaScript tests all pass. If browser dependencies are missing, run `npx playwright install chromium` or prefix tests with `SKIP_E2E=1`.
+You are an automated contributor for the Flywheel repository. Follow the conventions in AGENTS.md and README.md. Make small, incremental improvements or tackle an open GitHub issue. Ensure `pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`, `python -m flywheel.fit`, and `bash scripts/checks.sh` all pass. If browser dependencies are missing, run `npx playwright install chromium` or prefix tests with `SKIP_E2E=1`.
 
 USER:
 1. Identify a straightforward improvement or bug fix from the docs or issues.
 2. Implement the change using the existing project style.
 3. Update documentation when needed.
-4. Run `bash scripts/checks.sh` before committing.
+4. Run `pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`, `python -m flywheel.fit`, and `bash scripts/checks.sh`.
 
 OUTPUT:
 A pull request describing the change and summarizing test results.
@@ -26,6 +26,8 @@ Copy this entire block into Codex when you want the agent to automatically impro
 ## Implementation prompts
 Copy **one** of the prompts below into Codex when you want the agent to improve `docs/repo-feature-summary.md`.
 Each prompt is file-scoped, single-purpose and immediately actionable.
+
+Before using any implementation prompt, ensure the full test suite succeeds: `pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`, `python -m flywheel.fit`, and `bash scripts/checks.sh`.
 
 ### 1 Add ⭐ Stars & 🐞 Open-Issues columns
 ```


### PR DESCRIPTION
## Summary
- require full test suite in baseline Codex prompt
- expand CAD, physics, and spellcheck prompts with explicit test commands
- streamline CI failure fix prompt for flywheel

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689042ed7f50832f9798f8fea5ec753b