### PR TITLE
🐛 fix: clean existing paths before repo scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ python -m flywheel.agents.scanner
 ```
 
 Reports are written to `reports/`. Each report lists only top-level files and ignores
-directories.
+directories. Existing paths under the scanner's work area are removed before each
+clone so reports reflect a fresh snapshot.
 
 ### Viewing the 3D flywheel
 

--- a/flywheel/agents/scanner.py
+++ b/flywheel/agents/scanner.py
@@ -14,8 +14,13 @@ REPOS = [
 
 
 def clone_repo(repo: str, dest: Path) -> None:
+    """Clone ``repo`` into ``dest``, overwriting existing paths."""
+
     if dest.exists():
-        shutil.rmtree(dest)
+        if dest.is_dir():
+            shutil.rmtree(dest)
+        else:
+            dest.unlink()
     url = f"https://github.com/{repo}.git"
     subprocess.run(
         ["git", "clone", "--depth", "1", url, str(dest)],

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -17,6 +17,20 @@ def test_clone_repo(monkeypatch, tmp_path):
     assert calls[0][:4] == ["git", "clone", "--depth", "1"]
 
 
+def test_clone_repo_overwrites_file(monkeypatch, tmp_path):
+    dest = tmp_path / "dest"
+    dest.write_text("x")
+    calls = []
+
+    def fake_run(cmd, check):
+        calls.append(cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    scanner.clone_repo("foo/bar", dest)
+    assert calls[0][:4] == ["git", "clone", "--depth", "1"]
+    assert not dest.exists()
+
+
 def test_analyze_repo(tmp_path):
     (tmp_path / "a.txt").write_text("hi")
     (tmp_path / "b.md").write_text("yo")


### PR DESCRIPTION
## Summary
- remove existing files or directories before `clone_repo` clones
- document scanner overwrite behavior
- test file path replacement in `clone_repo`

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`

Refs: #123

------
https://chatgpt.com/codex/tasks/task_e_689c21a4bebc832fab3e9408516c6a94