### PR TITLE
docs: refresh codex spellcheck prompt

### DIFF
--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -19,13 +19,12 @@ CONTEXT:
 - Add unknown but legitimate words to [dict/allow.txt](../dict/allow.txt).
 - Follow [AGENTS.md](../AGENTS.md) and [README.md](../README.md); ensure these commands succeed:
   - `pre-commit run --all-files`
-  - `npm run lint`
   - `pytest -q`
   - `npm test -- --coverage`
   - `python -m flywheel.fit`
   - `bash scripts/checks.sh`
-  If browser dependencies are missing, run `npx playwright install --with-deps` or
-  prefix tests with `SKIP_E2E=1`.
+  If browser dependencies are missing, run `npx playwright install chromium` or prefix
+  tests with `SKIP_E2E=1`.
 
 REQUEST:
 1. Run the spellcheck command and inspect the results.


### PR DESCRIPTION
## Summary
- align spellcheck prompt with current repo checks
- update Playwright install guidance

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `SKIP_E2E=1 npm run jest -- --coverage`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68990e0de50c832f994b1fade5a37f91