### PR TITLE
🔧 fix: parse SCAD vars with comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ A successful run prints:
 All parts fit together.
 ```
 
+Lines may include inline ``//`` comments and negative values; the checker
+ignores the comments when parsing.
+
 Below is a simplified view of how the pieces stack:
 
 ```mermaid

--- a/flywheel/fit.py
+++ b/flywheel/fit.py
@@ -6,11 +6,17 @@ from typing import Dict, Tuple
 
 import trimesh
 
-_DEF_RE = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*([0-9.]+);")
+_DEF_RE = re.compile(
+    r"^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*([-+]?\d+(?:\.\d+)?)\s*;(?:\s*//.*)?$"
+)
 
 
 def parse_scad_vars(path: Path) -> Dict[str, float]:
-    """Return variable assignments parsed from a SCAD file."""
+    """Return variable assignments parsed from a SCAD file.
+
+    Inline ``//`` comments after the semicolon are ignored, and negative
+    numbers are supported.
+    """
     vars: Dict[str, float] = {}
     for line in Path(path).read_text().splitlines():
         m = _DEF_RE.match(line.strip())

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -16,6 +16,13 @@ def test_parse_scad_vars(tmp_path):
     assert vars == {"radius": 5.0, "height": 2.0}
 
 
+def test_parse_scad_vars_with_comments_and_negatives(tmp_path):
+    scad = tmp_path / "part.scad"
+    scad.write_text("radius = 5; // mm\nheight = -2; // depth\n")
+    vars = ff.parse_scad_vars(scad)
+    assert vars == {"radius": 5.0, "height": -2.0}
+
+
 def test_verify_fit(tmp_path, monkeypatch):
     assert ff.verify_fit(CAD_DIR, STL_DIR)
 


### PR DESCRIPTION
## What
- parse signed floats and ignore trailing // comments in SCAD parser
- document comment support in README

## Why
- fit check skipped variables when lines had comments or negatives

## How to Test
- `SKIP_E2E=1 pre-commit run --all-files`
- `pytest -q`
- `CI=1 npm run jest -- --coverage`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6893c06afed0832fa940845f718057fe