### PR TITLE
📝 : document OpenSCAD prerequisite for CAD exports

### DIFF
--- a/cad/README.md
+++ b/cad/README.md
@@ -2,6 +2,14 @@
 
 Source OpenSCAD files for the flywheel project.
 
+## Prerequisites
+
+Install the OpenSCAD command-line tools before exporting meshes, for example:
+
+```bash
+sudo apt-get install openscad
+```
+
 ## Available models
 
 - `stand.scad` – stand for a flywheel shaft using 608 bearings; post thickness


### PR DESCRIPTION
## Summary
- document requirement to install OpenSCAD CLI before exporting meshes

## Testing
- `RUN_SECURITY_ONLY=1 pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`


------
https://chatgpt.com/codex/tasks/task_e_689c21b04de8832faaa766a16dba716a