### PR TITLE
Honor --no-save-dev in update CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,16 @@ Install the CLI and inject dev tooling. Without `--yes`, the command prompts for
 pipx run flywheel init . --language python --save-dev --yes
 ```
 
+### Updating dev tooling
+
+Refresh CI workflows and config files in an existing repo:
+
+```bash
+flywheel update path/to/repo
+```
+
+Skip copying dev tooling with `--no-save-dev`.
+
 ### Generating Codex prompts
 
 Invoke the prompt agent to get repo-aware suggestions:

--- a/flywheel/__main__.py
+++ b/flywheel/__main__.py
@@ -87,6 +87,12 @@ def init_repo(args: argparse.Namespace) -> None:
         inject_dev(target)
 
 
+def update_repo(args: argparse.Namespace) -> None:
+    target = Path(args.path).resolve()
+    if args.save_dev:
+        inject_dev(target)
+
+
 PROMPT_TMPL = """# Purpose
 Assist developers working on this repository.
 
@@ -145,8 +151,19 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_update = sub.add_parser("update", help="update dev tooling")
     p_update.add_argument("path", help="target repository path")
-    p_update.add_argument("--save-dev", action="store_true", default=True)
-    p_update.set_defaults(func=lambda a: inject_dev(Path(a.path)))
+    p_update.add_argument(
+        "--save-dev",
+        action="store_true",
+        default=True,
+        help="inject dev tooling",
+    )
+    p_update.add_argument(
+        "--no-save-dev",
+        action="store_false",
+        dest="save_dev",
+        help="skip dev tooling",
+    )
+    p_update.set_defaults(func=update_repo)
 
     p_audit = sub.add_parser("audit", help="check for missing tooling")
     p_audit.add_argument("path", help="repository path")

--- a/tests/test_update_cli.py
+++ b/tests/test_update_cli.py
@@ -10,3 +10,19 @@ def test_update_cli(tmp_path):
     subprocess.run(cmd, check=True)
     wf = repo / ".github" / "workflows" / "01-lint-format.yml"
     assert wf.exists()
+
+
+def test_update_cli_no_save_dev(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cmd = [
+        sys.executable,
+        "-m",
+        "flywheel",
+        "update",
+        str(repo),
+        "--no-save-dev",
+    ]
+    subprocess.run(cmd, check=True)
+    wf = repo / ".github" / "workflows" / "01-lint-format.yml"
+    assert not wf.exists()


### PR DESCRIPTION
## Summary
- allow `flywheel update` to skip dev file injection with `--no-save-dev`
- document update command usage
- test `update` CLI respects `--no-save-dev`

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh` *(fails: KeyboardInterrupt)*


------
https://chatgpt.com/codex/tasks/task_e_689eb4e9e5c0832fabbf382b68cd5d2b