### PR TITLE
📝 docs: update spellcheck prompt instructions

### DIFF
--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -20,10 +20,10 @@ CONTEXT:
 - Follow [AGENTS.md](../AGENTS.md) and ensure these commands succeed:
   - `pre-commit run --all-files`
   - `pytest -q`
-  - `npm test -- --coverage`
+  - `npm test -- --coverage --coverageReporters=lcov`
   - `python -m flywheel.fit`
   - `bash scripts/checks.sh`
-  If browser dependencies are missing, run `npx playwright install chromium`
+  If browser dependencies are missing, run `npx playwright install --with-deps`
   or prefix tests with `SKIP_E2E=1`.
 
 REQUEST:


### PR DESCRIPTION
## Summary
- clarify test command coverage args for spellcheck prompt
- note modern Playwright install option

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `SKIP_E2E=1 npm test -- --coverage`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_68946a0527c8832f9e32e11ed695f7f6