### PR TITLE
🐛 : ignore directories in scanner reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Clone a set of repos and generate Markdown reports:
 python -m flywheel.agents.scanner
 ```
 
-Reports are written to `reports/`.
+Reports are written to `reports/`. Each report lists only top-level files and ignores
+directories.
 
 ### Viewing the 3D flywheel
 

--- a/flywheel/agents/scanner.py
+++ b/flywheel/agents/scanner.py
@@ -24,7 +24,12 @@ def clone_repo(repo: str, dest: Path) -> None:
 
 
 def analyze_repo(path: Path) -> str:
-    files = sorted(p.name for p in path.iterdir())
+    """Return a simple report listing top-level files.
+
+    Only regular files in ``path`` are included; directories are ignored.
+    """
+
+    files = sorted(p.name for p in path.iterdir() if p.is_file())
     report_lines = [
         f"# Report for {path.name}",
         "",

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -25,6 +25,13 @@ def test_analyze_repo(tmp_path):
     assert "- b.md" in report
 
 
+def test_analyze_repo_skips_directories(tmp_path):
+    (tmp_path / "a.txt").write_text("hi")
+    (tmp_path / "sub").mkdir()
+    report = scanner.analyze_repo(tmp_path)
+    assert "- sub" not in report
+
+
 def test_main(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
 


### PR DESCRIPTION
what: skip directories when listing top-level files.
why: scanner reports should only show files.
how to test: pre-commit run --all-files; pytest -q; SKIP_E2E=1 npm test -- --coverage; python -m flywheel.fit; RUN_SECURITY_ONLY=1 bash scripts/checks.sh
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_6896cc980704832f9cc74c12d8a05caa