### PR TITLE
Add timeout for branch lookup and refresh repo summary

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -7,57 +7,57 @@ This table tracks which flywheel features each related repository has adopted.
 | Repo | Branch | Commit | Trunk | Last-Updated (UTC) |
 | ---- | ------ | ------ | ----- | ----------------- |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `2c9ba51` | ✅ | 2025-08-07 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | n/a | n/a | n/a |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | n/a | n/a | n/a |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | n/a | n/a | n/a |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | n/a | n/a | n/a |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | n/a | n/a | n/a |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | n/a | n/a | n/a |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | n/a | n/a | n/a |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | n/a | n/a | n/a |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | main | n/a | n/a | n/a |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `350bd54` | ✅ | 2025-08-07 |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `f3ce251` | ✅ | 2025-08-07 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `35bd000` | ✅ | 2025-08-07 |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `861d04c` | ✅ | 2025-08-07 |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `9fd0aff` | ✅ | 2025-08-07 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | `9cd7208` | ❌ | 2025-08-07 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | `67c2d38` | ❌ | 2025-08-07 |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | `7032693` | ✅ | 2025-08-07 |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | main | `5eacc29` | ❌ | 2025-08-07 |
 
 ## Coverage & Installer
 | Repo | Coverage | Patch | Codecov | Installer | Last-Updated (UTC) |
 | ---- | -------- | ----- | ------- | --------- | ----------------- |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (100%) | — | ✅ | 🚀 uv | 2025-08-07 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | ✅ | 🔶 partial | n/a |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | ✅ | pip | n/a |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | ✅ | 🔶 partial | n/a |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | ✅ | pip | n/a |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | — | ✅ | 🔶 partial | n/a |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | — | ❌ | 🔶 partial | n/a |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | ✅ | 🔶 partial | n/a |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ (100%) | — | ✅ | 🔶 partial | n/a |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ (57%) | — | ✅ | 🔶 partial | n/a |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | ✅ | 🔶 partial | 2025-08-07 |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | ✅ | pip | 2025-08-07 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | ✅ | 🔶 partial | 2025-08-07 |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | ✅ | pip | 2025-08-07 |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | — | ✅ | 🔶 partial | 2025-08-07 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | — | ❌ | 🔶 partial | 2025-08-07 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | ✅ | 🔶 partial | 2025-08-07 |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ (100%) | — | ✅ | 🔶 partial | 2025-08-07 |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ (57%) | — | ✅ | 🔶 partial | 2025-08-07 |
 
 ## Policies & Automation
 | Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Last-Updated (UTC) |
 | ---- | ------- | -- | --------- | --------- | --------------- | ------------ | ---------- | ----------------- |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ | ✅ | 14 | ✅ | ✅ | ✅ | ✅ | 2025-08-07 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | n/a |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | n/a |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | n/a |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | n/a |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ❌ | n/a |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | n/a |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | n/a |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | n/a |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ | ❌ | 0 | ✅ | ❌ | ❌ | ✅ | n/a |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | 2025-08-07 |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | 2025-08-07 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | 2025-08-07 |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | 2025-08-07 |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ❌ | 2025-08-07 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | 2025-08-07 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | 2025-08-07 |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | 2025-08-07 |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ | ❌ | 0 | ✅ | ❌ | ❌ | ✅ | 2025-08-07 |
 
 ## Dark & Bright Pattern Scan
 | Repo | Dark Patterns | Bright Patterns | Last-Updated (UTC) |
 | ---- | ------------- | --------------- | ----------------- |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | 0 | 0 | 2025-08-07 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | 0 | 0 | n/a |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | 0 | 0 | n/a |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | 0 | 0 | n/a |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | 0 | 0 | n/a |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | 0 | 0 | n/a |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | 0 | 0 | n/a |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | 0 | 0 | n/a |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | 0 | 0 | n/a |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | 0 | 0 | n/a |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | 0 | 0 | 2025-08-07 |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | 0 | 0 | 2025-08-07 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | 0 | 0 | 2025-08-07 |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | 0 | 0 | 2025-08-07 |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | 0 | 0 | 2025-08-07 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | 0 | 0 | 2025-08-07 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | 0 | 0 | 2025-08-07 |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | 0 | 0 | 2025-08-07 |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | 0 | 0 | 2025-08-07 |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip.
 Coverage percentages are parsed from their badges where available. Codecov shows ✅ when a Codecov config or badge is present. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses.

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -231,6 +231,7 @@ class RepoCrawler:
             resp = self.session.get(
                 url,
                 headers={"Accept": "application/vnd.github+json"},
+                timeout=10,
             )
         except RequestException:
             return "main"

--- a/tests/test_branch_detection.py
+++ b/tests/test_branch_detection.py
@@ -39,3 +39,24 @@ class DummyBadJSON:
 def test_default_branch_bad_json():
     crawler = RepoCrawler([], session=DummyBadJSON())
     assert crawler._default_branch("demo/repo") == "main"
+
+
+class DummyTimeout:
+    def __init__(self):
+        self.headers = {}
+
+    def get(self, url, **kw):
+        assert "timeout" in kw
+
+        class Resp:
+            status_code = 200
+
+            def json(self):
+                return {"default_branch": "dev"}
+
+        return Resp()
+
+
+def test_default_branch_uses_timeout():
+    crawler = RepoCrawler([], session=DummyTimeout())
+    assert crawler._default_branch("demo/repo") == "dev"

--- a/tests/test_summary_generation.py
+++ b/tests/test_summary_generation.py
@@ -26,6 +26,7 @@ def test_summary_generation(monkeypatch):
     )
     assert "(95%)" in summary
     assert "—" not in summary
+    assert "n/a" not in summary
     assert (
         "| Repo | Dark Patterns | Bright Patterns | Last-Updated (UTC) |"  # noqa: E501
         in summary


### PR DESCRIPTION
## Summary
- avoid hangs when detecting default branch
- refresh repo feature summary and guard tests

## Testing
- `pre-commit run --all-files` *(interrupted)*
- `pytest -q`
- `npm run lint`
- `npm run test:ci` *(fails: Missing script)*
- `npm test -- --coverage` *(aborted during browser download)*
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6894360ff034832f9c19f6ef3800fc81