### PR TITLE
🐛: detect pip3 installs in RepoCrawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ or skip end-to-end tests by prefixing commands with `SKIP_E2E=1`.
 - Fast Python installs powered by [uv](https://github.com/astral-sh/uv)
 - Example code and templates
 - Python CLI with subcommands `init`, `update`, `audit`, `prompt`, and `crawl` that prompts interactively unless `--yes` is used
+- RepoCrawler detects installers like uv, pip/pip3, and poetry in workflows
 - [AGENTS.md](AGENTS.md) detailing included LLM assistants
 - [llms.txt](llms.txt) with quick context for AI helpers
 - [CLAUDE.md](CLAUDE.md) summarizing Anthropic guidance

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -54,7 +54,7 @@ class RepoCrawler:
     CI_KEYWORDS = ("ci", "test", "lint", "build", "docs", "qa")
 
     _UV = re.compile(r"setup-uv|uv venv", re.I)
-    _PIP = re.compile(r"pip install", re.I)
+    _PIP = re.compile(r"\bpip(?:3)?\s+install", re.I)
     _POETRY = re.compile(r"poetry\s+install", re.I)
     DARK_PATTERNS = [
         re.compile(r"onbeforeunload", re.I),

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -160,6 +160,7 @@ def test_has_ci_only_deploy_returns_false():
         ("uv pip install && pip install black", "pip"),
         ("python -m pip install -r requirements.txt", "pip"),
         ("RUN pip3 install uv && uv pip install .", "pip"),
+        ("pip3 install -r requirements.txt", "pip"),
     ],
 )
 def test_installer_strict(snippet, expected):


### PR DESCRIPTION
what: treat `pip3 install` as pip in installer detection.
why: RepoCrawler misclassified workflows using pip3.
how to test: `pre-commit run --all-files`, `pytest -q`, `SKIP_E2E=1 npm test -- --coverage`, `python -m flywheel.fit`, `SKIP_E2E=1 bash scripts/checks.sh`.
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_6896e9d38aa8832fba484ec39d95ea82