### PR TITLE
fix: pin Python 3.12 in CI workflows

### DIFF
--- a/.github/workflows/01-lint-format.yml
+++ b/.github/workflows/01-lint-format.yml
@@ -17,7 +17,7 @@ jobs:
         if: matrix.language == 'python'
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.12'
       - name: Install Py Lint Tools
         if: matrix.language == 'python'
         run: uv pip install --system flake8 black isort

--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -19,7 +19,7 @@ jobs:
         if: matrix.language == 'python'
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.12'
       - if: matrix.language == 'python'
         run: |
           uv pip install --system pytest pytest-cov coverage

--- a/.github/workflows/03-docs.yml
+++ b/.github/workflows/03-docs.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: astral-sh/setup-uv@v1
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.12'
       - run: |
           uv pip install --system linkchecker
           linkchecker README.md docs/ || true

--- a/.github/workflows/04-update-summary.yml
+++ b/.github/workflows/04-update-summary.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.12'
       - name: Setup uv
         uses: astral-sh/setup-uv@v1
       - name: Install dependencies

--- a/.github/workflows/06-prompt-docs.yml
+++ b/.github/workflows/06-prompt-docs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.12'
       - name: Setup uv
         uses: astral-sh/setup-uv@v1
       - name: Install dependencies

--- a/.github/workflows/nightly-scan.yml
+++ b/.github/workflows/nightly-scan.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.12'
       - uses: astral-sh/setup-uv@v1
       - run: |
           uv pip install --system -r requirements.txt

--- a/.github/workflows/update-repo-status.yml
+++ b/.github/workflows/update-repo-status.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: astral-sh/setup-uv@v1
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
       - name: Install deps
         run: uv pip install --system -r requirements.txt
       - name: Update README

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## [2025-08-14] - Pin Python version in CI
+- lock workflows to Python 3.12 to avoid uv install failures
+
 ## [2025-08-13] - Stabilize viewer model tests
 - ensure model dropdown options are loaded before evaluation

--- a/docs/pms/2025-08-14-python-313-install.md
+++ b/docs/pms/2025-08-14-python-313-install.md
@@ -1,0 +1,21 @@
+# Python 3.13 coverage install failure
+
+- **Date**: 2025-08-14
+- **Author**: Codex
+- **Status**: resolved
+
+## What went wrong
+GitHub Actions runners upgraded to Python 3.13. The tests workflow attempted to
+install pytest-cov and coverage with uv, but those packages lacked wheels for the
+new Python release, causing dependency installation to fail.
+
+## Root cause
+The workflows requested `python-version: '3.x'`, allowing the unexpected Python
+3.13 update that `uv pip install` could not satisfy.
+
+## Impact
+The Test Suite job exited before running tests, blocking CI on affected branches.
+
+## Actions to take
+- Pin workflows to Python 3.12.
+- Add a regression test for the Python version.

--- a/outages/2025-08-14-python-313-coverage.json
+++ b/outages/2025-08-14-python-313-coverage.json
@@ -1,0 +1,8 @@
+{
+  "id": "2025-08-14-python-313-coverage",
+  "date": "2025-08-14",
+  "component": "ci/tests",
+  "rootCause": "GitHub runner upgraded to Python 3.13, causing uv to fail installing coverage",
+  "resolution": "Pin GitHub Actions workflows to Python 3.12",
+  "references": ["https://github.com/futuroptimist/flywheel/actions/runs/16930813655"]
+}

--- a/tests/test_python_version.py
+++ b/tests/test_python_version.py
@@ -1,0 +1,5 @@
+import sys
+
+
+def test_python_version():
+    assert sys.version_info[:2] == (3, 12)


### PR DESCRIPTION
## Summary
- pin GitHub Actions workflows to Python 3.12
- add regression test enforcing Python 3.12

## Testing
- `SKIP_E2E=1 pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689d7758dcd8832f999d07cd4e1e0479