### PR TITLE
docs: clarify Playwright install in spellcheck prompt

### DIFF
--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -23,8 +23,8 @@ CONTEXT:
   - `npm test -- --coverage`
   - `python -m flywheel.fit`
   - `bash scripts/checks.sh`
-  If browser dependencies are missing, run `npx playwright install chromium` or
-  prefix tests with `SKIP_E2E=1`.
+  - If browser dependencies are missing, run `npx playwright install --with-deps` or set
+    `SKIP_E2E=1` before running tests.
 
 REQUEST:
 1. Run the spellcheck command and inspect the results.


### PR DESCRIPTION
## Summary
- clarify Playwright install/skip guidance in spellcheck prompt

## Testing
- pre-commit run --all-files
- pytest -q
- npm test -- --coverage
- python -m flywheel.fit
- SKIP_E2E=1 bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_6896e9d43c50832fb77cf4f0ded8d19d