### PR TITLE
🛠️ : – remove Playwright system dependencies

### DIFF
--- a/docs/pms/2025-08-16-playwright-apt-failure.md
+++ b/docs/pms/2025-08-16-playwright-apt-failure.md
@@ -1,0 +1,18 @@
+# Playwright Apt Failure
+
+- **Date**: 2025-08-16
+- **Author**: Codex
+- **Status**: resolved
+
+## What went wrong
+CI tests attempted to install system dependencies for Playwright using the `--with-deps` flag, leading to apt errors.
+
+## Root cause
+The Playwright install script fetched OS packages via apt, which occasionally failed in the GitHub Actions environment.
+
+## Impact
+JavaScript test jobs failed before executing tests, blocking merges.
+
+## Actions to take
+- Install only the Chromium browser without system dependencies.
+- Update checks and tests to prevent regression.

--- a/outages/2025-08-16-playwright-no-deps.json
+++ b/outages/2025-08-16-playwright-no-deps.json
@@ -1,0 +1,8 @@
+{
+  "id": "2025-08-16-playwright-no-deps",
+  "date": "2025-08-16",
+  "component": "tests/playwright",
+  "rootCause": "Playwright install step attempted to fetch system dependencies via --with-deps, causing apt failures in CI",
+  "resolution": "Install Chromium only without system dependencies and update tests",
+  "references": ["https://github.com/futuroptimist/flywheel/actions/runs/17004384104"]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "coverage": "npm run jest -- --coverage",
     "playwright": "playwright test",
-    "playwright:install": "playwright install --with-deps chromium",
+    "playwright:install": "playwright install chromium",
     "test": "npm run playwright:install && npm run jest -- && npm run playwright",
     "test:ci": "npm run playwright:install && npm run jest -- --coverage --coverageReporters=lcov && npm run playwright",
     "docs:dev": "npm --prefix docs-site run dev"

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -29,7 +29,7 @@ black --check . --exclude ".venv/|node_modules/"
 if [ -f package.json ]; then
   npm ci
   if [ -z "$SKIP_E2E" ]; then
-    npx playwright install --with-deps
+    npx playwright install chromium
     npm run lint
     npm run format:check
     npm run test:ci

--- a/tests/package-scripts.test.mjs
+++ b/tests/package-scripts.test.mjs
@@ -11,6 +11,6 @@ test('package.json defines test:ci script', () => {
 test('playwright:install only installs chromium', () => {
   const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url)));
   expect(pkg.scripts['playwright:install']).toBe(
-    'playwright install --with-deps chromium',
+    'playwright install chromium',
   );
 });


### PR DESCRIPTION
what: drop --with-deps flag from Playwright install and checks
why: CI run 17004384104 failed fetching apt deps for Chromium
how to test: pre-commit run --all-files && pytest -q && npm run test:ci && python -m flywheel.fit && SKIP_E2E=1 bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68a00c989554832fbdbb00dc69c366db