### PR TITLE
docs: clarify spellcheck prompt instructions

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -189,3 +189,5 @@ od
 fn
 utils
 qa
+precession
+mathrm

--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -17,14 +17,13 @@ Keep Markdown documentation free of spelling errors.
 CONTEXT:
 - Run `pyspelling -c .spellcheck.yaml` over all Markdown files.
 - Add unknown but legitimate words to [dict/allow.txt](../dict/allow.txt).
-- Follow [AGENTS.md](../AGENTS.md) and ensure these commands succeed:
+- Follow [AGENTS.md](../AGENTS.md) and [README.md](../README.md); ensure these commands succeed:
   - `pre-commit run --all-files`
   - `pytest -q`
   - `npm test -- --coverage`
   - `python -m flywheel.fit`
   - `bash scripts/checks.sh`
-  If browser dependencies are missing, run `npx playwright install chromium` or
-  prefix tests with `SKIP_E2E=1`.
+  - If browser dependencies are missing, run `npx playwright install chromium` or prefix tests with `SKIP_E2E=1`.
 
 REQUEST:
 1. Run the spellcheck command and inspect the results.
@@ -34,7 +33,7 @@ REQUEST:
 5. Commit the changes with a concise message and open a pull request.
 
 OUTPUT:
-A pull request URL that summarizes the fixes and shows passing check results.
+A pull request URL summarizing the fixes and showing passing check results.
 ```
 
 Copy this block whenever you want Codex to clean up spelling across the docs.


### PR DESCRIPTION
## Summary
- clarify spellcheck prompt with README link and browser-test guidance
- allow `precession` and LaTeX `mathrm` in dictionary

## Testing
- `pyspelling -c .spellcheck.yaml`
- `pre-commit run --all-files`
- `pytest -q`
- `SKIP_E2E=1 npm test -- --coverage`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896e9d43c50832fb77cf4f0ded8d19d