### PR TITLE
chore: skip linkchecker when missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- chore: skip link checker when binary is unavailable to keep CI green

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -51,4 +51,9 @@ run_security_checks
 if command -v pyspelling >/dev/null 2>&1 && [ -f .spellcheck.yaml ]; then
   pyspelling -c .spellcheck.yaml || true
 fi
-linkchecker README.md docs/ || true
+
+if command -v linkchecker >/dev/null 2>&1; then
+  linkchecker README.md docs/ || true
+else
+  echo "linkchecker not installed; skipping link check"
+fi

--- a/tests/test_checks_script.py
+++ b/tests/test_checks_script.py
@@ -18,3 +18,9 @@ def test_checks_script_skips_missing_security_tools(tmp_path):
     assert result.returncode == 0
     assert "bandit not installed" in result.stdout
     assert "safety not installed" in result.stdout
+
+
+def test_checks_script_handles_missing_linkchecker():
+    script = Path(__file__).resolve().parents[1] / "scripts" / "checks.sh"
+    content = script.read_text()
+    assert "linkchecker not installed" in content


### PR DESCRIPTION
## Summary
- avoid `linkchecker` failures by skipping when the binary is absent
- document the change in a new `CHANGELOG.md`
- test: ensure checks script embeds the skip message

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_6896e8ce24b4832fa9b7df4ee4bfaf21