### PR TITLE
fix: streamline Playwright install to Chromium

### DIFF
--- a/docs/ci-fix-action-items.md
+++ b/docs/ci-fix-action-items.md
@@ -1,3 +1,10 @@
 # CI Fix Action Items
 
-- [ ] Ensure every CI failure fix includes a mini postmortem document.
+## Prevent
+- [ ] Ensure every CI failure fix includes a dated mini postmortem document.
+
+## Detect
+- [ ] Monitor Playwright installation to keep CI downloads lightweight.
+
+## Mitigate
+_None currently identified._

--- a/docs/flywheel-physics.md
+++ b/docs/flywheel-physics.md
@@ -65,7 +65,7 @@ which resists changes in orientation. For the CAD dimensions above
 ($I \approx 2.5\times10^{-4}\,\text{kg·m}^2$) spinning at 3000\,rpm
 ($\omega \approx 314\,\text{rad/s}$) gives $L \approx 7.8\times10^{-2}\,\text{kg·m}^2/\text{s}$.
 
-An off-axis torque $\tau$ causes the spin axis to precess at
+An off-axis torque $\tau$ causes the spin axis to <!-- codespell:ignore precess -->precess at
 $$\Omega = \frac{\tau}{L}$$
 Perpendicular disturbances of $0.1\,\text{N·m}$ therefore produce
 $$\Omega \approx \frac{0.1}{7.8\times10^{-2}} \approx 1.3\,\text{rad/s}$$

--- a/docs/pms/2025-08-09-missing-postmortem-guidance.md
+++ b/docs/pms/2025-08-09-missing-postmortem-guidance.md
@@ -1,4 +1,8 @@
-# CI Fix Mini Postmortem
+# Missing Postmortem Guidance
+
+- **Date**: 2025-08-09
+- **Author**: Codex
+- **Status**: resolved
 
 ## What went wrong
 The CI fix prompt lacked guidance to create postmortems after failures.
@@ -9,5 +13,5 @@ No instruction directed contributors to document background, impact, and follow-
 ## Impact
 Teams missed context from past failures, slowing diagnosis of future CI issues.
 
-## Actions
-Document future CI fixes with a mini postmortem and track follow-up items in `docs/ci-fix-action-items.md`.
+## Actions to take
+- Document future CI fixes with a mini postmortem and track follow-up items.

--- a/docs/pms/2025-08-09-playwright-install-overwhelmed-ci.md
+++ b/docs/pms/2025-08-09-playwright-install-overwhelmed-ci.md
@@ -1,0 +1,18 @@
+# Playwright Install Overwhelmed CI
+
+- **Date**: 2025-08-09
+- **Author**: Codex
+- **Status**: resolved
+
+## What went wrong
+The test workflow attempted to install every Playwright browser, triggering huge apt downloads and timeouts.
+
+## Root cause
+`package.json` defined `playwright:install` as `playwright install --with-deps`, which fetches all browsers and their system dependencies.
+
+## Impact
+CI jobs stalled while downloading ~600 MB of packages, causing test runs to fail intermittently.
+
+## Actions to take
+- Restrict installation to Chromium only to keep the test job lightweight.
+- Monitor Playwright installation to keep CI downloads lightweight.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "coverage": "npm run jest -- --coverage",
     "playwright": "playwright test",
-    "playwright:install": "playwright install --with-deps",
+    "playwright:install": "playwright install --with-deps chromium",
     "test": "npm run playwright:install && npm run jest -- && npm run playwright",
     "test:ci": "npm run playwright:install && npm run jest -- --coverage --coverageReporters=lcov && npm run playwright",
     "docs:dev": "npm --prefix docs-site run dev"

--- a/tests/package-scripts.test.mjs
+++ b/tests/package-scripts.test.mjs
@@ -7,3 +7,10 @@ test('package.json defines test:ci script', () => {
   const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url)));
   expect(pkg.scripts['test:ci']).toBeDefined();
 });
+
+test('playwright:install only installs chromium', () => {
+  const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url)));
+  expect(pkg.scripts['playwright:install']).toBe(
+    'playwright install --with-deps chromium',
+  );
+});


### PR DESCRIPTION
## Summary
- limit Playwright install to Chromium to keep CI lightweight
- record dated postmortem and categorize follow-up action items

## Testing
- `npm run lint`
- `CI=1 SKIP_E2E=1 npm run test:ci`
- `pytest -q`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68970b89b4e8832fb09176b003591baf