### PR TITLE
🔧 fix: add template lockfile

### DIFF
--- a/docs/ci-fix-action-items.md
+++ b/docs/ci-fix-action-items.md
@@ -4,10 +4,13 @@
 - [x] Ensure every CI failure fix includes a dated mini postmortem document.
 - [ ] Regenerate `docs/prompt-docs-summary.md` with a valid Markdown table so spellcheck can cover it.
 - [x] Whitelist common physics notation like `precess` and `circ` in the spellcheck dictionary.
+- [x] Test templates for required `package-lock.json` files.
 
 ## Detect
 - [ ] Monitor Playwright installation to keep CI downloads lightweight.
+- [ ] Alert on missing lock files in template directories.
 
 ## Mitigate
 - [x] Whitelist "Untriaged" in the spellcheck dictionary.
 - [x] Skip auto-generated docs in spellcheck to prevent false positives.
+- [x] Commit missing `package-lock.json` for the JavaScript template.

--- a/docs/ci-fix-mini-pm.md
+++ b/docs/ci-fix-mini-pm.md
@@ -12,3 +12,18 @@ CI runs were blocked by the spellcheck job.
 ## Actions to take
 - [x] Add "Untriaged" to the spellcheck dictionary.
 - [ ] Regenerate `docs/prompt-docs-summary.md` with sanitized headings.
+
+---
+
+## What went wrong
+`npm ci` failed for `templates/javascript` because `package-lock.json` was missing.
+
+## Root cause
+The JavaScript template lacked a committed lock file required by `npm ci`.
+
+## Impact
+Template checks in CI failed, blocking the pipeline.
+
+## Actions to take
+- [x] Add `package-lock.json` to `templates/javascript`.
+- [x] Add test to ensure all templates include a lock file.

--- a/templates/javascript/package-lock.json
+++ b/templates/javascript/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "sample",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sample"
+    }
+  }
+}

--- a/tests/test_templates_package_lock.py
+++ b/tests/test_templates_package_lock.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_template_dirs_have_lockfiles():
+    """Ensure each template with package.json has a lock file."""
+    missing = []
+    for pkg in Path("templates").rglob("package.json"):
+        lock = pkg.with_name("package-lock.json")
+        if not lock.exists():
+            missing.append(str(lock))
+    assert not missing, f"missing package-lock.json: {missing}"


### PR DESCRIPTION
## Summary
- add missing `package-lock.json` for JavaScript template
- check templates for lock files in tests
- document CI failure and action items

## Testing
- `pre-commit run --files docs/ci-fix-mini-pm.md docs/ci-fix-action-items.md tests/test_templates_package_lock.py templates/javascript/package-lock.json`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit --help`


------
https://chatgpt.com/codex/tasks/task_e_68990dea6590832fae6497e215a44100