### PR TITLE
🐛: refresh repo crawler cache

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -1,3 +1,4 @@
+<!-- spellchecker: disable -->
 # Prompt Docs Summary
 
 This index is auto-generated with

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -57,7 +57,7 @@ This table tracks which flywheel features each related repository has adopted.
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
 | [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
 | [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ✅ | 6 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ | ✅ | 5 | ✅ | ❌ | ❌ | ✅ | ❌ | 2025-08-11 |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ | ✅ | 5 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
 
 ## Dark & Bright Pattern Scan
 | Repo | Dark Patterns | Bright Patterns | Last-Updated (UTC) |

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -204,7 +204,7 @@ class RepoCrawler:
             cache_dir = Path(".cache")
             cache_dir.mkdir(exist_ok=True)
             self.session = requests_cache.CachedSession(
-                cache_dir / "github-cache"
+                cache_dir / "github-cache", expire_after=3600
             )  # noqa: E501
         else:  # pragma: no cover - requests_cache not installed
             self.session = requests.Session()

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -56,8 +56,9 @@ def test_default_branch_errors():
 
 def test_init_uses_requests_cache(tmp_path, monkeypatch):
     class FakeSession:
-        def __init__(self, path):
+        def __init__(self, path, expire_after):
             self.path = path
+            self.expire_after = expire_after
             self.headers = {}
 
     fake_rc = SimpleNamespace(CachedSession=FakeSession)
@@ -66,6 +67,7 @@ def test_init_uses_requests_cache(tmp_path, monkeypatch):
     crawler = RepoCrawler([])
     assert isinstance(crawler.session, FakeSession)
     assert crawler.session.path == Path(".cache") / "github-cache"
+    assert crawler.session.expire_after == 3600
 
 
 def test_latest_commit_error():


### PR DESCRIPTION
## Summary
- expire `RepoCrawler` cache hourly so new docs are detected
- mark sugarkube's Code of Conduct and Contributing guides as present
- add missing spellchecker header in prompt docs summary

## Testing
- `pre-commit run --all-files` *(fails: KeyboardInterrupt)*
- `npm run lint`
- `npm run test:ci`
- `pytest -q`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a264b2e6c0832f896cf75df2aa1066