### PR TITLE
🛠️: pin docs linkcheck to Python 3.12

### DIFF
--- a/.github/workflows/03-docs.yml
+++ b/.github/workflows/03-docs.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: astral-sh/setup-uv@v1
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.12'
       - run: |
           uv pip install --system linkchecker
           linkchecker README.md docs/ || true

--- a/docs/ci-fix-action-items.md
+++ b/docs/ci-fix-action-items.md
@@ -4,9 +4,11 @@
 - [x] Ensure every CI failure fix includes a dated mini postmortem document.
 - [ ] Regenerate `docs/prompt-docs-summary.md` with a valid Markdown table so spellcheck can cover it.
 - [x] Whitelist common physics notation like `precess` and `circ` in the spellcheck dictionary.
+- [x] Pin docs link check workflow to Python 3.12 until `linkchecker` supports newer versions.
 
 ## Detect
 - [ ] Monitor Playwright installation to keep CI downloads lightweight.
+- [ ] Track `linkchecker` releases for Python 3.13 compatibility.
 
 ## Mitigate
 - [x] Whitelist "Untriaged" in the spellcheck dictionary.

--- a/docs/ci-fix-mini-pm.md
+++ b/docs/ci-fix-mini-pm.md
@@ -1,14 +1,33 @@
 # CI Mini Postmortem
 
-## What went wrong
+## 2025-08-10 – Docs link check failed on Python 3.13
+
+### What went wrong
+The link-check job in `.github/workflows/03-docs.yml` failed while installing `linkchecker`.
+
+### Root cause
+`actions/setup-python@v4` resolved to Python 3.13, which `linkchecker` does not yet support.
+
+### Impact
+Docs workflow runs on `main` were red, obscuring other CI signals.
+
+### Actions to take
+- [x] Pin Python to 3.12 in the docs workflow.
+- [ ] Monitor `linkchecker` for Python 3.13 compatibility.
+
+---
+
+## 2025-?? – Spellcheck false positive on "Untriaged"
+
+### What went wrong
 Spellcheck failed on `docs/prompt-docs-summary.md` due to the word "Untriaged".
 
-## Root cause
+### Root cause
 The term "Untriaged" was missing from the spellcheck allow list, causing a false positive.
 
-## Impact
+### Impact
 CI runs were blocked by the spellcheck job.
 
-## Actions to take
+### Actions to take
 - [x] Add "Untriaged" to the spellcheck dictionary.
 - [ ] Regenerate `docs/prompt-docs-summary.md` with sanitized headings.


### PR DESCRIPTION
## Summary
- pin docs workflow to Python 3.12 so linkchecker installs
- document the failure and follow-up actions

## Testing
- `bash scripts/checks.sh`
- `python -m pyspelling -c .spellcheck.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68990dea6590832fae6497e215a44100