### PR TITLE
📝 : – streamline testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ Run the full test suite before committing:
 ```bash
 pre-commit run --all-files
 pytest -q
-npm run lint
-npm test -- --coverage
 npm run test:ci
 python -m flywheel.fit
 bash scripts/checks.sh


### PR DESCRIPTION
what: drop redundant npm lint and coverage commands from README test block.
why: align docs with current workflow and avoid confusion.
how to test: pre-commit run --all-files; pytest -q; npm run test:ci; python -m flywheel.fit; bash scripts/checks.sh.
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_689eb4bc08b0832f863e340fe14c2a94