### PR TITLE
🔧 : treat neutral and skipped conclusions as success

### DIFF
--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -20,8 +20,12 @@ GITHUB_RE = re.compile(
 
 
 def status_to_emoji(conclusion: str | None) -> str:
-    """Return an emoji representing the run conclusion."""
-    if conclusion == "success":
+    """Return an emoji representing the workflow conclusion.
+
+    GitHub may mark runs as ``neutral`` or ``skipped`` when no jobs execute.
+    Treat those as successful for status reporting purposes.
+    """
+    if conclusion in {"success", "neutral", "skipped"}:
         return "✅"
     if conclusion is None:
         return "❓"

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -7,6 +7,8 @@ import src.repo_status as rs
 
 def test_status_to_emoji():
     assert rs.status_to_emoji("success") == "✅"
+    assert rs.status_to_emoji("neutral") == "✅"
+    assert rs.status_to_emoji("skipped") == "✅"
     assert rs.status_to_emoji("failure") == "❌"
     assert rs.status_to_emoji(None) == "❓"
 


### PR DESCRIPTION
what: classify 'neutral' and 'skipped' workflow results as passes.
why: GitHub may emit these when no jobs run; avoid marking them as failures.
how to test:
- `pre-commit run --all-files`
- `pytest -q`
- `SKIP_E2E=1 npm run test:ci`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_689c21a4bebc832fab3e9408516c6a94