### PR TITLE
Add SCAD non-finite postmortem

### DIFF
--- a/docs/pms/2025-08-16-scad-nonfinite.md
+++ b/docs/pms/2025-08-16-scad-nonfinite.md
@@ -1,0 +1,18 @@
+# SCAD parser accepted non-finite numbers
+
+- **Date**: 2025-08-16
+- **Author**: Codex
+- **Status**: resolved
+
+## What went wrong
+`parse_scad_vars` converted extremely large numeric literals to `inf` without error, allowing invalid geometry parameters.
+
+## Root cause
+Python's float conversion silently returns infinity for values beyond the double-precision range, and the parser lacked validation for finiteness.
+
+## Impact
+Non-finite parameters could propagate into fit checks, leading to misleading validations or resource exhaustion during model generation.
+
+## Actions to take
+- Validate parsed numbers with `math.isfinite` and raise `ValueError` on non-finite inputs.
+- Consider additional range checks for other CAD parameters.

--- a/flywheel/fit.py
+++ b/flywheel/fit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import re
 from pathlib import Path
 from typing import Dict, Tuple
@@ -40,7 +41,12 @@ def parse_scad_vars(path: str | Path) -> Dict[str, float]:
             m = _DEF_RE.match(part + ";")
             if m:
                 num = m.group(2).replace("_", "")
-                vars[m.group(1)] = float(num)
+                value = float(num)
+                if not math.isfinite(value):
+                    raise ValueError(
+                        f"Non-finite value for {m.group(1)}: {num}",
+                    )
+                vars[m.group(1)] = value
     return vars
 
 

--- a/outages/2025-08-16-scad-nonfinite.json
+++ b/outages/2025-08-16-scad-nonfinite.json
@@ -1,0 +1,8 @@
+{
+  "id": "scad-nonfinite",
+  "date": "2025-08-16",
+  "component": "parser",
+  "rootCause": "parse_scad_vars accepted non-finite numbers producing infinity",
+  "resolution": "validate numeric values and reject non-finite inputs",
+  "references": []
+}

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -2,6 +2,8 @@ import runpy
 import types
 from pathlib import Path
 
+import pytest
+
 import flywheel.fit as ff
 
 REPO = Path(__file__).resolve().parents[1]
@@ -56,6 +58,13 @@ def test_parse_scad_vars_numeric_underscores(tmp_path):
     scad.write_text("radius = 1_000.5;")
     vars = ff.parse_scad_vars(scad)
     assert vars == {"radius": 1000.5}
+
+
+def test_parse_scad_vars_rejects_non_finite(tmp_path):
+    scad = tmp_path / "part.scad"
+    scad.write_text("radius = 1e309;")
+    with pytest.raises(ValueError):
+        ff.parse_scad_vars(scad)
 
 
 def test_parse_scad_vars_multiple_per_line(tmp_path):


### PR DESCRIPTION
## Summary
- mirror incident report from flywheel

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a00c8d4e6c832f888f35eba318c8c6