### PR TITLE
Allow custom tolerance in CAD fit check

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ A successful run prints:
 All parts fit together.
 ```
 
+Call ``verify_fit`` directly with a custom ``tol`` value to tighten or relax
+the default ``0.1`` mm tolerance.
+
 Lines may include inline ``//`` comments, negative values, decimals without a
 leading zero, trailing decimal points, scientific notation, and underscore digit
 separators; the checker ignores the comments when parsing.

--- a/flywheel/fit.py
+++ b/flywheel/fit.py
@@ -55,8 +55,16 @@ def _dims(stl_path: Path) -> Tuple[float, float, float]:
 def verify_fit(
     scad_dir: Path = Path("cad"),
     stl_dir: Path = Path("stl"),
+    tol: float = 0.1,
 ) -> bool:
-    """Check that CAD parameters align across parts and match exported STLs."""
+    """Check that CAD parameters align across parts and match exported STLs.
+
+    Args:
+        scad_dir: Directory containing the source ``.scad`` files.
+        stl_dir: Directory containing the exported ``.stl`` meshes.
+        tol: Maximum allowed deviation when comparing dimensions in
+            millimeters. Defaults to ``0.1``.
+    """
     adapter = parse_scad_vars(scad_dir / "adapter.scad")
     shaft = parse_scad_vars(scad_dir / "shaft.scad")
     wheel = parse_scad_vars(scad_dir / "flywheel.scad")
@@ -66,8 +74,6 @@ def verify_fit(
     assert shaft["shaft_diameter"] == adapter["shaft_diameter"]
     assert wheel["shaft_diameter"] >= shaft["shaft_diameter"]
     assert stand["bearing_outer_d"] > shaft["shaft_diameter"]
-
-    tol = 0.1
 
     shaft_dims = _dims(stl_dir / "shaft.stl")
     assert abs(shaft_dims[2] - shaft["shaft_length"]) < tol

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -2,6 +2,8 @@ import runpy
 import types
 from pathlib import Path
 
+import pytest
+
 import flywheel.fit as ff
 
 REPO = Path(__file__).resolve().parents[1]
@@ -81,6 +83,18 @@ def test_parse_scad_vars_handles_bom(tmp_path):
 
 def test_verify_fit(tmp_path, monkeypatch):
     assert ff.verify_fit(CAD_DIR, STL_DIR)
+
+
+def test_verify_fit_custom_tol(monkeypatch):
+    original = ff._dims
+
+    def bumped(path):
+        x, y, z = original(path)
+        return x + 0.01, y, z
+
+    monkeypatch.setattr(ff, "_dims", bumped)
+    with pytest.raises(AssertionError):
+        ff.verify_fit(CAD_DIR, STL_DIR, tol=0.001)
 
 
 def test_ensure_obj_models_mock(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- expose `tol` parameter in `verify_fit` to tune dimension comparisons
- add regression test and document new tolerance option

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `SKIP_E2E=1 npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a00c69f4f0832fb975ae476c33e8f3