### PR TITLE
docs: refresh spellcheck prompt

### DIFF
--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -20,11 +20,11 @@ CONTEXT:
 - Follow [AGENTS.md](../AGENTS.md) and ensure these commands succeed:
   - `pre-commit run --all-files`
   - `pytest -q`
-  - `npm test -- --coverage --coverageReporters=lcov`
+  - `npm test -- --coverage`
   - `python -m flywheel.fit`
   - `bash scripts/checks.sh`
-  If browser dependencies are missing, run `npx playwright install --with-deps`
-  or prefix tests with `SKIP_E2E=1`.
+  If browser dependencies are missing, run `npx playwright install chromium` or
+  prefix tests with `SKIP_E2E=1`.
 
 REQUEST:
 1. Run the spellcheck command and inspect the results.


### PR DESCRIPTION
## Summary
- clarify npm coverage command and Playwright installation
- sync spellcheck prompt with current AGENTS instructions

## Testing
- `pre-commit run --all-files`
- `npm run lint`
- `pytest -q`
- `npm run jest -- --coverage`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896ccb9cb9c832fb1b97292fe2221d6