### PR TITLE
Curate prompt docs summary

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -1,138 +1,32 @@
 # Prompt Docs Summary
 
-This index is auto-generated with
-[scripts/update_prompt_docs_summary.py]
-(../../scripts/update_prompt_docs_summary.py)
-using RepoCrawler to discover prompt documents across repositories.
+This index is generated with
+[scripts/update_prompt_docs_summary.py](../../scripts/update_prompt_docs_summary.py)
+using RepoCrawler to discover prompt documents.
 
-All prompts are verified with OpenAI Codex. Other coding agents like Claude Code, Gemini CLI, and Cursor should work too.
+It is manually curated to list only major one-click prompts or pending feature requests.
 
-**60 one-click prompts verified across 10 repos (2 evergreen, 2 one-off, 8 unknown).**
+**4 one-click prompts verified across 1 repo (2 evergreen, 2 one-off).**
 
-One-off prompts are temporary—copy them into issues or PRs, implement, and then remove them from source docs.
+One-off prompts are temporary—copy them into issues or PRs, implement, and then remove them.
 
-All listed prompts are mechanically verified as 1-click ready: copy & paste without editing.
+All listed prompts contain copyable code blocks representing LLM prompts.
 
 ## Legend
 
-| Type      | Description                                                                                      |
-|-----------|--------------------------------------------------------------------------------------------------|
-| evergreen | prompts that can be reused to hillclimb toward goals like feature completeness or test coverage  |
-| one-off   | prompts to implement features or make recommended changes (glorified TODO; remove after cleanup) |
-| unknown   | catch-all; refine into another category or create a new one                                      |
+| Type      | Description                                                                              |
+|-----------|------------------------------------------------------------------------------------------|
+| evergreen | prompts that can be reused to hillclimb toward goals like feature completeness or tests |
+| one-off   | prompts to implement features or make recommended changes (remove after cleanup)        |
 
 ## **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**
 
-| Path                                                                                                                     | Prompt                                                                                                                                                                              | Type      | One-click?   |
-|--------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|--------------|
-| [docs/prompts/codex/automation.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/automation.md) | [Upgrade Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/automation.md#upgrade-prompt)                                                               | evergreen | yes          |
-| [docs/prompts/codex/spellcheck.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/spellcheck.md) | [Codex Spellcheck Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/spellcheck.md#codex-spellcheck-prompt)                                             | evergreen | yes          |
-| [docs/prompts/codex/ci-fix.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/ci-fix.md)         | [2 – Add a column to `docs/repo-feature-summary.md`](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/ci-fix.md#2-add-a-column-to-docsrepo-feature-summarymd) | unknown   | yes          |
-| [docs/prompts/codex/automation.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/automation.md) | [Implementation prompts](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/automation.md#implementation-prompts)                                               | one-off   | yes          |
-| [docs/prompts/codex/automation.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/automation.md) | [1 Add ⭐ Stars & 🐞 Open-Issues columns](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/automation.md#1-add-stars-open-issues-columns)                       | one-off   | yes          |
+| Path | Prompt | Type | One-click? |
+|------|--------|------|------------|
+| [docs/prompts/codex/automation.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/automation.md) | [Upgrade Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/automation.md#upgrade-prompt) | evergreen | yes |
+| [docs/prompts/codex/spellcheck.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/spellcheck.md) | [Codex Spellcheck Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/spellcheck.md#codex-spellcheck-prompt) | evergreen | yes |
+| [docs/prompts/codex/automation.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/automation.md) | [Implementation prompts](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/automation.md#implementation-prompts) | one-off | yes |
+| [docs/prompts/codex/automation.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/automation.md) | [1 Add ⭐ Stars & 🐞 Open-Issues columns](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/automation.md#1-add-stars-open-issues-columns) | one-off | yes |
 
-## [futuroptimist/axel](https://github.com/futuroptimist/axel)
-
-| Path                                                                                                                       | Prompt                                                                                                                                  | Type        | One-click?   |
-|----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|-------------|--------------|
-| [.axel/hillclimb/prompts/code.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/code.md)         | [code.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/code.md)                                              | unknown     | yes          |
-| [.axel/hillclimb/prompts/critique.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/critique.md) | [critique.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/critique.md)                                      | unknown     | yes          |
-| [.axel/hillclimb/prompts/plan.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/plan.md)         | [plan.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/plan.md)                                              | unknown     | yes          |
-| **[docs/prompts-codex-spellcheck.md](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex-spellcheck.md)**   | **[Codex Spellcheck Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)** | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md)**                         | **[Implementation Prompts](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#implementation-prompts)**              | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md)**                         | **[2. Update roadmap status](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#2-update-roadmap-status)**           | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md)**                         | **[How to Choose a Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#how-to-choose-a-prompt)**              | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md)**                         | **[Upgrade Prompt](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#upgrade-prompt)**                              | **unknown** | **yes**      |
-
-## [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)
-
-| Path                                                                                                                            | Prompt                                                                                                                                                           | Type        | One-click?   |
-|---------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|--------------|
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md)**                           | **[Codex Automation Prompt](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md#codex-automation-prompt)**                                  | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md)**                           | **[Implementation prompts](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md#implementation-prompts)**                                    | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md)**                           | **[2 Expand service improvement checklists](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md#2-expand-service-improvement-checklists)**  | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md)**                           | **[How to choose a prompt](https://github.com/futuroptimist/gabriel/blob/main/docs/prompts-codex.md#how-to-choose-a-prompt)**                                    | **unknown** | **yes**      |
-| [prompts/README.md](https://github.com/futuroptimist/gabriel/blob/main/prompts/README.md)                                       | [Prompt Templates](https://github.com/futuroptimist/gabriel/blob/main/prompts/README.md#prompt-templates)                                                        | unknown     | yes          |
-| [prompts/generate-improvements.md](https://github.com/futuroptimist/gabriel/blob/main/prompts/generate-improvements.md)         | [Generate Improvement Checklist Items](https://github.com/futuroptimist/gabriel/blob/main/prompts/generate-improvements.md#generate-improvement-checklist-items) | unknown     | yes          |
-| [prompts/scan-bright-dark-patterns.md](https://github.com/futuroptimist/gabriel/blob/main/prompts/scan-bright-dark-patterns.md) | [Scan for Bright and Dark Patterns](https://github.com/futuroptimist/gabriel/blob/main/prompts/scan-bright-dark-patterns.md#scan-for-bright-and-dark-patterns)   | unknown     | yes          |
-| [prompts/update-risk-model.md](https://github.com/futuroptimist/gabriel/blob/main/prompts/update-risk-model.md)                 | [Update Flywheel Risk Model](https://github.com/futuroptimist/gabriel/blob/main/prompts/update-risk-model.md#update-flywheel-risk-model)                         | unknown     | yes          |
-
-## [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist)
-
-| Path                                                                                                                              | Prompt                                                                                                                                           | Type        | One-click?   |
-|-----------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|-------------|--------------|
-| **[docs/prompts-codex-spellcheck.md](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-spellcheck.md)** | **[Codex Spellcheck Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)** | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex.md)**                       | **[Codex Automation Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex.md#codex-automation-prompt)**            | **unknown** | **yes**      |
-
-## [futuroptimist/token.place](https://github.com/futuroptimist/token.place)
-
-| Path                                                                                                                    | Prompt                                                                                                                                                                    | Type        | One-click?   |
-|-------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|--------------|
-| **[docs/prompts-codex-ci-fix.md](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex-ci-fix.md)** | **[Codex CI-Failure Fix Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex-ci-fix.md#codex-ci-failure-fix-prompt)**                        | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md)**               | **[token.place Codex Prompt](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md#tokenplace-codex-prompt)**                                      | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md)**               | **[Implementation prompts](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md#implementation-prompts)**                                         | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md)**               | **[1 Document environment variables in README](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md#1-document-environment-variables-in-readme)** | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md)**               | **[2 Add API rate limit test](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md#2-add-api-rate-limit-test)**                                   | **unknown** | **yes**      |
-
-## [democratizedspace/dspace](https://github.com/democratizedspace/dspace)
-
-| Path                                                                                                                                                                 | Prompt                                                                                                                                                                                                           | Type        | One-click?   |
-|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|--------------|
-| **[frontend/src/pages/docs/md/prompts-codex-meta.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex-meta.md)**         | **[Codex Meta Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex-meta.md#codex-meta-prompt)**                                                                  | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-codex-upgrader.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex-upgrader.md)** | **[Codex Prompt Upgrader](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex-upgrader.md#codex-prompt-upgrader)**                                                      | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-codex.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md)**                   | **[Writing great Codex prompts for the _dspace_ repo](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#writing-great-codex-prompts-for-the-dspace-repo)**         | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-codex.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md)**                   | **[1 Quick start (Web vs CLI)](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#1-quick-start-web-vs-cli)**                                                       | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-codex.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md)**                   | **[2 Prompt ingredients](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#2-prompt-ingredients)**                                                                 | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-codex.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md)**                   | **[Upgrade Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#upgrade-prompt)**                                                                             | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-codex.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md)**                   | **[Prompt Upgrader](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-codex.md#prompt-upgrader)**                                                                           | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-items.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md)**                   | **[Writing great item prompts for the _dspace_ repo](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md#writing-great-item-prompts-for-the-dspace-repo)**           | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-items.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md)**                   | **[1. Quick start (Web vs CLI)](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md#1-quick-start-web-vs-cli)**                                                      | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-items.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md)**                   | **[2. Prompt ingredients](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md#2-prompt-ingredients)**                                                                | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-items.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md)**                   | **[Implementation Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-items.md#implementation-prompt)**                                                               | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-processes.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md)**           | **[Writing great process prompts for the _dspace_ repo](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md#writing-great-process-prompts-for-the-dspace-repo)** | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-processes.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md)**           | **[1. Quick start (Web vs CLI)](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md#1-quick-start-web-vs-cli)**                                                  | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-processes.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md)**           | **[2 Prompt ingredients](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md#2-prompt-ingredients)**                                                             | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-processes.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md)**           | **[Implementation Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-processes.md#implementation-prompt)**                                                           | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-quests.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md)**                 | **[Writing great quest prompts for the _dspace_ repo](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md#writing-great-quest-prompts-for-the-dspace-repo)**        | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-quests.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md)**                 | **[1. Quick start (Web vs CLI)](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md#1-quick-start-web-vs-cli)**                                                     | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-quests.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md)**                 | **[2 Prompt ingredients](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md#2-prompt-ingredients)**                                                                | **unknown** | **yes**      |
-| **[frontend/src/pages/docs/md/prompts-quests.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md)**                 | **[Implementation Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-quests.md#implementation-prompt)**                                                              | **unknown** | **yes**      |
-
-## [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard)
-
-| Path                                                                                                      | Prompt                                                                                                                                                              | Type        | One-click?   |
-|-----------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|--------------|
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md)** | **[Codex prompts for the *f2clipboard* repo](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#codex-prompts-for-the-f2clipboard-repo)** | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md)** | **[Task-specific prompts](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#task-specific-prompts)**                                     | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md)** | **[2 Emit Markdown to stdout and clipboard](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#2-emit-markdown-to-stdout-and-clipboard)** | **unknown** | **yes**      |
-
-## [futuroptimist/sigma](https://github.com/futuroptimist/sigma)
-
-| Path                                                                                                                      | Prompt                                                                                                                                   | Type        | One-click?   |
-|---------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|--------------|
-| **[docs/prompts-codex-cad.md](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-cad.md)**               | **[Codex CAD Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-cad.md#codex-cad-prompt)**                      | **unknown** | **yes**      |
-| **[docs/prompts-codex-spellcheck.md](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-spellcheck.md)** | **[Codex Spellcheck Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)** | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex.md)**                       | **[Codex Automation Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex.md#codex-automation-prompt)**            | **unknown** | **yes**      |
-
-## [futuroptimist/wove](https://github.com/futuroptimist/wove)
-
-| Path                                                                                               | Prompt                                                                                                                                              | Type        | One-click?   |
-|----------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|--------------|
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md)** | **[Codex Automation Prompt](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md#codex-automation-prompt)**                        | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md)** | **[Implementation prompts](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md#implementation-prompts)**                          | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md)** | **[1 Add a Gauge Swatch section](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md#1-add-a-gauge-swatch-section)**              | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md)** | **[2 Document `checks.sh` in the README](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md#2-document-checkssh-in-the-readme)** | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md)** | **[3 Add a Crochet Glossary](https://github.com/futuroptimist/wove/blob/main/docs/prompts-codex.md#3-add-a-crochet-glossary)**                      | **unknown** | **yes**      |
-
-## [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)
-
-| Path                                                                                                              | Prompt                                                                                                                                       | Type        | One-click?   |
-|-------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|-------------|--------------|
-| **[docs/prompts-codex-docs.md](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex-docs.md)** | **[Codex Documentation Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex-docs.md#codex-documentation-prompt)** | **unknown** | **yes**      |
-| **[docs/prompts-codex.md](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex.md)**           | **[Codex Automation Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts-codex.md#codex-automation-prompt)**            | **unknown** | **yes**      |
-
-## Untriaged Prompt Docs
-
-None detected.
-
-_Updated automatically: 2025-08-15_
+More prompts will be added after they are vetted.
+See [prompts-filtering.md](prompts-filtering.md) for future curation instructions.

--- a/docs/prompts-filtering.md
+++ b/docs/prompts-filtering.md
@@ -1,0 +1,28 @@
+# Prompt Doc Filtering
+
+Guidance for future LLMs to keep `prompt-docs-summary.md` focused and useful.
+
+## Goals
+
+- Only link to sections that contain a fenced code block with an LLM prompt.
+- Surface major one-click prompts and outstanding feature requests.
+- Remove entries once the referenced work is complete.
+
+## Workflow
+
+1. Crawl repositories for Markdown files mentioning prompts.
+2. For each candidate section:
+   - Confirm a code block exists and represents an LLM prompt.
+   - Classify it as `evergreen` or `one-off`.
+   - Skip sections lacking code blocks or unrelated content.
+3. Update `prompt-docs-summary.md` with vetted entries only.
+4. Run the full suite of checks:
+   - `pre-commit run --all-files`
+   - `pytest -q`
+   - `npm run lint`
+   - `npm run test:ci`
+   - `python -m flywheel.fit`
+   - `bash scripts/checks.sh`
+5. Commit with a descriptive message and reference any relevant issues.
+6. Repeat as new prompts are added across repositories.
+


### PR DESCRIPTION
## Summary
- prune prompt-docs-summary to major one-click prompts
- add prompts-filtering guide for future LLM curation

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689edc564d48832fb263cc602b2f8b72