### PR TITLE
🐛: handle EXPECTED CI status as green

### DIFF
--- a/docs/ci-guide.md
+++ b/docs/ci-guide.md
@@ -21,3 +21,8 @@ setup accurately.
 |----------|---------------------|
 | Internal commits | The workflow will commit the summary when `main` is updated. |
 | Dependabot / external PRs | The push step is skipped; merge the PR and let `main` update the summary. |
+
+### Status interpretation
+
+`ci_state` treats GitHub's `EXPECTED` rollup status as green so pending required
+checks don't appear as failures on the dashboard.

--- a/src/ci_status.py
+++ b/src/ci_status.py
@@ -69,11 +69,13 @@ def ci_state(owner: str, repo: str, sha: str) -> str:
     Logic order:
       1. GraphQL rollup
       2. REST checks fall-back
+    The GitHub GraphQL API may return ``EXPECTED`` when required checks haven't
+    completed yet; this is treated as green to avoid false negatives.
     """
     state = _query_graphql(owner, repo, sha)
     if state is None:
         state = _query_rest(owner, repo, sha)
 
-    if state in ("SUCCESS", "PENDING", "NO_CI"):
+    if state in ("SUCCESS", "PENDING", "NO_CI", "EXPECTED"):
         return "green"
     return "red"

--- a/tests/test_ci_status.py
+++ b/tests/test_ci_status.py
@@ -1,0 +1,9 @@
+from src.ci_status import ci_state
+
+
+def test_ci_state_expected(monkeypatch):
+    monkeypatch.setattr(
+        "src.ci_status._query_graphql",
+        lambda o, r, s: "EXPECTED",
+    )
+    assert ci_state("o", "r", "s") == "green"


### PR DESCRIPTION
## Summary
- classify GitHub `EXPECTED` status as green in `ci_state`
- document handling of EXPECTED status in CI guide
- cover EXPECTED status with regression test

## Testing
- `pre-commit run --all-files`
- `npm run lint`
- `npm run test:ci`
- `npm test -- --coverage`
- `pytest -q`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68990e03f144832f81b6d365b4633cdc