### PR TITLE
🔧: skip run-checks in summary workflow

### DIFF
--- a/.github/workflows/04-update-summary.yml
+++ b/.github/workflows/04-update-summary.yml
@@ -32,6 +32,8 @@ jobs:
         run: |
           python -m flywheel crawl --repos-file docs/repo_list.txt --output docs/repo-feature-summary.md
       - name: Run pre-commit
+        env:
+          SKIP: run-checks
         run: |
           pre-commit run --files docs/repo-feature-summary.md || true
           git add docs/repo-feature-summary.md

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@
 ## [2025-08-15] - Fix spellcheck noise in prompt summary
 - disable spellchecker on generated summary to keep docs workflow green
 
+## [2025-08-16] - Skip run-checks in repo summary workflow
+- prevent Update Repo Feature Summary job from running full project checks
+
 ## [2025-08-14] - Pin Python version in CI
 - lock workflows to Python 3.12 to avoid uv install failures
 

--- a/docs/pms/2025-08-16-update-summary-precommit.md
+++ b/docs/pms/2025-08-16-update-summary-precommit.md
@@ -1,0 +1,18 @@
+# Update summary pre-commit failure
+
+- Date: 2025-08-16
+- Author: Codex Bot
+- Status: resolved
+
+## What went wrong
+The Update Repo Feature Summary workflow failed during its pre-commit step.
+
+## Root cause
+The workflow ran the `run-checks` pre-commit hook, triggering full project checks that require tools not present in the minimal workflow environment.
+
+## Impact
+The summary regeneration job failed, leaving `docs/repo-feature-summary.md` outdated.
+
+## Actions to take
+- Skip heavy hooks in lightweight workflows using `SKIP=run-checks`.
+- Consider dedicated pre-commit configs for doc-only automation.

--- a/outages/2025-08-16-update-summary-precommit.json
+++ b/outages/2025-08-16-update-summary-precommit.json
@@ -1,0 +1,8 @@
+{
+  "id": "2025-08-16-update-summary-precommit",
+  "date": "2025-08-16",
+  "component": "ci/update-summary",
+  "rootCause": "pre-commit in Update Repo Feature Summary workflow ran full project checks via run-checks hook, failing in minimal environment",
+  "resolution": "Skip run-checks hook using SKIP=run-checks so only formatting hooks run",
+  "references": ["https://github.com/futuroptimist/flywheel/actions/runs/17001987429"]
+}

--- a/tests/update-summary-workflow.test.mjs
+++ b/tests/update-summary-workflow.test.mjs
@@ -1,0 +1,8 @@
+import { readFileSync } from 'node:fs';
+import { test, expect } from '@jest/globals';
+
+const workflow = readFileSync(new URL('../.github/workflows/04-update-summary.yml', import.meta.url), 'utf8');
+
+test('summary workflow skips run-checks hook', () => {
+  expect(workflow).toMatch(/SKIP: run-checks/);
+});


### PR DESCRIPTION
## Summary
- skip `run-checks` hook in Update Repo Feature Summary workflow
- document outage and add regression test

## Testing
- `RUN_SECURITY_ONLY=1 pre-commit run --all-files`
- `npm run test:ci`
- `pytest -q`
- `python -m flywheel.fit`
- `RUN_SECURITY_ONLY=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a00c989554832fbdbb00dc69c366db