### PR TITLE
Skip utility SCAD libraries when exporting STLs

### DIFF
--- a/cad/README.md
+++ b/cad/README.md
@@ -13,7 +13,8 @@ Source OpenSCAD files for the flywheel project.
 
 ## Regenerating meshes
 
-Rebuild STL outputs and OBJ viewer models whenever a SCAD file changes:
+Rebuild STL outputs and OBJ viewer models whenever a SCAD file changes. Library
+modules in `cad/utils/` are skipped because they don't render standalone parts:
 
 ```bash
 scripts/build_stl.sh

--- a/scripts/build_stl.sh
+++ b/scripts/build_stl.sh
@@ -9,6 +9,10 @@ mkdir -p "$STL_DIR"
 while IFS= read -r -d '' scad; do
   rel="${scad#$SCAD_DIR/}"
   stl="$STL_DIR/${rel%.scad}.stl"
+  if [[ "$rel" == utils/* ]]; then
+    echo "[INFO] Skipping library $scad"
+    continue
+  fi
   mkdir -p "$(dirname "$stl")"
   if [ -f "$stl" ] && [ "$stl" -nt "$scad" ]; then
     echo "[INFO] Skipping $scad; STL up to date"


### PR DESCRIPTION
## Summary
- skip cad/utils libraries in STL build script
- document that library modules are excluded from mesh regeneration

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896e8be2c80832f95ed917792e36081