### PR TITLE
📝 docs: fix precession term

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -193,7 +193,6 @@ utils
 qa
 precession
 mathrm
-precess
 circ
 Lockfile
 Untriaged

--- a/docs/pms/2025-08-09-spellcheck-prompt-summary.md
+++ b/docs/pms/2025-08-09-spellcheck-prompt-summary.md
@@ -15,5 +15,5 @@ CI runs failed on the spelling step, blocking merges.
 
 ## Actions to take
 - Exclude the generated prompt docs summary from spellcheck.
-- Whitelist common physics notation like `precess` and `circ`.
+- Whitelist common physics notation like `precession` and `circ`.
 - Regenerate `docs/prompts/summary.md` with a valid Markdown table so spellcheck can cover it.


### PR DESCRIPTION
## Summary
- replace 'precess' with 'precession' in spellcheck postmortem
- tighten codespell dictionary to avoid masking typos

## Testing
- `SKIP=run-checks pre-commit run --all-files`
- `pytest -q`
- `npx playwright install chromium`
- `npm run test:ci`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f88c4d1ec832f8ae01df984ac7a01