### PR TITLE
🐛: ignore block comments in SCAD variable parser

### DIFF
--- a/docs/flywheel-construction.md
+++ b/docs/flywheel-construction.md
@@ -16,6 +16,7 @@ mounted to the shaft.
 ## Printing / Machining
 
 1. Adjust `diameter`, `height`, and `shaft_diameter` in the SCAD file as needed.
+   Inline `//` or block `/* ... */` comments are ignored by the CAD parser.
 2. Export to STL and slice with your preferred software.
 3. If using wood or metal, replicate the dimensions and center bore.
 

--- a/flywheel/fit.py
+++ b/flywheel/fit.py
@@ -16,11 +16,14 @@ _DEF_RE = re.compile(
 def parse_scad_vars(path: Path) -> Dict[str, float]:
     """Return variable assignments parsed from a SCAD file.
 
-    Inline ``//`` comments after the semicolon are ignored. The parser supports
-    negative values, decimals without a leading zero, and scientific notation.
+    Block comments ``/* ... */`` and inline ``//`` comments after the
+    semicolon are ignored. The parser supports negative values, decimals
+    without a leading zero, and scientific notation.
     """
+    text = Path(path).read_text()
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
     vars: Dict[str, float] = {}
-    for line in Path(path).read_text().splitlines():
+    for line in text.splitlines():
         m = _DEF_RE.match(line.strip())
         if m:
             vars[m.group(1)] = float(m.group(2))

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -23,6 +23,13 @@ def test_parse_scad_vars_with_comments_and_negatives(tmp_path):
     assert vars == {"radius": 5.0, "height": -2.0}
 
 
+def test_parse_scad_vars_ignores_block_comments(tmp_path):
+    scad = tmp_path / "part.scad"
+    scad.write_text("/*\n radius = 5;\n*/\nheight = 2;")
+    vars = ff.parse_scad_vars(scad)
+    assert vars == {"height": 2.0}
+
+
 def test_parse_scad_vars_without_leading_zero(tmp_path):
     scad = tmp_path / "part.scad"
     scad.write_text("radius = .5;")


### PR DESCRIPTION
## Summary
- skip /* ... */ sections when parsing SCAD vars
- document block comment support

## Testing
- pre-commit run --all-files
- pytest -q
- npm run lint
- npm run test:ci (missing script)
- SKIP_E2E=1 npm test -- --coverage
- npm run coverage
- python -m flywheel.fit
- bash scripts/checks.sh


------
https://chatgpt.com/codex/tasks/task_e_6896e9d38aa8832fba484ec39d95ea82