### PR TITLE
Add missing test:ci script for CI

### DIFF
--- a/docs/codex-custom-instructions.md
+++ b/docs/codex-custom-instructions.md
@@ -19,7 +19,7 @@
 - Diff display: unified
 - Line length: 100 chars
 - Package manager: npm (`npm ci`)
-- Test script: `npm run test:ci`
+- Test script: `npm run test:ci` (runs Jest and Playwright with coverage)
 
 # Standard Operating Procedures  (trigger ➔ instruction)
 Feature:   create a minimal PR containing (1) failing test, (2) code to pass, (3) doc update.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "playwright": "playwright test",
     "playwright:install": "playwright install --with-deps",
     "test": "npm run playwright:install && npm run jest -- && npm run playwright",
+    "test:ci": "npm run playwright:install && npm run jest -- --coverage --coverageReporters=lcov && npm run playwright",
     "docs:dev": "npm --prefix docs-site run dev"
   },
   "devDependencies": {

--- a/tests/package-scripts.test.mjs
+++ b/tests/package-scripts.test.mjs
@@ -1,0 +1,9 @@
+import { readFileSync } from 'node:fs';
+
+/**
+ * Ensure required npm scripts exist so CI workflows stay green.
+ */
+test('package.json defines test:ci script', () => {
+  const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url)));
+  expect(pkg.scripts['test:ci']).toBeDefined();
+});


### PR DESCRIPTION
## Summary
- add `test:ci` script to run Jest and Playwright with coverage
- document the script and test that it exists

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896e8ce24b4832fa9b7df4ee4bfaf21