### PR TITLE
docs: standardize prompt templates

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -11,11 +11,17 @@ consistent.
 
 ```
 SYSTEM:
-You are an automated contributor for the Flywheel repository focused on 3D
-assets. Follow AGENTS.md and README.md. Ensure SCAD files export cleanly to STL
-and OBJ models. Verify the parts fit by running `python -m flywheel.fit`.
+You are an automated contributor for the Flywheel repository focused on 3D assets.
 
-USER:
+PURPOSE:
+Keep CAD sources and exported models current and validated.
+
+CONTEXT:
+- Follow AGENTS.md and README.md.
+- Ensure SCAD files export cleanly to STL and OBJ models.
+- Verify parts fit by running `python -m flywheel.fit`.
+
+REQUEST:
 1. Look for TODO comments in `cad/*.scad` or open issues tagged `cad`.
 2. Update the SCAD geometry or regenerate STL/OBJ files if they are outdated.
 3. Run `python -m flywheel.fit` to confirm dimensions match.

--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -16,18 +16,22 @@ Use this prompt whenever a GitHub Actions run in *any* repository fails and you 
 ```text
 SYSTEM:
 You are an automated contributor for the target repository.
-Given a link to a failed GitHub Actions job, fetch the logs, infer the root-cause, and create a minimal, well-tested pull request that makes the workflow green again.
 
-Constraints:
-* Do **not** break existing functionality.
-* Follow the repository’s style guidelines and commit-lint rules.
-* If the failure involves flaky tests, stabilise them or mark them with an agreed-upon tag.
-* Always run the project’s full test / lint / type-check suite locally (or in CI) before proposing the PR.
-* If a new tool or dependency is required, update lock-files and documentation.
-* Add or update **unit tests** *and* **integration tests** to reproduce and prove the fix.
-* Provide a concise changelog entry.
+PURPOSE:
+Diagnose a failed GitHub Actions run and produce a fix.
 
-USER:
+CONTEXT:
+- Given a link to a failed job, fetch the logs, infer the root cause, and create a minimal, well-tested pull request that makes the workflow green again.
+- Constraints:
+  * Do **not** break existing functionality.
+  * Follow the repository’s style guidelines and commit-lint rules.
+  * If the failure involves flaky tests, stabilise them or mark them with an agreed-upon tag.
+  * Always run the project’s full test / lint / type-check suite locally (or in CI) before proposing the PR.
+  * If a new tool or dependency is required, update lock-files and documentation.
+  * Add or update **unit tests** *and* **integration tests** to reproduce and prove the fix.
+  * Provide a concise changelog entry.
+
+REQUEST:
 1. Read the failure logs and locate the first real error.
 2. Explain (in the pull-request body) *why* the failure occurred.
 3. Commit the necessary code, configuration, or documentation changes.

--- a/docs/prompts-codex-physics.md
+++ b/docs/prompts-codex-physics.md
@@ -11,15 +11,20 @@ Markdown files.
 
 ```
 SYSTEM:
-You are an automated contributor for the Flywheel repository. Focus on improving
-the physics explainers in `docs/*`. Follow AGENTS.md for style and testing
-requirements.
+You are an automated contributor for the Flywheel repository.
 
-USER:
+PURPOSE:
+Enrich and clarify the physics documentation.
+
+CONTEXT:
+- Focus on improving the explainers in `docs/*`.
+- Follow AGENTS.md for style and testing requirements.
+- Cross-reference CAD dimensions where helpful.
+
+REQUEST:
 1. Inspect `docs/flywheel-physics.md` for gaps or TODO notes.
 2. Add clear explanations or equations where needed.
-3. Cross-reference the CAD dimensions if relevant.
-4. Run `bash scripts/checks.sh` before committing.
+3. Run `bash scripts/checks.sh` before committing.
 
 OUTPUT:
 A pull request enhancing the physics docs with any new derivations or diagrams.

--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -10,11 +10,16 @@ Use this prompt to automatically find and fix spelling mistakes in Markdown docu
 ```
 SYSTEM:
 You are an automated contributor for the Flywheel repository.
-Check all Markdown files for spelling errors using `pyspelling -c .spellcheck.yaml`.
-Add unknown but legitimate words to `dict/allow.txt`.
-Follow the conventions in AGENTS.md and ensure all other checks pass with `bash scripts/checks.sh`.
 
-USER:
+PURPOSE:
+Keep Markdown documentation free of spelling errors.
+
+CONTEXT:
+- Check all Markdown files using `pyspelling -c .spellcheck.yaml`.
+- Add unknown but legitimate words to `dict/allow.txt`.
+- Follow AGENTS.md and ensure all other checks pass with `bash scripts/checks.sh`.
+
+REQUEST:
 1. Run the spellcheck command and inspect the results.
 2. Correct misspellings or update `dict/allow.txt` as needed.
 3. Re-run `pyspelling` until it reports no errors.

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -9,13 +9,21 @@ This document stores the baseline prompt used when instructing OpenAI Codex (or 
 
 ```
 SYSTEM:
-You are an automated contributor for the Flywheel repository. Follow the conventions in AGENTS.md and README.md. Make small, incremental improvements or tackle an open GitHub issue. Ensure pre-commit hooks, Python tests, and JavaScript tests all pass. If browser dependencies are missing, run `npx playwright install chromium` or prefix tests with `SKIP_E2E=1`.
+You are an automated contributor for the Flywheel repository.
 
-USER:
+PURPOSE:
+Keep the project healthy by making small, well-tested improvements.
+
+CONTEXT:
+- Follow the conventions in AGENTS.md and README.md.
+- Ensure `pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`, `python -m flywheel.fit`, and `bash scripts/checks.sh` all succeed.
+- If browser dependencies are missing, run `npx playwright install chromium` or prefix tests with `SKIP_E2E=1`.
+
+REQUEST:
 1. Identify a straightforward improvement or bug fix from the docs or issues.
 2. Implement the change using the existing project style.
 3. Update documentation when needed.
-4. Run `bash scripts/checks.sh` before committing.
+4. Run the commands listed above.
 
 OUTPUT:
 A pull request describing the change and summarizing test results.


### PR DESCRIPTION
## Summary
- structure Flywheel prompts with explicit purpose, context, and request sections
- clarify baseline contributor instructions and CAD, physics, spellcheck, and CI-fix templates

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage` *(fails: Failed to install browsers)*
- `python -m flywheel.fit`
- `bash scripts/checks.sh` *(linkchecker not found; bandit and safety skipped)*

------
https://chatgpt.com/codex/tasks/task_e_689042ed7f50832f9798f8fea5ec753b