### PR TITLE
📝 docs: update spellcheck prompt instructions

### DIFF
--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -20,12 +20,11 @@ CONTEXT:
 - Follow [AGENTS.md](../AGENTS.md) and ensure these commands succeed:
   - `pre-commit run --all-files`
   - `pytest -q`
-  - `npm run lint`
   - `npm test -- --coverage`
   - `python -m flywheel.fit`
   - `bash scripts/checks.sh`
   If browser dependencies are missing, run `npx playwright install chromium`
-  or prefix `SKIP_E2E=1` to tests.
+  or prefix tests with `SKIP_E2E=1`.
 
 REQUEST:
 1. Run the spellcheck command and inspect the results.


### PR DESCRIPTION
what: drop outdated npm lint step from spellcheck prompt
why: align doc with current required checks
how to test: pre-commit run --all-files; pytest -q; npm test -- --coverage;
  python -m flywheel.fit; bash scripts/checks.sh


------
https://chatgpt.com/codex/tasks/task_e_689436492bb0832f870ba2a552426225