### PR TITLE
Skip symlinks in repo scanner

### DIFF
--- a/flywheel/agents/scanner.py
+++ b/flywheel/agents/scanner.py
@@ -31,14 +31,14 @@ def clone_repo(repo: str, dest: Path) -> None:
 def analyze_repo(path: Path) -> str:
     """Return a simple report listing top-level files.
 
-    Only regular, non-hidden files in ``path`` are included; directories are
-    ignored.
+    Only regular, non-hidden files in ``path`` are included. Directories and
+    symlinks are ignored.
     """
 
     names = [
         p.name
         for p in path.iterdir()
-        if p.is_file() and not p.name.startswith(".")  # noqa: E501
+        if p.is_file() and not p.is_symlink() and not p.name.startswith(".")
     ]
     files = sorted(names)
     report_lines = [

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -54,6 +54,15 @@ def test_analyze_repo_skips_hidden_files(tmp_path):
     assert "- .secret" not in report
 
 
+def test_analyze_repo_skips_symlinks(tmp_path):
+    target = tmp_path / "real.txt"
+    target.write_text("hi")
+    (tmp_path / "link.txt").symlink_to(target)
+    report = scanner.analyze_repo(tmp_path)
+    assert "- real.txt" in report
+    assert "- link.txt" not in report
+
+
 def test_main(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
 


### PR DESCRIPTION
## Summary
- exclude symlinks when listing repo files
- test that symlinks are ignored

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689eb4bc08b0832f863e340fe14c2a94