### PR TITLE
docs: add Codex prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 **flywheel** is a GitHub template for rapid project bootstrapping. It bundles linting, testing, documentation checks, and LLM-powered agents to keep your repo healthy.
 
 The canonical Codex automation prompt lives in [docs/prompts/codex/automation.md](docs/prompts/codex/automation.md).
+Use this doc when adding automation to new repositories.
 
 ## Usage
 

--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -10,7 +10,8 @@ This document stores the baseline prompt used when instructing OpenAI Codex (or
 compatible agents) to contribute to the Flywheel repository. Keeping the prompt
 in version control lets us refine it over time and track what worked best. It
 serves as the canonical prompt that other repositories can copy to
-`docs/prompts/codex/automation.md` for consistent automation.
+`docs/prompts/codex/automation.md` for consistent automation. For propagation
+instructions, see [propagate.md](propagate.md).
 
 ```
 SYSTEM:


### PR DESCRIPTION
## What
- Link README to Codex automation prompt
- Cross-link propagation guide in automation prompt

## Why
- Aid contributors in finding the canonical prompt

## How to test
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `SKIP_E2E=1 npm run test:ci` *(fails: interrupted)*
- `python -m flywheel.fit`
- `bash scripts/checks.sh` *(interrupted installing deps)*

------
https://chatgpt.com/codex/tasks/task_e_689c220b3030832fbc26ceae45cf2598