### PR TITLE
🐛 allow SCAD parser to accept leadingless decimals

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ A successful run prints:
 All parts fit together.
 ```
 
-Lines may include inline ``//`` comments and negative values; the checker
-ignores the comments when parsing.
+Lines may include inline ``//`` comments, negative values, and decimals without a
+leading zero; the checker ignores the comments when parsing.
 
 Below is a simplified view of how the pieces stack:
 

--- a/flywheel/fit.py
+++ b/flywheel/fit.py
@@ -7,15 +7,16 @@ from typing import Dict, Tuple
 import trimesh
 
 _DEF_RE = re.compile(
-    r"^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*([-+]?\d+(?:\.\d+)?)\s*;(?:\s*//.*)?$"
+    r"^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*([-+]?(?:\d+(?:\.\d+)?|\.\d+))"
+    r"\s*;(?:\s*//.*)?$"
 )
 
 
 def parse_scad_vars(path: Path) -> Dict[str, float]:
     """Return variable assignments parsed from a SCAD file.
 
-    Inline ``//`` comments after the semicolon are ignored, and negative
-    numbers are supported.
+    Inline ``//`` comments after the semicolon are ignored. The parser supports
+    negative values and decimals without a leading zero.
     """
     vars: Dict[str, float] = {}
     for line in Path(path).read_text().splitlines():

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -23,6 +23,13 @@ def test_parse_scad_vars_with_comments_and_negatives(tmp_path):
     assert vars == {"radius": 5.0, "height": -2.0}
 
 
+def test_parse_scad_vars_without_leading_zero(tmp_path):
+    scad = tmp_path / "part.scad"
+    scad.write_text("radius = .5;")
+    vars = ff.parse_scad_vars(scad)
+    assert vars == {"radius": 0.5}
+
+
 def test_verify_fit(tmp_path, monkeypatch):
     assert ff.verify_fit(CAD_DIR, STL_DIR)
 


### PR DESCRIPTION
## Summary
- parse_scad_vars handles decimals without a leading zero
- document support in README

## Testing
- RUN_SECURITY_ONLY=1 SKIP_E2E=1 pre-commit run --all-files
- npm run lint
- npm run test:ci (fails: Missing script)
- SKIP_E2E=1 npm run jest -- --coverage
- pytest -q
- python -m flywheel.fit
- SKIP_E2E=1 bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_6893e19ab2f8832fb93aaa65810a0758