### PR TITLE
fix: handle missing linkchecker in checks script

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -192,3 +192,4 @@ circ
 
 Untriaged
 TODOs
+linkchecker

--- a/docs/ci-fix-action-items.md
+++ b/docs/ci-fix-action-items.md
@@ -5,6 +5,7 @@
 - [ ] Regenerate `docs/prompt-docs-summary.md` with a valid Markdown table so spellcheck can cover it.
 - [x] Whitelist common physics notation like `precess` and `circ` in the spellcheck dictionary.
 - [x] Test templates for required `package-lock.json` files.
+- [ ] Document linkchecker installation for local development.
 
 ## Detect
 - [ ] Monitor Playwright installation to keep CI downloads lightweight.
@@ -14,3 +15,4 @@
 - [x] Whitelist "Untriaged" in the spellcheck dictionary.
 - [x] Skip auto-generated docs in spellcheck to prevent false positives.
 - [x] Commit missing `package-lock.json` for the JavaScript template.
+- [x] Skip `linkchecker` when the binary is absent in checks.

--- a/docs/ci-fix-mini-pm.md
+++ b/docs/ci-fix-mini-pm.md
@@ -27,3 +27,21 @@ Template checks in CI failed, blocking the pipeline.
 ## Actions to take
 - [x] Add `package-lock.json` to `templates/javascript`.
 - [x] Add test to ensure all templates include a lock file.
+
+---
+
+## What went wrong
+`Docs Preview & Link Check` failed when `linkchecker` was missing, producing a
+`command not found` error.
+
+## Root cause
+`scripts/checks.sh` invoked `linkchecker` unconditionally, so environments
+without the tool surfaced errors during docs checks.
+
+## Impact
+Docs jobs emitted noisy failures and could block CI in environments lacking
+`linkchecker`.
+
+## Actions to take
+- [x] Skip `linkchecker` when the binary is absent.
+- [ ] Document how to install `linkchecker` locally.

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -20,6 +20,18 @@ if [ "${RUN_SECURITY_ONLY}" = "1" ]; then
   exit 0
 fi
 
+if [ "${RUN_DOCS_ONLY}" = "1" ]; then
+  if command -v pyspelling >/dev/null 2>&1 && [ -f .spellcheck.yaml ]; then
+    pyspelling -c .spellcheck.yaml || true
+  fi
+  if command -v linkchecker >/dev/null 2>&1; then
+    linkchecker README.md docs/ || true
+  else
+    echo "linkchecker not installed; skipping link check"
+  fi
+  exit 0
+fi
+
 # python checks
 flake8 . --exclude=.venv
 isort --check-only . --skip .venv
@@ -51,4 +63,8 @@ run_security_checks
 if command -v pyspelling >/dev/null 2>&1 && [ -f .spellcheck.yaml ]; then
   pyspelling -c .spellcheck.yaml || true
 fi
-linkchecker README.md docs/ || true
+if command -v linkchecker >/dev/null 2>&1; then
+  linkchecker README.md docs/ || true
+else
+  echo "linkchecker not installed; skipping link check"
+fi

--- a/tests/test_checks_script.py
+++ b/tests/test_checks_script.py
@@ -18,3 +18,18 @@ def test_checks_script_skips_missing_security_tools(tmp_path):
     assert result.returncode == 0
     assert "bandit not installed" in result.stdout
     assert "safety not installed" in result.stdout
+
+
+def test_checks_script_skips_missing_linkchecker(tmp_path):
+    script = Path(__file__).resolve().parents[1] / "scripts" / "checks.sh"
+    env = os.environ.copy()
+    env["RUN_DOCS_ONLY"] = "1"
+    env["PATH"] = "/usr/bin:/bin"
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0
+    assert "linkchecker not installed" in result.stdout


### PR DESCRIPTION
## Summary
- handle missing `linkchecker` in `scripts/checks.sh` and add docs-only mode
- record CI failure in mini postmortem and action items
- cover missing `linkchecker` with unit test and allow list

## Testing
- `pre-commit run --files scripts/checks.sh tests/test_checks_script.py docs/ci-fix-mini-pm.md docs/ci-fix-action-items.md dict/allow.txt`
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689986a2edbc832f9a26fb27a7894208