### PR TITLE
docs: clarify rim acceleration force

### DIFF
--- a/docs/flywheel-physics.md
+++ b/docs/flywheel-physics.md
@@ -156,6 +156,20 @@ $$a \approx 5\times10^3\,\text{m/s}^2$$
 which is roughly 500\,$g$.  Spokes and hubs must withstand this load to keep
 the wheel intact.
 
+The outward force on a rim segment of mass $m$ is
+
+$$F = m a = m r \omega^2$$
+
+For the CAD wheel in [`cad/flywheel.scad`](../cad/flywheel.scad), a
+5\,g screw near the edge sees roughly
+$$F \approx 5\times10^{-3} \times 0.05 \times 314^2 \approx 25\,\text{N}$$
+at 3000\,rpm, so even small fixtures need secure retention.
+
+```mermaid
+graph TD
+    m[mass m] -->|F = m r \omega^2| Fc[Centripetal force]
+```
+
 ## Spin-up time
 
 A constant torque $T$ causes angular acceleration $\alpha$ according to


### PR DESCRIPTION
what: add centripetal force example and diagram to rim acceleration section
why: clarify structural loads using CAD dimensions
how to test: pre-commit run --all-files; pytest -q; npm run lint; npm run test:ci; python -m flywheel.fit; bash scripts/checks.sh
Refs: none

------
https://chatgpt.com/codex/tasks/task_e_689bab39ad50832fa4432c59212df43c