### PR TITLE
♻️ refactor: centralize pattern scan suffixes

### DIFF
--- a/docs/dark-patterns.md
+++ b/docs/dark-patterns.md
@@ -2,6 +2,8 @@
 
 This guide catalogs user-hostile design tactics, explains why they are problematic, and offers "bright pattern" alternatives that respect the user's agency. See [bright-patterns.md](bright-patterns.md) for a dedicated catalog of pro-user practices. The repo crawler counts potential dark patterns across related projects and records the results in `docs/repo-feature-summary.md`.
 
+Each source file is counted at most once, even if multiple patterns appear within it.
+
 ## Why avoid dark patterns?
 
 Manipulative interfaces erode trust and may even violate privacy or consumer protection laws. Sustainable communities grow when contributors feel respected and in control of their data.

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -56,6 +56,16 @@ class RepoCrawler:
     _UV = re.compile(r"setup-uv|uv venv", re.I)
     _PIP = re.compile(r"pip install", re.I)
     _POETRY = re.compile(r"poetry\s+install", re.I)
+    SCAN_SUFFIXES = (
+        ".js",
+        ".ts",
+        ".tsx",
+        ".py",
+        ".html",
+        ".md",
+        ".json",
+    )
+
     DARK_PATTERNS = [
         re.compile(r"onbeforeunload", re.I),
         re.compile(r"navigator\.clipboard\.writeText", re.I),
@@ -105,17 +115,7 @@ class RepoCrawler:
         count = 0
         files = self._list_files(repo, branch)[:50]
         for path in files:
-            if not path.endswith(
-                (
-                    ".js",
-                    ".ts",
-                    ".tsx",
-                    ".py",
-                    ".html",
-                    ".md",
-                    ".json",
-                )
-            ):
+            if not path.endswith(self.SCAN_SUFFIXES):
                 continue
             text = self._fetch_file(repo, path, branch)
             if not text:
@@ -130,17 +130,7 @@ class RepoCrawler:
         count = 0
         files = self._list_files(repo, branch)[:50]
         for path in files:
-            if not path.endswith(
-                (
-                    ".js",
-                    ".ts",
-                    ".tsx",
-                    ".py",
-                    ".html",
-                    ".md",
-                    ".json",
-                )
-            ):
+            if not path.endswith(self.SCAN_SUFFIXES):
                 continue
             text = self._fetch_file(repo, path, branch)
             if not text:

--- a/tests/test_pattern_detection.py
+++ b/tests/test_pattern_detection.py
@@ -37,6 +37,14 @@ def test_pattern_detection_skips(monkeypatch):
     assert crawler._detect_bright_patterns("foo/bar", "main") == 1
 
 
+def test_bright_patterns_count_once_per_file(monkeypatch):
+    crawler = rc.RepoCrawler([])
+    monkeypatch.setattr(crawler, "_list_files", lambda r, b: ["script.js"])
+    text = "unsubscribe opt-out delete account"
+    monkeypatch.setattr(crawler, "_fetch_file", lambda r, p, b: text)
+    assert crawler._detect_bright_patterns("foo/bar", "main") == 1
+
+
 def test_list_files_errors(monkeypatch):
     crawler = rc.RepoCrawler([])
 


### PR DESCRIPTION
## What
- share extension list via RepoCrawler.SCAN_SUFFIXES
- note per-file counting in docs
- add regression test for bright patterns

## Why
- reduce duplication and clarify pattern metrics

## How to Test
- `pre-commit run --all-files`
- `pytest -q`
- `SKIP_E2E=1 npm test -- --coverage`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`
- `bandit -r flywheel -q`

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68943630f2d8832f91018bb59b8d6c60