### PR TITLE
📝 : Update spellcheck prompt to use codespell

### DIFF
--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -15,7 +15,7 @@ PURPOSE:
 Keep Markdown documentation free of spelling errors.
 
 CONTEXT:
-- Run `pyspelling -c .spellcheck.yaml` over all Markdown files.
+- Run `codespell --ignore-words dict/allow.txt` over all Markdown files.
 - Add unknown but legitimate words to [dict/allow.txt](../dict/allow.txt).
 - Follow [AGENTS.md](../AGENTS.md) and ensure these commands succeed:
   - `pre-commit run --all-files`
@@ -29,7 +29,7 @@ CONTEXT:
 REQUEST:
 1. Run the spellcheck command and inspect the results.
 2. Correct misspellings or update `dict/allow.txt` as needed.
-3. Re-run `pyspelling` until it reports no errors.
+3. Re-run `codespell` until it reports no errors.
 4. Run all checks listed above.
 5. Commit the changes with a concise message and open a pull request.
 


### PR DESCRIPTION
what: replace pyspelling references with codespell in prompt doc.
why: repository uses codespell for typo checking.
how to test:
- pre-commit run --all-files
- pytest -q
- SKIP_E2E=1 npm test -- --coverage
- python -m flywheel.fit
- SKIP_E2E=1 bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_6896e9d43c50832fb77cf4f0ded8d19d