### PR TITLE
Guard Codecov uploads without token

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -3,6 +3,8 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       matrix:
         language: [python, javascript]
@@ -41,19 +43,25 @@ jobs:
 
       # --- Upload coverage only if the matching report exists ---
       - name: Upload Python coverage
-        if: matrix.language == 'python' && hashFiles('coverage.xml') != ''
+        if: >-
+          matrix.language == 'python' &&
+          hashFiles('coverage.xml') != '' &&
+          env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: python
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
       - name: Upload JS coverage
-        if: matrix.language == 'javascript' && hashFiles('coverage/lcov.info') != ''
+        if: >-
+          matrix.language == 'javascript' &&
+          hashFiles('coverage/lcov.info') != '' &&
+          env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           flags: javascript
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [2025-08-15] - Skip Codecov upload without token
+- guard coverage uploads so forks without secrets keep CI green
+
 ## [2025-08-15] - Safely handle symbolic link destinations
 - avoid deleting linked directories when cloning repos
 

--- a/docs/pms/2025-08-15-codecov-token-missing.md
+++ b/docs/pms/2025-08-15-codecov-token-missing.md
@@ -1,0 +1,18 @@
+# Codecov token missing in CI
+
+- **Date**: 2025-08-15
+- **Author**: Codex
+- **Status**: resolved
+
+## What went wrong
+Codecov upload steps failed when the required CODECOV_TOKEN secret was absent on forked pull requests, causing the test workflow to error.
+
+## Root cause
+The test workflow always invoked the Codecov action with a token, which is unavailable to external contributors.
+
+## Impact
+Fork-based pull requests could not complete the test job, blocking merges.
+
+## Actions to take
+- Guard Codecov steps on token presence.
+- Allow coverage uploads to fail without breaking CI.

--- a/outages/2025-08-15-codecov-token.json
+++ b/outages/2025-08-15-codecov-token.json
@@ -1,0 +1,8 @@
+{
+  "id": "codecov-token-missing",
+  "date": "2025-08-15",
+  "component": "github-actions",
+  "rootCause": "Codecov uploads required a secret token unavailable to forked PRs, causing the workflow to fail.",
+  "resolution": "Upload steps now check for CODECOV_TOKEN and do not fail the build when absent.",
+  "references": []
+}

--- a/tests/codecov-workflow.test.mjs
+++ b/tests/codecov-workflow.test.mjs
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { test, expect } from '@jest/globals';
+
+// Ensure Codecov uploads don't break when secrets are unavailable
+const workflow = readFileSync(new URL('../.github/workflows/02-tests.yml', import.meta.url), 'utf8');
+
+test('Codecov uploads are gated on CODECOV_TOKEN', () => {
+  expect(workflow).toMatch(/CODECOV_TOKEN/);
+  expect(workflow).toMatch(/env\.CODECOV_TOKEN != ''/);
+});
+
+test('Codecov failures do not break CI', () => {
+  expect(workflow).toMatch(/fail_ci_if_error: false/);
+});


### PR DESCRIPTION
## Summary
- skip Codecov uploads when `CODECOV_TOKEN` is missing so forked PRs pass
- test workflow for Codecov guard and non-fatal uploads
- document outage and postmortem

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f88d33848832f95dfd23b66e11924