### PR TITLE
fix: guard repo crawl against missing commit data

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -6,58 +6,58 @@ This table tracks which flywheel features each related repository has adopted.
 ## Basics
 | Repo | Branch | Commit | Trunk | Last-Updated (UTC) |
 | ---- | ------ | ------ | ----- | ----------------- |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `2c9ba51` | ✅ | 2025-08-07 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | n/a | n/a | n/a |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | n/a | n/a | n/a |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | n/a | n/a | n/a |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | n/a | n/a | n/a |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | n/a | n/a | n/a |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | n/a | n/a | n/a |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | n/a | n/a | n/a |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | n/a | n/a | n/a |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | main | n/a | n/a | n/a |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `ad22ce6` | ✅ | 2025-08-07 |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `350bd54` | ✅ | 2025-08-07 |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `f3ce251` | ✅ | 2025-08-07 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `35bd000` | ❌ | 2025-08-07 |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `861d04c` | ✅ | 2025-08-07 |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `9fd0aff` | ✅ | 2025-08-07 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | `9cd7208` | ✅ | 2025-08-07 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | `67c2d38` | ✅ | 2025-08-07 |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | `7032693` | ✅ | 2025-08-07 |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | main | `5eacc29` | ✅ | 2025-08-07 |
 
 ## Coverage & Installer
 | Repo | Coverage | Patch | Codecov | Installer | Last-Updated (UTC) |
 | ---- | -------- | ----- | ------- | --------- | ----------------- |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ (100%) | — | ✅ | 🚀 uv | 2025-08-07 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | ✅ | 🔶 partial | n/a |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | ✅ | pip | n/a |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | ✅ | 🔶 partial | n/a |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | ✅ | pip | n/a |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ❌ | — | ✅ | 🔶 partial | n/a |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | — | ❌ | 🔶 partial | n/a |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | ✅ | 🔶 partial | n/a |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ (100%) | — | ✅ | 🔶 partial | n/a |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ (57%) | — | ✅ | 🔶 partial | n/a |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ (100%) | — | ✅ | 🚀 uv | 2025-08-07 |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ (100%) | — | ✅ | 🚀 uv | 2025-08-07 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ (100%) | — | ✅ | 🚀 uv | 2025-08-07 |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ (100%) | — | ✅ | pip | 2025-08-07 |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ (100%) | — | ✅ | 🔶 partial | 2025-08-07 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | — | ❌ | 🚀 uv | 2025-08-07 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ (100%) | — | ✅ | 🚀 uv | 2025-08-07 |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ (100%) | — | ✅ | pip | 2025-08-07 |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ (57%) | — | ✅ | 🚀 uv | 2025-08-07 |
 
 ## Policies & Automation
 | Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Last-Updated (UTC) |
 | ---- | ------- | -- | --------- | --------- | --------------- | ------------ | ---------- | ----------------- |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ | ✅ | 14 | ✅ | ✅ | ✅ | ✅ | 2025-08-07 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | n/a |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | n/a |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | n/a |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | n/a |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ❌ | n/a |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | n/a |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | n/a |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ❌ | 0 | ✅ | ✅ | ✅ | ✅ | n/a |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ | ❌ | 0 | ✅ | ❌ | ❌ | ✅ | n/a |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ | ✅ | 3 | ✅ | ✅ | ✅ | ✅ | 2025-08-07 |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ | ✅ | 5 | ✅ | ✅ | ✅ | ✅ | 2025-08-07 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | 2025-08-07 |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ | ✅ | 5 | ✅ | ✅ | ✅ | ✅ | 2025-08-07 |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ | ✅ | 8 | ✅ | ✅ | ✅ | ❌ | 2025-08-07 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | 2025-08-07 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | 2025-08-07 |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ✅ | 6 | ✅ | ✅ | ✅ | ✅ | 2025-08-07 |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ | ✅ | 5 | ✅ | ❌ | ❌ | ✅ | 2025-08-07 |
 
 ## Dark & Bright Pattern Scan
 | Repo | Dark Patterns | Bright Patterns | Last-Updated (UTC) |
 | ---- | ------------- | --------------- | ----------------- |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | 0 | 0 | 2025-08-07 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | 0 | 0 | n/a |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | 0 | 0 | n/a |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | 0 | 0 | n/a |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | 0 | 0 | n/a |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | 0 | 0 | n/a |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | 0 | 0 | n/a |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | 0 | 0 | n/a |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | 0 | 0 | n/a |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | 0 | 0 | n/a |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | 0 | 1 | 2025-08-07 |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | 0 | 8 | 2025-08-07 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | 0 | 0 | 2025-08-07 |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | 0 | 1 | 2025-08-07 |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | 0 | 0 | 2025-08-07 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | 0 | 0 | 2025-08-07 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | 0 | 0 | 2025-08-07 |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | 0 | 0 | 2025-08-07 |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | 0 | 0 | 2025-08-07 |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip.
 Coverage percentages are parsed from their badges where available. Codecov shows ✅ when a Codecov config or badge is present. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses.

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -638,6 +638,15 @@ class RepoCrawler:
 
     def generate_summary(self) -> str:
         repos = self.crawl()
+        missing = []
+        for r in repos:
+            if not r.latest_commit or not r.commit_date:
+                missing.append(r.name)
+        if missing:
+            raise RuntimeError(
+                "Missing commit data for: {}. Pass a GitHub token via "
+                "GITHUB_TOKEN to avoid rate limits.".format(", ".join(missing))
+            )
         lines = [
             "# Repo Feature Summary",
             "",

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -23,9 +23,19 @@ class DummySession:
 
         if url.startswith("https://api.github.com/repos/"):
             if url.endswith("/commits?per_page=1&sha=main"):
-                return Resp('[{"sha": "deadbeef"}]', 200)
+                return Resp(
+                    '[{"sha": "deadbeef", "commit": {"author": {"date": '
+                    '"2024-01-01T00:00:00Z"}}}]',
+                    200,
+                )
             if url.endswith("/commits?per_page=2&sha=main"):
-                return Resp('[{"sha": "cafecafe"}, {"sha": "deadbeef"}]', 200)
+                return Resp(
+                    '[{"sha": "cafecafe", "commit": {"author": {"date": '
+                    '"2024-01-02T00:00:00Z"}}},'
+                    '{"sha": "deadbeef", "commit": {"author": {"date": '
+                    '"2024-01-01T00:00:00Z"}}}]',
+                    200,
+                )
             if "/contents/.github/workflows" in url:
                 import json
 
@@ -183,6 +193,7 @@ def test_generate_summary_installer_variants(monkeypatch):
         latest_commit="cafec0d",
         workflow_count=1,
         trunk_green=True,
+        commit_date="2024-01-01",
     )
     info_partial = info_uv.__class__(
         **{**info_uv.__dict__, "name": "demo/partial", "installer": "partial"}
@@ -211,6 +222,7 @@ def test_generate_summary_other_installer(monkeypatch):
         latest_commit="1234567",
         workflow_count=1,
         trunk_green=True,
+        commit_date="2024-01-01",
     )
     crawler = rc.RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
@@ -235,6 +247,7 @@ def test_summary_column_order(monkeypatch):
         latest_commit="abcdef0",
         workflow_count=1,
         trunk_green=True,
+        commit_date="2024-01-01",
     )
     crawler = rc.RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])
@@ -287,6 +300,7 @@ def test_generate_summary_with_patch(monkeypatch):
         latest_commit="abcdef1",
         workflow_count=1,
         trunk_green=False,
+        commit_date="2024-01-01",
     )
     crawler = rc.RepoCrawler([])
     monkeypatch.setattr(crawler, "crawl", lambda: [info])

--- a/tests/test_summary_generation.py
+++ b/tests/test_summary_generation.py
@@ -1,3 +1,5 @@
+import pytest
+
 from flywheel.repocrawler import RepoCrawler
 
 
@@ -30,3 +32,14 @@ def test_summary_generation(monkeypatch):
         "| Repo | Dark Patterns | Bright Patterns | Last-Updated (UTC) |"  # noqa: E501
         in summary
     )
+
+
+def test_summary_generation_missing_commit(monkeypatch):
+    crawler = RepoCrawler(["foo/bar"])
+    monkeypatch.setattr(
+        crawler,
+        "_latest_commit",
+        lambda *a, **kw: (None, None),
+    )
+    with pytest.raises(RuntimeError):
+        crawler.generate_summary()


### PR DESCRIPTION
## Summary
- raise error when repo summary lacks commit metadata
- add regression tests for missing commit data
- regenerate repo feature summary with complete entries

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci` *(fails: Missing script "test:ci")*
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6894360ff034832f9c19f6ef3800fc81