### PR TITLE
docs: add Codex prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Use this doc when adding automation to new repositories.
 1. **Use as a template** on GitHub.
 2. Clone your new repo and run `./scripts/setup.sh YOURNAME NEWREPO` to personalize placeholders.
 3. Commit and push to start the flywheel.
+4. Review the [Codex automation prompt](docs/prompts/codex/automation.md) for baseline tasks.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- link README to Codex automation prompt for baseline guidance

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh` *(failed: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_689d777e6d28832fa5c4b80a9f3c286c