### PR TITLE
📝 : use npm build in CI-fix prompt – remove pnpm reference

### DIFF
--- a/docs/prompts/codex/ci-fix.md
+++ b/docs/prompts/codex/ci-fix.md
@@ -1,6 +1,6 @@
 ---
 title: 'Codex CI-Failure Fix Prompt'
-slug:  'codex-ci-fix'
+slug: 'codex-ci-fix'
 ---
 
 # OpenAI Codex CI-Failure Fix Prompt
@@ -84,7 +84,7 @@ Create the file above at docs/prompts/codex/ci-fix.md.
 
 Apply the table patch (or edit manually; don’t forget the pipe alignment).
 
-Run pnpm docs:build (or your docs generator) to ensure no broken links.
+Run `npm --prefix docs-site run build` (or your docs generator) to ensure no broken links.
 
 Push and open a PR in flywheel; once merged, downstream repos can import the new prompt automatically through Flywheel’s existing propagation workflow.
 


### PR DESCRIPTION
what: align ci-fix prompt with npm docs build and tidy slug
why: repo uses npm; pnpm docs command was outdated
how: SKIP=end-of-file-fixer,run-checks pre-commit run --all-files
     pytest -q
     npm run lint
     npm run test:ci
     python -m flywheel.fit
     SKIP_E2E=1 bash scripts/checks.sh
Refs: none

------
https://chatgpt.com/codex/tasks/task_e_689d775259b4832f827e3f003e7733d2