### PR TITLE
docs: add Codex prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ pipx run flywheel init . --language python --save-dev --yes
 
 ### Generating Codex prompts
 
+See [docs/prompts/codex/automation.md](docs/prompts/codex/automation.md) for the
+canonical automation prompt.
+
 Invoke the prompt agent to get repo-aware suggestions:
 
 ```bash


### PR DESCRIPTION
## Summary
- link README to canonical Codex automation prompt

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c220b3030832fbc26ceae45cf2598