### PR TITLE
📝 : add mini postmortem guidance

### DIFF
--- a/docs/ci-fix-action-items.md
+++ b/docs/ci-fix-action-items.md
@@ -1,0 +1,3 @@
+# CI Fix Action Items
+
+- [ ] Ensure every CI failure fix includes a mini postmortem document.

--- a/docs/ci-fix-mini-pm.md
+++ b/docs/ci-fix-mini-pm.md
@@ -1,0 +1,13 @@
+# CI Fix Mini Postmortem
+
+## What went wrong
+The CI fix prompt lacked guidance to create postmortems after failures.
+
+## Root cause
+No instruction directed contributors to document background, impact, and follow-up steps.
+
+## Impact
+Teams missed context from past failures, slowing diagnosis of future CI issues.
+
+## Actions
+Document future CI fixes with a mini postmortem and track follow-up items in `docs/ci-fix-action-items.md`.

--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -45,6 +45,12 @@ A GitHub pull request URL. The PR must include:
 * Evidence that **all** checks are now passing (`✔️`).
 * Links to any new or updated tests.
 Copy this block verbatim whenever you want Codex to repair a failing workflow run. After each successful run, refine the instructions in this file so the next run is even smoother.
+After opening the pull request, add `docs/ci-fix-mini-pm.md` capturing:
+- What went wrong
+- Root cause
+- Impact
+- Actions to take
+Record the actions as a markdown checklist in `docs/ci-fix-action-items.md`.
 ```
 
 ### Why this mirrors the existing pattern


### PR DESCRIPTION
## Summary
- document mini postmortem requirements in CI fix prompt
- add initial mini PM and action checklist files

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest -q`
- `npm test -- --coverage`
- `npm run lint`
- `npm run test:ci` *(fails: Missing script "test:ci")*
- `python -m flywheel.fit`
- `bash scripts/checks.sh` *(missing tools: linkchecker, bandit, safety)*

------
https://chatgpt.com/codex/tasks/task_e_6896e58c1c24832fb7005864e92c4ecc