### PR TITLE
docs: derive material energy limit for flywheel

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -142,6 +142,7 @@ yyyy
 LTS
 MPa
 rpm
+kJ
 pytest
 Futuroptimist
 composable

--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -143,6 +143,8 @@ LTS
 MPa
 rpm
 kJ
+kilojoule
+kilojoules
 pytest
 Futuroptimist
 composable

--- a/docs/flywheel-physics.md
+++ b/docs/flywheel-physics.md
@@ -145,8 +145,10 @@ $$E = \tfrac{1}{2} m r^2 \omega^2$$
 shows that material strength caps the stored energy at
 $$E_{max} = \tfrac{\sigma_y}{2\rho} m$$
 independent of radius. For the CAD wheel in [`cad/flywheel.scad`](../cad/flywheel.scad)
-with $m \approx 0.19\,\text{kg}$, PLA allows roughly $E_{max} \approx 4.5\,\text{kJ}$—
-far above the $12\,\text{J}$ stored at 3000\,rpm.
+with $m \approx 0.19\,\text{kg}$, PLA allows roughly $E_{max} \approx 4.5\,\text{kJ}$
+(about 4.5 kilojoules)—far above the $12\,\text{J}$ stored at 3000\,rpm.  Real prints
+fail sooner from layer adhesion and voids, so treat this limit as a best-case upper
+bound.
 
 ```mermaid
 graph TD

--- a/docs/flywheel-physics.md
+++ b/docs/flywheel-physics.md
@@ -140,6 +140,14 @@ same radius, $\omega_{max} \approx 4.4\times10^3\,\text{rad/s}$ or about
 42\,000\,rpm.  Designers typically apply a safety factor of at least two and
 operate well below this bound.
 
+Substituting this limit into the thin-rim energy expression
+$$E = \tfrac{1}{2} m r^2 \omega^2$$
+shows that material strength caps the stored energy at
+$$E_{max} = \tfrac{\sigma_y}{2\rho} m$$
+independent of radius. For the CAD wheel in [`cad/flywheel.scad`](../cad/flywheel.scad)
+with $m \approx 0.19\,\text{kg}$, PLA allows roughly $E_{max} \approx 4.5\,\text{kJ}$—
+far above the $12\,\text{J}$ stored at 3000\,rpm.
+
 ```mermaid
 graph TD
     R[Radius r = 50 mm] --> V[v = ω r]


### PR DESCRIPTION
## Summary
- explain how hoop stress bounds flywheel energy
- apply limit to default CAD wheel

## Testing
- `RUN_SECURITY_ONLY=1 pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `RUN_SECURITY_ONLY=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c2209e938832fbdc32dcb21d42c87