### PR TITLE
feat: detect pipx installer in RepoCrawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ or skip end-to-end tests by prefixing commands with `SKIP_E2E=1`.
 - Fast Python installs powered by [uv](https://github.com/astral-sh/uv)
 - Example code and templates
 - Python CLI with subcommands `init`, `update`, `audit`, `prompt`, and `crawl` that prompts interactively unless `--yes` is used
-- RepoCrawler detects installers like uv, pip/pip3, and poetry in workflows
+- RepoCrawler detects installers like uv, pipx, pip/pip3, and poetry in workflows
 - [AGENTS.md](AGENTS.md) detailing included LLM assistants
 - [llms.txt](llms.txt) with quick context for AI helpers
 - [CLAUDE.md](CLAUDE.md) summarizing Anthropic guidance

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -55,6 +55,7 @@ class RepoCrawler:
 
     _UV = re.compile(r"setup-uv|uv venv", re.I)
     _PIP = re.compile(r"\bpip(?:3)?\s+install", re.I)
+    _PIPX = re.compile(r"\bpipx\s+install", re.I)
     _POETRY = re.compile(r"poetry\s+install", re.I)
     DARK_PATTERNS = [
         re.compile(r"onbeforeunload", re.I),
@@ -456,9 +457,15 @@ class RepoCrawler:
         return False
 
     def _detect_installer(self, text: str) -> str:
-        """Return installer hint based on workflow snippets."""
+        """Return installer hint based on workflow snippets.
+
+        Detects ``uv``, ``pipx``, ``pip`` and ``poetry`` keywords and returns
+        ``partial`` when no installer is found.
+        """
         if self._UV.search(text):
             return "uv"
+        if self._PIPX.search(text):
+            return "pipx"
         if self._PIP.search(text):
             return "pip"
         if self._POETRY.search(text):

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -172,6 +172,7 @@ def test_installer_additional():
     c = RepoCrawler([])
     assert c._detect_installer("setup-uv") == "uv"
     assert c._detect_installer("poetry install") == "poetry"
+    assert c._detect_installer("pipx install flywheel") == "pipx"
     assert c._detect_installer("echo nothing") == "partial"
 
 


### PR DESCRIPTION
## Summary
- detect `pipx install` in RepoCrawler
- document pipx support and add regression test

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `SKIP_E2E=1 npm run test:ci`
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a00c69f4f0832fb975ae476c33e8f3