### PR TITLE
Allow parse_scad_vars to accept string paths

### DIFF
--- a/flywheel/fit.py
+++ b/flywheel/fit.py
@@ -13,15 +13,19 @@ _DEF_RE = re.compile(
 )
 
 
-def parse_scad_vars(path: Path) -> Dict[str, float]:
+def parse_scad_vars(path: str | Path) -> Dict[str, float]:
     """Return variable assignments parsed from a SCAD file.
+
+    Args:
+        path: String or :class:`~pathlib.Path` pointing to the SCAD file.
 
     Block comments ``/* ... */`` and inline ``//`` comments after the
     semicolon are ignored. The parser supports negative values, decimals
     without a leading zero, trailing decimal points, scientific notation,
     and multiple assignments on the same line.
     """
-    text = Path(path).read_text()
+    path = Path(path)
+    text = path.read_text()
     text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
     vars: Dict[str, float] = {}
     for raw_line in text.splitlines():

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -58,6 +58,13 @@ def test_parse_scad_vars_multiple_per_line(tmp_path):
     assert vars == {"radius": 5.0, "height": 2.0}
 
 
+def test_parse_scad_vars_accepts_str_path(tmp_path):
+    scad = tmp_path / "part.scad"
+    scad.write_text("radius = 5;")
+    vars = ff.parse_scad_vars(str(scad))
+    assert vars == {"radius": 5.0}
+
+
 def test_verify_fit(tmp_path, monkeypatch):
     assert ff.verify_fit(CAD_DIR, STL_DIR)
 


### PR DESCRIPTION
## Summary
- allow `parse_scad_vars` to take str paths
- test string path support

## Testing
- `SKIP=run-checks,linkchecker pre-commit run --all-files`
- `SKIP_E2E=1 pytest -q`
- `npm run lint`
- `SKIP_E2E=1 npm run test:ci`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689d767ddf40832f9022b6cfac88a40f