### PR TITLE
Add outage catalog and CI prompt guidance

### DIFF
--- a/docs/dspace-integration.md
+++ b/docs/dspace-integration.md
@@ -7,6 +7,7 @@
 - Demonstrates offline-friendly patterns for storing quest data.
 - Provides a concrete target for the `quest-generator` script included here.
 - Shares the same CI and documentation style as Flywheel for frictionless contributions.
+- Maintains a structured outage catalog under `/outages` so fixes propagate across repositories.
 
 ## Quick start
 

--- a/docs/prompts/codex/ci-fix.md
+++ b/docs/prompts/codex/ci-fix.md
@@ -23,6 +23,7 @@ Diagnose a failed GitHub Actions run and produce a fix.
 
 CONTEXT:
 - Given a link to a failed job, fetch the logs, infer the root cause, and create a minimal, well-tested pull request that makes the workflow green again.
+- Consult existing outage entries in `/outages` for similar symptoms.
 - Constraints:
   * Do **not** break existing functionality.
   * Follow the repository’s style guidelines and commit-lint rules.
@@ -36,9 +37,10 @@ REQUEST:
 1. Read the failure logs and locate the first real error.
 2. Explain (in the pull-request body) *why* the failure occurred.
 3. Commit the necessary code, configuration, or documentation changes.
-4. Push to a branch named `codex/ci-fix/<short-description>`.
-5. Open a pull request that – once merged – makes the default branch CI-green.
-6. After merge, post a follow-up comment on this prompt with lessons learned so we can refine it.
+4. Record the incident in `outages/YYYY-MM-DD-<slug>.json` using `outages/schema.json`.
+5. Push to a branch named `codex/ci-fix/<short-description>`.
+6. Open a pull request that – once merged – makes the default branch CI-green.
+7. After merge, post a follow-up comment on this prompt with lessons learned so we can refine it.
 
 OUTPUT:
 A GitHub pull request URL. The PR must include:
@@ -53,6 +55,7 @@ After opening the pull request, create a new postmortem file under `docs/pms/` n
 - Impact
 - Actions to take
 Keep action items inside the postmortem so each regression has its own standalone record.
+Log each incident in `/outages` so future fixes can reference past outages.
 ```
 
 ### Why this mirrors the existing pattern

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -46,18 +46,18 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ❌ | ❌ | ❌ |
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ❌ | ❌ | ❌ | ❌ |
 ## Policies & Automation
-| Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Last-Updated (UTC) |
-| ---- | ------- | -- | --------- | --------- | --------------- | ------------ | ---------- | ----------------- |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ | ✅ | 16 | ✅ | ✅ | ✅ | ✅ | 2025-08-11 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | 2025-08-11 |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ | ✅ | 5 | ✅ | ✅ | ✅ | ✅ | 2025-08-11 |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ | ✅ | 5 | ✅ | ✅ | ✅ | ✅ | 2025-08-11 |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ | ✅ | 5 | ✅ | ✅ | ✅ | ✅ | 2025-08-11 |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ | ✅ | 8 | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | 2025-08-11 |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | 2025-08-11 |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ✅ | 6 | ✅ | ✅ | ✅ | ✅ | 2025-08-11 |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ | ✅ | 5 | ✅ | ❌ | ❌ | ✅ | 2025-08-11 |
+| Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Outages | Last-Updated (UTC) |
+| ---- | ------- | -- | --------- | --------- | --------------- | ------------ | ---------- | ------- | ----------------- |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ | ✅ | 16 | ✅ | ✅ | ✅ | ✅ | ✅ | 2025-08-11 |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ | ✅ | 5 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ | ✅ | 5 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ | ✅ | 5 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ | ✅ | 8 | ✅ | ✅ | ✅ | ❌ | ✅ | 2025-08-11 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ✅ | 6 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ | ✅ | 5 | ✅ | ❌ | ❌ | ✅ | ❌ | 2025-08-11 |
 
 ## Dark & Bright Pattern Scan
 | Repo | Dark Patterns | Bright Patterns | Last-Updated (UTC) |
@@ -75,5 +75,6 @@ This table tracks which flywheel features each related repository has adopted.
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip.
 Coverage percentages are parsed from their badges where available. Codecov shows ✅ when a Codecov config or badge is present. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses.
+The Outages column notes whether the repository keeps a structured incident log under `/outages`.
 The commit column shows the short SHA of the latest default branch commit at crawl time. The Trunk column indicates whether CI is green for that commit. Dark Patterns and Bright Patterns list counts of suspicious or positive code snippets detected.
 Last-Updated (UTC) records the date of the commit used for each row.

--- a/outages/README.md
+++ b/outages/README.md
@@ -1,0 +1,16 @@
+# Outage Catalog
+
+Structured archive of past outages. Each outage is stored as a JSON file using the
+schema in `schema.json`.
+
+File naming: `YYYY-MM-DD-<slug>.json`.
+
+Required fields:
+- `id`: unique identifier
+- `date`: ISO date
+- `component`: affected subsystem
+- `rootCause`: brief description of failure cause
+- `resolution`: how it was fixed
+- `references`: array of related links (PRs, issues, docs)
+
+Agents can parse these files to learn from previous incidents.

--- a/outages/schema.json
+++ b/outages/schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Outage record",
+  "type": "object",
+  "required": ["id", "date", "component", "rootCause", "resolution", "references"],
+  "properties": {
+    "id": { "type": "string" },
+    "date": { "type": "string", "format": "date" },
+    "component": { "type": "string" },
+    "rootCause": { "type": "string" },
+    "resolution": { "type": "string" },
+    "references": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}


### PR DESCRIPTION
what: add outages/ schema and docs, update CI-fix prompt and repo summary
why: propagate outage tracking upstream for reuse
how to test: pytest -q; npm run test:ci; python -m flywheel.fit; bash scripts/checks.sh (failed to complete)
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_689c215a6048832fac1494c1d3fa4f5d