### PR TITLE
fix: skip e2e tests during pre-commit checks

### DIFF
--- a/docs/ci-fix-action-items.md
+++ b/docs/ci-fix-action-items.md
@@ -11,3 +11,4 @@
 ## Mitigate
 - [x] Whitelist "Untriaged" in the spellcheck dictionary.
 - [x] Skip auto-generated docs in spellcheck to prevent false positives.
+- [x] Skip Playwright e2e tests during pre-commit checks by detecting `PRE_COMMIT`.

--- a/docs/ci-fix-mini-pm.md
+++ b/docs/ci-fix-mini-pm.md
@@ -1,14 +1,14 @@
 # CI Mini Postmortem
 
 ## What went wrong
-Spellcheck failed on `docs/prompt-docs-summary.md` due to the word "Untriaged".
+Pre-commit's `run project checks` hook executed Playwright end-to-end tests, leading to long runtimes and occasional timeouts during CI runs.
 
 ## Root cause
-The term "Untriaged" was missing from the spellcheck allow list, causing a false positive.
+`scripts/checks.sh` only skipped Playwright when `SKIP_E2E` was set. Pre-commit runs did not set this flag, so the hook downloaded browsers and ran e2e tests.
 
 ## Impact
-CI runs were blocked by the spellcheck job.
+Developers and CI pipelines were slowed or blocked when the hook attempted to download and run Playwright assets.
 
 ## Actions to take
-- [x] Add "Untriaged" to the spellcheck dictionary.
-- [ ] Regenerate `docs/prompt-docs-summary.md` with sanitized headings.
+- [x] Skip Playwright steps when the `PRE_COMMIT` flag is present.
+- [ ] Monitor pre-commit runtime and evaluate re-enabling e2e tests if overhead drops.

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -28,13 +28,13 @@ black --check . --exclude ".venv/"
 # js checks
 if [ -f package.json ]; then
   npm ci
-  if [ -z "$SKIP_E2E" ]; then
+  if [ -z "$SKIP_E2E" ] && [ -z "$PRE_COMMIT" ]; then
     npx playwright install --with-deps
     npm run lint
     npm run format:check
     npm test -- --coverage
   else
-    echo "SKIP_E2E set; skipping Playwright installation and e2e tests" >&2
+    echo "Skipping Playwright installation and e2e tests" >&2
     npm run lint
     npm run format:check
     npm run jest -- --coverage

--- a/tests/test_precommit_env.py
+++ b/tests/test_precommit_env.py
@@ -1,0 +1,32 @@
+import os
+import subprocess
+
+
+def test_checks_sh_skips_e2e_when_pre_commit(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for cmd in [
+        "npm",
+        "npx",
+        "flake8",
+        "isort",
+        "black",
+        "pytest",
+        "bandit",
+        "safety",
+        "pyspelling",
+        "linkchecker",
+    ]:
+        script_path = bin_dir / cmd
+        script_path.write_text("#!/bin/sh\nexit 0\n")
+        script_path.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["PRE_COMMIT"] = "1"
+
+    result = subprocess.run(
+        ["bash", "scripts/checks.sh"], capture_output=True, text=True, env=env
+    )
+    assert "Skipping Playwright installation and e2e tests" in result.stderr
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- skip Playwright install when pre-commit runs project checks
- document pre-commit runtime regression and mitigation

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68990dea6590832fae6497e215a44100