### PR TITLE
Handle uppercase extensions in pattern scan

### DIFF
--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -70,6 +70,16 @@ class RepoCrawler:
         re.compile(r"no[-_ ]?tracking", re.I),
     ]
 
+    CODE_EXTENSIONS = (
+        ".js",
+        ".ts",
+        ".tsx",
+        ".py",
+        ".html",
+        ".md",
+        ".json",
+    )
+
     DOCKER_FILES = (
         "Dockerfile",
         "Dockerfile.dev",
@@ -102,20 +112,15 @@ class RepoCrawler:
         return []
 
     def _detect_dark_patterns(self, repo: str, branch: str) -> int:
+        """Count dark UX patterns in code and docs.
+
+        File extension checks are case-insensitive.
+        """
+
         count = 0
         files = self._list_files(repo, branch)[:50]
         for path in files:
-            if not path.endswith(
-                (
-                    ".js",
-                    ".ts",
-                    ".tsx",
-                    ".py",
-                    ".html",
-                    ".md",
-                    ".json",
-                )
-            ):
+            if not path.lower().endswith(self.CODE_EXTENSIONS):
                 continue
             text = self._fetch_file(repo, path, branch)
             if not text:
@@ -127,20 +132,15 @@ class RepoCrawler:
         return count
 
     def _detect_bright_patterns(self, repo: str, branch: str) -> int:
+        """Count positive UX patterns in code and docs.
+
+        File extension checks are case-insensitive.
+        """
+
         count = 0
         files = self._list_files(repo, branch)[:50]
         for path in files:
-            if not path.endswith(
-                (
-                    ".js",
-                    ".ts",
-                    ".tsx",
-                    ".py",
-                    ".html",
-                    ".md",
-                    ".json",
-                )
-            ):
+            if not path.lower().endswith(self.CODE_EXTENSIONS):
                 continue
             text = self._fetch_file(repo, path, branch)
             if not text:

--- a/tests/test_pattern_detection.py
+++ b/tests/test_pattern_detection.py
@@ -37,6 +37,22 @@ def test_pattern_detection_skips(monkeypatch):
     assert crawler._detect_bright_patterns("foo/bar", "main") == 1
 
 
+def test_pattern_detection_case_insensitive_extensions(monkeypatch):
+    crawler = rc.RepoCrawler([])
+    monkeypatch.setattr(
+        crawler,
+        "_list_files",
+        lambda repo, branch: ["INDEX.JS", "README.MD"],
+    )
+
+    def fetch(repo, path, branch):
+        return "onbeforeunload" if path == "INDEX.JS" else "delete account"
+
+    monkeypatch.setattr(crawler, "_fetch_file", fetch)
+    assert crawler._detect_dark_patterns("foo/bar", "main") == 1
+    assert crawler._detect_bright_patterns("foo/bar", "main") == 1
+
+
 def test_list_files_errors(monkeypatch):
     crawler = rc.RepoCrawler([])
 


### PR DESCRIPTION
## Summary
- treat dark/bright pattern detection file extension checks case-insensitively
- cover uppercase paths with unit test

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `SKIP_E2E=1 npm run jest -- --coverage`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896e9d38aa8832fba484ec39d95ea82