### PR TITLE
📝: outline prompt doc cleanup

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -5,6 +5,9 @@ This index is auto-generated with
 (../../scripts/update_prompt_docs_summary.py)
 using RepoCrawler to discover prompt documents across repositories.
 
+Refer to [prompts-major-filter.md](prompts-major-filter.md) for guidance on trimming
+this list to only major one-click prompts or pending feature requests.
+
 All prompts are verified with OpenAI Codex. Other coding agents like Claude Code, Gemini CLI, and Cursor should work too.
 
 **60 one-click prompts verified across 10 repos (2 evergreen, 2 one-off, 8 unknown).**

--- a/docs/prompts-major-filter.md
+++ b/docs/prompts-major-filter.md
@@ -1,0 +1,34 @@
+# Prompt Docs Cleanup Plan
+
+This document provides step-by-step instructions for a future LLM to refine
+[prompt-docs-summary.md](prompt-docs-summary.md) so it only lists major prompts
+that are either ready for one-click use or describe pending unimplemented feature
+requests.
+
+## Goals
+- Keep the summary focused on high-value prompts.
+- Remove entries that lack LLM-ready code blocks or that do not correspond to
+  actionable feature requests.
+- Maintain links to evergreen one-click prompts.
+
+## Review Procedure
+1. Open `prompt-docs-summary.md` and inspect each linked section.
+2. Follow the link and verify that:
+   - The section contains a code block intended as an LLM prompt.
+   - The prompt is either evergreen one-click or an unimplemented feature request.
+3. If either condition fails, remove the row from the summary.
+4. When in doubt, err on the side of trimming the entry and note it for review.
+
+## Regeneration
+After editing, run:
+
+```bash
+python scripts/update_prompt_docs_summary.py
+```
+
+This regenerates the table to include only approved prompts. Repeat the review
+process if new entries appear.
+
+## Incremental Improvements
+Apply these steps in small commits, gradually converging on a concise summary.
+Future agents should continue pruning as new prompt docs are added.


### PR DESCRIPTION
## Summary
- add prompts-major-filter.md with step-by-step instructions to keep prompt-docs-summary lean
- note cleanup plan in prompt-docs-summary.md

## Testing
- `RUN_SECURITY_ONLY=1 pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `RUN_SECURITY_ONLY=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689edc564d48832fb263cc602b2f8b72