### PR TITLE
📝 : schedule repo summary refresh

### DIFF
--- a/.github/workflows/04-update-summary.yml
+++ b/.github/workflows/04-update-summary.yml
@@ -1,10 +1,13 @@
 name: Update Repo Feature Summary
 on:
   push:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
 jobs:
   crawl:
     permissions:
-      contents: read
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -40,3 +43,11 @@ jobs:
           pre-commit run --files docs/repo-feature-summary.md
       - name: Publish summary
         run: cat docs/repo-feature-summary.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Commit summary
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add docs/repo-feature-summary.md
+          git commit -m "📝 : update repo feature summary" || exit 0
+          git push

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ flywheel crawl --repos-file docs/repo_list.txt --output docs/repo-feature-summar
 
 Append `@branch` to any repo to crawl a non-default branch, e.g. `owner/name@dev`. Lines in `docs/repo_list.txt` are combined with any repos passed on the command line.
 Pass `--token YOURTOKEN` or set `GITHUB_TOKEN` to avoid API rate limits.
-The `Update Repo Feature Summary` workflow commits `docs/repo-feature-summary.md` to `main` after each merge.
+The `Update Repo Feature Summary` workflow runs nightly and after each merge, committing `docs/repo-feature-summary.md` to `main` so the table stays fresh.
 The summary records the short SHA of the latest commit, the name of each repository's default branch, and whether the latest commit passed CI on that branch.
 
 ### Auditing dev tooling

--- a/docs/ci-guide.md
+++ b/docs/ci-guide.md
@@ -2,7 +2,7 @@
 
 The `crawl` workflow generates a Markdown summary of features across related repositories. Earlier versions attempted to commit that file back to the branch that triggered the run. Pull requests opened by bots like Dependabot use a read‑only `GITHUB_TOKEN`, so the push failed and the job ended with exit code 128.
 
-The workflow now commits `docs/repo-feature-summary.md` only when it runs on the `main` branch. Pull requests opened by bots like Dependabot simply skip that step so the job succeeds. After the PR is merged and a push hits `main`, the workflow updates and commits the summary automatically. You can still generate it locally if you need the file before merging.
+The workflow commits `docs/repo-feature-summary.md` only when it runs on the `main` branch. Pull requests opened by bots like Dependabot simply skip that step so the job succeeds. After the PR is merged, a nightly scheduled run updates and commits the summary automatically so it stays current. You can still generate it locally if you need the file before merging.
 
 ## How to update the summary locally
 1. Check out the branch you want to update.

--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -6,75 +6,60 @@ This table tracks which flywheel features each related repository has adopted.
 ## Basics
 | Repo | Branch | Commit | Trunk | Last-Updated (UTC) |
 | ---- | ------ | ------ | ----- | ----------------- |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `d29090f` | ✅ | 2025-08-11 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `d7a8f0b` | ✅ | 2025-08-11 |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `1b8d9a4` | ✅ | 2025-08-11 |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `b027810` | ✅ | 2025-08-11 |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `13cc241` | ✅ | 2025-08-11 |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `5e5f5f1` | ✅ | 2025-08-11 |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | `4b3762f` | ✅ | 2025-08-11 |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | `92361ce` | ✅ | 2025-08-11 |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | `95edb5b` | ✅ | 2025-08-11 |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | main | `219a6e3` | ✅ | 2025-08-11 |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | main | `2bf2608` | ✅ | 2025-08-18 |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | main | `7f1cc3c` | ✅ | 2025-08-16 |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | main | `a26c207` | ✅ | 2025-08-16 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | main | `699d02a` | ✅ | 2025-08-18 |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | main | `4de57cd` | ✅ | 2025-08-16 |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | v3 | `a6e01b3` | ✅ | 2025-08-18 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | main | `d019235` | ✅ | 2025-08-16 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | main | `a7fd055` | ✅ | 2025-08-16 |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | main | `e73708a` | ✅ | 2025-08-16 |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | main | `19b9053` | ✅ | 2025-08-17 |
 
 ## Coverage & Installer
 | Repo | Coverage | Patch | Codecov | Installer | Last-Updated (UTC) |
 | ---- | -------- | ----- | ------- | --------- | ----------------- |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ❌ | — | ✅ | 🚀 uv | 2025-08-11 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ❌ | — | ✅ | 🚀 uv | 2025-08-11 |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ❌ | — | ✅ | 🚀 uv | 2025-08-11 |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ❌ | — | ✅ | 🚀 uv | 2025-08-11 |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ❌ | — | ✅ | pip | 2025-08-11 |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✔️ | — | ✅ | 🔶 partial | 2025-08-11 |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | — | ❌ | 🚀 uv | 2025-08-11 |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✔️ | — | ✅ | 🚀 uv | 2025-08-11 |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ❌ | — | ✅ | pip | 2025-08-11 |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | 57% | — | ✅ | 🚀 uv | 2025-08-11 |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✔️ | — | ✅ | 🚀 uv | 2025-08-18 |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ❌ | — | ✅ | 🚀 uv | 2025-08-16 |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ❌ | — | ✅ | 🚀 uv | 2025-08-16 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✔️ | — | ✅ | 🚀 uv | 2025-08-18 |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | 99% | — | ✅ | pip | 2025-08-16 |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✔️ | — | ✅ | 🔶 partial | 2025-08-18 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✔️ | — | ✅ | 🚀 uv | 2025-08-16 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✔️ | — | ✅ | 🚀 uv | 2025-08-16 |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ❌ | — | ✅ | pip | 2025-08-16 |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | 57% | — | ✅ | 🚀 uv | 2025-08-17 |
 
-
-## Security & Dependency Health
-| Repo | Dependabot | Secret-Scanning | CodeQL | Snyk (badge) |
-| ---- | ---------- | --------------- | ------ | ------------ |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ | ❌ | ✅ | ❌ |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ | ❌ | ❌ | ❌ |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ | ❌ | ❌ | ❌ |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ❌ | ❌ | ❌ | ❌ |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ | ❌ | ✅ | ❌ |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ | ❌ | ❌ | ❌ |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ❌ | ❌ | ❌ | ❌ |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ❌ | ❌ | ❌ | ❌ |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ❌ | ❌ | ❌ |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ❌ | ❌ | ❌ | ❌ |
 ## Policies & Automation
-| Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Outages | Last-Updated (UTC) |
-| ---- | ------- | -- | --------- | --------- | --------------- | ------------ | ---------- | ------- | ----------------- |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ | ✅ | 16 | ✅ | ✅ | ✅ | ✅ | ✅ | 2025-08-11 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ | ✅ | 5 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ | ✅ | 5 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ | ✅ | 5 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ | ✅ | 8 | ✅ | ✅ | ✅ | ❌ | ✅ | 2025-08-11 |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ✅ | 6 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ | ✅ | 5 | ✅ | ✅ | ✅ | ✅ | ❌ | 2025-08-11 |
+| Repo | License | CI | Workflows | AGENTS.md | Code of Conduct | Contributing | Pre-commit | Last-Updated (UTC) |
+| ---- | ------- | -- | --------- | --------- | --------------- | ------------ | ---------- | ----------------- |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | ✅ | ✅ | 17 | ✅ | ✅ | ✅ | ✅ | 2025-08-18 |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | 2025-08-16 |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | ✅ | ✅ | 5 | ✅ | ✅ | ✅ | ✅ | 2025-08-16 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | ✅ | ✅ | 5 | ✅ | ✅ | ✅ | ✅ | 2025-08-18 |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | ✅ | ✅ | 6 | ✅ | ✅ | ✅ | ✅ | 2025-08-16 |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | ✅ | ✅ | 8 | ✅ | ✅ | ✅ | ✅ | 2025-08-18 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | 2025-08-16 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | ✅ | ✅ | 4 | ✅ | ✅ | ✅ | ✅ | 2025-08-16 |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | ✅ | ✅ | 6 | ✅ | ✅ | ✅ | ✅ | 2025-08-16 |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | ✅ | ✅ | 6 | ✅ | ✅ | ✅ | ✅ | 2025-08-17 |
 
 ## Dark & Bright Pattern Scan
 | Repo | Dark Patterns | Bright Patterns | Last-Updated (UTC) |
 | ---- | ------------- | --------------- | ----------------- |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | 0 | 0 | 2025-08-11 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel) | 0 | 1 | 2025-08-11 |
-| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | 0 | 8 | 2025-08-11 |
-| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | 0 | 0 | 2025-08-11 |
-| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | 0 | 1 | 2025-08-11 |
-| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | 0 | 0 | 2025-08-11 |
-| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | 0 | 0 | 2025-08-11 |
-| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | 0 | 0 | 2025-08-11 |
-| [futuroptimist/wove](https://github.com/futuroptimist/wove) | 0 | 0 | 2025-08-11 |
-| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | 0 | 0 | 2025-08-11 |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)** | 0 | 0 | 2025-08-18 |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel) | 0 | 1 | 2025-08-16 |
+| [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel) | 0 | 8 | 2025-08-16 |
+| [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | 0 | 0 | 2025-08-18 |
+| [futuroptimist/token.place](https://github.com/futuroptimist/token.place) | 0 | 1 | 2025-08-16 |
+| [democratizedspace/dspace](https://github.com/democratizedspace/dspace) | 0 | 0 | 2025-08-18 |
+| [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard) | 0 | 0 | 2025-08-16 |
+| [futuroptimist/sigma](https://github.com/futuroptimist/sigma) | 0 | 0 | 2025-08-16 |
+| [futuroptimist/wove](https://github.com/futuroptimist/wove) | 0 | 0 | 2025-08-16 |
+| [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube) | 0 | 0 | 2025-08-17 |
 
 Legend: ✅ indicates the repo has adopted that feature from flywheel. 🚀 uv means only uv was found. 🔶 partial signals a mix of uv and pip.
-Coverage percentages are parsed from Codecov badges, including shields.io variants, where available. Codecov shows ✅ when a Codecov config or badge is present. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses.
-The Outages column notes whether the repository keeps a structured incident log under `/outages`.
+Coverage percentages are parsed from their badges where available. Codecov shows ✅ when a Codecov config or badge is present. Patch shows ✅ when diff coverage is at least 90% and ❌ otherwise, with the percentage in parentheses.
 The commit column shows the short SHA of the latest default branch commit at crawl time. The Trunk column indicates whether CI is green for that commit. Dark Patterns and Bright Patterns list counts of suspicious or positive code snippets detected.
 Last-Updated (UTC) records the date of the commit used for each row.


### PR DESCRIPTION
what: run repo feature summary workflow nightly and commit results
why: avoid stale timestamps in docs/repo-feature-summary.md
how to test:
- pre-commit run --all-files
- pytest -q
- npm run test:ci
- python -m flywheel.fit
- bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68a2a0750dec832f99caf01775563ba2