### PR TITLE
🩹 – allow scientific notation in SCAD variable parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ A successful run prints:
 All parts fit together.
 ```
 
-Lines may include inline ``//`` comments, negative values, and decimals without a
-leading zero; the checker ignores the comments when parsing.
+Lines may include inline ``//`` comments, negative values, decimals without a
+leading zero, and scientific notation; the checker ignores the comments when
+parsing.
 
 Below is a simplified view of how the pieces stack:
 

--- a/flywheel/fit.py
+++ b/flywheel/fit.py
@@ -7,8 +7,9 @@ from typing import Dict, Tuple
 import trimesh
 
 _DEF_RE = re.compile(
-    r"^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*([-+]?(?:\d+(?:\.\d+)?|\.\d+))"
-    r"\s*;(?:\s*//.*)?$"
+    r"^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*"
+    r"([-+]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][-+]?\d+)?)\s*"
+    r";(?:\s*//.*)?$"
 )
 
 
@@ -16,7 +17,7 @@ def parse_scad_vars(path: Path) -> Dict[str, float]:
     """Return variable assignments parsed from a SCAD file.
 
     Inline ``//`` comments after the semicolon are ignored. The parser supports
-    negative values and decimals without a leading zero.
+    negative values, decimals without a leading zero, and scientific notation.
     """
     vars: Dict[str, float] = {}
     for line in Path(path).read_text().splitlines():

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -30,6 +30,13 @@ def test_parse_scad_vars_without_leading_zero(tmp_path):
     assert vars == {"radius": 0.5}
 
 
+def test_parse_scad_vars_scientific_notation(tmp_path):
+    scad = tmp_path / "part.scad"
+    scad.write_text("radius = 1e-3;")
+    vars = ff.parse_scad_vars(scad)
+    assert vars == {"radius": 0.001}
+
+
 def test_verify_fit(tmp_path, monkeypatch):
     assert ff.verify_fit(CAD_DIR, STL_DIR)
 


### PR DESCRIPTION
## Summary
- parse SCAD variables in scientific notation
- document and test exponential values

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_6896cc980704832f9cc74c12d8a05caa