### PR TITLE
docs: remove obsolete security-table prompt

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -4,19 +4,18 @@ This index is auto-generated with [scripts/update_prompt_docs_summary.py](../scr
 
 ## **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**
 
-| Prompt                                                                                                                                                                 | Type      |
-|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
-| [OpenAI Codex CAD Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cad.md#openai-codex-cad-prompt)                                       | evergreen |
-| [OpenAI Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md#openai-codex-ci-failure-fix-prompt)              | evergreen |
-| [Obsolete Prompt Cleanup](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cleanup.md#obsolete-prompt-cleanup)                                   | evergreen |
-| [OpenAI Codex Physics Explainer Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-physics.md#openai-codex-physics-explainer-prompt)       | evergreen |
-| [Codex Prompt Propagation Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-propagate.md#codex-prompt-propagation-prompt)                 | evergreen |
-| [Codex Spellcheck Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)                                | evergreen |
-| [Codex Automation Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#codex-automation-prompt)                                           | evergreen |
-| [Implementation prompts](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#implementation-prompts)                                             | one       |
-| [1 Add ⭐ Stars & 🐞 Open-Issues columns](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#1-add-stars-open-issues-columns)                     | one       |
-| [2 Create a Security & Dependency Health table](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#2-create-a-security-dependency-health-table) | one       |
-| [Upgrade Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#upgrade-prompt)                                                             | evergreen |
+| Prompt                                                                                                                                                           | Type      |
+|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| [OpenAI Codex CAD Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cad.md#openai-codex-cad-prompt)                                 | evergreen |
+| [OpenAI Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md#openai-codex-ci-failure-fix-prompt)        | evergreen |
+| [Obsolete Prompt Cleanup](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cleanup.md#obsolete-prompt-cleanup)                             | evergreen |
+| [OpenAI Codex Physics Explainer Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-physics.md#openai-codex-physics-explainer-prompt) | evergreen |
+| [Codex Prompt Propagation Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-propagate.md#codex-prompt-propagation-prompt)           | evergreen |
+| [Codex Spellcheck Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)                          | evergreen |
+| [Codex Automation Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#codex-automation-prompt)                                     | evergreen |
+| [Implementation prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#implementation-prompt)                                         | one       |
+| [1 Add ⭐ Stars & 🐞 Open-Issues columns](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#1-add-stars-open-issues-columns)               | one       |
+| [Upgrade Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#upgrade-prompt)                                                       | evergreen |
 
 ## [futuroptimist/axel](https://github.com/futuroptimist/axel)
 
@@ -97,38 +96,22 @@ This index is auto-generated with [scripts/update_prompt_docs_summary.py](../scr
 
 ## Untriaged Prompt Docs
 
-| Repo                                                                          | Prompt                                                                                                                                                                 | Type      |
-|-------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [OpenAI Codex CAD Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cad.md#openai-codex-cad-prompt)                                       | evergreen |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [OpenAI Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md#openai-codex-ci-failure-fix-prompt)              | evergreen |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Obsolete Prompt Cleanup](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cleanup.md#obsolete-prompt-cleanup)                                   | evergreen |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [OpenAI Codex Physics Explainer Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-physics.md#openai-codex-physics-explainer-prompt)       | evergreen |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Codex Prompt Propagation Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-propagate.md#codex-prompt-propagation-prompt)                 | evergreen |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Codex Spellcheck Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)                                | evergreen |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Codex Automation Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#codex-automation-prompt)                                           | evergreen |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Implementation prompts](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#implementation-prompts)                                             | one       |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [1 Add ⭐ Stars & 🐞 Open-Issues columns](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#1-add-stars-open-issues-columns)                     | one       |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [2 Create a Security & Dependency Health table](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#2-create-a-security-dependency-health-table) | one       |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Upgrade Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#upgrade-prompt)                                                             | evergreen |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/code.md)                                                                                    |           |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/critique.md)                                                                                |           |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/plan.md)                                                                                    |           |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex-ci-fix.md)                                                            |           |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [Codex Spellcheck Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex-spellcheck.md)                                                            |           |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | [Codex Spellcheck Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-spellcheck.md)                                                   |           |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | [Codex Video Script Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-video-script.md)                                               |           |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | [Futuroptimist Codex Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex.md)                                                           |           |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     | [Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex-ci-fix.md)                                                     |           |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     | [Codex Security Review Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex-security.md)                                                  |           |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [Codex CI-Failure Fix Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex-ci-fix.md)                                  |           |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | [Codex CAD Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-cad.md)                                                                         |           |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | [Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-ci-fix.md)                                                           |           |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | [Codex Spellcheck Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-spellcheck.md)                                                           |           |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | [Sigma Codex Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex.md)                                                                           |           |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove)                   | [Codex CAD Prompt](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex-cad.md)                                                                          |           |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)         | [Sugarkube Codex CAD Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex-cad.md)                                                           |           |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)         | [Sugarkube Codex Docs Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex-docs.md)                                                         |           |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)         | [Sugarkube Codex Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex.md)                                                                   |           |
+| Repo                                                                      | Prompt                                                                                                                       | Type   |
+|---------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|--------|
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**   | [Implementation prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#implementation-prompt)     | one    |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)               | [Axel Codex Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md)                                   |        |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)         | [Gabriel Codex Prompt](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md)                             |        |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)         | [Prompt Templates](https://github.com/futuroptimist/gabriel/blob/main/prompts/README.md)                                     |        |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)         | [Generate Improvement Checklist Items](https://github.com/futuroptimist/gabriel/blob/main/prompts/generate-improvements.md)  |        |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)         | [Scan for Bright and Dark Patterns](https://github.com/futuroptimist/gabriel/blob/main/prompts/scan-bright-dark-patterns.md) |        |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)         | [Update Flywheel Risk Model](https://github.com/futuroptimist/gabriel/blob/main/prompts/update-risk-model.md)                |        |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | [token.place Codex Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md)                     |        |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)   | [Codex Prompts](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md)             |        |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)   | [Item Prompts](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md)              |        |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)   | [Process Prompts](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md)       |        |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)   | [Quest Prompts](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md)            |        |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | [Codex Prompts](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md)                                |        |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove)               | [Wove Codex Prompt](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md)                                   |        |
 
 ## TODO Prompts for Other Repos
 

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -43,9 +43,9 @@ The DEV assistant must output the JSON object first, then the diff in a fenced d
 
 Copy this entire block into Codex when you want the agent to automatically improve Flywheel. This version adds a critic role and machine-readable manifest to streamline review and automation. Update the instructions after each successful run so they stay relevant.
 
-## Implementation prompts
-Copy **one** of the prompts below into Codex when you want the agent to improve `docs/repo-feature-summary.md`.
-Each prompt is file-scoped, single-purpose and immediately actionable.
+## Implementation prompt
+Copy the prompt below into Codex when you want the agent to improve `docs/repo-feature-summary.md`.
+This prompt is file-scoped, single-purpose and immediately actionable.
 
 ### 1 Add ⭐ Stars & 🐞 Open-Issues columns
 Type: one-off
@@ -73,39 +73,11 @@ OUTPUT
 Return **only** the patch (diff) required.
 ```
 
-### 2 Create a Security & Dependency Health table
-Type: one-off
-```
-SYSTEM: You are an automated contributor for **futuroptimist/flywheel**.
-
-GOAL
-Introduce a new table, **Security & Dependency Health**, below “Coverage & Installer”. Columns:
-
-| Repo | Dependabot | Secret-Scanning | CodeQL | Snyk (badge) |
-
-FILES OF INTEREST
-- docs/repo-feature-summary.md
-- scripts/security-scan.mjs (new helper, can call GitHub API)
-- .github/workflows/security-scan.yml (new)
-
-REQUIREMENTS
-1. Detect presence of `.github/dependabot.yml`, secret-scanning status via the REST API, and badges for CodeQL & Snyk in each repo README.
-2. Count ✔️/❌ per repo and render the table.
-3. Wire a nightly workflow that rebuilds the markdown and opens an automated PR when values change.
-4. Maintain > 90 % test coverage for the new script.
-
-ACCEPTANCE CHECK
-`npm run coverage && npm run lint && act -j security-scan` pass locally.
-
-OUTPUT
-A PR adding the new table, scan script and workflow.
-```
-
 ### How to choose a prompt
 
 | When you want to…                        | Use prompt |
 |------------------------------------------|-----------|
-| Add new insights (metrics, health scans) | 1 or 2    |
+| Add new insights (metrics, health scans) | 1         |
 
 ### Notes for human contributors
 


### PR DESCRIPTION
## Summary
- drop implemented security & dependency health prompt
- regen prompt docs summary

## Testing
- `pre-commit run --all-files` *(fails: run-checks exit 1)*
- `pytest -q`
- `SKIP_E2E=1 npm run test:ci` *(fails: dpkg lock error)*
- `python -m flywheel.fit`
- `bash scripts/checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_689986a85a20832faeb9f21a574f6a26