### PR TITLE
🔧 fix: support trailing decimals in SCAD parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ A successful run prints:
 All parts fit together.
 ```
 
-Lines may include inline ``//`` comments, negative values, and decimals without a
-leading zero; the checker ignores the comments when parsing.
+Lines may include inline ``//`` comments, negative values, decimals without a
+leading zero, or trailing decimal points; the checker ignores the comments when
+parsing.
 
 Below is a simplified view of how the pieces stack:
 

--- a/flywheel/fit.py
+++ b/flywheel/fit.py
@@ -7,7 +7,7 @@ from typing import Dict, Tuple
 import trimesh
 
 _DEF_RE = re.compile(
-    r"^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*([-+]?(?:\d+(?:\.\d+)?|\.\d+))"
+    r"^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*([-+]?(?:\d+(?:\.\d*)?|\.\d+))"
     r"\s*;(?:\s*//.*)?$"
 )
 
@@ -16,7 +16,8 @@ def parse_scad_vars(path: Path) -> Dict[str, float]:
     """Return variable assignments parsed from a SCAD file.
 
     Inline ``//`` comments after the semicolon are ignored. The parser supports
-    negative values and decimals without a leading zero.
+    negative values, decimals without a leading zero, and numbers ending with a
+    trailing decimal point.
     """
     vars: Dict[str, float] = {}
     for line in Path(path).read_text().splitlines():

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -30,6 +30,13 @@ def test_parse_scad_vars_without_leading_zero(tmp_path):
     assert vars == {"radius": 0.5}
 
 
+def test_parse_scad_vars_trailing_decimal(tmp_path):
+    scad = tmp_path / "part.scad"
+    scad.write_text("radius = 5.;")
+    vars = ff.parse_scad_vars(scad)
+    assert vars == {"radius": 5.0}
+
+
 def test_verify_fit(tmp_path, monkeypatch):
     assert ff.verify_fit(CAD_DIR, STL_DIR)
 


### PR DESCRIPTION
## Summary
- allow parse_scad_vars to parse numbers with trailing decimal points
- document trailing decimal support
- test parsing of trailing decimal values

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68943630f2d8832f91018bb59b8d6c60