### PR TITLE
docs: add upgrade prompt for Codex docs

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -144,3 +144,5 @@ yyyy
 LTS
 MPa
 rpm
+
+pytest

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -143,3 +143,20 @@ A single PR implementing the change.
 - Use the CI matrix to test on Node 18 LTS and the latest Node 20.
 - Rerun `npm run docs-lint` after any markdown change to preserve table pipes.
 - Tip – Codex can `npm i`, run tests and open PRs autonomously; keep your goal sentence tight and your acceptance check explicit.
+
+## Upgrade Prompt
+
+Use this prompt to refine Flywheel's own prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the Flywheel repository. Follow `AGENTS.md` and `README.md`. Ensure `pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`, `python -m flywheel.fit`, and `bash scripts/checks.sh` pass before committing. If browser dependencies are missing, run `npx playwright install chromium` or prefix tests with `SKIP_E2E=1`.
+
+USER:
+1. Pick one prompt doc under `docs/` (for example, `prompts-codex-spellcheck.md`).
+2. Fix outdated instructions, links or formatting.
+3. Run the checks above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```


### PR DESCRIPTION
## Summary
- document an Upgrade Prompt to keep Flywheel prompt docs up to date

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run jest -- --coverage`
- `python -m flywheel.fit`
- `RUN_SECURITY_ONLY=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68905d35df70832fbb2654c6268f7119