### PR TITLE
docs: sync spellcheck prompt instructions

### DIFF
--- a/docs/prompts/codex/spellcheck.md
+++ b/docs/prompts/codex/spellcheck.md
@@ -24,7 +24,6 @@ CONTEXT:
   Ensure these commands succeed:
   - `pre-commit run --all-files`
   - `pytest -q`
-  - `npm run lint`
   - `npm run test:ci`
   - `python -m flywheel.fit`
   - `bash scripts/checks.sh`


### PR DESCRIPTION
## Summary
- remove outdated lint step from spellcheck prompt

## Testing
- `pre-commit run --all-files`
- `npm run lint`
- `pytest -q`
- `SKIP_E2E=1 npm run test:ci`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a00c6d4368832f808a46bd1d361e6e