### PR TITLE
🐛: handle braces in README prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Invoke the prompt agent to get repo-aware suggestions:
 flywheel prompt
 ```
 
+README content containing `{` or `}` characters is handled safely.
+
 ### Generating repo feature summary
 
 Create a Markdown table showing which flywheel files each repo uses:

--- a/flywheel/__main__.py
+++ b/flywheel/__main__.py
@@ -111,7 +111,8 @@ def prompt(args: argparse.Namespace) -> None:
         snippet = "\n".join(readme.read_text().splitlines()[:20])
     else:
         snippet = "No README found."  # pragma: no cover
-    print(PROMPT_TMPL.format(snippet=snippet))
+    # Avoid ``str.format`` so braces in README snippets don't break formatting
+    print(PROMPT_TMPL.replace("{snippet}", snippet))
 
 
 def crawl(args: argparse.Namespace) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,18 @@ def test_prompt_no_readme(tmp_path):
     assert "No README found." in result.stdout
 
 
+def test_prompt_handles_braces(tmp_path):
+    readme = tmp_path / "README.md"
+    readme.write_text("Hello {braced} world")
+    result = subprocess.run(
+        [sys.executable, "-m", "flywheel", "prompt", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "{braced}" in result.stdout
+
+
 def test_cli_help():
     result = subprocess.run(
         [sys.executable, "-m", "flywheel", "--help"],


### PR DESCRIPTION
## Summary
- avoid format crash when README contains braces by replacing placeholder
- document that flywheel prompt handles braces safely
- add regression test for brace handling

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `SKIP_E2E=1 npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f88bb3cb4832f88a07b19bd8d5a58