### PR TITLE
🐛 : report patch coverage below threshold

### DIFF
--- a/docs/ci-guide.md
+++ b/docs/ci-guide.md
@@ -16,6 +16,11 @@ name contains common keywords like `ci`, `test`, `lint`, `build`, `docs`, or
 keywords in at least one workflow filename so the feature summary reflects your
 setup accurately.
 
+## Patch coverage reporting
+`flywheel crawl` records Codecov patch coverage even when it falls below the
+90% threshold. The summary shows a ❌ with the percentage for low coverage
+instead of omitting the value.
+
 ## CI best practices
 | Scenario | Recommended approach |
 |----------|---------------------|

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -516,7 +516,7 @@ class RepoCrawler:
                     .get("totals", {})
                     .get("coverage_diff")  # noqa: E501
                 )
-                if diff is not None and diff >= 90:
+                if diff is not None:
                     return float(diff)
             except Exception:
                 pass

--- a/tests/test_coverage_errors.py
+++ b/tests/test_coverage_errors.py
@@ -72,7 +72,7 @@ def test_patch_coverage_compare_on_error(monkeypatch):
 
     crawler = RepoCrawler([], session=Sess())
     pct = crawler._patch_coverage_from_codecov("foo/bar", "main")
-    assert pct is None
+    assert pct == 77.0
 
 
 def test_patch_coverage_compare_request_exception(monkeypatch):

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -313,8 +313,35 @@ def test_summary_column_order(monkeypatch):
     assert "`abcdef0`" in row
 
 
-def test_patch_coverage_svg():
+def test_patch_coverage_api_value_used():
     crawler = rc.RepoCrawler([], session=DummySession({}))
+    pct = crawler._patch_coverage_from_codecov("foo/bar", "main")
+    assert pct == 73.0
+
+
+def test_patch_coverage_falls_back_to_badge():
+    class NoDiffSession:
+        def __init__(self):
+            self.headers = {}
+
+        def get(self, url, **kwargs):
+            class Resp:
+                def __init__(self, text, status):
+                    self.text = text
+                    self.status_code = status
+
+                def json(self):
+                    import json
+
+                    return json.loads(self.text)
+
+            if url.startswith("https://codecov.io/api/gh/"):
+                return Resp('{"commit": {"totals": {}}}', 200)
+            if url.startswith("https://img.shields.io/codecov"):
+                return Resp("<svg>95%</svg>", 200)
+            return Resp("", 404)
+
+    crawler = rc.RepoCrawler([], session=NoDiffSession())
     pct = crawler._patch_coverage_from_codecov("foo/bar", "main")
     assert pct == 95.0
 


### PR DESCRIPTION
what: record Codecov patch coverage even when under 90%
why: low diff coverage was hidden, making failing patches look healthy
how to test: pre-commit run --all-files && pytest -q && npm run test:ci && python -m flywheel.fit && SKIP_E2E=1 bash scripts/checks.sh
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_689c21a4bebc832fab3e9408516c6a94