### PR TITLE
Handle UTF‑8 BOM in SCAD parser

### DIFF
--- a/flywheel/fit.py
+++ b/flywheel/fit.py
@@ -20,12 +20,14 @@ def parse_scad_vars(path: str | Path) -> Dict[str, float]:
         path: String or :class:`~pathlib.Path` pointing to the SCAD file.
 
     Block comments ``/* ... */`` and inline ``//`` comments after the
-    semicolon are ignored. The parser supports negative values, decimals
-    without a leading zero, trailing decimal points, scientific notation,
-    and multiple assignments on the same line.
+    semicolon are ignored. The parser strips an initial UTF‑8 BOM and
+    supports negative values, decimals without a leading zero, trailing
+    decimal points, scientific notation, and multiple assignments on the
+    same line.
     """
     path = Path(path)
     text = path.read_text()
+    text = text.lstrip("\ufeff")  # Handle UTF-8 BOM
     text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
     vars: Dict[str, float] = {}
     for raw_line in text.splitlines():

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -65,6 +65,13 @@ def test_parse_scad_vars_accepts_str_path(tmp_path):
     assert vars == {"radius": 5.0}
 
 
+def test_parse_scad_vars_handles_bom(tmp_path):
+    scad = tmp_path / "part.scad"
+    scad.write_text("radius = 5;\n", encoding="utf-8-sig")
+    vars = ff.parse_scad_vars(scad)
+    assert vars == {"radius": 5.0}
+
+
 def test_verify_fit(tmp_path, monkeypatch):
     assert ff.verify_fit(CAD_DIR, STL_DIR)
 


### PR DESCRIPTION
## Summary
- strip UTF-8 BOM in parse_scad_vars to read BOM-prefixed files
- test SCAD parser against BOM input

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689eb4bc08b0832f863e340fe14c2a94