### PR TITLE
fix: allow underscores in SCAD numeric values

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ All parts fit together.
 ```
 
 Lines may include inline ``//`` comments, negative values, decimals without a
-leading zero, trailing decimal points, and scientific notation; the checker
-ignores the comments when parsing.
+leading zero, trailing decimal points, scientific notation, and underscore digit
+separators; the checker ignores the comments when parsing.
 
 Below is a simplified view of how the pieces stack:
 

--- a/flywheel/fit.py
+++ b/flywheel/fit.py
@@ -8,7 +8,8 @@ import trimesh
 
 _DEF_RE = re.compile(
     r"^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*"
-    r"([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)\s*"
+    r"([-+]?(?:\d(?:_?\d)*(?:\.(?:\d(?:_?\d)*)?)?|\.\d(?:_?\d)*)"
+    r"(?:[eE][-+]?\d(?:_?\d)*)?)\s*"
     r";(?:\s*//.*)?$"
 )
 
@@ -22,8 +23,8 @@ def parse_scad_vars(path: str | Path) -> Dict[str, float]:
     Block comments ``/* ... */`` and inline ``//`` comments after the
     semicolon are ignored. The parser strips an initial UTF‑8 BOM and
     supports negative values, decimals without a leading zero, trailing
-    decimal points, scientific notation, and multiple assignments on the
-    same line.
+    decimal points, scientific notation, underscore digit separators, and
+    multiple assignments on the same line.
     """
     path = Path(path)
     text = path.read_text()
@@ -38,7 +39,8 @@ def parse_scad_vars(path: str | Path) -> Dict[str, float]:
                 continue
             m = _DEF_RE.match(part + ";")
             if m:
-                vars[m.group(1)] = float(m.group(2))
+                num = m.group(2).replace("_", "")
+                vars[m.group(1)] = float(num)
     return vars
 
 

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -51,6 +51,13 @@ def test_parse_scad_vars_trailing_decimal(tmp_path):
     assert vars == {"radius": 5.0}
 
 
+def test_parse_scad_vars_numeric_underscores(tmp_path):
+    scad = tmp_path / "part.scad"
+    scad.write_text("radius = 1_000.5;")
+    vars = ff.parse_scad_vars(scad)
+    assert vars == {"radius": 1000.5}
+
+
 def test_parse_scad_vars_multiple_per_line(tmp_path):
     scad = tmp_path / "part.scad"
     scad.write_text("radius=5;height=2;")


### PR DESCRIPTION
what: handle underscore separators in parse_scad_vars and docs
why: numbers like 1_000 are valid OpenSCAD syntax
how to test:
- pre-commit run --all-files
- pytest -q
- npm run lint
- SKIP_E2E=1 npm run test:ci
- python -m flywheel.fit
- SKIP_E2E=1 bash scripts/checks.sh


------
https://chatgpt.com/codex/tasks/task_e_689f88bb3cb4832f88a07b19bd8d5a58