### PR TITLE
🐛: parse trailing decimal in SCAD vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ All parts fit together.
 ```
 
 Lines may include inline ``//`` comments, negative values, decimals without a
-leading zero, and scientific notation; the checker ignores the comments when
-parsing.
+leading zero, trailing decimal points, and scientific notation; the checker
+ignores the comments when parsing.
 
 Below is a simplified view of how the pieces stack:
 

--- a/flywheel/fit.py
+++ b/flywheel/fit.py
@@ -8,7 +8,7 @@ import trimesh
 
 _DEF_RE = re.compile(
     r"^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*"
-    r"([-+]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][-+]?\d+)?)\s*"
+    r"([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)\s*"
     r";(?:\s*//.*)?$"
 )
 
@@ -18,7 +18,7 @@ def parse_scad_vars(path: Path) -> Dict[str, float]:
 
     Block comments ``/* ... */`` and inline ``//`` comments after the
     semicolon are ignored. The parser supports negative values, decimals
-    without a leading zero, and scientific notation.
+    without a leading zero, trailing decimal points, and scientific notation.
     """
     text = Path(path).read_text()
     text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -44,6 +44,13 @@ def test_parse_scad_vars_scientific_notation(tmp_path):
     assert vars == {"radius": 0.001}
 
 
+def test_parse_scad_vars_trailing_decimal(tmp_path):
+    scad = tmp_path / "part.scad"
+    scad.write_text("radius = 5.;")
+    vars = ff.parse_scad_vars(scad)
+    assert vars == {"radius": 5.0}
+
+
 def test_verify_fit(tmp_path, monkeypatch):
     assert ff.verify_fit(CAD_DIR, STL_DIR)
 


### PR DESCRIPTION
## Summary
- handle trailing decimal floats in `parse_scad_vars`
- document support for trailing decimals in README

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm test -- --coverage`
- `npm run test:ci`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68990e03f144832f81b6d365b4633cdc