### PR TITLE
docs: add Codex prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ or skip end-to-end tests by prefixing commands with `SKIP_E2E=1`.
 - [CLAUDE.md](CLAUDE.md) summarizing Anthropic guidance
 - [codex-custom-instructions.md](docs/codex-custom-instructions.md) for Codex rules
   and a [runbook.yml](runbook.yml) checklist for repo setup
-- Codex automation prompt in `docs/prompts-codex.md`
-- CAD update prompt in `docs/prompts-codex-cad.md`
-- Physics explainer prompt in `docs/prompts-codex-physics.md`
-- Cross-repo prompt index in `docs/prompt-docs-summary.md` listing `prompts-items.md`, `prompts-quests.md`, and `prompts-codex.md` across repos
+- [Codex automation prompt](docs/prompts-codex.md)
+- [CAD update prompt](docs/prompts-codex-cad.md)
+- [Physics explainer prompt](docs/prompts-codex-physics.md)
+- Cross-repo prompt index in [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) listing `prompts-items.md`, `prompts-quests.md`, and `prompts-codex.md` across repos
 - Axel integration guide in `docs/axel-integration.md`
 - DSPACE synergy doc in `docs/dspace-integration.md`
 - Cross-repo roadmap in `docs/REPOS_ROADMAP.md`


### PR DESCRIPTION
## Summary
- link Codex prompt docs in README for easier discovery

## Testing
- `SKIP=run-checks pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68990df7a704832f82efdcd1d40ebbb6