### PR TITLE
🐛 fix: detect CI via workflow keywords

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -188,3 +188,4 @@ len
 od
 fn
 utils
+qa

--- a/docs/ci-guide.md
+++ b/docs/ci-guide.md
@@ -9,6 +9,13 @@ The workflow now commits `docs/repo-feature-summary.md` only when it runs on the
 2. Run `flywheel crawl --repos-file docs/repo_list.txt --output docs/repo-feature-summary.md`.
 3. Commit the updated `docs/repo-feature-summary.md` yourself.
 
+## Workflow naming for CI detection
+`flywheel crawl` marks a repository as having CI only when a workflow file
+name contains common keywords like `ci`, `test`, `lint`, `build`, `docs`, or
+`qa`. A lone `deploy.yml` will be treated as missing CI. Include one of these
+keywords in at least one workflow filename so the feature summary reflects your
+setup accurately.
+
 ## CI best practices
 | Scenario | Recommended approach |
 |----------|---------------------|

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -51,7 +51,7 @@ class RepoCrawler:
     # Filenames whose presence in `.github/workflows/` signals that the repo
     # runs some form of continuous integration. This keeps the heuristic broad
     # so repos with custom workflow names still count.
-    CI_KEYWORDS = ("ci", "test", "lint", "build", "docs")
+    CI_KEYWORDS = ("ci", "test", "lint", "build", "docs", "qa")
 
     _UV = re.compile(r"setup-uv|uv venv", re.I)
     _PIP = re.compile(r"pip install", re.I)
@@ -445,8 +445,12 @@ class RepoCrawler:
         return set()
 
     def _has_ci(self, workflow_files: set[str]) -> bool:
-        """Return True if the repo defines any workflows."""
-        return len(workflow_files) > 0
+        """Return True if workflow names suggest continuous integration."""
+        for name in workflow_files:
+            lower = name.lower()
+            if any(key in lower for key in self.CI_KEYWORDS):
+                return True
+        return False
 
     def _detect_installer(self, text: str) -> str:
         """Return installer hint based on workflow snippets."""

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -148,9 +148,9 @@ def test_coverage_from_codecov_non_200():
     assert crawler._project_coverage_from_codecov("demo/repo", "main") is None
 
 
-def test_has_ci_false():
+def test_has_ci_only_deploy_returns_false():
     crawler = RepoCrawler([])
-    assert crawler._has_ci({"deploy.yml"}) is True
+    assert crawler._has_ci({"deploy.yml"}) is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- ensure RepoCrawler checks workflow filenames for CI keywords
- document workflow naming requirement

## Testing
- pre-commit run --files dict/allow.txt docs/ci-guide.md flywheel/repocrawler.py tests/test_repocrawler_extra.py
- pytest -q
- npm test -- --coverage
- python -m flywheel.fit
- bash scripts/checks.sh
- npm run lint
- npm run test:ci (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_6896cc980704832f9cc74c12d8a05caa