### PR TITLE
📝 : – expand flywheel physics derivations

### DIFF
--- a/docs/flywheel-physics.md
+++ b/docs/flywheel-physics.md
@@ -9,21 +9,37 @@ and how GitHub renders formulas using LaTeX.
 For a solid cylinder,
 $$I = \tfrac{1}{2} m r^2$$
 where $m$ is mass and $r$ is radius.
-Most flywheels include a bore for the shaft.  Treating the wheel as a
+Most flywheels include a bore for the shaft. Treating the wheel as a
 thick-walled cylinder with inner radius $r_i$ and outer radius $r_o$ gives
 $$I = \tfrac{1}{2} m (r_o^2 + r_i^2)$$
+obtained by integrating the mass distribution:
+$$
+\begin{aligned}
+I &= \int_{r_i}^{r_o} r'^2 (2\pi\rho h r'\,\mathrm{d}r') \\
+  &= \tfrac{1}{2}\pi\rho h (r_o^4 - r_i^4) \\
+  &= \tfrac{1}{2} m (r_o^2 + r_i^2)
+\end{aligned}
+$$
 Setting $r_i \to 0$ recovers the solid-disk formula, while the thin-rim limit
 ($r_i \approx r_o$) approaches $$I = m r_o^2,$$ doubling inertia for the same mass.
 
 ```mermaid
 graph LR
     A[Solid disk] -->|I = \tfrac{1}{2} m r^2| B[Inertia]
-    C[Thin rim] -->|I = m r^2| B
+    C[Thick wall] -->|I = \tfrac{1}{2} m (r_o^2 + r_i^2)| B
+    D[Thin rim] -->|I = m r^2| B
 ```
 
 Integrating the mass distribution shows where this expression comes from:
 
-$$I = \int_0^r r'^2\, \mathrm{d}m = \int_0^r r'^2 (2\pi \rho h r'\, \mathrm{d}r') = \tfrac{1}{2}\pi \rho h r^4 = \tfrac{1}{2} m r^2$$
+$$
+\begin{aligned}
+I &= \int_0^r r'^2\, \mathrm{d}m \\
+  &= \int_0^r r'^2 (2\pi \rho h r'\, \mathrm{d}r') \\
+  &= \tfrac{1}{2}\pi \rho h r^4 \\
+  &= \tfrac{1}{2} m r^2
+\end{aligned}
+$$
 
 where $\rho$ is the material density and $h$ the cylinder height.
 
@@ -35,21 +51,25 @@ with angular velocity $\omega$ in radians per second.
 
 ### Example using CAD dimensions
 
-The stock CAD model in [`cad/flywheel.scad`](../cad/flywheel.scad) defines a
-thick disk with outer radius $r_o=50\,\text{mm}$, inner radius $r_i=5\,\text{mm}$ for
-the shaft, and height $h=20\,\text{mm}$.  For material density $\rho$, the mass is
+The stock CAD model in [`cad/flywheel.scad`](../cad/flywheel.scad) sets
+`diameter = 100` and `shaft_diameter = 10`, so $r_o = 50\,\text{mm}$,
+$r_i = 5\,\text{mm}$ and $h = 20\,\text{mm}$. For material density $\rho$, the mass is
 
 $$m = \rho\pi (r_o^2 - r_i^2) h$$
 
-Converting the CAD dimensions to SI units gives $r = 0.05\,\text{m}$ and
-$h = 0.02\,\text{m}$.  PLA has density
-$\rho \approx 1.25\,\text{g/cm}^3 = 1.25\times10^3\,\text{kg/m}^3$.
-The volume is $V = \pi r^2 h \approx 1.6\times10^{-4}\,\text{m}^3$, so the mass is
-$m = \rho V \approx 0.20\,\text{kg}$.
+Converting the CAD dimensions to SI units gives
+$r_o = 0.05\,\text{m}$, $r_i = 0.005\,\text{m}$ and $h = 0.02\,\text{m}$.
+PLA has density $\rho \approx 1.25\,\text{g/cm}^3 = 1.25\times10^3\,\text{kg/m}^3$.
+The volume is $V = \pi (r_o^2 - r_i^2) h \approx 1.6\times10^{-4}\,\text{m}^3$,
+so the mass is $m \approx 0.19\,\text{kg}$.
 
-$$I = \tfrac{1}{2} m r^2 \approx 2.5\times10^{-4}\,\text{kg·m}^2.$$ At
-3000\,rpm the angular speed is $\omega = \tfrac{2\pi n}{60} \approx 314\,\text{rad/s}$,
+Using the thick-walled formula,
+$$I = \tfrac{1}{2} m (r_o^2 + r_i^2) \approx 2.5\times10^{-4}\,\text{kg·m}^2.$$
+At 3000\,rpm the angular speed is $\omega = \tfrac{2\pi n}{60} \approx 314\,\text{rad/s}$,
 so the wheel stores roughly $$E \approx 12\,\text{J}.$$
+
+Actual mass varies with material density and print infill, so adjust $\rho$
+to match your filament.
 
 If the wheel were a thin rim of the same mass, the inertia would double:
 $$I_{rim} = m r^2.$$
@@ -69,7 +89,13 @@ An off-axis torque $\tau$ causes the spin axis to <!-- codespell:ignore precess 
 $$\Omega = \frac{\tau}{L}$$
 Perpendicular disturbances of $0.1\,\text{N·m}$ therefore produce
 $$\Omega \approx \frac{0.1}{7.8\times10^{-2}} \approx 1.3\,\text{rad/s}$$
-about $75^\circ/\text{s}$, which can twist the stand or mounts.
+about $75^\circ/\text{s}$, which can twist the stand or mounts such as the one in
+[`cad/stand.scad`](../cad/stand.scad).
+
+```mermaid
+graph TD
+    T[Torque \tau] --> P[Precession \Omega = \tau / L]
+```
 
 ## Rim speed and material limits
 
@@ -118,29 +144,6 @@ Using the same CAD dimensions as above ($I \approx 2.5\times10^{-4}\,\text{kg·m
 a modest $0.5\,\text{N·m}$ motor torque spins the wheel to
 3000\,rpm ($\omega \approx 314\,\text{rad/s}$) in about $t \approx 0.16\,\text{s}$.
 
-## Angular momentum and gyroscopic effects
-
-The flywheel's angular momentum is
-
-$$L = I\omega$$
-
-which resists changes in orientation. Using the CAD values above
-($I \approx 2.5\times10^{-4}\,\text{kg·m}^2$, $\omega \approx 314\,\text{rad/s}$)
-gives $L \approx 7.8\times10^{-2}\,\text{kg·m}^2/\text{s}$.
-
-Applying a torque $\tau$ perpendicular to the spin axis causes the wheel to
-undergo precession at rate
-
-$$\Omega = \frac{\tau}{L}.$$
-
-```mermaid
-graph TD
-    L[Angular momentum L] --> O[Precession \Omega = \tau/L]
-```
-
-Even small hobbyist wheels can exhibit noticeable gyroscopic behavior when spun
-at high speed.
-
 ## Spin-down from friction
 
 Even unloaded, bearing and air drag slowly bleed energy from the wheel. Approximating a
@@ -158,22 +161,6 @@ diameter, 7\,mm thick) around the 8\,mm shaft from
 $T_f \approx 10^{-3}\,\text{N·m}$, so the example wheel ($I \approx
 2.5\times10^{-4}\,\text{kg·m}^2$) coasts from 3000\,rpm ($\omega_0 \approx
 314\,\text{rad/s}$) for roughly $t \approx 80\,\text{s}$.
-
-## Angular momentum and precession
-
-The spinning wheel also carries angular momentum
-$$L = I \omega$$
-which resists changes in orientation.  With the CAD inertia above and
-$\omega \approx 314\,\text{rad/s}$, the wheel has
-$L \approx 0.078\,\text{kg·m}^2/\text{s}$.  A torque $\tau$ applied
-perpendicular to $L$ induces precession at
-$$\Omega = \frac{\tau}{L}$$
-on the stand in [`cad/stand.scad`](../cad/stand.scad).
-
-```mermaid
-graph TD
-    T[Torque \tau] --> P[Precession \Omega = \tau / L]
-```
 
 ## Forces on the adapter
 


### PR DESCRIPTION
what: derive thick-walled inertia, link to CAD values, prune duplicate sections
why: improves clarity and keeps physics explainer consistent
how to test: pre-commit run --files docs/flywheel-physics.md;
  pytest -q; npm run jest -- --coverage; SKIP_E2E=1 npm run test:ci;
  python -m flywheel.fit; RUN_SECURITY_ONLY=1 bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68990df46148832f8ca0b6ffa7e195cf