### PR TITLE
docs: add Codex prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **flywheel** is a GitHub template for rapid project bootstrapping. It bundles linting, testing, documentation checks, and LLM-powered agents to keep your repo healthy.
 
-For LLM automation prompts, see [docs/prompts-codex.md](docs/prompts-codex.md).
+The canonical Codex automation prompt lives in [docs/prompts-codex.md](docs/prompts-codex.md).
 
 ## Usage
 

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -8,7 +8,9 @@ Type: evergreen
 
 This document stores the baseline prompt used when instructing OpenAI Codex (or
 compatible agents) to contribute to the Flywheel repository. Keeping the prompt
-in version control lets us refine it over time and track what worked best.
+in version control lets us refine it over time and track what worked best. It
+serves as the canonical prompt that other repositories can copy to
+`docs/prompts-codex.md` for consistent automation.
 
 ```
 SYSTEM:


### PR DESCRIPTION
## Summary
- reference canonical Codex automation prompt
- note prompt document is reusable across repos

## Testing
- `npm run lint`
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689986b6fb74832fa772bd5ecef8ddfa