### PR TITLE
🧹 chore: tidy allow list

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -189,7 +189,6 @@ precession
 mathrm
 precess
 circ
-
 Lockfile
 Untriaged
 TODOs


### PR DESCRIPTION
what: drop stray blank line in dict/allow.txt.
why: keep codespell allowlist compact.
how to test:
- pre-commit run --all-files
- pytest -q
- npm run test:ci
- python -m flywheel.fit
- SKIP_E2E=1 bash scripts/checks.sh


------
https://chatgpt.com/codex/tasks/task_e_689c22162640832f8ef403eebfd753b2