### PR TITLE
Add repo status workflow and tests

### DIFF
--- a/.github/workflows/update-repo-status.yml
+++ b/.github/workflows/update-repo-status.yml
@@ -1,0 +1,39 @@
+name: Update Repo Statuses
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-repo-status
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: astral-sh/setup-uv@v1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install deps
+        run: uv pip install --system -r requirements.txt
+      - name: Update README
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python src/repo_status.py
+      - name: Commit changes
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add README.md
+          git commit -m 'docs: update repo statuses' || exit 0
+          git push

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -1,0 +1,92 @@
+"""Update README with repo status emojis.
+
+Fetches the latest GitHub Actions run for each repo listed in the README's
+"Related Projects" section and prepends a green check, red cross, or question
+mark depending on whether the most recent workflow run on the default branch
+completed successfully, failed, or hasn't completed.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import requests
+
+GITHUB_RE = re.compile(
+    r"https://github.com/([\w-]+)/([\w.-]+)" r"(?:/tree/([\w./-]+))?"
+)
+
+
+def status_to_emoji(conclusion: str | None) -> str:
+    """Return an emoji representing the run conclusion."""
+    if conclusion == "success":
+        return "✅"
+    if conclusion is None:
+        return "❓"
+    return "❌"
+
+
+def fetch_repo_status(
+    repo: str,
+    token: str | None = None,
+    branch: str | None = None,
+    attempts: int = 2,
+) -> str:
+    """Return an emoji for the latest workflow run conclusion for ``repo``.
+
+    The GitHub API occasionally returns inconsistent data if a workflow is
+    updating while we query it. To catch this non-determinism we fetch the
+    status multiple times and ensure all results match. If they differ we raise
+    ``RuntimeError`` so the calling workflow fails loudly.
+    """
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    url = (
+        "https://api.github.com/repos/{repo}/actions/runs"
+        "?per_page=1&status=completed".format(repo=repo)
+    )
+    if branch:
+        url += f"&branch={branch}"
+
+    def _fetch() -> str | None:
+        resp = requests.get(url, headers=headers, timeout=10)
+        resp.raise_for_status()
+        runs = resp.json().get("workflow_runs", [])
+        return runs[0].get("conclusion") if runs else None
+
+    conclusions = [_fetch() for _ in range(attempts)]
+    if len(set(conclusions)) > 1:
+        raise RuntimeError(
+            f"Non-deterministic workflow conclusion for {repo}: {conclusions}"
+        )
+    return status_to_emoji(conclusions[0])
+
+
+def update_readme(readme_path: Path, token: str | None = None) -> None:
+    """Update README with status emojis for related project repos."""
+    lines = readme_path.read_text().splitlines()
+    in_section = False
+    for i, line in enumerate(lines):
+        if line.strip() == "## Related Projects":
+            in_section = True
+            continue
+        if in_section and line.startswith("## "):
+            break
+        if in_section and line.startswith("- "):
+            match = GITHUB_RE.search(line)
+            if match:
+                repo = f"{match.group(1)}/{match.group(2)}"
+                branch = match.group(3)
+                emoji = fetch_repo_status(repo, token, branch)
+                lines[i] = re.sub(r"^(\-\s*)(?:[✅❌❓]\s*)*", r"\1", line)
+                lines[i] = f"- {emoji} {lines[i][2:].lstrip()}"
+    readme_path.write_text("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    token = os.environ.get("GITHUB_TOKEN")
+    update_readme(Path(__file__).resolve().parent.parent / "README.md", token)

--- a/tests/test_ci_status_module.py
+++ b/tests/test_ci_status_module.py
@@ -1,0 +1,19 @@
+import src.ci_status as cs
+import src.table_builder as tb
+
+
+def test_ci_state_graphql(monkeypatch):
+    monkeypatch.setattr(cs, "_query_graphql", lambda o, r, s: "SUCCESS")
+    assert cs.ci_state("o", "r", "sha") == "green"
+
+
+def test_ci_state_rest_fallback(monkeypatch):
+    monkeypatch.setattr(cs, "_query_graphql", lambda o, r, s: None)
+    monkeypatch.setattr(cs, "_query_rest", lambda o, r, s: "FAILURE")
+    assert cs.ci_state("o", "r", "sha") == "red"
+
+
+def test_trunk_cell(monkeypatch):
+    monkeypatch.setattr(tb, "ci_state", lambda o, r, s: "green")
+    assert tb.trunk_cell("o", "r", "sha") == "✅"
+    assert tb.trunk_cell("o", "r", "") == "n/a"

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -1,0 +1,62 @@
+import re
+
+import pytest
+
+import src.repo_status as rs
+
+
+def test_status_to_emoji():
+    assert rs.status_to_emoji("success") == "✅"
+    assert rs.status_to_emoji("failure") == "❌"
+    assert rs.status_to_emoji(None) == "❓"
+
+
+def test_fetch_repo_status_success(monkeypatch):
+    class Resp:
+        def __init__(self, conclusion):
+            self._conclusion = conclusion
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"workflow_runs": [{"conclusion": self._conclusion}]}
+
+    def fake_get(url, headers, timeout):
+        return Resp("success")
+
+    monkeypatch.setattr(rs.requests, "get", fake_get)
+    assert rs.fetch_repo_status("owner/repo") == "✅"
+
+
+def test_fetch_repo_status_inconsistent(monkeypatch):
+    conclusions = iter(["success", "failure"])
+
+    class Resp:
+        def __init__(self, conclusion):
+            self._conclusion = conclusion
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"workflow_runs": [{"conclusion": self._conclusion}]}
+
+    def fake_get(url, headers, timeout):
+        return Resp(next(conclusions))
+
+    monkeypatch.setattr(rs.requests, "get", fake_get)
+    with pytest.raises(RuntimeError):
+        rs.fetch_repo_status("owner/repo", attempts=2)
+
+
+def test_update_readme(tmp_path, monkeypatch):
+    readme = tmp_path / "README.md"
+    readme.write_text("## Related Projects\n- https://github.com/a/b\n")
+
+    monkeypatch.setattr(rs, "fetch_repo_status", lambda *args, **kwargs: "✅")
+
+    rs.update_readme(readme)
+    data = readme.read_text().splitlines()
+    assert data[1].startswith("- ✅ ")
+    assert re.search(r"https://github.com/a/b", data[1])


### PR DESCRIPTION
## Summary
- add scheduled workflow to refresh README repo statuses
- implement repo_status utility with coverage for CI helpers

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_689ade02e064832fb26c03f021727e40