### PR TITLE
Recognize shields.io Codecov badges

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -74,7 +74,7 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | 0 | 0 | 2025-08-11 |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip.
-Coverage percentages are parsed from their badges where available. Codecov shows ✅ when a Codecov config or badge is present. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses.
+Coverage percentages are parsed from Codecov badges, including shields.io variants, where available. Codecov shows ✅ when a Codecov config or badge is present. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses.
 The Outages column notes whether the repository keeps a structured incident log under `/outages`.
 The commit column shows the short SHA of the latest default branch commit at crawl time. The Trunk column indicates whether CI is green for that commit. Dark Patterns and Bright Patterns list counts of suspicious or positive code snippets detected.
 Last-Updated (UTC) records the date of the commit used for each row.

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -535,7 +535,10 @@ class RepoCrawler:
         if not readme:
             return None
 
-        if not re.search(r"codecov.io/.+?/badge.svg", readme):
+        if not re.search(
+            r"codecov.io/.+?/badge.svg|img.shields.io/codecov",
+            readme,
+        ):
             return None
 
         pct = self._project_coverage_from_codecov(repo, branch)

--- a/tests/test_repocrawler.py
+++ b/tests/test_repocrawler.py
@@ -160,6 +160,22 @@ def test_parse_coverage_codecov():
     assert result == "95%"
 
 
+def test_parse_coverage_shields(monkeypatch):
+    crawler = rc.RepoCrawler([])
+    # fmt: off
+    readme = (
+        "![Coverage]("
+        "https://img.shields.io/codecov/c/github/foo/bar/main.svg"
+        ")"
+    )
+    # fmt: on
+    monkeypatch.setattr(
+        crawler, "_project_coverage_from_codecov", lambda repo, branch: "88%"
+    )
+    result = crawler._parse_coverage(readme, "foo/bar", "main")
+    assert result == "88%"
+
+
 def test_uses_codecov_from_readme():
     sess = DummySession({})
     crawler = rc.RepoCrawler([], session=sess)


### PR DESCRIPTION
## Summary
- parse Codecov coverage badges served via shields.io
- document coverage badge detection
- test coverage parsing on shields.io badges

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `SKIP_E2E=1 npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f88bb3cb4832f88a07b19bd8d5a58