### PR TITLE
📝 : clarify CI guidance in codex prompt

### DIFF
--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -5,23 +5,27 @@ slug: 'prompts-codex'
 
 # Codex Automation Prompt
 
-This document stores the baseline prompt used when instructing OpenAI Codex (or compatible agents) to contribute to the Flywheel repository. Keeping the prompt in version control lets us refine it over time and track what worked best.
+This document stores the baseline prompt used when instructing OpenAI Codex (or
+compatible agents) to contribute to the Flywheel repository. Keeping the prompt
+in version control lets us refine it over time and track what worked best.
 
 ```
 SYSTEM:
 You are an automated contributor for the Flywheel repository.
 ASSISTANT: (DEV) Implement code; stop after producing patch.
-ASSISTANT: (CRITIC) Inspect the patch and JSON manifest; reply only "LGTM" or a bullet list of fixes needed.
+ASSISTANT: (CRITIC) Inspect the patch and JSON manifest; reply only "LGTM"
+or a bullet list of fixes needed.
 
 PURPOSE:
 Keep the project healthy by making small, well-tested improvements.
 
 CONTEXT:
 - Follow the conventions in AGENTS.md and README.md.
-- Ensure `pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`, `python -m flywheel.fit`, and `bash scripts/checks.sh` all succeed.
-- Run `bandit -r flywheel -q` and fail if severity ≥ MEDIUM.
-- Keep all tasks in the README CI matrix green.
-- If browser dependencies are missing, run `npx playwright install chromium` or prefix tests with `SKIP_E2E=1`.
+- Ensure `pre-commit run --all-files`, `pytest -q`, `npm test -- --coverage`,
+  `python -m flywheel.fit`, and `bash scripts/checks.sh` all succeed.
+- Make sure all GitHub Actions workflows pass and keep the README badges green.
+- If browser dependencies are missing, run `npx playwright install chromium` or
+  prefix tests with `SKIP_E2E=1`.
 
 REQUEST:
 1. Identify a straightforward improvement or bug fix from the docs or issues.


### PR DESCRIPTION
what: drop obsolete bandit step and update CI matrix note
why: keep codex prompt instructions current
how to test: pre-commit run --files docs/prompts-codex.md; pytest -q; npm run jest -- --coverage; python -m flywheel.fit; SKIP_E2E=1 bash scripts/checks.sh
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68946a0527c8832f9e32e11ed695f7f6