### PR TITLE
docs: add CAD README

### DIFF
--- a/cad/README.md
+++ b/cad/README.md
@@ -1,0 +1,23 @@
+# CAD Models
+
+Source OpenSCAD files for the flywheel project.
+
+## Available models
+
+- `stand.scad` – stand for a flywheel shaft using 608 bearings
+- `shaft.scad` – straight shaft sized for 608 bearings
+- `adapter.scad` – clamp adapter that attaches the flywheel to the shaft
+- `flywheel.scad` – simple cylindrical flywheel with center bore
+
+## Regenerating meshes
+
+Rebuild STL outputs and OBJ viewer models whenever a SCAD file changes:
+
+```bash
+scripts/build_stl.sh
+python - <<'PY'
+from webapp.app import ensure_obj_models
+ensure_obj_models()
+PY
+python -m flywheel.fit
+```


### PR DESCRIPTION
## Summary
- document SCAD models and mesh regeneration commands
- verify STL/OBJ exports and part fit

## Testing
- `RUN_SECURITY_ONLY=1 pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage` *(failed: extensive Playwright dependency install)*
- `python -m flywheel.fit`
- `RUN_SECURITY_ONLY=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689469f00730832fa08ff796dd44a9d9