### PR TITLE
fix: add missing test:ci script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "playwright": "playwright test",
     "playwright:install": "playwright install --with-deps",
     "test": "npm run playwright:install && npm run jest -- && npm run playwright",
+    "test:ci": "npm run jest -- --coverage",
     "docs:dev": "npm --prefix docs-site run dev"
   },
   "devDependencies": {

--- a/tests/test_ci_script.test.mjs
+++ b/tests/test_ci_script.test.mjs
@@ -1,0 +1,13 @@
+import { readFile } from 'fs/promises';
+import { fileURLToPath } from 'url';
+
+async function loadPackage() {
+  const pkgPath = new URL('../package.json', import.meta.url);
+  const content = await readFile(pkgPath, 'utf8');
+  return JSON.parse(content);
+}
+
+test('package.json includes test:ci script', async () => {
+  const pkg = await loadPackage();
+  expect(pkg.scripts['test:ci']).toBeDefined();
+});


### PR DESCRIPTION
## Summary
- add `test:ci` npm script and test verifying its presence

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896e8ce24b4832fa9b7df4ee4bfaf21