### PR TITLE
fix: sort scanner report filenames case-insensitively

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ python -m flywheel.agents.scanner
 ```
 
 Reports are written to `reports/`. Each report lists only top-level non-hidden files and
-ignores directories. Existing paths under the scanner's work area are removed before
-each clone so reports reflect a fresh snapshot.
+ignores directories. File names are sorted case-insensitively. Existing paths under the
+scanner's work area are removed before each clone so reports reflect a fresh snapshot.
 
 ### Viewing the 3D flywheel
 

--- a/flywheel/agents/scanner.py
+++ b/flywheel/agents/scanner.py
@@ -37,7 +37,7 @@ def analyze_repo(path: Path) -> str:
     """Return a simple report listing top-level files.
 
     Only regular, non-hidden files in ``path`` are included. Directories and
-    symlinks are ignored.
+    symlinks are ignored. Filenames are sorted case-insensitively.
     """
 
     names = [
@@ -45,7 +45,7 @@ def analyze_repo(path: Path) -> str:
         for p in path.iterdir()
         if p.is_file() and not p.is_symlink() and not p.name.startswith(".")
     ]
-    files = sorted(names)
+    files = sorted(names, key=str.lower)
     report_lines = [
         f"# Report for {path.name}",
         "",

--- a/tests/test_scanner_case_sort.py
+++ b/tests/test_scanner_case_sort.py
@@ -1,0 +1,9 @@
+import flywheel.agents.scanner as scanner
+
+
+def test_analyze_repo_sorts_case_insensitive(tmp_path):
+    (tmp_path / "a.txt").write_text("hi")
+    (tmp_path / "B.txt").write_text("yo")
+    report = scanner.analyze_repo(tmp_path)
+    lines = [line for line in report.splitlines() if line.startswith("- ")]
+    assert lines == ["- a.txt", "- B.txt"]


### PR DESCRIPTION
## Summary
- ensure scanner report sorts filenames case-insensitively
- document sorting behavior and test coverage

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `SKIP_E2E=1 npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f88bb3cb4832f88a07b19bd8d5a58