### PR TITLE
docs: classify prompts and add cleanup tooling

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -2,49 +2,138 @@
 
 This index is auto-generated with [scripts/update_prompt_docs_summary.py](../scripts/update_prompt_docs_summary.py) using RepoCrawler to discover prompt documents across repositories.
 
-| Repo                                                                          | Document                                                                                                                          | Title                                |
-|-------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [prompts-codex-cad.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cad.md)                             | Codex CAD Prompt                     |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [prompts-codex-ci-fix.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md)                       | Codex CI-Failure Fix Prompt          |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [prompts-codex-physics.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-physics.md)                     | Codex Physics Explainer Prompt       |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [prompts-codex-propagate.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-propagate.md)                 | Codex Prompt Propagation Prompt      |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [prompts-codex-spellcheck.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-spellcheck.md)               | Codex Spellcheck Prompt              |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [prompts-codex.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md)                                     | Flywheel Codex Prompt                |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [code.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/code.md)                                        |                                      |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [critique.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/critique.md)                                |                                      |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [plan.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/plan.md)                                        |                                      |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [prompts-codex-ci-fix.md](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex-ci-fix.md)                           | Codex CI-Failure Fix Prompt          |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [prompts-codex-spellcheck.md](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex-spellcheck.md)                   | Codex Spellcheck Prompt              |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [prompts-codex.md](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md)                                         | Axel Codex Prompt                    |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | [prompts-codex.md](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md)                                      | Gabriel Codex Prompt                 |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | [README.md](https://github.com/futuroptimist/gabriel/blob/main/prompts/README.md)                                                 | Prompt Templates                     |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | [generate-improvements.md](https://github.com/futuroptimist/gabriel/blob/main/prompts/generate-improvements.md)                   | Generate Improvement Checklist Items |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | [scan-bright-dark-patterns.md](https://github.com/futuroptimist/gabriel/blob/main/prompts/scan-bright-dark-patterns.md)           | Scan for Bright and Dark Patterns    |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | [update-risk-model.md](https://github.com/futuroptimist/gabriel/blob/main/prompts/update-risk-model.md)                           | Update Flywheel Risk Model           |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | [prompts-codex-spellcheck.md](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-spellcheck.md)          | Codex Spellcheck Prompt              |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | [prompts-codex-video-script.md](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-video-script.md)      | Codex Video Script Prompt            |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | [prompts-codex.md](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex.md)                                | Futuroptimist Codex Prompt           |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     | [prompts-codex-ci-fix.md](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex-ci-fix.md)                    | Codex CI-Failure Fix Prompt          |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     | [prompts-codex-security.md](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex-security.md)                | Codex Security Review Prompt         |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     | [prompts-codex.md](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md)                                  | token.place Codex Prompt             |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [prompts-codex-ci-fix.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex-ci-fix.md) | Codex CI-Failure Fix Prompt          |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [prompts-codex.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md)               | Codex Prompts                        |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [prompts-items.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md)               | Item Prompts                         |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [prompts-processes.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md)       | Process Prompts                      |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [prompts-quests.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md)             | Quest Prompts                        |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard)     | [prompts-codex.md](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md)                                  | Codex Prompts                        |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | [prompts-codex-cad.md](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-cad.md)                                | Codex CAD Prompt                     |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | [prompts-codex-ci-fix.md](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-ci-fix.md)                          | Codex CI-Failure Fix Prompt          |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | [prompts-codex-spellcheck.md](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-spellcheck.md)                  | Codex Spellcheck Prompt              |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | [prompts-codex.md](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex.md)                                        | Sigma Codex Prompt                   |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove)                   | [prompts-codex-cad.md](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex-cad.md)                                 | Codex CAD Prompt                     |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove)                   | [prompts-codex.md](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md)                                         | Wove Codex Prompt                    |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)         | [prompts-codex-cad.md](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex-cad.md)                            | Sugarkube Codex CAD Prompt           |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)         | [prompts-codex-docs.md](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex-docs.md)                          | Sugarkube Codex Docs Prompt          |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)         | [prompts-codex.md](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex.md)                                    | Sugarkube Codex Prompt               |
+## **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**
+
+| Prompt                                                                                                                                                                 | Type      |
+|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| [OpenAI Codex CAD Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cad.md#openai-codex-cad-prompt)                                       | evergreen |
+| [OpenAI Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md#openai-codex-ci-failure-fix-prompt)              | evergreen |
+| [Obsolete Prompt Cleanup](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cleanup.md#obsolete-prompt-cleanup)                                   | evergreen |
+| [OpenAI Codex Physics Explainer Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-physics.md#openai-codex-physics-explainer-prompt)       | evergreen |
+| [Codex Prompt Propagation Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-propagate.md#codex-prompt-propagation-prompt)                 | evergreen |
+| [Codex Spellcheck Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)                                | evergreen |
+| [Codex Automation Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#codex-automation-prompt)                                           | evergreen |
+| [Implementation prompts](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#implementation-prompts)                                             | one       |
+| [1 Add ⭐ Stars & 🐞 Open-Issues columns](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#1-add-stars-open-issues-columns)                     | one       |
+| [2 Create a Security & Dependency Health table](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#2-create-a-security-dependency-health-table) | one       |
+| [Upgrade Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#upgrade-prompt)                                                             | evergreen |
+
+## [futuroptimist/axel](https://github.com/futuroptimist/axel)
+
+| Prompt                                                                                                      | Type   |
+|-------------------------------------------------------------------------------------------------------------|--------|
+| [](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/code.md)                         |        |
+| [](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/critique.md)                     |        |
+| [](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/plan.md)                         |        |
+| [Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex-ci-fix.md) |        |
+| [Codex Spellcheck Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex-spellcheck.md) |        |
+| [Axel Codex Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md)                  |        |
+
+## [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)
+
+| Prompt                                                                                                                       | Type   |
+|------------------------------------------------------------------------------------------------------------------------------|--------|
+| [Gabriel Codex Prompt](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md)                             |        |
+| [Prompt Templates](https://github.com/futuroptimist/gabriel/blob/main/prompts/README.md)                                     |        |
+| [Generate Improvement Checklist Items](https://github.com/futuroptimist/gabriel/blob/main/prompts/generate-improvements.md)  |        |
+| [Scan for Bright and Dark Patterns](https://github.com/futuroptimist/gabriel/blob/main/prompts/scan-bright-dark-patterns.md) |        |
+| [Update Flywheel Risk Model](https://github.com/futuroptimist/gabriel/blob/main/prompts/update-risk-model.md)                |        |
+
+## [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist)
+
+| Prompt                                                                                                                   | Type   |
+|--------------------------------------------------------------------------------------------------------------------------|--------|
+| [Codex Spellcheck Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-spellcheck.md)     |        |
+| [Codex Video Script Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-video-script.md) |        |
+| [Futuroptimist Codex Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex.md)             |        |
+
+## [futuroptimist/token.place](https://github.com/futuroptimist/token.place)
+
+| Prompt                                                                                                                | Type   |
+|-----------------------------------------------------------------------------------------------------------------------|--------|
+| [Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex-ci-fix.md)    |        |
+| [Codex Security Review Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex-security.md) |        |
+| [token.place Codex Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md)              |        |
+
+## [democratizedspace/dspace](https://github.com/democratizedspace/dspace)
+
+| Prompt                                                                                                                                | Type   |
+|---------------------------------------------------------------------------------------------------------------------------------------|--------|
+| [Codex CI-Failure Fix Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex-ci-fix.md) |        |
+| [Codex Prompts](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md)                      |        |
+| [Item Prompts](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md)                       |        |
+| [Process Prompts](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md)                |        |
+| [Quest Prompts](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md)                     |        |
+
+## [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard)
+
+| Prompt                                                                                        | Type   |
+|-----------------------------------------------------------------------------------------------|--------|
+| [Codex Prompts](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md) |        |
+
+## [futuroptimist/sigma](https://github.com/futuroptimist/sigma)
+
+| Prompt                                                                                                       | Type   |
+|--------------------------------------------------------------------------------------------------------------|--------|
+| [Codex CAD Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-cad.md)               |        |
+| [Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-ci-fix.md) |        |
+| [Codex Spellcheck Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-spellcheck.md) |        |
+| [Sigma Codex Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex.md)                 |        |
+
+## [futuroptimist/wove](https://github.com/futuroptimist/wove)
+
+| Prompt                                                                                        | Type   |
+|-----------------------------------------------------------------------------------------------|--------|
+| [Codex CAD Prompt](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex-cad.md) |        |
+| [Wove Codex Prompt](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md)    |        |
+
+## [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)
+
+| Prompt                                                                                                         | Type   |
+|----------------------------------------------------------------------------------------------------------------|--------|
+| [Sugarkube Codex CAD Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex-cad.md)   |        |
+| [Sugarkube Codex Docs Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex-docs.md) |        |
+| [Sugarkube Codex Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex.md)           |        |
 
 ## Untriaged Prompt Docs
 
-None detected.
+| Repo                                                                          | Prompt                                                                                                                                                                 | Type      |
+|-------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [OpenAI Codex CAD Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cad.md#openai-codex-cad-prompt)                                       | evergreen |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [OpenAI Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md#openai-codex-ci-failure-fix-prompt)              | evergreen |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Obsolete Prompt Cleanup](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cleanup.md#obsolete-prompt-cleanup)                                   | evergreen |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [OpenAI Codex Physics Explainer Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-physics.md#openai-codex-physics-explainer-prompt)       | evergreen |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Codex Prompt Propagation Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-propagate.md#codex-prompt-propagation-prompt)                 | evergreen |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Codex Spellcheck Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)                                | evergreen |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Codex Automation Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#codex-automation-prompt)                                           | evergreen |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Implementation prompts](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#implementation-prompts)                                             | one       |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [1 Add ⭐ Stars & 🐞 Open-Issues columns](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#1-add-stars-open-issues-columns)                     | one       |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [2 Create a Security & Dependency Health table](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#2-create-a-security-dependency-health-table) | one       |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Upgrade Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#upgrade-prompt)                                                             | evergreen |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/code.md)                                                                                    |           |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/critique.md)                                                                                |           |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/plan.md)                                                                                    |           |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex-ci-fix.md)                                                            |           |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [Codex Spellcheck Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex-spellcheck.md)                                                            |           |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | [Codex Spellcheck Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-spellcheck.md)                                                   |           |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | [Codex Video Script Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-video-script.md)                                               |           |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | [Futuroptimist Codex Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex.md)                                                           |           |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     | [Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex-ci-fix.md)                                                     |           |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     | [Codex Security Review Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex-security.md)                                                  |           |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [Codex CI-Failure Fix Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex-ci-fix.md)                                  |           |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | [Codex CAD Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-cad.md)                                                                         |           |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | [Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-ci-fix.md)                                                           |           |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | [Codex Spellcheck Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-spellcheck.md)                                                           |           |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | [Sigma Codex Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex.md)                                                                           |           |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove)                   | [Codex CAD Prompt](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex-cad.md)                                                                          |           |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)         | [Sugarkube Codex CAD Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex-cad.md)                                                           |           |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)         | [Sugarkube Codex Docs Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex-docs.md)                                                         |           |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)         | [Sugarkube Codex Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex.md)                                                                   |           |
+
+## TODO Prompts for Other Repos
+
+| Repo | Suggested Prompt | Type | Notes |
+|------|-----------------|------|-------|
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | Add Codex security review prompt | evergreen | TODO: provide security checklist similar to Flywheel's |
 
 _Updated automatically: 2025-08-10_

--- a/docs/prompt-docs-todos.md
+++ b/docs/prompt-docs-todos.md
@@ -1,0 +1,3 @@
+| Repo | Suggested Prompt | Type | Notes |
+|------|-----------------|------|-------|
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | Add Codex security review prompt | evergreen | TODO: provide security checklist similar to Flywheel's | 

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -4,6 +4,7 @@ slug: 'prompts-codex-cad'
 ---
 
 # OpenAI Codex CAD Prompt
+Type: evergreen
 
 Use this prompt whenever CAD models or STL exports need updating. It mirrors the
 style of DSPACE's `prompts-codex.md` so the automation workflows stay

--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -4,6 +4,7 @@ slug:  'prompts-codex-ci-fix'
 ---
 
 # OpenAI Codex CI-Failure Fix Prompt
+Type: evergreen
 
 Use this prompt whenever a GitHub Actions run in *any* repository fails and you want Codex to diagnose and repair the problem automatically.
 **Human set-up steps (do these *before* switching ChatGPT into “Code” mode):**

--- a/docs/prompts-codex-cleanup.md
+++ b/docs/prompts-codex-cleanup.md
@@ -1,0 +1,31 @@
+---
+title: 'Codex Prompt Cleanup'
+slug: 'prompts-codex-cleanup'
+---
+
+# Obsolete Prompt Cleanup
+Type: evergreen
+
+Use this prompt to remove one-off prompts that have already been implemented and to prune TODO entries targeting other repositories.
+
+```text
+SYSTEM: You are an automated contributor for the Flywheel repository.
+
+PURPOSE:
+Maintain prompt hygiene by deleting fulfilled one-off prompts and clearing completed TODOs in `docs/prompt-docs-todos.md`.
+
+CONTEXT:
+- Scan `docs/` for prompts marked `Type: one-off` whose features exist in the codebase.
+- Delete those prompt sections or files.
+- Remove matching rows from `docs/prompt-docs-todos.md`.
+- Regenerate `docs/prompt-docs-summary.md` using `python scripts/update_prompt_docs_summary.py`.
+- Follow `AGENTS.md` for testing requirements.
+
+REQUEST:
+1. Identify an obsolete prompt or external TODO entry.
+2. Remove it and update references.
+3. Run all required checks before committing.
+
+OUTPUT:
+A pull request that deletes outdated prompts and cleans up corresponding TODO items.
+```

--- a/docs/prompts-codex-physics.md
+++ b/docs/prompts-codex-physics.md
@@ -4,6 +4,7 @@ slug: 'prompts-codex-physics'
 ---
 
 # OpenAI Codex Physics Explainer Prompt
+Type: evergreen
 
 Use this prompt to automatically expand Flywheel's physics documentation. The
 agent pulls formulas or explanations from the codebase and updates relevant

--- a/docs/prompts-codex-propagate.md
+++ b/docs/prompts-codex-propagate.md
@@ -4,6 +4,7 @@ slug: 'prompts-codex-propagate'
 ---
 
 # Codex Prompt Propagation Prompt
+Type: evergreen
 
 Use this prompt to ask Codex to seed missing `prompts-*.md` files across repositories listed in
 [`docs/repo-feature-summary.md`](repo-feature-summary.md).

--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -4,6 +4,7 @@ slug: 'prompts-codex-spellcheck'
 ---
 
 # Codex Spellcheck Prompt
+Type: evergreen
 
 Use this prompt to find and fix spelling mistakes in Markdown docs before opening a pull request.
 

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -4,6 +4,7 @@ slug: 'prompts-codex'
 ---
 
 # Codex Automation Prompt
+Type: evergreen
 
 This document stores the baseline prompt used when instructing OpenAI Codex (or
 compatible agents) to contribute to the Flywheel repository. Keeping the prompt
@@ -47,6 +48,7 @@ Copy **one** of the prompts below into Codex when you want the agent to improve 
 Each prompt is file-scoped, single-purpose and immediately actionable.
 
 ### 1 Add ⭐ Stars & 🐞 Open-Issues columns
+Type: one-off
 ```
 SYSTEM: You are an automated contributor for the **futuroptimist/flywheel** repository.
 
@@ -72,6 +74,7 @@ Return **only** the patch (diff) required.
 ```
 
 ### 2 Create a Security & Dependency Health table
+Type: one-off
 ```
 SYSTEM: You are an automated contributor for **futuroptimist/flywheel**.
 
@@ -112,6 +115,7 @@ A PR adding the new table, scan script and workflow.
 - Tip – Codex can `npm i`, run tests and open PRs autonomously; keep your goal sentence tight and your acceptance check explicit.
 
 ## Upgrade Prompt
+Type: evergreen
 
 Use this prompt to refine Flywheel's own prompt documentation.
 


### PR DESCRIPTION
## Summary
- mark prompt docs as evergreen or one-off and add an evergreen cleanup prompt
- restructure prompt summary by repo with optional TODOs for other projects
- extend summary generator to parse individual prompts and track external TODOs

## Testing
- `npm run lint`
- `npm run test:ci`
- `pytest -q`
- `npm test -- --coverage`
- `python -m flywheel.fit`
- `bash scripts/checks.sh` *(fails: pre-commit not installed, apt warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68990f1e91f4832f8090d80c37c1ea2a