### PR TITLE
ci: stabilize viewer model dropdown tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## [2025-08-13] - Stabilize viewer model tests
+- ensure model dropdown options are loaded before evaluation

--- a/docs/pms/2025-08-13-playwright-dropdown-wait.md
+++ b/docs/pms/2025-08-13-playwright-dropdown-wait.md
@@ -1,0 +1,18 @@
+# Playwright dropdown wait
+
+- **Date**: 2025-08-13
+- **Author**: Codex
+- **Status**: resolved
+
+## What went wrong
+Viewer model tests queried the dropdown before options loaded, causing Playwright to report interrupted tests in CI.
+
+## Root cause
+The tests called `page.$$eval` on `#model-select option` without waiting for the elements to exist.
+
+## Impact
+CI `test:ci` workflow failed intermittently, preventing merges.
+
+## Actions to take
+- Wait for dropdown options before evaluation.
+- Monitor CI for further flakes.

--- a/tests/js/test_viewer_models.spec.js
+++ b/tests/js/test_viewer_models.spec.js
@@ -2,6 +2,9 @@ import { test, expect } from '@playwright/test';
 
 // Helper to get available model names from the page context
 async function getModelOptions(page) {
+  await page.waitForFunction(() =>
+    document.querySelectorAll('#model-select option').length > 0,
+  );
   return page.$$eval('#model-select option', opts => opts.map(o => o.value));
 }
 


### PR DESCRIPTION
## Summary
- wait for viewer model dropdown options before evaluation to avoid Playwright timeouts
- document fix in changelog and postmortem

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `RUN_SECURITY_ONLY=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c21b740fc832fb79599fb74a392b6