### PR TITLE
Parameterize shaft resolution and refresh docs

### DIFF
--- a/cad/README.md
+++ b/cad/README.md
@@ -6,7 +6,7 @@ Source OpenSCAD files for the flywheel project.
 
 - `stand.scad` – stand for a flywheel shaft using 608 bearings
 - `shaft.scad` – straight shaft sized for 608 bearings (exposes `shaft()` module for easy
-  customization)
+  customization; override `$fs` via the `resolution_fs` variable for finer meshes)
 - `adapter.scad` – clamp adapter that attaches the flywheel to the shaft with configurable
   bore clearance
 - `flywheel.scad` – cylindrical flywheel with center bore and optional shaft clearance

--- a/cad/shaft.scad
+++ b/cad/shaft.scad
@@ -3,9 +3,11 @@
 
 shaft_diameter = 8;   // mm
 shaft_length = 150;   // mm
+resolution_fs = 0.5;  // mm, surface resolution
 
-module shaft(shaft_d, shaft_len) {
-    cylinder(r = shaft_d / 2, h = shaft_len, $fs = 0.5);
+// Allow callers to override `$fs` for finer or coarser meshes
+module shaft(shaft_d, shaft_len, $fs = resolution_fs) {
+    cylinder(r = shaft_d / 2, h = shaft_len);
 }
 
 shaft(shaft_diameter, shaft_length);


### PR DESCRIPTION
## Summary
- allow $fs override via `resolution_fs` in `shaft.scad`
- document new knob in CAD README

## Testing
- pre-commit run --all-files (SKIP=run-checks)
- pytest -q
- npm run lint
- npm run test:ci
- python -m flywheel.fit
- bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_689bab3592f8832f8af3f511fa8b46ab