### PR TITLE
📝 : clarify web viewer setup steps

### DIFF
--- a/docs/web-viewer.md
+++ b/docs/web-viewer.md
@@ -19,10 +19,12 @@ assimp export stl/stand.stl webapp/static/models/stand.obj
 
 ## Running Locally
 
+Ensure Node.js 20 or newer is installed. Then run:
+
 ```bash
 uv pip install -r requirements.txt
-npm install
-npx playwright install
+npm ci
+npx playwright install chromium
 python webapp/app.py
 ```
 


### PR DESCRIPTION
what: note Node.js 20+, npm ci, and chromium install for web viewer
why: align viewer docs with repo conventions for reproducible setup
how to test:
- pre-commit run --all-files
- pytest -q
- npm run test:ci
- python -m flywheel.fit
- SKIP_E2E=1 bash scripts/checks.sh


------
https://chatgpt.com/codex/tasks/task_e_68a00c69f4f0832fb975ae476c33e8f3