### PR TITLE
🐛 fix: ensure scanner report ends with newline

### DIFF
--- a/flywheel/agents/scanner.py
+++ b/flywheel/agents/scanner.py
@@ -37,7 +37,9 @@ def analyze_repo(path: Path) -> str:
     """Return a simple report listing top-level files.
 
     Only regular, non-hidden files in ``path`` are included. Directories and
-    symlinks are ignored. Filenames are sorted case-insensitively.
+    symlinks are ignored. Filenames are sorted case-insensitively. The returned
+    Markdown string ends with a trailing newline so that writing it directly to
+    disk produces a POSIX-compliant file.
     """
 
     names = [
@@ -55,7 +57,7 @@ def analyze_repo(path: Path) -> str:
     report_lines.extend(f"- {name}" for name in files)
     report_lines.append("")
     report_lines.append("*(OpenAI analysis would go here)*")
-    return "\n".join(report_lines)
+    return "\n".join(report_lines) + "\n"
 
 
 def main() -> None:

--- a/tests/test_scanner_newline.py
+++ b/tests/test_scanner_newline.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from flywheel.agents.scanner import analyze_repo
+
+
+def test_analyze_repo_trailing_newline(tmp_path: Path) -> None:
+    """Report ends with newline and skips hidden files and directories."""
+    (tmp_path / "B.txt").write_text("b")
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / ".hidden").write_text("secret")
+    (tmp_path / "dir").mkdir()
+
+    report = analyze_repo(tmp_path)
+
+    assert report.endswith("\n")
+    lines = report.splitlines()
+    assert "- a.txt" in lines
+    assert "- B.txt" in lines
+    assert "- .hidden" not in lines
+    assert "- dir" not in lines


### PR DESCRIPTION
## What
- ensure `analyze_repo` appends trailing newline
- test that scanner skips hidden entries and adds newline

## Why
- reports were missing POSIX-compliant newline

## How to Test
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68a00c69f4f0832fb975ae476c33e8f3