### PR TITLE
📝 Docs: codex – clarify diff output discipline

### DIFF
--- a/docs/codex-custom-instructions.md
+++ b/docs/codex-custom-instructions.md
@@ -41,3 +41,9 @@ Refs: #issue-id
 
 # Quick-reference
 Feature | Fix | Refactor | Docs | Chore
+
+# Output discipline
+- When asked for code or diffs, emit exactly one fenced block in the requested
+  language.
+- For diffs, use a unified `diff` block and avoid extra headings, "Copy" text,
+  or multiple code fences.


### PR DESCRIPTION
## Summary
- document how Codex should emit a single fenced block for diffs or code snippets

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_689ad51e3288832f827d91b374eb4652