### PR TITLE
docs: remove unused 'precess' allowlist entry

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -193,7 +193,6 @@ utils
 qa
 precession
 mathrm
-precess
 circ
 Lockfile
 Untriaged

--- a/docs/pms/2025-08-09-spellcheck-prompt-summary.md
+++ b/docs/pms/2025-08-09-spellcheck-prompt-summary.md
@@ -15,5 +15,5 @@ CI runs failed on the spelling step, blocking merges.
 
 ## Actions to take
 - Exclude the generated prompt docs summary from spellcheck.
-- Whitelist common physics notation like `precess` and `circ`.
+- Whitelist common physics notation like `precession` and `circ`.
 - Regenerate `docs/prompts/summary.md` with a valid Markdown table so spellcheck can cover it.


### PR DESCRIPTION
## Summary
- remove unused `precess` entry from codespell allowlist
- fix physics note to reference `precession`

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689eb4c8c330832facd85d265aae04e9