### PR TITLE
docs: add Codex prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ or skip end-to-end tests by prefixing commands with `SKIP_E2E=1`.
 - [CLAUDE.md](CLAUDE.md) summarizing Anthropic guidance
 - [codex-custom-instructions.md](docs/codex-custom-instructions.md) for Codex rules
   and a [runbook.yml](runbook.yml) checklist for repo setup
-- Codex automation prompt in `docs/prompts/codex/automation.md`
+- [Codex automation prompt](docs/prompts/codex/automation.md)
 - CAD update prompt in `docs/prompts/codex/cad.md`
 - Physics explainer prompt in `docs/prompts/codex/physics.md`
 - Cross-repo prompt index in `docs/prompts/summary.md` listing `prompts-items.md`, `prompts-quests.md`, and `prompts-codex.md` across repos


### PR DESCRIPTION
## Summary
- link Codex automation prompt in README
- surface baseline prompt for repo automation

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci` *(fails: Playwright could not reach server)*
- `python -m flywheel.fit`
- `RUN_SECURITY_ONLY=1 bash scripts/checks.sh`

Status: needs-triage


------
https://chatgpt.com/codex/tasks/task_e_689c220b3030832fbc26ceae45cf2598