### PR TITLE
🛠️ : – guard against blank prompt doc cells

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -194,4 +194,6 @@ Lockfile
 Untriaged
 TODOs
 whitespace
+stdout
+summarise
 EOF

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -4,114 +4,236 @@ This index is auto-generated with [scripts/update_prompt_docs_summary.py](../scr
 
 ## **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**
 
-| Prompt                                                                                                                                                                 | Type      |
-|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
-| [OpenAI Codex CAD Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cad.md#openai-codex-cad-prompt)                                       | evergreen |
-| [OpenAI Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md#openai-codex-ci-failure-fix-prompt)              | evergreen |
-| [Obsolete Prompt Cleanup](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cleanup.md#obsolete-prompt-cleanup)                                   | evergreen |
-| [OpenAI Codex Physics Explainer Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-physics.md#openai-codex-physics-explainer-prompt)       | evergreen |
-| [Codex Prompt Propagation Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-propagate.md#codex-prompt-propagation-prompt)                 | evergreen |
-| [Codex Spellcheck Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)                                | evergreen |
-| [Codex Automation Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#codex-automation-prompt)                                           | evergreen |
-| [Implementation prompts](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#implementation-prompts)                                             | one       |
-| [1 Add ⭐ Stars & 🐞 Open-Issues columns](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#1-add-stars-open-issues-columns)                     | one       |
-| [2 Create a Security & Dependency Health table](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#2-create-a-security-dependency-health-table) | one       |
-| [Upgrade Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#upgrade-prompt)                                                             | evergreen |
+| Prompt                                                                                                                                                                              | Type      |
+|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| [OpenAI Codex CAD Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cad.md#openai-codex-cad-prompt)                                                    | evergreen |
+| [OpenAI Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md#openai-codex-ci-failure-fix-prompt)                           | evergreen |
+| [2 – Add a column to `docs/repo-feature-summary.md`](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md#2-add-a-column-to-docsrepo-feature-summarymd) | unknown   |
+| [3 – Committing & propagating](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md#3-committing-propagating)                                           | unknown   |
+| [4 – Further reading & references](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md#4-further-reading-references)                                   | unknown   |
+| [Obsolete Prompt Cleanup](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cleanup.md#obsolete-prompt-cleanup)                                                | evergreen |
+| [OpenAI Codex Physics Explainer Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-physics.md#openai-codex-physics-explainer-prompt)                    | evergreen |
+| [Codex Prompt Propagation Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-propagate.md#codex-prompt-propagation-prompt)                              | evergreen |
+| [Codex Spellcheck Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)                                             | evergreen |
+| [Codex Automation Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#codex-automation-prompt)                                                        | evergreen |
+| [Implementation prompts](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#implementation-prompts)                                                          | one       |
+| [1 Add ⭐ Stars & 🐞 Open-Issues columns](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#1-add-stars-open-issues-columns)                                  | one       |
+| [2 Create a Security & Dependency Health table](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#2-create-a-security-dependency-health-table)              | one       |
+| [How to choose a prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#how-to-choose-a-prompt)                                                          | unknown   |
+| [Upgrade Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#upgrade-prompt)                                                                          | evergreen |
 
 ## [futuroptimist/axel](https://github.com/futuroptimist/axel)
 
-| Prompt                                                                                                      | Type   |
-|-------------------------------------------------------------------------------------------------------------|--------|
-| [](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/code.md)                         |        |
-| [](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/critique.md)                     |        |
-| [](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/plan.md)                         |        |
-| [Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex-ci-fix.md) |        |
-| [Codex Spellcheck Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex-spellcheck.md) |        |
-| [Axel Codex Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md)                  |        |
+| Prompt                                                                                                                                                      | Type    |
+|-------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| [code.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/code.md)                                                                  | unknown |
+| [critique.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/critique.md)                                                          | unknown |
+| [plan.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/plan.md)                                                                  | unknown |
+| [OpenAI Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex-ci-fix.md#openai-codex-ci-failure-fix-prompt)       | unknown |
+| [Codex Spellcheck Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)                         | unknown |
+| [Automation Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#automation-prompt)                                                | unknown |
+| [Implementation Prompts](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#implementation-prompts)                                      | unknown |
+| [1. Fetch repositories from the GitHub API](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#1-fetch-repositories-from-the-github-api) | unknown |
+| [2. Update roadmap status](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#2-update-roadmap-status)                                   | unknown |
+| [How to Choose a Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#how-to-choose-a-prompt)                                      | unknown |
+| [Upgrade Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#upgrade-prompt)                                                      | unknown |
 
 ## [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)
 
-| Prompt                                                                                                                       | Type   |
-|------------------------------------------------------------------------------------------------------------------------------|--------|
-| [Gabriel Codex Prompt](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md)                             |        |
-| [Prompt Templates](https://github.com/futuroptimist/gabriel/blob/main/prompts/README.md)                                     |        |
-| [Generate Improvement Checklist Items](https://github.com/futuroptimist/gabriel/blob/main/prompts/generate-improvements.md)  |        |
-| [Scan for Bright and Dark Patterns](https://github.com/futuroptimist/gabriel/blob/main/prompts/scan-bright-dark-patterns.md) |        |
-| [Update Flywheel Risk Model](https://github.com/futuroptimist/gabriel/blob/main/prompts/update-risk-model.md)                |        |
+| Prompt                                                                                                                                                           | Type    |
+|------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| [Codex Automation Prompt](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md#codex-automation-prompt)                                      | unknown |
+| [Implementation prompts](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md#implementation-prompts)                                        | unknown |
+| [1 Track a new related repository](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md#1-track-a-new-related-repository)                    | unknown |
+| [2 Expand service improvement checklists](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md#2-expand-service-improvement-checklists)      | unknown |
+| [How to choose a prompt](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md#how-to-choose-a-prompt)                                        | unknown |
+| [Prompt Templates](https://github.com/futuroptimist/gabriel/blob/main/prompts/README.md#prompt-templates)                                                        | unknown |
+| [Prompt Catalog](https://github.com/futuroptimist/gabriel/blob/main/prompts/README.md#prompt-catalog)                                                            | unknown |
+| [Generate Improvement Checklist Items](https://github.com/futuroptimist/gabriel/blob/main/prompts/generate-improvements.md#generate-improvement-checklist-items) | unknown |
+| [Scan for Bright and Dark Patterns](https://github.com/futuroptimist/gabriel/blob/main/prompts/scan-bright-dark-patterns.md#scan-for-bright-and-dark-patterns)   | unknown |
+| [Update Flywheel Risk Model](https://github.com/futuroptimist/gabriel/blob/main/prompts/update-risk-model.md#update-flywheel-risk-model)                         | unknown |
 
 ## [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist)
 
-| Prompt                                                                                                                   | Type   |
-|--------------------------------------------------------------------------------------------------------------------------|--------|
-| [Codex Spellcheck Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-spellcheck.md)     |        |
-| [Codex Video Script Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-video-script.md) |        |
-| [Futuroptimist Codex Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex.md)             |        |
+| Prompt                                                                                                                                             | Type    |
+|----------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| [Codex Spellcheck Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)       | unknown |
+| [Codex Video Script Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-video-script.md#codex-video-script-prompt) | unknown |
+| [Codex Automation Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex.md#codex-automation-prompt)                  | unknown |
 
 ## [futuroptimist/token.place](https://github.com/futuroptimist/token.place)
 
-| Prompt                                                                                                                | Type   |
-|-----------------------------------------------------------------------------------------------------------------------|--------|
-| [Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex-ci-fix.md)    |        |
-| [Codex Security Review Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex-security.md) |        |
-| [token.place Codex Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md)              |        |
+| Prompt                                                                                                                                                                | Type    |
+|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| [Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex-ci-fix.md#codex-ci-failure-fix-prompt)                        | unknown |
+| [Codex Security Review Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex-security.md#codex-security-review-prompt)                    | unknown |
+| [token.place Codex Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md#tokenplace-codex-prompt)                                      | unknown |
+| [Implementation prompts](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md#implementation-prompts)                                         | unknown |
+| [1 Document environment variables in README](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md#1-document-environment-variables-in-readme) | unknown |
+| [2 Add API rate limit test](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md#2-add-api-rate-limit-test)                                   | unknown |
 
 ## [democratizedspace/dspace](https://github.com/democratizedspace/dspace)
 
-| Prompt                                                                                                                                | Type   |
-|---------------------------------------------------------------------------------------------------------------------------------------|--------|
-| [Codex CI-Failure Fix Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex-ci-fix.md) |        |
-| [Codex Prompts](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md)                      |        |
-| [Item Prompts](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md)                       |        |
-| [Process Prompts](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md)                |        |
-| [Quest Prompts](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md)                     |        |
+| Prompt                                                                                                                                                                                                       | Type    |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| [OpenAI Codex CI-Failure Fix Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex-ci-fix.md#openai-codex-ci-failure-fix-prompt)                              | unknown |
+| [Writing great Codex prompts for the _dspace_ repo](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#writing-great-codex-prompts-for-the-dspace-repo)         | unknown |
+| [1 Quick start (Web vs CLI)](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#1-quick-start-web-vs-cli)                                                       | unknown |
+| [2 Prompt ingredients](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#2-prompt-ingredients)                                                                 | unknown |
+| [3 Reusable template](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#3-reusable-template)                                                                   | unknown |
+| [Implementation Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#implementation-prompt)                                                               | unknown |
+| [Upgrade Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#upgrade-prompt)                                                                             | unknown |
+| [Writing great item prompts for the _dspace_ repo](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md#writing-great-item-prompts-for-the-dspace-repo)           | unknown |
+| [1 Quick start (Web vs CLI)](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md#1-quick-start-web-vs-cli)                                                       | unknown |
+| [2 Prompt ingredients](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md#2-prompt-ingredients)                                                                 | unknown |
+| [3 Reusable template](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md#3-reusable-template)                                                                   | unknown |
+| [Implementation Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md#implementation-prompt)                                                               | unknown |
+| [Upgrade prompt for existing items](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md#upgrade-prompt-for-existing-items)                                       | unknown |
+| [Writing great process prompts for the _dspace_ repo](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md#writing-great-process-prompts-for-the-dspace-repo) | unknown |
+| [1 Quick start (Web vs CLI)](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md#1-quick-start-web-vs-cli)                                                   | unknown |
+| [2 Prompt ingredients](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md#2-prompt-ingredients)                                                             | unknown |
+| [3 Reusable template](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md#3-reusable-template)                                                               | unknown |
+| [Implementation Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md#implementation-prompt)                                                           | unknown |
+| [Upgrade prompt for existing processes](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md#upgrade-prompt-for-existing-processes)                           | unknown |
+| [Writing great quest prompts for the _dspace_ repo](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md#writing-great-quest-prompts-for-the-dspace-repo)        | unknown |
+| [1 Quick start (Web vs CLI)](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md#1-quick-start-web-vs-cli)                                                      | unknown |
+| [2 Prompt ingredients](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md#2-prompt-ingredients)                                                                | unknown |
+| [3 Reusable template](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md#3-reusable-template)                                                                  | unknown |
+| [Implementation Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md#implementation-prompt)                                                              | unknown |
+| [Upgrade prompt for new quests](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md#upgrade-prompt-for-new-quests)                                              | unknown |
 
 ## [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard)
 
-| Prompt                                                                                        | Type   |
-|-----------------------------------------------------------------------------------------------|--------|
-| [Codex Prompts](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md) |        |
+| Prompt                                                                                                                                                          | Type    |
+|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| [Codex prompts for the *f2clipboard* repo](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#codex-prompts-for-the-f2clipboard-repo) | unknown |
+| [Baseline automation prompt](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#baseline-automation-prompt)                           | unknown |
+| [Roadmap implementation prompt](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#roadmap-implementation-prompt)                     | unknown |
+| [Task-specific prompts](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#task-specific-prompts)                                     | unknown |
+| [1 Size-gate logs and summarise via LLM](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#1-size-gate-logs-and-summarise-via-llm)   | unknown |
+| [2 Emit Markdown to stdout and clipboard](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#2-emit-markdown-to-stdout-and-clipboard) | unknown |
 
 ## [futuroptimist/sigma](https://github.com/futuroptimist/sigma)
 
-| Prompt                                                                                                       | Type   |
-|--------------------------------------------------------------------------------------------------------------|--------|
-| [Codex CAD Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-cad.md)               |        |
-| [Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-ci-fix.md) |        |
-| [Codex Spellcheck Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-spellcheck.md) |        |
-| [Sigma Codex Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex.md)                 |        |
+| Prompt                                                                                                                                   | Type    |
+|------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| [Codex CAD Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-cad.md#codex-cad-prompt)                          | unknown |
+| [Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-ci-fix.md#codex-ci-failure-fix-prompt) | unknown |
+| [Codex Spellcheck Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)     | unknown |
+| [Codex Automation Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex.md#codex-automation-prompt)                | unknown |
 
 ## [futuroptimist/wove](https://github.com/futuroptimist/wove)
 
-| Prompt                                                                                        | Type   |
-|-----------------------------------------------------------------------------------------------|--------|
-| [Codex CAD Prompt](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex-cad.md) |        |
-| [Wove Codex Prompt](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md)    |        |
+| Prompt                                                                                                                                          | Type    |
+|-------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| [Codex CAD Prompt](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex-cad.md#codex-cad-prompt)                                  | unknown |
+| [Codex Automation Prompt](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md#codex-automation-prompt)                        | unknown |
+| [Implementation prompts](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md#implementation-prompts)                          | unknown |
+| [1 Add a Gauge Swatch section](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md#1-add-a-gauge-swatch-section)              | unknown |
+| [2 Document `checks.sh` in the README](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md#2-document-checkssh-in-the-readme) | unknown |
+| [3 Add a Crochet Glossary](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md#3-add-a-crochet-glossary)                      | unknown |
 
 ## [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)
 
-| Prompt                                                                                                         | Type   |
-|----------------------------------------------------------------------------------------------------------------|--------|
-| [Sugarkube Codex CAD Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex-cad.md)   |        |
-| [Sugarkube Codex Docs Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex-docs.md) |        |
-| [Sugarkube Codex Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex.md)           |        |
+| Prompt                                                                                                                                   | Type    |
+|------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| [OpenAI Codex CAD Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex-cad.md#openai-codex-cad-prompt)        | unknown |
+| [Codex Documentation Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex-docs.md#codex-documentation-prompt) | unknown |
+| [Codex Automation Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex.md#codex-automation-prompt)            | unknown |
 
 ## Untriaged Prompt Docs
 
-| Repo                                                                      | Prompt                                                                                                                       | Type   |
-|---------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|--------|
-| [futuroptimist/axel](https://github.com/futuroptimist/axel)               | [Axel Codex Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md)                                   |        |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)         | [Gabriel Codex Prompt](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md)                             |        |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)         | [Prompt Templates](https://github.com/futuroptimist/gabriel/blob/main/prompts/README.md)                                     |        |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)         | [Generate Improvement Checklist Items](https://github.com/futuroptimist/gabriel/blob/main/prompts/generate-improvements.md)  |        |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)         | [Scan for Bright and Dark Patterns](https://github.com/futuroptimist/gabriel/blob/main/prompts/scan-bright-dark-patterns.md) |        |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)         | [Update Flywheel Risk Model](https://github.com/futuroptimist/gabriel/blob/main/prompts/update-risk-model.md)                |        |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | [token.place Codex Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md)                     |        |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)   | [Codex Prompts](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md)             |        |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)   | [Item Prompts](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md)              |        |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)   | [Process Prompts](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md)       |        |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)   | [Quest Prompts](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md)            |        |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | [Codex Prompts](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md)                                |        |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove)               | [Wove Codex Prompt](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md)                                   |        |
+| Repo                                                                          | Prompt                                                                                                                                                                                                       | Type      |
+|-------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [OpenAI Codex CAD Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cad.md#openai-codex-cad-prompt)                                                                             | evergreen |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [OpenAI Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md#openai-codex-ci-failure-fix-prompt)                                                    | evergreen |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [2 – Add a column to `docs/repo-feature-summary.md`](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md#2-add-a-column-to-docsrepo-feature-summarymd)                          | unknown   |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [3 – Committing & propagating](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md#3-committing-propagating)                                                                    | unknown   |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [4 – Further reading & references](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-ci-fix.md#4-further-reading-references)                                                            | unknown   |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Obsolete Prompt Cleanup](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-cleanup.md#obsolete-prompt-cleanup)                                                                         | evergreen |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [OpenAI Codex Physics Explainer Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-physics.md#openai-codex-physics-explainer-prompt)                                             | evergreen |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Codex Prompt Propagation Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-propagate.md#codex-prompt-propagation-prompt)                                                       | evergreen |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Codex Spellcheck Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)                                                                      | evergreen |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Codex Automation Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#codex-automation-prompt)                                                                                 | evergreen |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Implementation prompts](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#implementation-prompts)                                                                                   | one       |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [1 Add ⭐ Stars & 🐞 Open-Issues columns](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#1-add-stars-open-issues-columns)                                                           | one       |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [2 Create a Security & Dependency Health table](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#2-create-a-security-dependency-health-table)                                       | one       |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [How to choose a prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#how-to-choose-a-prompt)                                                                                   | unknown   |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [Upgrade Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-codex.md#upgrade-prompt)                                                                                                   | evergreen |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [code.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/code.md)                                                                                                                   | unknown   |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [critique.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/critique.md)                                                                                                           | unknown   |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [plan.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/plan.md)                                                                                                                   | unknown   |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [OpenAI Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex-ci-fix.md#openai-codex-ci-failure-fix-prompt)                                                        | unknown   |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [Codex Spellcheck Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)                                                                          | unknown   |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [Automation Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#automation-prompt)                                                                                                 | unknown   |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [Implementation Prompts](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#implementation-prompts)                                                                                       | unknown   |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [1. Fetch repositories from the GitHub API](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#1-fetch-repositories-from-the-github-api)                                                  | unknown   |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [2. Update roadmap status](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#2-update-roadmap-status)                                                                                    | unknown   |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [How to Choose a Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#how-to-choose-a-prompt)                                                                                       | unknown   |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   | [Upgrade Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#upgrade-prompt)                                                                                                       | unknown   |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | [Codex Automation Prompt](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md#codex-automation-prompt)                                                                                  | unknown   |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | [Implementation prompts](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md#implementation-prompts)                                                                                    | unknown   |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | [1 Track a new related repository](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md#1-track-a-new-related-repository)                                                                | unknown   |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | [2 Expand service improvement checklists](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md#2-expand-service-improvement-checklists)                                                  | unknown   |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | [How to choose a prompt](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md#how-to-choose-a-prompt)                                                                                    | unknown   |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | [Prompt Templates](https://github.com/futuroptimist/gabriel/blob/main/prompts/README.md#prompt-templates)                                                                                                    | unknown   |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | [Prompt Catalog](https://github.com/futuroptimist/gabriel/blob/main/prompts/README.md#prompt-catalog)                                                                                                        | unknown   |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | [Generate Improvement Checklist Items](https://github.com/futuroptimist/gabriel/blob/main/prompts/generate-improvements.md#generate-improvement-checklist-items)                                             | unknown   |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | [Scan for Bright and Dark Patterns](https://github.com/futuroptimist/gabriel/blob/main/prompts/scan-bright-dark-patterns.md#scan-for-bright-and-dark-patterns)                                               | unknown   |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             | [Update Flywheel Risk Model](https://github.com/futuroptimist/gabriel/blob/main/prompts/update-risk-model.md#update-flywheel-risk-model)                                                                     | unknown   |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | [Codex Spellcheck Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)                                                                 | unknown   |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | [Codex Video Script Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-video-script.md#codex-video-script-prompt)                                                           | unknown   |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | [Codex Automation Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex.md#codex-automation-prompt)                                                                            | unknown   |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     | [Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex-ci-fix.md#codex-ci-failure-fix-prompt)                                                               | unknown   |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     | [Codex Security Review Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex-security.md#codex-security-review-prompt)                                                           | unknown   |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     | [token.place Codex Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md#tokenplace-codex-prompt)                                                                             | unknown   |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     | [Implementation prompts](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md#implementation-prompts)                                                                                | unknown   |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     | [1 Document environment variables in README](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md#1-document-environment-variables-in-readme)                                        | unknown   |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     | [2 Add API rate limit test](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md#2-add-api-rate-limit-test)                                                                          | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [OpenAI Codex CI-Failure Fix Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex-ci-fix.md#openai-codex-ci-failure-fix-prompt)                              | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [Writing great Codex prompts for the _dspace_ repo](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#writing-great-codex-prompts-for-the-dspace-repo)         | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [1 Quick start (Web vs CLI)](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#1-quick-start-web-vs-cli)                                                       | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [2 Prompt ingredients](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#2-prompt-ingredients)                                                                 | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [3 Reusable template](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#3-reusable-template)                                                                   | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [Implementation Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#implementation-prompt)                                                               | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [Upgrade Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#upgrade-prompt)                                                                             | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [Writing great item prompts for the _dspace_ repo](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md#writing-great-item-prompts-for-the-dspace-repo)           | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [1 Quick start (Web vs CLI)](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md#1-quick-start-web-vs-cli)                                                       | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [2 Prompt ingredients](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md#2-prompt-ingredients)                                                                 | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [3 Reusable template](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md#3-reusable-template)                                                                   | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [Implementation Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md#implementation-prompt)                                                               | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [Upgrade prompt for existing items](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md#upgrade-prompt-for-existing-items)                                       | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [Writing great process prompts for the _dspace_ repo](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md#writing-great-process-prompts-for-the-dspace-repo) | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [1 Quick start (Web vs CLI)](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md#1-quick-start-web-vs-cli)                                                   | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [2 Prompt ingredients](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md#2-prompt-ingredients)                                                             | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [3 Reusable template](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md#3-reusable-template)                                                               | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [Implementation Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md#implementation-prompt)                                                           | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [Upgrade prompt for existing processes](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md#upgrade-prompt-for-existing-processes)                           | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [Writing great quest prompts for the _dspace_ repo](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md#writing-great-quest-prompts-for-the-dspace-repo)        | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [1 Quick start (Web vs CLI)](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md#1-quick-start-web-vs-cli)                                                      | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [2 Prompt ingredients](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md#2-prompt-ingredients)                                                                | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [3 Reusable template](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md#3-reusable-template)                                                                  | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [Implementation Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md#implementation-prompt)                                                              | unknown   |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       | [Upgrade prompt for new quests](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md#upgrade-prompt-for-new-quests)                                              | unknown   |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard)     | [Codex prompts for the *f2clipboard* repo](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#codex-prompts-for-the-f2clipboard-repo)                                              | unknown   |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard)     | [Baseline automation prompt](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#baseline-automation-prompt)                                                                        | unknown   |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard)     | [Roadmap implementation prompt](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#roadmap-implementation-prompt)                                                                  | unknown   |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard)     | [Task-specific prompts](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#task-specific-prompts)                                                                                  | unknown   |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard)     | [1 Size-gate logs and summarise via LLM](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#1-size-gate-logs-and-summarise-via-llm)                                                | unknown   |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard)     | [2 Emit Markdown to stdout and clipboard](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#2-emit-markdown-to-stdout-and-clipboard)                                              | unknown   |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | [Codex CAD Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-cad.md#codex-cad-prompt)                                                                                              | unknown   |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | [Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-ci-fix.md#codex-ci-failure-fix-prompt)                                                                     | unknown   |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | [Codex Spellcheck Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)                                                                         | unknown   |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma)                 | [Codex Automation Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex.md#codex-automation-prompt)                                                                                    | unknown   |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove)                   | [Codex CAD Prompt](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex-cad.md#codex-cad-prompt)                                                                                               | unknown   |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove)                   | [Codex Automation Prompt](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md#codex-automation-prompt)                                                                                     | unknown   |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove)                   | [Implementation prompts](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md#implementation-prompts)                                                                                       | unknown   |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove)                   | [1 Add a Gauge Swatch section](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md#1-add-a-gauge-swatch-section)                                                                           | unknown   |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove)                   | [2 Document `checks.sh` in the README](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md#2-document-checkssh-in-the-readme)                                                              | unknown   |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove)                   | [3 Add a Crochet Glossary](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md#3-add-a-crochet-glossary)                                                                                   | unknown   |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)         | [OpenAI Codex CAD Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex-cad.md#openai-codex-cad-prompt)                                                                            | unknown   |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)         | [Codex Documentation Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex-docs.md#codex-documentation-prompt)                                                                     | unknown   |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)         | [Codex Automation Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex.md#codex-automation-prompt)                                                                                | unknown   |
 
 ## TODO Prompts for Other Repos
 

--- a/scripts/update_prompt_docs_summary.py
+++ b/scripts/update_prompt_docs_summary.py
@@ -74,20 +74,20 @@ def extract_prompts(text: str, base_url: str) -> List[List[str]]:
     for i, line in enumerate(lines):
         if line.startswith("# ") and not line.startswith("##"):
             title = line[2:].strip()
-            ptype = find_type(lines, i + 1)
+            ptype = find_type(lines, i + 1) or "unknown"
             anchor = slugify(title)
-            if ptype:
-                prompts.append([f"[{title}]({base_url}#{anchor})", ptype])
+            prompts.append([f"[{title}]({base_url}#{anchor})", ptype])
         elif line.startswith("## ") or line.startswith("### "):
             title = line.lstrip("#").strip()
             if is_prompt_heading(title):
-                ptype = find_type(lines, i + 1)
+                ptype = find_type(lines, i + 1) or "unknown"
                 anchor = slugify(title)
-                if ptype:
-                    prompts.append([f"[{title}]({base_url}#{anchor})", ptype])
+                prompts.append([f"[{title}]({base_url}#{anchor})", ptype])
     if not prompts:
         title = extract_title(text)
-        prompts.append([f"[{title}]({base_url})", ""])
+        if not title:
+            title = base_url.split("/")[-1]
+        prompts.append([f"[{title}]({base_url})", "unknown"])
     return prompts
 
 

--- a/tests/test_prompt_docs_summary.py
+++ b/tests/test_prompt_docs_summary.py
@@ -16,3 +16,11 @@ def test_dspace_rows_present():
     doc = Path("docs/prompt-docs-summary.md").read_text()
     msg = "dspace prompt docs missing"
     assert doc.count("democratizedspace/dspace") >= 2, msg
+
+
+def test_no_blank_cells():
+    doc = Path("docs/prompt-docs-summary.md")
+    for line in doc.read_text().splitlines():
+        if line.startswith("|"):
+            cells = [c.strip() for c in line.split("|")[1:-1]]
+            assert all(cells), f"blank cell in line: {line}"


### PR DESCRIPTION
## What
- default missing prompt titles and types to avoid blank cells
- test prompt docs summary for blank table entries
- allow `stdout` and `summarise` in spellcheck

## Why
- keep auto-generated docs readable
- prevent regressions when new prompt docs are added

## How to Test
- `SKIP=run-checks pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `RUN_SECURITY_ONLY=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689ada4df550832f90a77f499d873075