### PR TITLE
fix: use Node 20 in CI

### DIFF
--- a/.github/workflows/01-lint-format.yml
+++ b/.github/workflows/01-lint-format.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.language == 'javascript'
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install JS Lint Tools
         if: matrix.language == 'javascript' && hashFiles('package.json') != ''
         run: npm install --no-audit --no-fund

--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -31,7 +31,7 @@ jobs:
         if: matrix.language == 'javascript'
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - if: matrix.language == 'javascript' && hashFiles('package.json') != ''
         run: |
           npm install --no-audit --no-fund

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The canonical Codex automation prompt lives in [docs/prompts/codex/automation.md
 
 ## Testing
 
+Ensure you have Node.js 20+ installed.
+
 Run the full test suite before committing:
 
 ```bash

--- a/docs/pms/2025-08-13-node-version-mismatch.md
+++ b/docs/pms/2025-08-13-node-version-mismatch.md
@@ -1,0 +1,21 @@
+# Node version mismatch in CI
+
+- **Date**: 2025-08-13
+- **Author**: Codex
+- **Status**: resolved
+
+## What went wrong
+JavaScript tests ran on Node 18 in GitHub Actions, while the project now
+targets Node 20 features. The mismatch caused the test job to fail.
+
+## Root cause
+Workflows pinned Node 18 and lacked a guard to ensure the required runtime
+version.
+
+## Impact
+CI failed on the test job, blocking merges.
+
+## Actions to take
+- Upgrade workflow node versions to 20.
+- Add a test asserting the Node.js major version.
+- Document the Node 20 prerequisite in the README.

--- a/tests/node-version.test.mjs
+++ b/tests/node-version.test.mjs
@@ -1,0 +1,10 @@
+import { test, expect } from '@jest/globals';
+
+function parseMajor(version) {
+  return Number(version.split('.')[0]);
+}
+
+test('Node.js major version is at least 20', () => {
+  const major = parseMajor(process.versions.node);
+  expect(major).toBeGreaterThanOrEqual(20);
+});


### PR DESCRIPTION
## Summary
- ensure CI uses Node 20 for JavaScript tasks
- add test guarding minimum Node version
- document Node 20 prerequisite

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c21b740fc832fb79599fb74a392b6