### PR TITLE
fix: install Playwright deps for e2e tests

### DIFF
--- a/docs/pms/2025-08-20-playwright-deps.md
+++ b/docs/pms/2025-08-20-playwright-deps.md
@@ -1,0 +1,18 @@
+# Playwright deps missing
+
+- Date: 2025-08-20
+- Author: codex
+- Status: fixed
+
+## What went wrong
+Playwright tests failed to launch Chromium during CI runs.
+
+## Root cause
+Required system libraries were not installed before executing Playwright.
+
+## Impact
+End-to-end test suite exited with errors, blocking merges.
+
+## Actions to take
+- Ensure `npm run playwright:install` installs system dependencies in CI.
+- Monitor future runs for missing library errors.

--- a/outages/2025-08-20-playwright-deps.json
+++ b/outages/2025-08-20-playwright-deps.json
@@ -1,0 +1,8 @@
+{
+  "id": "2025-08-20-playwright-deps",
+  "date": "2025-08-20",
+  "component": "tests/playwright",
+  "rootCause": "Playwright tests ran without required system dependencies, causing browser launch failures",
+  "resolution": "Install Playwright system dependencies before running end-to-end tests",
+  "references": ["https://github.com/futuroptimist/flywheel/actions/runs/17072058088"]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "coverage": "npm run jest -- --coverage",
     "playwright": "playwright test",
-    "playwright:install": "playwright install chromium",
+    "playwright:install": "playwright install-deps chromium && playwright install chromium",
     "test": "npm run playwright:install && npm run jest -- && npm run playwright",
     "test:ci": "npm run playwright:install && npm run jest -- --coverage --coverageReporters=lcov && npm run playwright",
     "docs:dev": "npm --prefix docs-site run dev"

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -29,7 +29,7 @@ black --check . --exclude ".venv/|node_modules/"
 if [ -f package.json ]; then
   npm ci
   if [ -z "$SKIP_E2E" ]; then
-    npx playwright install chromium
+    npm run playwright:install
     npm run lint
     npm run format:check
     npm run test:ci

--- a/tests/package-scripts.test.mjs
+++ b/tests/package-scripts.test.mjs
@@ -8,9 +8,9 @@ test('package.json defines test:ci script', () => {
   expect(pkg.scripts['test:ci']).toBeDefined();
 });
 
-test('playwright:install only installs chromium', () => {
+test('playwright:install installs browser and deps', () => {
   const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url)));
   expect(pkg.scripts['playwright:install']).toBe(
-    'playwright install chromium',
+    'playwright install-deps chromium && playwright install chromium',
   );
 });


### PR DESCRIPTION
## Summary
- ensure Playwright installs system dependencies
- run checks via shared helper to use new install step
- document and record outage for missing deps

## Testing
- `pre-commit run --all-files`
- `npm run test:ci`
- `pytest -q`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a57b8e8d18832f85efd1597b09c7c1