### PR TITLE
Taper spool core sleeve from 63 mm to 64 mm

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ or skip end-to-end tests by prefixing commands with `SKIP_E2E=1`.
 - Web viewer instructions in `docs/web-viewer.md`
 - CI troubleshooting tips in `docs/ci-guide.md`
 - Nightly STL exports are committed back to `stl/` after each run
-- Sunlu spool core sleeve adapter [STL](stl/spool_core_sleeve/sunlu55_to63_len60.stl)
+- Sunlu spool core sleeve adapter (63→64 mm) [STL](./stl/spool_core_sleeve/sunlu55_to63_len60.stl)
 - Flywheel construction guide in `docs/flywheel-construction.md` with CAD files in `cad/`
   including `stand.scad`, `shaft.scad`, and `adapter.scad`. Assembly details live in `docs/flywheel-stand.md`, clamp instructions in `docs/flywheel-adapter.md`, and physics in `docs/flywheel-physics.md`
 

--- a/cad/README.md
+++ b/cad/README.md
@@ -22,10 +22,11 @@ sudo apt-get install openscad
   (override `$fs` via the `resolution_fs` variable for finer meshes)
 - `utils/spool_core_sleeve.scad` – parametric spool core sleeve library
   (see `examples/spool_core_sleeve_example.scad`; a pre-generated
-  `sunlu55_to63_len60` sleeve lives in `stl/spool_core_sleeve/`)
+  `sunlu55_to63_len60` 63→64 mm tapered sleeve lives in
+  `stl/spool_core_sleeve/`)
 - `examples/spool_core_sleeve_example.scad` – demo spool core sleeve; the
   corresponding OBJ lives in `webapp/static/models/examples/` and the
-  pre-generated sleeve's OBJ is at
+  pre-generated 63→64 mm sleeve's OBJ is at
   `webapp/static/models/spool_core_sleeve/sunlu55_to63_len60.obj`
 
 ## Regenerating meshes

--- a/cad/examples/spool_core_sleeve_example.scad
+++ b/cad/examples/spool_core_sleeve_example.scad
@@ -2,7 +2,8 @@
 // This example file lets you render the sleeve from the CLI:
 //
 //   openscad -o out.stl \
-//     -D INNER_ID=55 -D TARGET_OD=63 -D LENGTH=60 -D CLEARANCE=0.20 \
+//     -D INNER_ID=55 -D TARGET_OD=63 -D TARGET_OD_END=64 \
+//     -D LENGTH=60 -D CLEARANCE=0.20 \
 //     cad/examples/spool_core_sleeve_example.scad
 //
 // or to use a named preset:
@@ -14,19 +15,21 @@
 use <../utils/spool_core_sleeve.scad>;
 
 // Defaults (overridable via -D)
-INNER_ID  = is_undef(INNER_ID)  ? 55   : INNER_ID;
-TARGET_OD = is_undef(TARGET_OD) ? 63   : TARGET_OD;
-LENGTH    = is_undef(LENGTH)    ? 60   : LENGTH;
-CLEARANCE = is_undef(CLEARANCE) ? 0.20 : CLEARANCE;
+INNER_ID       = is_undef(INNER_ID)       ? 55   : INNER_ID;
+TARGET_OD      = is_undef(TARGET_OD)      ? 63   : TARGET_OD;
+TARGET_OD_END  = is_undef(TARGET_OD_END)  ? TARGET_OD : TARGET_OD_END;
+LENGTH         = is_undef(LENGTH)         ? 60   : LENGTH;
+CLEARANCE      = is_undef(CLEARANCE)      ? 0.20 : CLEARANCE;
 
 // If PRESET is provided, it takes precedence
 if (!is_undef(PRESET)) {
     spool_core_sleeve_preset(PRESET);
 } else {
     spool_core_sleeve(
-        inner_id = INNER_ID,
-        target_od = TARGET_OD,
-        length = LENGTH,
-        clearance = CLEARANCE
+        inner_id      = INNER_ID,
+        target_od     = TARGET_OD,
+        target_od_end = TARGET_OD_END,
+        length        = LENGTH,
+        clearance     = CLEARANCE
     );
 }

--- a/cad/utils/spool_core_sleeve.scad
+++ b/cad/utils/spool_core_sleeve.scad
@@ -4,12 +4,14 @@
 //  Library module for parametric spool-core sleeves.
 //  Example usage:
 //      use <../utils/spool_core_sleeve.scad>;
-//      spool_core_sleeve(inner_id=55, target_od=63, length=60, clearance=0.20);
+//      spool_core_sleeve(inner_id=55, target_od=63, target_od_end=64,
+//                        length=60, clearance=0.20);
 //
 //  Parameters:
 //    inner_id   — measured bore ID (mm), e.g. 55 (≈AMS axle)
-//    target_od  — outer diameter of sleeve (mm), e.g. 63 (Sunlu spool)
-//    length     — axial length (mm), e.g. 60
+//    target_od      — outer diameter at z=0 (mm), e.g. 63 (Sunlu spool)
+//    target_od_end  — outer diameter at z=length (mm); defaults to target_od
+//    length         — axial length (mm), e.g. 60
 //    clearance  — extra diameter added to bore (total), default 0.20
 //    $fn_outer  — circle resolution for outer cylinder
 //    $fn_inner  — circle resolution for inner bore
@@ -21,26 +23,32 @@
 */
 
 module spool_core_sleeve(
-    inner_id   = 55,
-    target_od  = 63,
-    length     = 60,
-    clearance  = 0.20,
-    $fn_outer  = 200,
-    $fn_inner  = 150
+    inner_id      = 55,
+    target_od     = 63,
+    target_od_end = undef,
+    length        = 60,
+    clearance     = 0.20,
+    $fn_outer     = 200,
+    $fn_inner     = 150
 ) {
+    target_od_end = is_undef(target_od_end) ? target_od : target_od_end;
+
     // Basic parameter validation
     assert(
-        target_od > inner_id + 2 * clearance,
-        str("invalid dims: target_od (", target_od, ") must exceed inner_id + "
-            , "2*clearance (", inner_id + 2 * clearance, ")")
+        min(target_od, target_od_end) > inner_id + 2 * clearance,
+        str("invalid dims: outer diameters (", target_od, ", ", target_od_end,
+            ") must exceed inner_id + 2*clearance (",
+            inner_id + 2 * clearance, ")")
     );
 
-    wall_mm = (target_od - inner_id) / 2;
-    echo(str("Radial wall thickness: ", wall_mm, " mm"));
+    wall_start = (target_od - inner_id) / 2;
+    wall_end   = (target_od_end - inner_id) / 2;
+    echo(str("Radial wall thickness: ", wall_start, " mm -> ",
+             wall_end, " mm"));
 
     difference() {
-        // OUTER
-        cylinder(d = target_od, h = length, $fn = $fn_outer);
+        // OUTER – linearly interpolate between diameters
+        cylinder(d1 = target_od, d2 = target_od_end, h = length, $fn = $fn_outer);
         // BORE — extended ±1mm to avoid z-fusing
         translate([0, 0, -1])
             cylinder(
@@ -51,7 +59,7 @@ module spool_core_sleeve(
 
 // Optional named presets (extend as you collect measurements)
 function _spool_core_sleeve_preset(preset) =
-    (preset == "sunlu55_to63_len60") ? [55, 63, 60, 0.20] : undef;
+    (preset == "sunlu55_to63_len60") ? [55, 63, 64, 60, 0.20] : undef;
 
 module spool_core_sleeve_preset(
     preset = "sunlu55_to63_len60", $fn_outer = 200, $fn_inner = 150
@@ -59,12 +67,13 @@ module spool_core_sleeve_preset(
     p = _spool_core_sleeve_preset(preset);
     assert(p != undef, str("unknown preset: ", preset));
     spool_core_sleeve(
-        inner_id = p[0],
-        target_od = p[1],
-        length = p[2],
-        clearance = p[3],
-        $fn_outer = $fn_outer,
-        $fn_inner = $fn_inner
+        inner_id      = p[0],
+        target_od     = p[1],
+        target_od_end = p[2],
+        length        = p[3],
+        clearance     = p[4],
+        $fn_outer     = $fn_outer,
+        $fn_inner     = $fn_inner
     );
 }
 

--- a/docs/spool-core-sleeve.md
+++ b/docs/spool-core-sleeve.md
@@ -1,8 +1,9 @@
 # Core‑Sleeve Spool Adapter (OpenSCAD utility module)
 
 A tiny, reusable OpenSCAD module for adapting filament spools: it slides into the
-spool’s bore (`inner_id`) and expands the wall to a desired outer diameter (`target_od`),
-over the full spool width (`length`). It echoes computed wall thickness so CI can
+spool’s bore (`inner_id`) and expands the wall to desired outer diameters
+(`target_od` → `target_od_end`) over the full spool width (`length`). It echoes
+computed wall thickness so CI can
 sanity‑check builds.
 
 ## Quick start
@@ -11,7 +12,8 @@ sanity‑check builds.
 use "../utils/spool_core_sleeve.scad";
 
 // direct parameters
-spool_core_sleeve(inner_id=55, target_od=63, length=60, clearance=0.20);
+spool_core_sleeve(inner_id=55, target_od=63, target_od_end=64,
+                  length=60, clearance=0.20);
 
 // or via named preset
 spool_core_sleeve_preset("sunlu55_to63_len60");
@@ -21,10 +23,11 @@ spool_core_sleeve_preset("sunlu55_to63_len60");
 
 | Name        | Type | Default | Notes                               |
 |-------------|------|---------|-------------------------------------|
-| `inner_id`  | mm   | 55      | Measured bore (ID) of the spool     |
-| `target_od` | mm   | 63      | Desired sleeve outer diameter (OD)  |
-| `length`    | mm   | 60      | Axial length (match spool width)    |
-| `clearance` | mm   | 0.20    | Added to diameter of bore (total)   |
+| `inner_id`      | mm   | 55      | Measured bore (ID) of the spool     |
+| `target_od`     | mm   | 63      | Sleeve OD at z=0                    |
+| `target_od_end` | mm   | 63      | Sleeve OD at z=length               |
+| `length`        | mm   | 60      | Axial length (match spool width)    |
+| `clearance`     | mm   | 0.20    | Added to diameter of bore (total)   |
 | `$fn_outer` | —    | 200     | Facets for outer cylinder           |
 | `$fn_inner` | —    | 150     | Facets for inner bore               |
 
@@ -37,7 +40,8 @@ Example (Linux/macOS):
 
 ```bash
 openscad -o stl/spool_core_sleeve/sunlu55_to63_len60.stl \
-  -D INNER_ID=55 -D TARGET_OD=63 -D LENGTH=60 -D CLEARANCE=0.20 \
+  -D INNER_ID=55 -D TARGET_OD=63 -D TARGET_OD_END=64 \
+  -D LENGTH=60 -D CLEARANCE=0.20 \
   cad/examples/spool_core_sleeve_example.scad
 ```
 

--- a/scripts/openscad_render_spool_core_sleeve.sh
+++ b/scripts/openscad_render_spool_core_sleeve.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 # Render a spool sleeve STL from parameters or a named PRESET.
 # Usage examples:
-#   scripts/openscad_render_spool_core_sleeve.sh 55 63 60 0.20
+#   scripts/openscad_render_spool_core_sleeve.sh 55 63 64 60 0.20
+#   scripts/openscad_render_spool_core_sleeve.sh 55 63 60 0.20  # end defaults to 63
 #   PRESET=sunlu55_to63_len60 scripts/openscad_render_spool_core_sleeve.sh
 # Outputs to stl/spool_core_sleeve/<name>.stl and logs echo to a .log file.
 
@@ -20,17 +21,25 @@ if [[ "${PRESET:-}" != "" ]]; then
     DEFINE=(-D "PRESET=\"${PRESET}\"")
 else
     if [[ $# -lt 4 ]]; then
-        echo "Usage: $0 INNER_ID TARGET_OD LENGTH CLEARANCE"
+        echo "Usage: $0 INNER_ID TARGET_OD [TARGET_OD_END] LENGTH CLEARANCE"
         echo " or: PRESET=name $0"
         exit 2
     fi
     INNER_ID="$1"
     TARGET_OD="$2"
-    LENGTH="$3"
-    CLEARANCE="$4"
-    NAME="id${INNER_ID}_od${TARGET_OD}_len${LENGTH}_clr${CLEARANCE}"
+    if [[ $# -ge 5 ]]; then
+        TARGET_OD_END="$3"
+        LENGTH="$4"
+        CLEARANCE="$5"
+    else
+        TARGET_OD_END="$2"
+        LENGTH="$3"
+        CLEARANCE="$4"
+    fi
+    NAME="id${INNER_ID}_od${TARGET_OD}to${TARGET_OD_END}_len${LENGTH}_clr${CLEARANCE}"
     DEFINE=(-D "INNER_ID=${INNER_ID}" -D "TARGET_OD=${TARGET_OD}" \
-        -D "LENGTH=${LENGTH}" -D "CLEARANCE=${CLEARANCE}")
+        -D "TARGET_OD_END=${TARGET_OD_END}" -D "LENGTH=${LENGTH}" \
+        -D "CLEARANCE=${CLEARANCE}")
 fi
 
 OUT_STL="${OUT_DIR}/${NAME}.stl"

--- a/stl/spool_core_sleeve/sunlu55_to63_len60.stl
+++ b/stl/spool_core_sleeve/sunlu55_to63_len60.stl
@@ -1,2410 +1,5252 @@
 solid OpenSCAD_Model
-  facet normal 0.998886 0.0471925 0
+  facet normal 0.999843 0.015663 -0.00833202
     outer loop
-      vertex 31.4845 0.989438 60
-      vertex 31.4378 1.9779 0
-      vertex 31.4378 1.9779 60
-    endloop
-  endfacet
-  facet normal 0.998886 0.0471925 0
-    outer loop
-      vertex 31.4378 1.9779 0
-      vertex 31.4845 0.989438 60
-      vertex 31.4845 0.989438 0
-    endloop
-  endfacet
-  facet normal 0.999877 0.0156635 0
-    outer loop
-      vertex 31.5 0 60
-      vertex 31.4845 0.989438 0
-      vertex 31.4845 0.989438 60
-    endloop
-  endfacet
-  facet normal 0.999877 0.0156635 0
-    outer loop
-      vertex 31.4845 0.989438 0
-      vertex 31.5 0 60
       vertex 31.5 0 0
+      vertex 31.4845 0.989438 0
+      vertex 32 0 60
     endloop
   endfacet
-  facet normal 0.99692 0.0784189 0
+  facet normal 0.935443 0.35338 -0.00833085
     outer loop
-      vertex 31.4378 1.9779 60
-      vertex 31.3602 2.96441 0
-      vertex 31.3602 2.96441 60
+      vertex 29.6377 10.6702 0
+      vertex 29.288 11.5959 0
+      vertex 29.7528 11.78 60
     endloop
   endfacet
-  facet normal 0.99692 0.0784189 0
+  facet normal 0.382657 0.923853 -0.00833035
     outer loop
-      vertex 31.3602 2.96441 0
-      vertex 31.4378 1.9779 60
-      vertex 31.4378 1.9779 0
-    endloop
-  endfacet
-  facet normal -0.979237 0.202719 0
-    outer loop
-      vertex -30.942 5.90251 0
-      vertex -30.7414 6.87151 60
-      vertex -30.7414 6.87151 0
-    endloop
-  endfacet
-  facet normal -0.979237 0.202719 0
-    outer loop
-      vertex -30.7414 6.87151 60
-      vertex -30.942 5.90251 0
-      vertex -30.942 5.90251 60
-    endloop
-  endfacet
-  facet normal -0.140872 -0.990028 0
-    outer loop
-      vertex -4.92768 -31.1122 0
-      vertex -3.948 -31.2516 60
-      vertex -4.92768 -31.1122 60
-    endloop
-  endfacet
-  facet normal -0.140872 -0.990028 -0
-    outer loop
-      vertex -3.948 -31.2516 60
-      vertex -4.92768 -31.1122 0
-      vertex -3.948 -31.2516 0
-    endloop
-  endfacet
-  facet normal 0.38267 0.923885 -0
-    outer loop
-      vertex 12.5102 28.9093 0
-      vertex 11.5959 29.288 60
-      vertex 12.5102 28.9093 60
-    endloop
-  endfacet
-  facet normal 0.38267 0.923885 0
-    outer loop
-      vertex 11.5959 29.288 60
       vertex 12.5102 28.9093 0
       vertex 11.5959 29.288 0
+      vertex 12.7087 29.3681 60
     endloop
   endfacet
-  facet normal 0.0784189 -0.99692 0
+  facet normal 0.467895 -0.883745 -0.00833201
     outer loop
-      vertex 1.9779 -31.4378 0
-      vertex 2.96441 -31.3602 60
-      vertex 1.9779 -31.4378 60
+      vertex 14.5277 -28.5122 60
+      vertex 14.3007 -28.0667 0
+      vertex 15.1752 -27.6037 0
     endloop
   endfacet
-  facet normal 0.0784189 -0.99692 0
+  facet normal 0.780395 0.625231 -0.00833116
     outer loop
-      vertex 2.96441 -31.3602 60
-      vertex 1.9779 -31.4378 0
-      vertex 2.96441 -31.3602 0
+      vertex 25.285 19.613 60
+      vertex 24.2712 20.0789 0
+      vertex 24.6564 20.3976 60
     endloop
   endfacet
-  facet normal -0.99692 -0.0784189 0
+  facet normal 0.760409 0.649391 -0.00833117
     outer loop
-      vertex -31.3602 -2.96441 0
-      vertex -31.4378 -1.9779 60
-      vertex -31.4378 -1.9779 0
+      vertex 24.2712 20.0789 0
+      vertex 24.0036 21.162 60
+      vertex 24.6564 20.3976 60
     endloop
   endfacet
-  facet normal -0.99692 -0.0784189 0
+  facet normal 0.946059 0.323888 -0.00833312
     outer loop
-      vertex -31.4378 -1.9779 60
-      vertex -31.3602 -2.96441 0
-      vertex -31.3602 -2.96441 60
+      vertex 30.4338 9.88854 60
+      vertex 29.6377 10.6702 0
+      vertex 30.1082 10.8396 60
     endloop
   endfacet
-  facet normal 0.99396 0.109745 0
+  facet normal -0.718086 0.695904 -0.00833251
     outer loop
-      vertex 31.3602 2.96441 60
-      vertex 31.2516 3.948 0
-      vertex 31.2516 3.948 60
-    endloop
-  endfacet
-  facet normal 0.99396 0.109745 0
-    outer loop
-      vertex 31.2516 3.948 0
-      vertex 31.3602 2.96441 60
-      vertex 31.3602 2.96441 0
-    endloop
-  endfacet
-  facet normal 0.835809 -0.549021 0
-    outer loop
-      vertex 26.053 -17.7056 60
-      vertex 26.5963 -16.8785 0
-      vertex 26.5963 -16.8785 60
-    endloop
-  endfacet
-  facet normal 0.835809 -0.549021 0
-    outer loop
-      vertex 26.5963 -16.8785 0
-      vertex 26.053 -17.7056 60
-      vertex 26.053 -17.7056 0
-    endloop
-  endfacet
-  facet normal -0.263855 0.964562 0
-    outer loop
-      vertex -7.83373 30.5104 0
-      vertex -8.78822 30.2493 60
-      vertex -7.83373 30.5104 60
-    endloop
-  endfacet
-  facet normal -0.263855 0.964562 0
-    outer loop
-      vertex -8.78822 30.2493 60
-      vertex -7.83373 30.5104 0
-      vertex -8.78822 30.2493 0
-    endloop
-  endfacet
-  facet normal -0.73962 0.673025 0
-    outer loop
-      vertex -23.6285 20.8313 0
-      vertex -22.9625 21.5632 60
       vertex -22.9625 21.5632 0
+      vertex -23.327 21.9055 60
+      vertex -22.6274 22.6274 60
     endloop
   endfacet
-  facet normal -0.73962 0.673025 0
+  facet normal 0.92384 0.382687 -0.0083309
     outer loop
-      vertex -22.9625 21.5632 60
-      vertex -23.6285 20.8313 0
-      vertex -23.6285 20.8313 60
+      vertex 29.7528 11.78 60
+      vertex 29.288 11.5959 0
+      vertex 29.3681 12.7087 60
     endloop
   endfacet
-  facet normal -0.411533 0.911395 0
+  facet normal -0.411434 0.911402 -0.00833034
     outer loop
       vertex -12.5102 28.9093 0
-      vertex -13.412 28.5021 60
-      vertex -12.5102 28.9093 60
+      vertex -13.6249 28.9545 60
+      vertex -12.7087 29.3681 60
     endloop
   endfacet
-  facet normal -0.411533 0.911395 0
+  facet normal 0.739594 -0.673001 -0.00833251
     outer loop
-      vertex -13.412 28.5021 60
-      vertex -12.5102 28.9093 0
-      vertex -13.412 28.5021 0
-    endloop
-  endfacet
-  facet normal 0.549021 0.835809 -0
-    outer loop
-      vertex 17.7056 26.053 0
-      vertex 16.8785 26.5963 60
-      vertex 17.7056 26.053 60
-    endloop
-  endfacet
-  facet normal 0.549021 0.835809 0
-    outer loop
-      vertex 16.8785 26.5963 60
-      vertex 17.7056 26.053 0
-      vertex 16.8785 26.5963 0
-    endloop
-  endfacet
-  facet normal -0.522557 0.852604 0
-    outer loop
-      vertex -16.0348 27.1134 0
-      vertex -16.8785 26.5963 60
-      vertex -16.0348 27.1134 60
-    endloop
-  endfacet
-  facet normal -0.522557 0.852604 0
-    outer loop
-      vertex -16.8785 26.5963 60
-      vertex -16.0348 27.1134 0
-      vertex -16.8785 26.5963 0
-    endloop
-  endfacet
-  facet normal -0.964562 -0.263855 0
-    outer loop
-      vertex -30.2493 -8.78822 0
-      vertex -30.5104 -7.83373 60
-      vertex -30.5104 -7.83373 0
-    endloop
-  endfacet
-  facet normal -0.964562 -0.263855 0
-    outer loop
-      vertex -30.5104 -7.83373 60
-      vertex -30.2493 -8.78822 0
-      vertex -30.2493 -8.78822 60
-    endloop
-  endfacet
-  facet normal 0.73962 -0.673025 0
-    outer loop
-      vertex 22.9625 -21.5632 60
-      vertex 23.6285 -20.8313 0
-      vertex 23.6285 -20.8313 60
-    endloop
-  endfacet
-  facet normal 0.73962 -0.673025 0
-    outer loop
-      vertex 23.6285 -20.8313 0
-      vertex 22.9625 -21.5632 60
+      vertex 23.327 -21.9055 60
       vertex 22.9625 -21.5632 0
-    endloop
-  endfacet
-  facet normal -0.0784189 0.99692 0
-    outer loop
-      vertex -1.9779 31.4378 0
-      vertex -2.96441 31.3602 60
-      vertex -1.9779 31.4378 60
-    endloop
-  endfacet
-  facet normal -0.0784189 0.99692 0
-    outer loop
-      vertex -2.96441 31.3602 60
-      vertex -1.9779 31.4378 0
-      vertex -2.96441 31.3602 0
-    endloop
-  endfacet
-  facet normal 0.99692 -0.0784189 0
-    outer loop
-      vertex 31.3602 -2.96441 60
-      vertex 31.4378 -1.9779 0
-      vertex 31.4378 -1.9779 60
-    endloop
-  endfacet
-  facet normal 0.99692 -0.0784189 0
-    outer loop
-      vertex 31.4378 -1.9779 0
-      vertex 31.3602 -2.96441 60
-      vertex 31.3602 -2.96441 0
-    endloop
-  endfacet
-  facet normal 0.946061 0.323987 0
-    outer loop
-      vertex 29.9583 9.73403 60
-      vertex 29.6377 10.6702 0
-      vertex 29.6377 10.6702 60
-    endloop
-  endfacet
-  facet normal 0.946061 0.323987 0
-    outer loop
-      vertex 29.6377 10.6702 0
-      vertex 29.9583 9.73403 60
-      vertex 29.9583 9.73403 0
-    endloop
-  endfacet
-  facet normal -0.883776 0.467911 0
-    outer loop
-      vertex -28.0667 14.3007 0
-      vertex -27.6037 15.1752 60
-      vertex -27.6037 15.1752 0
-    endloop
-  endfacet
-  facet normal -0.883776 0.467911 0
-    outer loop
-      vertex -27.6037 15.1752 60
-      vertex -28.0667 14.3007 0
-      vertex -28.0667 14.3007 60
-    endloop
-  endfacet
-  facet normal -0.760361 -0.6495 0
-    outer loop
-      vertex -23.6285 -20.8313 0
-      vertex -24.2712 -20.0789 60
-      vertex -24.2712 -20.0789 0
-    endloop
-  endfacet
-  facet normal -0.760361 -0.6495 0
-    outer loop
-      vertex -24.2712 -20.0789 60
-      vertex -23.6285 -20.8313 0
-      vertex -23.6285 -20.8313 60
-    endloop
-  endfacet
-  facet normal 0.868635 0.495453 0
-    outer loop
-      vertex 27.6037 15.1752 60
-      vertex 27.1134 16.0348 0
-      vertex 27.1134 16.0348 60
-    endloop
-  endfacet
-  facet normal 0.868635 0.495453 0
-    outer loop
-      vertex 27.1134 16.0348 0
-      vertex 27.6037 15.1752 60
-      vertex 27.6037 15.1752 0
-    endloop
-  endfacet
-  facet normal -0.38267 0.923885 0
-    outer loop
-      vertex -11.5959 29.288 0
-      vertex -12.5102 28.9093 60
-      vertex -11.5959 29.288 60
-    endloop
-  endfacet
-  facet normal -0.38267 0.923885 0
-    outer loop
-      vertex -12.5102 28.9093 60
-      vertex -11.5959 29.288 0
-      vertex -12.5102 28.9093 0
-    endloop
-  endfacet
-  facet normal -0.549021 0.835809 0
-    outer loop
-      vertex -16.8785 26.5963 0
-      vertex -17.7056 26.053 60
-      vertex -16.8785 26.5963 60
-    endloop
-  endfacet
-  facet normal -0.549021 0.835809 0
-    outer loop
-      vertex -17.7056 26.053 60
-      vertex -16.8785 26.5963 0
-      vertex -17.7056 26.053 0
-    endloop
-  endfacet
-  facet normal 0.780445 0.625225 0
-    outer loop
-      vertex 24.8899 19.3066 60
-      vertex 24.2712 20.0789 0
-      vertex 24.2712 20.0789 60
-    endloop
-  endfacet
-  facet normal 0.780445 0.625225 0
-    outer loop
-      vertex 24.2712 20.0789 0
-      vertex 24.8899 19.3066 60
-      vertex 24.8899 19.3066 0
-    endloop
-  endfacet
-  facet normal 0.625225 0.780445 -0
-    outer loop
-      vertex 20.0789 24.2712 0
-      vertex 19.3066 24.8899 60
-      vertex 20.0789 24.2712 60
-    endloop
-  endfacet
-  facet normal 0.625225 0.780445 0
-    outer loop
-      vertex 19.3066 24.8899 60
-      vertex 20.0789 24.2712 0
-      vertex 19.3066 24.8899 0
-    endloop
-  endfacet
-  facet normal 0.955784 0.294069 0
-    outer loop
-      vertex 30.2493 8.78822 60
-      vertex 29.9583 9.73403 0
-      vertex 29.9583 9.73403 60
-    endloop
-  endfacet
-  facet normal 0.955784 0.294069 0
-    outer loop
-      vertex 29.9583 9.73403 0
-      vertex 30.2493 8.78822 60
-      vertex 30.2493 8.78822 0
-    endloop
-  endfacet
-  facet normal -0.263855 -0.964562 0
-    outer loop
-      vertex -8.78822 -30.2493 0
-      vertex -7.83373 -30.5104 60
-      vertex -8.78822 -30.2493 60
-    endloop
-  endfacet
-  facet normal -0.263855 -0.964562 -0
-    outer loop
-      vertex -7.83373 -30.5104 60
-      vertex -8.78822 -30.2493 0
-      vertex -7.83373 -30.5104 0
-    endloop
-  endfacet
-  facet normal 0.985098 0.171993 0
-    outer loop
-      vertex 31.1122 4.92768 60
-      vertex 30.942 5.90251 0
-      vertex 30.942 5.90251 60
-    endloop
-  endfacet
-  facet normal 0.985098 0.171993 0
-    outer loop
-      vertex 30.942 5.90251 0
-      vertex 31.1122 4.92768 60
-      vertex 31.1122 4.92768 0
-    endloop
-  endfacet
-  facet normal -0.323987 -0.946061 0
-    outer loop
-      vertex -10.6702 -29.6377 0
-      vertex -9.73403 -29.9583 60
-      vertex -10.6702 -29.6377 60
-    endloop
-  endfacet
-  facet normal -0.323987 -0.946061 -0
-    outer loop
-      vertex -9.73403 -29.9583 60
-      vertex -10.6702 -29.6377 0
-      vertex -9.73403 -29.9583 0
-    endloop
-  endfacet
-  facet normal 0.294069 0.955784 -0
-    outer loop
-      vertex 9.73403 29.9583 0
-      vertex 8.78822 30.2493 60
-      vertex 9.73403 29.9583 60
-    endloop
-  endfacet
-  facet normal 0.294069 0.955784 0
-    outer loop
-      vertex 8.78822 30.2493 60
-      vertex 9.73403 29.9583 0
-      vertex 8.78822 30.2493 0
-    endloop
-  endfacet
-  facet normal -0.868635 -0.495453 0
-    outer loop
-      vertex -27.1134 -16.0348 0
-      vertex -27.6037 -15.1752 60
-      vertex -27.6037 -15.1752 0
-    endloop
-  endfacet
-  facet normal -0.868635 -0.495453 0
-    outer loop
-      vertex -27.6037 -15.1752 60
-      vertex -27.1134 -16.0348 0
-      vertex -27.1134 -16.0348 60
-    endloop
-  endfacet
-  facet normal 0.760361 -0.6495 0
-    outer loop
-      vertex 23.6285 -20.8313 60
-      vertex 24.2712 -20.0789 0
-      vertex 24.2712 -20.0789 60
-    endloop
-  endfacet
-  facet normal 0.760361 -0.6495 0
-    outer loop
-      vertex 24.2712 -20.0789 0
-      vertex 23.6285 -20.8313 60
       vertex 23.6285 -20.8313 0
     endloop
   endfacet
-  facet normal 0.202719 -0.979237 0
+  facet normal -0.382687 0.92384 -0.0083309
     outer loop
-      vertex 5.90251 -30.942 0
-      vertex 6.87151 -30.7414 60
-      vertex 5.90251 -30.942 60
+      vertex -11.5959 29.288 0
+      vertex -12.7087 29.3681 60
+      vertex -11.78 29.7528 60
     endloop
   endfacet
-  facet normal 0.202719 -0.979237 0
+  facet normal 0.294042 -0.955756 -0.00833157
     outer loop
-      vertex 6.87151 -30.7414 60
-      vertex 5.90251 -30.942 0
-      vertex 6.87151 -30.7414 0
+      vertex 9.88854 -30.4338 60
+      vertex 8.92772 -30.7294 60
+      vertex 9.73403 -29.9583 0
     endloop
   endfacet
-  facet normal -0.575008 -0.818148 0
+  facet normal -0.998858 0.0470502 -0.00833345
     outer loop
-      vertex -18.5152 -25.484 0
-      vertex -17.7056 -26.053 60
-      vertex -18.5152 -25.484 60
+      vertex -31.4378 1.9779 0
+      vertex -31.9842 1.00514 60
+      vertex -31.9369 2.0093 60
     endloop
   endfacet
-  facet normal -0.575008 -0.818148 -0
+  facet normal -0.97918 0.202823 -0.00833106
     outer loop
-      vertex -17.7056 -26.053 60
-      vertex -18.5152 -25.484 0
-      vertex -17.7056 -26.053 0
+      vertex -30.7414 6.87151 0
+      vertex -31.4332 5.9962 60
+      vertex -31.2293 6.98058 60
     endloop
   endfacet
-  facet normal 0.979237 -0.202719 0
+  facet normal -0.979203 -0.202712 -0.00833294
     outer loop
-      vertex 30.7414 -6.87151 60
-      vertex 30.942 -5.90251 0
-      vertex 30.942 -5.90251 60
+      vertex -30.7414 -6.87151 0
+      vertex -31.4332 -5.9962 60
+      vertex -30.942 -5.90251 0
     endloop
   endfacet
-  facet normal 0.979237 -0.202719 0
-    outer loop
-      vertex 30.942 -5.90251 0
-      vertex 30.7414 -6.87151 60
-      vertex 30.7414 -6.87151 0
-    endloop
-  endfacet
-  facet normal -0.695852 0.718185 0
-    outer loop
-      vertex -21.5632 22.9625 0
-      vertex -22.2739 22.2739 60
-      vertex -21.5632 22.9625 60
-    endloop
-  endfacet
-  facet normal -0.695852 0.718185 0
-    outer loop
-      vertex -22.2739 22.2739 60
-      vertex -21.5632 22.9625 0
-      vertex -22.2739 22.2739 0
-    endloop
-  endfacet
-  facet normal -0.998886 0.0471925 0
+  facet normal -0.998851 0.0471908 -0.00833112
     outer loop
       vertex -31.4845 0.989438 0
-      vertex -31.4378 1.9779 60
+      vertex -31.9842 1.00514 60
       vertex -31.4378 1.9779 0
     endloop
   endfacet
-  facet normal -0.998886 0.0471925 0
+  facet normal 0.964529 -0.263846 -0.00833128
     outer loop
-      vertex -31.4378 1.9779 60
-      vertex -31.4845 0.989438 0
-      vertex -31.4845 0.989438 60
+      vertex 30.7294 -8.92772 60
+      vertex 30.2493 -8.78822 0
+      vertex 30.5104 -7.83373 0
     endloop
   endfacet
-  facet normal -0.818148 0.575008 0
+  facet normal 0.549002 -0.83578 -0.00833338
     outer loop
-      vertex -26.053 17.7056 0
-      vertex -25.484 18.5152 60
+      vertex 17.9867 -26.4666 60
+      vertex 16.8785 -26.5963 0
+      vertex 17.7056 -26.053 0
+    endloop
+  endfacet
+  facet normal 0.140951 0.989981 -0.0083313
+    outer loop
+      vertex 4.92768 31.1122 0
+      vertex 4.01066 31.7477 60
+      vertex 5.0059 31.606 60
+    endloop
+  endfacet
+  facet normal -0.81812 0.574988 -0.00833197
+    outer loop
       vertex -25.484 18.5152 0
-    endloop
-  endfacet
-  facet normal -0.818148 0.575008 0
-    outer loop
-      vertex -25.484 18.5152 60
       vertex -26.053 17.7056 0
-      vertex -26.053 17.7056 60
+      vertex -25.8885 18.8091 60
     endloop
   endfacet
-  facet normal -0.0156635 0.999877 0
+  facet normal 0.522413 0.852652 -0.00833084
     outer loop
-      vertex 0 31.5 0
-      vertex -0.989438 31.4845 60
-      vertex 0 31.5 60
+      vertex 17.1465 27.0185 60
+      vertex 16.0348 27.1134 0
+      vertex 16.2893 27.5437 60
     endloop
   endfacet
-  facet normal -0.0156635 0.999877 0
+  facet normal 0.294059 0.955751 -0.00833129
     outer loop
-      vertex -0.989438 31.4845 60
+      vertex 9.73403 29.9583 0
+      vertex 8.78822 30.2493 0
+      vertex 8.92772 30.7294 60
+    endloop
+  endfacet
+  facet normal -0.955756 -0.294042 -0.00833157
+    outer loop
+      vertex -30.4338 -9.88854 60
+      vertex -30.7294 -8.92772 60
+      vertex -29.9583 -9.73403 0
+    endloop
+  endfacet
+  facet normal 0.323976 0.946029 -0.00833157
+    outer loop
+      vertex 10.6702 29.6377 0
+      vertex 9.73403 29.9583 0
+      vertex 9.88854 30.4338 60
+    endloop
+  endfacet
+  facet normal 0.015663 0.999843 -0.00833202
+    outer loop
+      vertex 0.989438 31.4845 0
       vertex 0 31.5 0
+      vertex 0 32 60
+    endloop
+  endfacet
+  facet normal 0.353508 0.935394 -0.00833312
+    outer loop
+      vertex 11.78 29.7528 60
+      vertex 10.6702 29.6377 0
+      vertex 10.8396 30.1082 60
+    endloop
+  endfacet
+  facet normal -0.202712 -0.979203 -0.00833294
+    outer loop
+      vertex -5.9962 -31.4332 60
+      vertex -6.87151 -30.7414 0
+      vertex -5.90251 -30.942 0
+    endloop
+  endfacet
+  facet normal -0.575057 0.818071 -0.00833338
+    outer loop
+      vertex -17.7056 26.053 0
+      vertex -18.8091 25.8885 60
+      vertex -17.9867 26.4666 60
+    endloop
+  endfacet
+  facet normal -0.439949 0.897984 -0.00833201
+    outer loop
+      vertex -14.3007 28.0667 0
+      vertex -14.5277 28.5122 60
+      vertex -13.412 28.5021 0
+    endloop
+  endfacet
+  facet normal 0.739572 -0.673026 -0.00833305
+    outer loop
+      vertex 24.0036 -21.162 60
+      vertex 23.327 -21.9055 60
+      vertex 23.6285 -20.8313 0
+    endloop
+  endfacet
+  facet normal 0.760409 -0.649391 -0.00833117
+    outer loop
+      vertex 24.6564 -20.3976 60
+      vertex 24.0036 -21.162 60
+      vertex 24.2712 -20.0789 0
+    endloop
+  endfacet
+  facet normal -0.852652 0.522413 -0.00833084
+    outer loop
+      vertex -27.1134 16.0348 0
+      vertex -27.5437 16.2893 60
+      vertex -27.0185 17.1465 60
+    endloop
+  endfacet
+  facet normal -0.998858 -0.0470502 -0.00833345
+    outer loop
+      vertex -31.9369 -2.0093 60
+      vertex -31.9842 -1.00514 60
+      vertex -31.4378 -1.9779 0
+    endloop
+  endfacet
+  facet normal -0.897984 -0.439949 -0.00833201
+    outer loop
+      vertex -28.0667 -14.3007 0
+      vertex -28.5122 -14.5277 60
+      vertex -28.5021 -13.412 0
+    endloop
+  endfacet
+  facet normal 0.780418 0.625203 -0.00833175
+    outer loop
+      vertex 24.8899 19.3066 0
+      vertex 24.2712 20.0789 0
+      vertex 25.285 19.613 60
+    endloop
+  endfacet
+  facet normal 0.883728 0.467926 -0.00833141
+    outer loop
+      vertex 28.5122 14.5277 60
+      vertex 27.6037 15.1752 0
+      vertex 28.0418 15.4161 60
+    endloop
+  endfacet
+  facet normal 0.294042 0.955756 -0.00833157
+    outer loop
+      vertex 9.73403 29.9583 0
+      vertex 8.92772 30.7294 60
+      vertex 9.88854 30.4338 60
+    endloop
+  endfacet
+  facet normal -0.0784162 0.996886 -0.00833233
+    outer loop
+      vertex -2.96441 31.3602 0
+      vertex -3.01147 31.858 60
+      vertex -1.9779 31.4378 0
+    endloop
+  endfacet
+  facet normal 0.171889 -0.985081 -0.00833294
+    outer loop
+      vertex 5.9962 -31.4332 60
+      vertex 5.0059 -31.606 60
+      vertex 5.90251 -30.942 0
+    endloop
+  endfacet
+  facet normal -0.548998 -0.835782 -0.00833331
+    outer loop
+      vertex -17.1465 -27.0185 60
+      vertex -17.9867 -26.4666 60
+      vertex -16.8785 -26.5963 0
+    endloop
+  endfacet
+  facet normal -0.382657 0.923853 -0.00833035
+    outer loop
+      vertex -12.5102 28.9093 0
+      vertex -12.7087 29.3681 60
+      vertex -11.5959 29.288 0
+    endloop
+  endfacet
+  facet normal -0.739594 0.673001 -0.00833251
+    outer loop
+      vertex -22.9625 21.5632 0
+      vertex -23.6285 20.8313 0
+      vertex -23.327 21.9055 60
+    endloop
+  endfacet
+  facet normal -0.868586 -0.495468 -0.00833082
+    outer loop
+      vertex -27.5437 -16.2893 60
+      vertex -28.0418 -15.4161 60
+      vertex -27.1134 -16.0348 0
+    endloop
+  endfacet
+  facet normal -0.923853 -0.382657 -0.00833035
+    outer loop
+      vertex -28.9093 -12.5102 0
+      vertex -29.3681 -12.7087 60
+      vertex -29.288 -11.5959 0
+    endloop
+  endfacet
+  facet normal 0.015663 -0.999843 -0.00833202
+    outer loop
+      vertex 0.989438 -31.4845 0
+      vertex 0 -32 60
+      vertex 0 -31.5 0
+    endloop
+  endfacet
+  facet normal -0.695904 -0.718086 -0.00833251
+    outer loop
+      vertex -21.9055 -23.327 60
+      vertex -22.6274 -22.6274 60
+      vertex -21.5632 -22.9625 0
+    endloop
+  endfacet
+  facet normal -0.799705 -0.600335 -0.00833177
+    outer loop
+      vertex -25.285 -19.613 60
+      vertex -25.484 -18.5152 0
+      vertex -24.8899 -19.3066 0
+    endloop
+  endfacet
+  facet normal 0.818071 0.575057 -0.00833338
+    outer loop
+      vertex 26.053 17.7056 0
+      vertex 25.8885 18.8091 60
+      vertex 26.4666 17.9867 60
+    endloop
+  endfacet
+  facet normal 0.835782 0.548998 -0.00833331
+    outer loop
+      vertex 26.5963 16.8785 0
+      vertex 26.4666 17.9867 60
+      vertex 27.0185 17.1465 60
+    endloop
+  endfacet
+  facet normal -0.140951 -0.989981 -0.0083313
+    outer loop
+      vertex -4.01066 -31.7477 60
+      vertex -5.0059 -31.606 60
+      vertex -4.92768 -31.1122 0
+    endloop
+  endfacet
+  facet normal 0.897984 0.439949 -0.00833201
+    outer loop
+      vertex 28.5021 13.412 0
+      vertex 28.0667 14.3007 0
+      vertex 28.5122 14.5277 60
+    endloop
+  endfacet
+  facet normal 0.0470502 -0.998858 -0.00833345
+    outer loop
+      vertex 2.0093 -31.9369 60
+      vertex 1.00514 -31.9842 60
+      vertex 1.9779 -31.4378 0
+    endloop
+  endfacet
+  facet normal -0.495468 -0.868586 -0.00833082
+    outer loop
+      vertex -15.4161 -28.0418 60
+      vertex -16.2893 -27.5437 60
+      vertex -16.0348 -27.1134 0
+    endloop
+  endfacet
+  facet normal 0.0157167 -0.999842 -0.00833113
+    outer loop
+      vertex 1.00514 -31.9842 60
+      vertex 0 -32 60
+      vertex 0.989438 -31.4845 0
+    endloop
+  endfacet
+  facet normal 0.868586 0.495468 -0.00833082
+    outer loop
+      vertex 28.0418 15.4161 60
+      vertex 27.1134 16.0348 0
+      vertex 27.5437 16.2893 60
+    endloop
+  endfacet
+  facet normal 0.97918 0.202823 -0.00833106
+    outer loop
+      vertex 31.4332 5.9962 60
+      vertex 30.7414 6.87151 0
+      vertex 31.2293 6.98058 60
+    endloop
+  endfacet
+  facet normal 0.989981 -0.140951 -0.0083313
+    outer loop
+      vertex 31.606 -5.0059 60
+      vertex 31.1122 -4.92768 0
+      vertex 31.7477 -4.01066 60
+    endloop
+  endfacet
+  facet normal 0.202823 -0.97918 -0.00833106
+    outer loop
+      vertex 6.98058 -31.2293 60
+      vertex 5.9962 -31.4332 60
+      vertex 6.87151 -30.7414 0
+    endloop
+  endfacet
+  facet normal 0.439942 0.897987 -0.00833189
+    outer loop
+      vertex 14.5277 28.5122 60
+      vertex 13.412 28.5021 0
+      vertex 13.6249 28.9545 60
+    endloop
+  endfacet
+  facet normal -0.522413 0.852652 -0.00833084
+    outer loop
+      vertex -16.0348 27.1134 0
+      vertex -17.1465 27.0185 60
+      vertex -16.2893 27.5437 60
+    endloop
+  endfacet
+  facet normal 0.964515 0.263898 -0.00833217
+    outer loop
+      vertex 30.9947 7.95808 60
+      vertex 30.5104 7.83373 0
+      vertex 30.7294 8.92772 60
+    endloop
+  endfacet
+  facet normal 0.71816 0.695828 -0.00833075
+    outer loop
+      vertex 22.9625 21.5632 0
+      vertex 22.2739 22.2739 0
+      vertex 22.6274 22.6274 60
+    endloop
+  endfacet
+  facet normal -0.955756 0.294042 -0.00833157
+    outer loop
+      vertex -29.9583 9.73403 0
+      vertex -30.7294 8.92772 60
+      vertex -30.4338 9.88854 60
+    endloop
+  endfacet
+  facet normal -0.673001 0.739594 -0.00833251
+    outer loop
+      vertex -21.5632 22.9625 0
+      vertex -21.9055 23.327 60
+      vertex -20.8313 23.6285 0
+    endloop
+  endfacet
+  facet normal 0.140868 0.989993 -0.00833271
+    outer loop
+      vertex 4.92768 31.1122 0
+      vertex 3.948 31.2516 0
+      vertex 4.01066 31.7477 60
+    endloop
+  endfacet
+  facet normal 0.202823 0.97918 -0.00833106
+    outer loop
+      vertex 6.87151 30.7414 0
+      vertex 5.9962 31.4332 60
+      vertex 6.98058 31.2293 60
+    endloop
+  endfacet
+  facet normal 0.911402 0.411434 -0.00833034
+    outer loop
+      vertex 29.3681 12.7087 60
+      vertex 28.9093 12.5102 0
+      vertex 28.9545 13.6249 60
+    endloop
+  endfacet
+  facet normal 0.575057 0.818071 -0.00833338
+    outer loop
+      vertex 18.8091 25.8885 60
+      vertex 17.7056 26.053 0
+      vertex 17.9867 26.4666 60
+    endloop
+  endfacet
+  facet normal 0.985081 0.171889 -0.00833294
+    outer loop
+      vertex 31.606 5.0059 60
+      vertex 30.942 5.90251 0
+      vertex 31.4332 5.9962 60
+    endloop
+  endfacet
+  facet normal -0.548998 0.835782 -0.00833331
+    outer loop
+      vertex -16.8785 26.5963 0
+      vertex -17.9867 26.4666 60
+      vertex -17.1465 27.0185 60
+    endloop
+  endfacet
+  facet normal 0.955751 -0.294059 -0.00833129
+    outer loop
+      vertex 30.7294 -8.92772 60
+      vertex 29.9583 -9.73403 0
+      vertex 30.2493 -8.78822 0
+    endloop
+  endfacet
+  facet normal 0.233365 0.972354 -0.00833216
+    outer loop
+      vertex 7.83373 30.5104 0
+      vertex 6.98058 31.2293 60
+      vertex 7.95808 30.9947 60
+    endloop
+  endfacet
+  facet normal 0.35338 0.935443 -0.00833085
+    outer loop
+      vertex 11.5959 29.288 0
+      vertex 10.6702 29.6377 0
+      vertex 11.78 29.7528 60
+    endloop
+  endfacet
+  facet normal -0.323888 0.946059 -0.00833312
+    outer loop
+      vertex -10.6702 29.6377 0
+      vertex -10.8396 30.1082 60
+      vertex -9.88854 30.4338 60
+    endloop
+  endfacet
+  facet normal -0.985064 0.171987 -0.00833129
+    outer loop
+      vertex -31.1122 4.92768 0
+      vertex -31.606 5.0059 60
+      vertex -30.942 5.90251 0
+    endloop
+  endfacet
+  facet normal 0.998858 -0.0470502 -0.00833345
+    outer loop
+      vertex 31.9369 -2.0093 60
+      vertex 31.4378 -1.9779 0
+      vertex 31.9842 -1.00514 60
+    endloop
+  endfacet
+  facet normal -0.911363 0.411518 -0.00833188
+    outer loop
+      vertex -28.9093 12.5102 0
+      vertex -28.9545 13.6249 60
+      vertex -28.5021 13.412 0
+    endloop
+  endfacet
+  facet normal 0.92384 -0.382687 -0.0083309
+    outer loop
+      vertex 29.3681 -12.7087 60
+      vertex 29.288 -11.5959 0
+      vertex 29.7528 -11.78 60
+    endloop
+  endfacet
+  facet normal -0.495436 0.868604 -0.00833144
+    outer loop
+      vertex -15.1752 27.6037 0
+      vertex -16.0348 27.1134 0
+      vertex -15.4161 28.0418 60
+    endloop
+  endfacet
+  facet normal 0.83578 0.549002 -0.00833338
+    outer loop
+      vertex 26.5963 16.8785 0
+      vertex 26.053 17.7056 0
+      vertex 26.4666 17.9867 60
+    endloop
+  endfacet
+  facet normal 0.739572 0.673026 -0.00833305
+    outer loop
+      vertex 23.6285 20.8313 0
+      vertex 23.327 21.9055 60
+      vertex 24.0036 21.162 60
+    endloop
+  endfacet
+  facet normal -0.81812 -0.574988 -0.00833197
+    outer loop
+      vertex -25.8885 -18.8091 60
+      vertex -26.053 -17.7056 0
+      vertex -25.484 -18.5152 0
+    endloop
+  endfacet
+  facet normal -0.0471908 0.998851 -0.00833112
+    outer loop
       vertex -0.989438 31.4845 0
+      vertex -1.9779 31.4378 0
+      vertex -1.00514 31.9842 60
     endloop
   endfacet
-  facet normal 0.353393 -0.935475 0
+  facet normal -0.993925 0.109741 -0.00833271
     outer loop
-      vertex 10.6702 -29.6377 0
-      vertex 11.5959 -29.288 60
-      vertex 10.6702 -29.6377 60
+      vertex -31.3602 2.96441 0
+      vertex -31.7477 4.01066 60
+      vertex -31.2516 3.948 0
     endloop
   endfacet
-  facet normal 0.353393 -0.935475 0
+  facet normal 0.0471908 -0.998851 -0.00833112
     outer loop
-      vertex 11.5959 -29.288 60
+      vertex 1.00514 -31.9842 60
+      vertex 0.989438 -31.4845 0
+      vertex 1.9779 -31.4378 0
+    endloop
+  endfacet
+  facet normal -0.411518 0.911363 -0.00833188
+    outer loop
+      vertex -13.412 28.5021 0
+      vertex -13.6249 28.9545 60
+      vertex -12.5102 28.9093 0
+    endloop
+  endfacet
+  facet normal 0.35338 -0.935443 -0.00833085
+    outer loop
+      vertex 11.78 -29.7528 60
       vertex 10.6702 -29.6377 0
       vertex 11.5959 -29.288 0
     endloop
   endfacet
-  facet normal -0.985098 -0.171993 0
+  facet normal -0.972354 0.233365 -0.00833216
     outer loop
-      vertex -30.942 -5.90251 0
-      vertex -31.1122 -4.92768 60
-      vertex -31.1122 -4.92768 0
+      vertex -30.5104 7.83373 0
+      vertex -31.2293 6.98058 60
+      vertex -30.9947 7.95808 60
     endloop
   endfacet
-  facet normal -0.985098 -0.171993 0
+  facet normal 0.673026 0.739572 -0.00833305
     outer loop
-      vertex -31.1122 -4.92768 60
-      vertex -30.942 -5.90251 0
-      vertex -30.942 -5.90251 60
+      vertex 21.9055 23.327 60
+      vertex 20.8313 23.6285 0
+      vertex 21.162 24.0036 60
     endloop
   endfacet
-  facet normal 0.0471925 -0.998886 0
+  facet normal 0.946059 -0.323888 -0.00833312
     outer loop
-      vertex 0.989438 -31.4845 0
-      vertex 1.9779 -31.4378 60
-      vertex 0.989438 -31.4845 60
+      vertex 30.1082 -10.8396 60
+      vertex 29.6377 -10.6702 0
+      vertex 30.4338 -9.88854 60
     endloop
   endfacet
-  facet normal 0.0471925 -0.998886 0
+  facet normal -0.883728 -0.467926 -0.00833141
     outer loop
-      vertex 1.9779 -31.4378 60
-      vertex 0.989438 -31.4845 0
-      vertex 1.9779 -31.4378 0
+      vertex -28.0418 -15.4161 60
+      vertex -28.5122 -14.5277 60
+      vertex -27.6037 -15.1752 0
     endloop
   endfacet
-  facet normal -0.353393 0.935475 0
+  facet normal -0.0784836 0.996881 -0.00833346
     outer loop
-      vertex -10.6702 29.6377 0
-      vertex -11.5959 29.288 60
-      vertex -10.6702 29.6377 60
+      vertex -1.9779 31.4378 0
+      vertex -3.01147 31.858 60
+      vertex -2.0093 31.9369 60
     endloop
   endfacet
-  facet normal -0.353393 0.935475 0
+  facet normal 0.883745 0.467895 -0.00833201
     outer loop
-      vertex -11.5959 29.288 60
-      vertex -10.6702 29.6377 0
-      vertex -11.5959 29.288 0
+      vertex 28.0667 14.3007 0
+      vertex 27.6037 15.1752 0
+      vertex 28.5122 14.5277 60
     endloop
   endfacet
-  facet normal -0.6495 0.760361 0
+  facet normal 0.171987 -0.985064 -0.00833129
     outer loop
-      vertex -20.0789 24.2712 0
-      vertex -20.8313 23.6285 60
-      vertex -20.0789 24.2712 60
-    endloop
-  endfacet
-  facet normal -0.6495 0.760361 0
-    outer loop
-      vertex -20.8313 23.6285 60
-      vertex -20.0789 24.2712 0
-      vertex -20.8313 23.6285 0
-    endloop
-  endfacet
-  facet normal 0.171993 -0.985098 0
-    outer loop
-      vertex 4.92768 -31.1122 0
-      vertex 5.90251 -30.942 60
-      vertex 4.92768 -31.1122 60
-    endloop
-  endfacet
-  facet normal 0.171993 -0.985098 0
-    outer loop
-      vertex 5.90251 -30.942 60
+      vertex 5.0059 -31.606 60
       vertex 4.92768 -31.1122 0
       vertex 5.90251 -30.942 0
     endloop
   endfacet
-  facet normal 0.140872 0.990028 -0
+  facet normal -0.263846 -0.964529 -0.00833128
     outer loop
-      vertex 4.92768 31.1122 0
-      vertex 3.948 31.2516 60
-      vertex 4.92768 31.1122 60
+      vertex -7.83373 -30.5104 0
+      vertex -8.92772 -30.7294 60
+      vertex -8.78822 -30.2493 0
     endloop
   endfacet
-  facet normal 0.140872 0.990028 0
+  facet normal 0.979203 0.202712 -0.00833294
     outer loop
-      vertex 3.948 31.2516 60
-      vertex 4.92768 31.1122 0
-      vertex 3.948 31.2516 0
+      vertex 30.942 5.90251 0
+      vertex 30.7414 6.87151 0
+      vertex 31.4332 5.9962 60
     endloop
   endfacet
-  facet normal 0.852604 -0.522557 0
+  facet normal 0.575057 -0.818071 -0.00833338
     outer loop
-      vertex 26.5963 -16.8785 60
-      vertex 27.1134 -16.0348 0
-      vertex 27.1134 -16.0348 60
-    endloop
-  endfacet
-  facet normal 0.852604 -0.522557 0
-    outer loop
-      vertex 27.1134 -16.0348 0
-      vertex 26.5963 -16.8785 60
-      vertex 26.5963 -16.8785 0
-    endloop
-  endfacet
-  facet normal 0.467911 0.883776 -0
-    outer loop
-      vertex 15.1752 27.6037 0
-      vertex 14.3007 28.0667 60
-      vertex 15.1752 27.6037 60
-    endloop
-  endfacet
-  facet normal 0.467911 0.883776 0
-    outer loop
-      vertex 14.3007 28.0667 60
-      vertex 15.1752 27.6037 0
-      vertex 14.3007 28.0667 0
-    endloop
-  endfacet
-  facet normal 0.935475 0.353393 0
-    outer loop
-      vertex 29.6377 10.6702 60
-      vertex 29.288 11.5959 0
-      vertex 29.288 11.5959 60
-    endloop
-  endfacet
-  facet normal 0.935475 0.353393 0
-    outer loop
-      vertex 29.288 11.5959 0
-      vertex 29.6377 10.6702 60
-      vertex 29.6377 10.6702 0
-    endloop
-  endfacet
-  facet normal 0.549021 -0.835809 0
-    outer loop
-      vertex 16.8785 -26.5963 0
-      vertex 17.7056 -26.053 60
-      vertex 16.8785 -26.5963 60
-    endloop
-  endfacet
-  facet normal 0.549021 -0.835809 0
-    outer loop
-      vertex 17.7056 -26.053 60
-      vertex 16.8785 -26.5963 0
+      vertex 17.9867 -26.4666 60
       vertex 17.7056 -26.053 0
+      vertex 18.8091 -25.8885 60
     endloop
   endfacet
-  facet normal 0.955784 -0.294069 0
+  facet normal -0.97918 -0.202823 -0.00833106
     outer loop
-      vertex 29.9583 -9.73403 60
-      vertex 30.2493 -8.78822 0
-      vertex 30.2493 -8.78822 60
+      vertex -31.2293 -6.98058 60
+      vertex -31.4332 -5.9962 60
+      vertex -30.7414 -6.87151 0
     endloop
   endfacet
-  facet normal 0.955784 -0.294069 0
+  facet normal 0.979203 -0.202712 -0.00833294
     outer loop
-      vertex 30.2493 -8.78822 0
-      vertex 29.9583 -9.73403 60
-      vertex 29.9583 -9.73403 0
+      vertex 31.4332 -5.9962 60
+      vertex 30.7414 -6.87151 0
+      vertex 30.942 -5.90251 0
     endloop
   endfacet
-  facet normal -0.883776 -0.467911 0
+  facet normal 0.140951 -0.989981 -0.0083313
     outer loop
-      vertex -27.6037 -15.1752 0
-      vertex -28.0667 -14.3007 60
-      vertex -28.0667 -14.3007 0
-    endloop
-  endfacet
-  facet normal -0.883776 -0.467911 0
-    outer loop
-      vertex -28.0667 -14.3007 60
-      vertex -27.6037 -15.1752 0
-      vertex -27.6037 -15.1752 60
-    endloop
-  endfacet
-  facet normal -0.233437 0.972372 0
-    outer loop
-      vertex -6.87151 30.7414 0
-      vertex -7.83373 30.5104 60
-      vertex -6.87151 30.7414 60
-    endloop
-  endfacet
-  facet normal -0.233437 0.972372 0
-    outer loop
-      vertex -7.83373 30.5104 60
-      vertex -6.87151 30.7414 0
-      vertex -7.83373 30.5104 0
-    endloop
-  endfacet
-  facet normal -0.972372 0.233437 0
-    outer loop
-      vertex -30.7414 6.87151 0
-      vertex -30.5104 7.83373 60
-      vertex -30.5104 7.83373 0
-    endloop
-  endfacet
-  facet normal -0.972372 0.233437 0
-    outer loop
-      vertex -30.5104 7.83373 60
-      vertex -30.7414 6.87151 0
-      vertex -30.7414 6.87151 60
-    endloop
-  endfacet
-  facet normal 0.923885 -0.38267 0
-    outer loop
-      vertex 28.9093 -12.5102 60
-      vertex 29.288 -11.5959 0
-      vertex 29.288 -11.5959 60
-    endloop
-  endfacet
-  facet normal 0.923885 -0.38267 0
-    outer loop
-      vertex 29.288 -11.5959 0
-      vertex 28.9093 -12.5102 60
-      vertex 28.9093 -12.5102 0
-    endloop
-  endfacet
-  facet normal 0.0156635 -0.999877 0
-    outer loop
-      vertex 0 -31.5 0
-      vertex 0.989438 -31.4845 60
-      vertex 0 -31.5 60
-    endloop
-  endfacet
-  facet normal 0.0156635 -0.999877 0
-    outer loop
-      vertex 0.989438 -31.4845 60
-      vertex 0 -31.5 0
-      vertex 0.989438 -31.4845 0
-    endloop
-  endfacet
-  facet normal 0.140872 -0.990028 0
-    outer loop
-      vertex 3.948 -31.2516 0
-      vertex 4.92768 -31.1122 60
-      vertex 3.948 -31.2516 60
-    endloop
-  endfacet
-  facet normal 0.140872 -0.990028 0
-    outer loop
-      vertex 4.92768 -31.1122 60
-      vertex 3.948 -31.2516 0
+      vertex 5.0059 -31.606 60
+      vertex 4.01066 -31.7477 60
       vertex 4.92768 -31.1122 0
     endloop
   endfacet
-  facet normal 0.964562 0.263855 0
+  facet normal -0.935443 0.35338 -0.00833085
     outer loop
-      vertex 30.5104 7.83373 60
-      vertex 30.2493 8.78822 0
-      vertex 30.2493 8.78822 60
+      vertex -29.6377 10.6702 0
+      vertex -29.7528 11.78 60
+      vertex -29.288 11.5959 0
     endloop
   endfacet
-  facet normal 0.964562 0.263855 0
+  facet normal -0.852575 0.522539 -0.00833329
     outer loop
-      vertex 30.2493 8.78822 0
-      vertex 30.5104 7.83373 60
-      vertex 30.5104 7.83373 0
+      vertex -26.5963 16.8785 0
+      vertex -27.1134 16.0348 0
+      vertex -27.0185 17.1465 60
     endloop
   endfacet
-  facet normal 0.202719 0.979237 -0
+  facet normal 0.600335 -0.799705 -0.00833177
     outer loop
-      vertex 6.87151 30.7414 0
-      vertex 5.90251 30.942 60
-      vertex 6.87151 30.7414 60
+      vertex 19.613 -25.285 60
+      vertex 18.5152 -25.484 0
+      vertex 19.3066 -24.8899 0
     endloop
   endfacet
-  facet normal 0.202719 0.979237 0
+  facet normal -0.411518 -0.911363 -0.00833188
     outer loop
-      vertex 5.90251 30.942 60
-      vertex 6.87151 30.7414 0
-      vertex 5.90251 30.942 0
+      vertex -12.5102 -28.9093 0
+      vertex -13.6249 -28.9545 60
+      vertex -13.412 -28.5021 0
     endloop
   endfacet
-  facet normal -0.780445 0.625225 0
+  facet normal 0.0784162 -0.996886 -0.00833233
+    outer loop
+      vertex 3.01147 -31.858 60
+      vertex 1.9779 -31.4378 0
+      vertex 2.96441 -31.3602 0
+    endloop
+  endfacet
+  facet normal 0.996881 -0.0784836 -0.00833346
+    outer loop
+      vertex 31.858 -3.01147 60
+      vertex 31.4378 -1.9779 0
+      vertex 31.9369 -2.0093 60
+    endloop
+  endfacet
+  facet normal -0.911363 -0.411518 -0.00833188
+    outer loop
+      vertex -28.5021 -13.412 0
+      vertex -28.9545 -13.6249 60
+      vertex -28.9093 -12.5102 0
+    endloop
+  endfacet
+  facet normal -0.780418 0.625203 -0.00833175
     outer loop
       vertex -24.8899 19.3066 0
-      vertex -24.2712 20.0789 60
+      vertex -25.285 19.613 60
       vertex -24.2712 20.0789 0
     endloop
   endfacet
-  facet normal -0.780445 0.625225 0
+  facet normal -0.780395 0.625231 -0.00833116
     outer loop
-      vertex -24.2712 20.0789 60
-      vertex -24.8899 19.3066 0
-      vertex -24.8899 19.3066 60
+      vertex -24.2712 20.0789 0
+      vertex -25.285 19.613 60
+      vertex -24.6564 20.3976 60
     endloop
   endfacet
-  facet normal 0.6495 -0.760361 0
+  facet normal -0.140868 0.989993 -0.00833271
     outer loop
-      vertex 20.0789 -24.2712 0
-      vertex 20.8313 -23.6285 60
-      vertex 20.0789 -24.2712 60
+      vertex -3.948 31.2516 0
+      vertex -4.92768 31.1122 0
+      vertex -4.01066 31.7477 60
     endloop
   endfacet
-  facet normal 0.6495 -0.760361 0
+  facet normal -0.233429 0.972338 -0.00833106
     outer loop
-      vertex 20.8313 -23.6285 60
+      vertex -6.87151 30.7414 0
+      vertex -7.83373 30.5104 0
+      vertex -6.98058 31.2293 60
+    endloop
+  endfacet
+  facet normal -0.92384 -0.382687 -0.0083309
+    outer loop
+      vertex -29.3681 -12.7087 60
+      vertex -29.7528 -11.78 60
+      vertex -29.288 -11.5959 0
+    endloop
+  endfacet
+  facet normal 0.955756 -0.294042 -0.00833157
+    outer loop
+      vertex 30.4338 -9.88854 60
+      vertex 29.9583 -9.73403 0
+      vertex 30.7294 -8.92772 60
+    endloop
+  endfacet
+  facet normal 0.673001 -0.739594 -0.00833251
+    outer loop
+      vertex 21.9055 -23.327 60
+      vertex 20.8313 -23.6285 0
+      vertex 21.5632 -22.9625 0
+    endloop
+  endfacet
+  facet normal 0.649478 -0.760335 -0.00833307
+    outer loop
+      vertex 21.162 -24.0036 60
       vertex 20.0789 -24.2712 0
       vertex 20.8313 -23.6285 0
     endloop
   endfacet
-  facet normal 0.0471925 0.998886 -0
+  facet normal -0.739594 -0.673001 -0.00833251
     outer loop
-      vertex 1.9779 31.4378 0
-      vertex 0.989438 31.4845 60
-      vertex 1.9779 31.4378 60
+      vertex -23.327 -21.9055 60
+      vertex -23.6285 -20.8313 0
+      vertex -22.9625 -21.5632 0
     endloop
   endfacet
-  facet normal 0.0471925 0.998886 0
+  facet normal -0.92384 0.382687 -0.0083309
     outer loop
-      vertex 0.989438 31.4845 60
-      vertex 1.9779 31.4378 0
-      vertex 0.989438 31.4845 0
+      vertex -29.288 11.5959 0
+      vertex -29.7528 11.78 60
+      vertex -29.3681 12.7087 60
     endloop
   endfacet
-  facet normal -0.140872 0.990028 0
+  facet normal 0.233429 0.972338 -0.00833106
+    outer loop
+      vertex 7.83373 30.5104 0
+      vertex 6.87151 30.7414 0
+      vertex 6.98058 31.2293 60
+    endloop
+  endfacet
+  facet normal 0.996886 0.0784162 -0.00833233
+    outer loop
+      vertex 31.4378 1.9779 0
+      vertex 31.3602 2.96441 0
+      vertex 31.858 3.01147 60
+    endloop
+  endfacet
+  facet normal -0.382657 -0.923853 -0.00833035
+    outer loop
+      vertex -11.5959 -29.288 0
+      vertex -12.7087 -29.3681 60
+      vertex -12.5102 -28.9093 0
+    endloop
+  endfacet
+  facet normal -0.946059 -0.323888 -0.00833312
+    outer loop
+      vertex -30.1082 -10.8396 60
+      vertex -30.4338 -9.88854 60
+      vertex -29.6377 -10.6702 0
+    endloop
+  endfacet
+  facet normal -0.996881 -0.0784836 -0.00833346
+    outer loop
+      vertex -31.858 -3.01147 60
+      vertex -31.9369 -2.0093 60
+      vertex -31.4378 -1.9779 0
+    endloop
+  endfacet
+  facet normal -0.109741 0.993925 -0.00833271
     outer loop
       vertex -3.948 31.2516 0
-      vertex -4.92768 31.1122 60
-      vertex -3.948 31.2516 60
+      vertex -4.01066 31.7477 60
+      vertex -2.96441 31.3602 0
     endloop
   endfacet
-  facet normal -0.140872 0.990028 0
+  facet normal 0.97918 -0.202823 -0.00833106
     outer loop
-      vertex -4.92768 31.1122 60
-      vertex -3.948 31.2516 0
-      vertex -4.92768 31.1122 0
+      vertex 31.2293 -6.98058 60
+      vertex 30.7414 -6.87151 0
+      vertex 31.4332 -5.9962 60
     endloop
   endfacet
-  facet normal 0.233437 -0.972372 0
+  facet normal 0.999843 -0.015663 -0.00833202
     outer loop
-      vertex 6.87151 -30.7414 0
-      vertex 7.83373 -30.5104 60
-      vertex 6.87151 -30.7414 60
+      vertex 32 0 60
+      vertex 31.4845 -0.989438 0
+      vertex 31.5 0 0
     endloop
   endfacet
-  facet normal 0.233437 -0.972372 0
+  facet normal 0.993928 -0.109719 -0.00833234
     outer loop
-      vertex 7.83373 -30.5104 60
-      vertex 6.87151 -30.7414 0
-      vertex 7.83373 -30.5104 0
+      vertex 31.7477 -4.01066 60
+      vertex 31.3602 -2.96441 0
+      vertex 31.858 -3.01147 60
     endloop
   endfacet
-  facet normal -0.171993 -0.985098 0
+  facet normal 0.999842 0.0157167 -0.00833113
     outer loop
-      vertex -5.90251 -30.942 0
-      vertex -4.92768 -31.1122 60
-      vertex -5.90251 -30.942 60
+      vertex 32 0 60
+      vertex 31.4845 0.989438 0
+      vertex 31.9842 1.00514 60
     endloop
   endfacet
-  facet normal -0.171993 -0.985098 -0
+  facet normal -0.868604 -0.495436 -0.00833144
     outer loop
-      vertex -4.92768 -31.1122 60
-      vertex -5.90251 -30.942 0
-      vertex -4.92768 -31.1122 0
+      vertex -27.1134 -16.0348 0
+      vertex -28.0418 -15.4161 60
+      vertex -27.6037 -15.1752 0
     endloop
   endfacet
-  facet normal 0.673025 0.73962 -0
+  facet normal 0.999842 -0.0157167 -0.00833113
     outer loop
-      vertex 21.5632 22.9625 0
-      vertex 20.8313 23.6285 60
-      vertex 21.5632 22.9625 60
+      vertex 31.9842 -1.00514 60
+      vertex 31.4845 -0.989438 0
+      vertex 32 0 60
     endloop
   endfacet
-  facet normal 0.673025 0.73962 0
+  facet normal -0.695828 -0.71816 -0.00833075
     outer loop
-      vertex 20.8313 23.6285 60
-      vertex 21.5632 22.9625 0
-      vertex 20.8313 23.6285 0
+      vertex -21.5632 -22.9625 0
+      vertex -22.6274 -22.6274 60
+      vertex -22.2739 -22.2739 0
     endloop
   endfacet
-  facet normal 0.898015 0.439964 0
+  facet normal 0.140868 -0.989993 -0.00833271
     outer loop
-      vertex 28.5021 13.412 60
-      vertex 28.0667 14.3007 0
-      vertex 28.0667 14.3007 60
+      vertex 4.01066 -31.7477 60
+      vertex 3.948 -31.2516 0
+      vertex 4.92768 -31.1122 0
     endloop
   endfacet
-  facet normal 0.898015 0.439964 0
+  facet normal 0.625203 0.780418 -0.00833175
     outer loop
-      vertex 28.0667 14.3007 0
-      vertex 28.5021 13.412 60
-      vertex 28.5021 13.412 0
-    endloop
-  endfacet
-  facet normal 0.600356 0.799733 -0
-    outer loop
+      vertex 20.0789 24.2712 0
       vertex 19.3066 24.8899 0
-      vertex 18.5152 25.484 60
-      vertex 19.3066 24.8899 60
+      vertex 19.613 25.285 60
     endloop
   endfacet
-  facet normal 0.600356 0.799733 0
+  facet normal 0.522539 0.852575 -0.00833329
     outer loop
-      vertex 18.5152 25.484 60
-      vertex 19.3066 24.8899 0
-      vertex 18.5152 25.484 0
-    endloop
-  endfacet
-  facet normal -0.0471925 0.998886 0
-    outer loop
-      vertex -0.989438 31.4845 0
-      vertex -1.9779 31.4378 60
-      vertex -0.989438 31.4845 60
-    endloop
-  endfacet
-  facet normal -0.0471925 0.998886 0
-    outer loop
-      vertex -1.9779 31.4378 60
-      vertex -0.989438 31.4845 0
-      vertex -1.9779 31.4378 0
-    endloop
-  endfacet
-  facet normal 0.495453 0.868635 -0
-    outer loop
+      vertex 16.8785 26.5963 0
       vertex 16.0348 27.1134 0
-      vertex 15.1752 27.6037 60
-      vertex 16.0348 27.1134 60
+      vertex 17.1465 27.0185 60
     endloop
   endfacet
-  facet normal 0.495453 0.868635 0
+  facet normal 0.625231 0.780395 -0.00833116
     outer loop
-      vertex 15.1752 27.6037 60
-      vertex 16.0348 27.1134 0
-      vertex 15.1752 27.6037 0
+      vertex 20.0789 24.2712 0
+      vertex 19.613 25.285 60
+      vertex 20.3976 24.6564 60
     endloop
   endfacet
-  facet normal -0.718185 0.695852 0
+  facet normal -0.979203 0.202712 -0.00833294
     outer loop
-      vertex -22.9625 21.5632 0
-      vertex -22.2739 22.2739 60
-      vertex -22.2739 22.2739 0
+      vertex -30.942 5.90251 0
+      vertex -31.4332 5.9962 60
+      vertex -30.7414 6.87151 0
     endloop
   endfacet
-  facet normal -0.718185 0.695852 0
+  facet normal -0.353508 0.935394 -0.00833312
     outer loop
-      vertex -22.2739 22.2739 60
-      vertex -22.9625 21.5632 0
-      vertex -22.9625 21.5632 60
-    endloop
-  endfacet
-  facet normal -0.323987 0.946061 0
-    outer loop
-      vertex -9.73403 29.9583 0
-      vertex -10.6702 29.6377 60
-      vertex -9.73403 29.9583 60
-    endloop
-  endfacet
-  facet normal -0.323987 0.946061 0
-    outer loop
-      vertex -10.6702 29.6377 60
-      vertex -9.73403 29.9583 0
       vertex -10.6702 29.6377 0
+      vertex -11.78 29.7528 60
+      vertex -10.8396 30.1082 60
     endloop
   endfacet
-  facet normal -0.911395 -0.411533 0
+  facet normal 0.649391 -0.760409 -0.00833117
     outer loop
-      vertex -28.5021 -13.412 0
-      vertex -28.9093 -12.5102 60
-      vertex -28.9093 -12.5102 0
+      vertex 20.3976 -24.6564 60
+      vertex 20.0789 -24.2712 0
+      vertex 21.162 -24.0036 60
     endloop
   endfacet
-  facet normal -0.911395 -0.411533 0
+  facet normal -0.993928 -0.109719 -0.00833234
     outer loop
-      vertex -28.9093 -12.5102 60
-      vertex -28.5021 -13.412 0
-      vertex -28.5021 -13.412 60
+      vertex -31.7477 -4.01066 60
+      vertex -31.858 -3.01147 60
+      vertex -31.3602 -2.96441 0
     endloop
   endfacet
-  facet normal -0.990028 -0.140872 0
+  facet normal -0.993928 0.109719 -0.00833234
     outer loop
-      vertex -31.1122 -4.92768 0
-      vertex -31.2516 -3.948 60
-      vertex -31.2516 -3.948 0
+      vertex -31.3602 2.96441 0
+      vertex -31.858 3.01147 60
+      vertex -31.7477 4.01066 60
     endloop
   endfacet
-  facet normal -0.990028 -0.140872 0
+  facet normal 0.799698 -0.600345 -0.00833199
     outer loop
-      vertex -31.2516 -3.948 60
-      vertex -31.1122 -4.92768 0
-      vertex -31.1122 -4.92768 60
+      vertex 25.8885 -18.8091 60
+      vertex 25.285 -19.613 60
+      vertex 25.484 -18.5152 0
     endloop
   endfacet
-  facet normal -0.467911 -0.883776 0
+  facet normal -0.989993 0.140868 -0.00833271
     outer loop
-      vertex -15.1752 -27.6037 0
-      vertex -14.3007 -28.0667 60
-      vertex -15.1752 -27.6037 60
+      vertex -31.2516 3.948 0
+      vertex -31.7477 4.01066 60
+      vertex -31.1122 4.92768 0
     endloop
   endfacet
-  facet normal -0.467911 -0.883776 -0
+  facet normal -0.202823 -0.97918 -0.00833106
     outer loop
-      vertex -14.3007 -28.0667 60
+      vertex -5.9962 -31.4332 60
+      vertex -6.98058 -31.2293 60
+      vertex -6.87151 -30.7414 0
+    endloop
+  endfacet
+  facet normal -0.411434 -0.911402 -0.00833034
+    outer loop
+      vertex -12.7087 -29.3681 60
+      vertex -13.6249 -28.9545 60
+      vertex -12.5102 -28.9093 0
+    endloop
+  endfacet
+  facet normal 0.852575 0.522539 -0.00833329
+    outer loop
+      vertex 27.1134 16.0348 0
+      vertex 26.5963 16.8785 0
+      vertex 27.0185 17.1465 60
+    endloop
+  endfacet
+  facet normal -0.140951 0.989981 -0.0083313
+    outer loop
+      vertex -4.92768 31.1122 0
+      vertex -5.0059 31.606 60
+      vertex -4.01066 31.7477 60
+    endloop
+  endfacet
+  facet normal 0.109719 0.993928 -0.00833234
+    outer loop
+      vertex 4.01066 31.7477 60
+      vertex 2.96441 31.3602 0
+      vertex 3.01147 31.858 60
+    endloop
+  endfacet
+  facet normal -0.818071 -0.575057 -0.00833338
+    outer loop
+      vertex -25.8885 -18.8091 60
+      vertex -26.4666 -17.9867 60
+      vertex -26.053 -17.7056 0
+    endloop
+  endfacet
+  facet normal 0.946029 -0.323976 -0.00833157
+    outer loop
+      vertex 30.4338 -9.88854 60
+      vertex 29.6377 -10.6702 0
+      vertex 29.9583 -9.73403 0
+    endloop
+  endfacet
+  facet normal -0.467895 -0.883745 -0.00833201
+    outer loop
+      vertex -14.5277 -28.5122 60
       vertex -15.1752 -27.6037 0
       vertex -14.3007 -28.0667 0
     endloop
   endfacet
-  facet normal 0.99396 -0.109745 0
+  facet normal 0.625203 -0.780418 -0.00833175
     outer loop
-      vertex 31.2516 -3.948 60
-      vertex 31.3602 -2.96441 0
-      vertex 31.3602 -2.96441 60
-    endloop
-  endfacet
-  facet normal 0.99396 -0.109745 0
-    outer loop
-      vertex 31.3602 -2.96441 0
-      vertex 31.2516 -3.948 60
-      vertex 31.2516 -3.948 0
-    endloop
-  endfacet
-  facet normal -0.964562 0.263855 0
-    outer loop
-      vertex -30.5104 7.83373 0
-      vertex -30.2493 8.78822 60
-      vertex -30.2493 8.78822 0
-    endloop
-  endfacet
-  facet normal -0.964562 0.263855 0
-    outer loop
-      vertex -30.2493 8.78822 60
-      vertex -30.5104 7.83373 0
-      vertex -30.5104 7.83373 60
-    endloop
-  endfacet
-  facet normal 0.883776 0.467911 0
-    outer loop
-      vertex 28.0667 14.3007 60
-      vertex 27.6037 15.1752 0
-      vertex 27.6037 15.1752 60
-    endloop
-  endfacet
-  facet normal 0.883776 0.467911 0
-    outer loop
-      vertex 27.6037 15.1752 0
-      vertex 28.0667 14.3007 60
-      vertex 28.0667 14.3007 0
-    endloop
-  endfacet
-  facet normal 0.780445 -0.625225 0
-    outer loop
-      vertex 24.2712 -20.0789 60
-      vertex 24.8899 -19.3066 0
-      vertex 24.8899 -19.3066 60
-    endloop
-  endfacet
-  facet normal 0.780445 -0.625225 0
-    outer loop
-      vertex 24.8899 -19.3066 0
-      vertex 24.2712 -20.0789 60
-      vertex 24.2712 -20.0789 0
-    endloop
-  endfacet
-  facet normal 0.964562 -0.263855 0
-    outer loop
-      vertex 30.2493 -8.78822 60
-      vertex 30.5104 -7.83373 0
-      vertex 30.5104 -7.83373 60
-    endloop
-  endfacet
-  facet normal 0.964562 -0.263855 0
-    outer loop
-      vertex 30.5104 -7.83373 0
-      vertex 30.2493 -8.78822 60
-      vertex 30.2493 -8.78822 0
-    endloop
-  endfacet
-  facet normal -0.990028 0.140872 0
-    outer loop
-      vertex -31.2516 3.948 0
-      vertex -31.1122 4.92768 60
-      vertex -31.1122 4.92768 0
-    endloop
-  endfacet
-  facet normal -0.990028 0.140872 0
-    outer loop
-      vertex -31.1122 4.92768 60
-      vertex -31.2516 3.948 0
-      vertex -31.2516 3.948 60
-    endloop
-  endfacet
-  facet normal -0.999877 -0.0156635 0
-    outer loop
-      vertex -31.4845 -0.989438 0
-      vertex -31.5 0 60
-      vertex -31.5 0 0
-    endloop
-  endfacet
-  facet normal -0.999877 -0.0156635 0
-    outer loop
-      vertex -31.5 0 60
-      vertex -31.4845 -0.989438 0
-      vertex -31.4845 -0.989438 60
-    endloop
-  endfacet
-  facet normal 0.263855 -0.964562 0
-    outer loop
-      vertex 7.83373 -30.5104 0
-      vertex 8.78822 -30.2493 60
-      vertex 7.83373 -30.5104 60
-    endloop
-  endfacet
-  facet normal 0.263855 -0.964562 0
-    outer loop
-      vertex 8.78822 -30.2493 60
-      vertex 7.83373 -30.5104 0
-      vertex 8.78822 -30.2493 0
-    endloop
-  endfacet
-  facet normal 0.972372 0.233437 0
-    outer loop
-      vertex 30.7414 6.87151 60
-      vertex 30.5104 7.83373 0
-      vertex 30.5104 7.83373 60
-    endloop
-  endfacet
-  facet normal 0.972372 0.233437 0
-    outer loop
-      vertex 30.5104 7.83373 0
-      vertex 30.7414 6.87151 60
-      vertex 30.7414 6.87151 0
-    endloop
-  endfacet
-  facet normal 0.946061 -0.323987 0
-    outer loop
-      vertex 29.6377 -10.6702 60
-      vertex 29.9583 -9.73403 0
-      vertex 29.9583 -9.73403 60
-    endloop
-  endfacet
-  facet normal 0.946061 -0.323987 0
-    outer loop
-      vertex 29.9583 -9.73403 0
-      vertex 29.6377 -10.6702 60
-      vertex 29.6377 -10.6702 0
-    endloop
-  endfacet
-  facet normal 0.979237 0.202719 0
-    outer loop
-      vertex 30.942 5.90251 60
-      vertex 30.7414 6.87151 0
-      vertex 30.7414 6.87151 60
-    endloop
-  endfacet
-  facet normal 0.979237 0.202719 0
-    outer loop
-      vertex 30.7414 6.87151 0
-      vertex 30.942 5.90251 60
-      vertex 30.942 5.90251 0
-    endloop
-  endfacet
-  facet normal 0.990028 0.140872 0
-    outer loop
-      vertex 31.2516 3.948 60
-      vertex 31.1122 4.92768 0
-      vertex 31.1122 4.92768 60
-    endloop
-  endfacet
-  facet normal 0.990028 0.140872 0
-    outer loop
-      vertex 31.1122 4.92768 0
-      vertex 31.2516 3.948 60
-      vertex 31.2516 3.948 0
-    endloop
-  endfacet
-  facet normal 0.799733 -0.600356 0
-    outer loop
-      vertex 24.8899 -19.3066 60
-      vertex 25.484 -18.5152 0
-      vertex 25.484 -18.5152 60
-    endloop
-  endfacet
-  facet normal 0.799733 -0.600356 0
-    outer loop
-      vertex 25.484 -18.5152 0
-      vertex 24.8899 -19.3066 60
-      vertex 24.8899 -19.3066 0
-    endloop
-  endfacet
-  facet normal 0.998886 -0.0471925 0
-    outer loop
-      vertex 31.4378 -1.9779 60
-      vertex 31.4845 -0.989438 0
-      vertex 31.4845 -0.989438 60
-    endloop
-  endfacet
-  facet normal 0.998886 -0.0471925 0
-    outer loop
-      vertex 31.4845 -0.989438 0
-      vertex 31.4378 -1.9779 60
-      vertex 31.4378 -1.9779 0
-    endloop
-  endfacet
-  facet normal -0.946061 0.323987 0
-    outer loop
-      vertex -29.9583 9.73403 0
-      vertex -29.6377 10.6702 60
-      vertex -29.6377 10.6702 0
-    endloop
-  endfacet
-  facet normal -0.946061 0.323987 0
-    outer loop
-      vertex -29.6377 10.6702 60
-      vertex -29.9583 9.73403 0
-      vertex -29.9583 9.73403 60
-    endloop
-  endfacet
-  facet normal 0.898015 -0.439964 0
-    outer loop
-      vertex 28.0667 -14.3007 60
-      vertex 28.5021 -13.412 0
-      vertex 28.5021 -13.412 60
-    endloop
-  endfacet
-  facet normal 0.898015 -0.439964 0
-    outer loop
-      vertex 28.5021 -13.412 0
-      vertex 28.0667 -14.3007 60
-      vertex 28.0667 -14.3007 0
-    endloop
-  endfacet
-  facet normal -0.38267 -0.923885 0
-    outer loop
-      vertex -12.5102 -28.9093 0
-      vertex -11.5959 -29.288 60
-      vertex -12.5102 -28.9093 60
-    endloop
-  endfacet
-  facet normal -0.38267 -0.923885 -0
-    outer loop
-      vertex -11.5959 -29.288 60
-      vertex -12.5102 -28.9093 0
-      vertex -11.5959 -29.288 0
-    endloop
-  endfacet
-  facet normal -0.718185 -0.695852 0
-    outer loop
-      vertex -22.2739 -22.2739 0
-      vertex -22.9625 -21.5632 60
-      vertex -22.9625 -21.5632 0
-    endloop
-  endfacet
-  facet normal -0.718185 -0.695852 0
-    outer loop
-      vertex -22.9625 -21.5632 60
-      vertex -22.2739 -22.2739 0
-      vertex -22.2739 -22.2739 60
-    endloop
-  endfacet
-  facet normal 0.439964 0.898015 -0
-    outer loop
-      vertex 14.3007 28.0667 0
-      vertex 13.412 28.5021 60
-      vertex 14.3007 28.0667 60
-    endloop
-  endfacet
-  facet normal 0.439964 0.898015 0
-    outer loop
-      vertex 13.412 28.5021 60
-      vertex 14.3007 28.0667 0
-      vertex 13.412 28.5021 0
-    endloop
-  endfacet
-  facet normal -0.575008 0.818148 0
-    outer loop
-      vertex -17.7056 26.053 0
-      vertex -18.5152 25.484 60
-      vertex -17.7056 26.053 60
-    endloop
-  endfacet
-  facet normal -0.575008 0.818148 0
-    outer loop
-      vertex -18.5152 25.484 60
-      vertex -17.7056 26.053 0
-      vertex -18.5152 25.484 0
-    endloop
-  endfacet
-  facet normal -0.202719 0.979237 0
-    outer loop
-      vertex -5.90251 30.942 0
-      vertex -6.87151 30.7414 60
-      vertex -5.90251 30.942 60
-    endloop
-  endfacet
-  facet normal -0.202719 0.979237 0
-    outer loop
-      vertex -6.87151 30.7414 60
-      vertex -5.90251 30.942 0
-      vertex -6.87151 30.7414 0
-    endloop
-  endfacet
-  facet normal -0.73962 -0.673025 0
-    outer loop
-      vertex -22.9625 -21.5632 0
-      vertex -23.6285 -20.8313 60
-      vertex -23.6285 -20.8313 0
-    endloop
-  endfacet
-  facet normal -0.73962 -0.673025 0
-    outer loop
-      vertex -23.6285 -20.8313 60
-      vertex -22.9625 -21.5632 0
-      vertex -22.9625 -21.5632 60
-    endloop
-  endfacet
-  facet normal 0.972372 -0.233437 0
-    outer loop
-      vertex 30.5104 -7.83373 60
-      vertex 30.7414 -6.87151 0
-      vertex 30.7414 -6.87151 60
-    endloop
-  endfacet
-  facet normal 0.972372 -0.233437 0
-    outer loop
-      vertex 30.7414 -6.87151 0
-      vertex 30.5104 -7.83373 60
-      vertex 30.5104 -7.83373 0
-    endloop
-  endfacet
-  facet normal -0.946061 -0.323987 0
-    outer loop
-      vertex -29.6377 -10.6702 0
-      vertex -29.9583 -9.73403 60
-      vertex -29.9583 -9.73403 0
-    endloop
-  endfacet
-  facet normal -0.946061 -0.323987 0
-    outer loop
-      vertex -29.9583 -9.73403 60
-      vertex -29.6377 -10.6702 0
-      vertex -29.6377 -10.6702 60
-    endloop
-  endfacet
-  facet normal 0.495453 -0.868635 0
-    outer loop
-      vertex 15.1752 -27.6037 0
-      vertex 16.0348 -27.1134 60
-      vertex 15.1752 -27.6037 60
-    endloop
-  endfacet
-  facet normal 0.495453 -0.868635 0
-    outer loop
-      vertex 16.0348 -27.1134 60
-      vertex 15.1752 -27.6037 0
-      vertex 16.0348 -27.1134 0
-    endloop
-  endfacet
-  facet normal 0.923885 0.38267 0
-    outer loop
-      vertex 29.288 11.5959 60
-      vertex 28.9093 12.5102 0
-      vertex 28.9093 12.5102 60
-    endloop
-  endfacet
-  facet normal 0.923885 0.38267 0
-    outer loop
-      vertex 28.9093 12.5102 0
-      vertex 29.288 11.5959 60
-      vertex 29.288 11.5959 0
-    endloop
-  endfacet
-  facet normal 0.985098 -0.171993 0
-    outer loop
-      vertex 30.942 -5.90251 60
-      vertex 31.1122 -4.92768 0
-      vertex 31.1122 -4.92768 60
-    endloop
-  endfacet
-  facet normal 0.985098 -0.171993 0
-    outer loop
-      vertex 31.1122 -4.92768 0
-      vertex 30.942 -5.90251 60
-      vertex 30.942 -5.90251 0
-    endloop
-  endfacet
-  facet normal 0.323987 -0.946061 0
-    outer loop
-      vertex 9.73403 -29.9583 0
-      vertex 10.6702 -29.6377 60
-      vertex 9.73403 -29.9583 60
-    endloop
-  endfacet
-  facet normal 0.323987 -0.946061 0
-    outer loop
-      vertex 10.6702 -29.6377 60
-      vertex 9.73403 -29.9583 0
-      vertex 10.6702 -29.6377 0
-    endloop
-  endfacet
-  facet normal -0.171993 0.985098 0
-    outer loop
-      vertex -4.92768 31.1122 0
-      vertex -5.90251 30.942 60
-      vertex -4.92768 31.1122 60
-    endloop
-  endfacet
-  facet normal -0.171993 0.985098 0
-    outer loop
-      vertex -5.90251 30.942 60
-      vertex -4.92768 31.1122 0
-      vertex -5.90251 30.942 0
-    endloop
-  endfacet
-  facet normal 0.467911 -0.883776 0
-    outer loop
-      vertex 14.3007 -28.0667 0
-      vertex 15.1752 -27.6037 60
-      vertex 14.3007 -28.0667 60
-    endloop
-  endfacet
-  facet normal 0.467911 -0.883776 0
-    outer loop
-      vertex 15.1752 -27.6037 60
-      vertex 14.3007 -28.0667 0
-      vertex 15.1752 -27.6037 0
-    endloop
-  endfacet
-  facet normal 0.263855 0.964562 -0
-    outer loop
-      vertex 8.78822 30.2493 0
-      vertex 7.83373 30.5104 60
-      vertex 8.78822 30.2493 60
-    endloop
-  endfacet
-  facet normal 0.263855 0.964562 0
-    outer loop
-      vertex 7.83373 30.5104 60
-      vertex 8.78822 30.2493 0
-      vertex 7.83373 30.5104 0
-    endloop
-  endfacet
-  facet normal -0.923885 0.38267 0
-    outer loop
-      vertex -29.288 11.5959 0
-      vertex -28.9093 12.5102 60
-      vertex -28.9093 12.5102 0
-    endloop
-  endfacet
-  facet normal -0.923885 0.38267 0
-    outer loop
-      vertex -28.9093 12.5102 60
-      vertex -29.288 11.5959 0
-      vertex -29.288 11.5959 60
-    endloop
-  endfacet
-  facet normal 0.522557 -0.852604 0
-    outer loop
-      vertex 16.0348 -27.1134 0
-      vertex 16.8785 -26.5963 60
-      vertex 16.0348 -27.1134 60
-    endloop
-  endfacet
-  facet normal 0.522557 -0.852604 0
-    outer loop
-      vertex 16.8785 -26.5963 60
-      vertex 16.0348 -27.1134 0
-      vertex 16.8785 -26.5963 0
-    endloop
-  endfacet
-  facet normal -0.549021 -0.835809 0
-    outer loop
-      vertex -17.7056 -26.053 0
-      vertex -16.8785 -26.5963 60
-      vertex -17.7056 -26.053 60
-    endloop
-  endfacet
-  facet normal -0.549021 -0.835809 -0
-    outer loop
-      vertex -16.8785 -26.5963 60
-      vertex -17.7056 -26.053 0
-      vertex -16.8785 -26.5963 0
-    endloop
-  endfacet
-  facet normal 0.171993 0.985098 -0
-    outer loop
-      vertex 5.90251 30.942 0
-      vertex 4.92768 31.1122 60
-      vertex 5.90251 30.942 60
-    endloop
-  endfacet
-  facet normal 0.171993 0.985098 0
-    outer loop
-      vertex 4.92768 31.1122 60
-      vertex 5.90251 30.942 0
-      vertex 4.92768 31.1122 0
-    endloop
-  endfacet
-  facet normal 0.852604 0.522557 0
-    outer loop
-      vertex 27.1134 16.0348 60
-      vertex 26.5963 16.8785 0
-      vertex 26.5963 16.8785 60
-    endloop
-  endfacet
-  facet normal 0.852604 0.522557 0
-    outer loop
-      vertex 26.5963 16.8785 0
-      vertex 27.1134 16.0348 60
-      vertex 27.1134 16.0348 0
-    endloop
-  endfacet
-  facet normal 0.575008 0.818148 -0
-    outer loop
-      vertex 18.5152 25.484 0
-      vertex 17.7056 26.053 60
-      vertex 18.5152 25.484 60
-    endloop
-  endfacet
-  facet normal 0.575008 0.818148 0
-    outer loop
-      vertex 17.7056 26.053 60
-      vertex 18.5152 25.484 0
-      vertex 17.7056 26.053 0
-    endloop
-  endfacet
-  facet normal -0.818148 -0.575008 0
-    outer loop
-      vertex -25.484 -18.5152 0
-      vertex -26.053 -17.7056 60
-      vertex -26.053 -17.7056 0
-    endloop
-  endfacet
-  facet normal -0.818148 -0.575008 0
-    outer loop
-      vertex -26.053 -17.7056 60
-      vertex -25.484 -18.5152 0
-      vertex -25.484 -18.5152 60
-    endloop
-  endfacet
-  facet normal 0.818148 0.575008 0
-    outer loop
-      vertex 26.053 17.7056 60
-      vertex 25.484 18.5152 0
-      vertex 25.484 18.5152 60
-    endloop
-  endfacet
-  facet normal 0.818148 0.575008 0
-    outer loop
-      vertex 25.484 18.5152 0
-      vertex 26.053 17.7056 60
-      vertex 26.053 17.7056 0
-    endloop
-  endfacet
-  facet normal -0.935475 -0.353393 0
-    outer loop
-      vertex -29.288 -11.5959 0
-      vertex -29.6377 -10.6702 60
-      vertex -29.6377 -10.6702 0
-    endloop
-  endfacet
-  facet normal -0.935475 -0.353393 0
-    outer loop
-      vertex -29.6377 -10.6702 60
-      vertex -29.288 -11.5959 0
-      vertex -29.288 -11.5959 60
-    endloop
-  endfacet
-  facet normal 0.323987 0.946061 -0
-    outer loop
-      vertex 10.6702 29.6377 0
-      vertex 9.73403 29.9583 60
-      vertex 10.6702 29.6377 60
-    endloop
-  endfacet
-  facet normal 0.323987 0.946061 0
-    outer loop
-      vertex 9.73403 29.9583 60
-      vertex 10.6702 29.6377 0
-      vertex 9.73403 29.9583 0
-    endloop
-  endfacet
-  facet normal 0.625225 -0.780445 0
-    outer loop
-      vertex 19.3066 -24.8899 0
-      vertex 20.0789 -24.2712 60
-      vertex 19.3066 -24.8899 60
-    endloop
-  endfacet
-  facet normal 0.625225 -0.780445 0
-    outer loop
-      vertex 20.0789 -24.2712 60
+      vertex 19.613 -25.285 60
       vertex 19.3066 -24.8899 0
       vertex 20.0789 -24.2712 0
     endloop
   endfacet
-  facet normal -0.495453 0.868635 0
+  facet normal 0.411434 0.911402 -0.00833034
     outer loop
-      vertex -15.1752 27.6037 0
-      vertex -16.0348 27.1134 60
-      vertex -15.1752 27.6037 60
+      vertex 13.6249 28.9545 60
+      vertex 12.5102 28.9093 0
+      vertex 12.7087 29.3681 60
     endloop
   endfacet
-  facet normal -0.495453 0.868635 0
+  facet normal -0.233429 -0.972338 -0.00833106
     outer loop
-      vertex -16.0348 27.1134 60
-      vertex -15.1752 27.6037 0
-      vertex -16.0348 27.1134 0
+      vertex -6.98058 -31.2293 60
+      vertex -7.83373 -30.5104 0
+      vertex -6.87151 -30.7414 0
     endloop
   endfacet
-  facet normal -0.495453 -0.868635 0
+  facet normal 0.549002 0.83578 -0.00833338
     outer loop
-      vertex -16.0348 -27.1134 0
-      vertex -15.1752 -27.6037 60
-      vertex -16.0348 -27.1134 60
-    endloop
-  endfacet
-  facet normal -0.495453 -0.868635 -0
-    outer loop
-      vertex -15.1752 -27.6037 60
-      vertex -16.0348 -27.1134 0
-      vertex -15.1752 -27.6037 0
-    endloop
-  endfacet
-  facet normal 0.0784189 0.99692 -0
-    outer loop
-      vertex 2.96441 31.3602 0
-      vertex 1.9779 31.4378 60
-      vertex 2.96441 31.3602 60
-    endloop
-  endfacet
-  facet normal 0.0784189 0.99692 0
-    outer loop
-      vertex 1.9779 31.4378 60
-      vertex 2.96441 31.3602 0
-      vertex 1.9779 31.4378 0
-    endloop
-  endfacet
-  facet normal 0.835809 0.549021 0
-    outer loop
-      vertex 26.5963 16.8785 60
-      vertex 26.053 17.7056 0
-      vertex 26.053 17.7056 60
-    endloop
-  endfacet
-  facet normal 0.835809 0.549021 0
-    outer loop
-      vertex 26.053 17.7056 0
-      vertex 26.5963 16.8785 60
-      vertex 26.5963 16.8785 0
-    endloop
-  endfacet
-  facet normal 0.718185 0.695852 0
-    outer loop
-      vertex 22.9625 21.5632 60
-      vertex 22.2739 22.2739 0
-      vertex 22.2739 22.2739 60
-    endloop
-  endfacet
-  facet normal 0.718185 0.695852 0
-    outer loop
-      vertex 22.2739 22.2739 0
-      vertex 22.9625 21.5632 60
-      vertex 22.9625 21.5632 0
-    endloop
-  endfacet
-  facet normal -0.673025 0.73962 0
-    outer loop
-      vertex -20.8313 23.6285 0
-      vertex -21.5632 22.9625 60
-      vertex -20.8313 23.6285 60
-    endloop
-  endfacet
-  facet normal -0.673025 0.73962 0
-    outer loop
-      vertex -21.5632 22.9625 60
-      vertex -20.8313 23.6285 0
-      vertex -21.5632 22.9625 0
-    endloop
-  endfacet
-  facet normal -0.972372 -0.233437 0
-    outer loop
-      vertex -30.5104 -7.83373 0
-      vertex -30.7414 -6.87151 60
-      vertex -30.7414 -6.87151 0
-    endloop
-  endfacet
-  facet normal -0.972372 -0.233437 0
-    outer loop
-      vertex -30.7414 -6.87151 60
-      vertex -30.5104 -7.83373 0
-      vertex -30.5104 -7.83373 60
-    endloop
-  endfacet
-  facet normal 0.911395 0.411533 0
-    outer loop
-      vertex 28.9093 12.5102 60
-      vertex 28.5021 13.412 0
-      vertex 28.5021 13.412 60
-    endloop
-  endfacet
-  facet normal 0.911395 0.411533 0
-    outer loop
-      vertex 28.5021 13.412 0
-      vertex 28.9093 12.5102 60
-      vertex 28.9093 12.5102 0
-    endloop
-  endfacet
-  facet normal 0.868635 -0.495453 0
-    outer loop
-      vertex 27.1134 -16.0348 60
-      vertex 27.6037 -15.1752 0
-      vertex 27.6037 -15.1752 60
-    endloop
-  endfacet
-  facet normal 0.868635 -0.495453 0
-    outer loop
-      vertex 27.6037 -15.1752 0
-      vertex 27.1134 -16.0348 60
-      vertex 27.1134 -16.0348 0
-    endloop
-  endfacet
-  facet normal -0.911395 0.411533 0
-    outer loop
-      vertex -28.9093 12.5102 0
-      vertex -28.5021 13.412 60
-      vertex -28.5021 13.412 0
-    endloop
-  endfacet
-  facet normal -0.911395 0.411533 0
-    outer loop
-      vertex -28.5021 13.412 60
-      vertex -28.9093 12.5102 0
-      vertex -28.9093 12.5102 60
-    endloop
-  endfacet
-  facet normal 0.990028 -0.140872 0
-    outer loop
-      vertex 31.1122 -4.92768 60
-      vertex 31.2516 -3.948 0
-      vertex 31.2516 -3.948 60
-    endloop
-  endfacet
-  facet normal 0.990028 -0.140872 0
-    outer loop
-      vertex 31.2516 -3.948 0
-      vertex 31.1122 -4.92768 60
-      vertex 31.1122 -4.92768 0
-    endloop
-  endfacet
-  facet normal -0.923885 -0.38267 0
-    outer loop
-      vertex -28.9093 -12.5102 0
-      vertex -29.288 -11.5959 60
-      vertex -29.288 -11.5959 0
-    endloop
-  endfacet
-  facet normal -0.923885 -0.38267 0
-    outer loop
-      vertex -29.288 -11.5959 60
-      vertex -28.9093 -12.5102 0
-      vertex -28.9093 -12.5102 60
-    endloop
-  endfacet
-  facet normal -0.353393 -0.935475 0
-    outer loop
-      vertex -11.5959 -29.288 0
-      vertex -10.6702 -29.6377 60
-      vertex -11.5959 -29.288 60
-    endloop
-  endfacet
-  facet normal -0.353393 -0.935475 -0
-    outer loop
-      vertex -10.6702 -29.6377 60
-      vertex -11.5959 -29.288 0
-      vertex -10.6702 -29.6377 0
-    endloop
-  endfacet
-  facet normal -0.935475 0.353393 0
-    outer loop
-      vertex -29.6377 10.6702 0
-      vertex -29.288 11.5959 60
-      vertex -29.288 11.5959 0
-    endloop
-  endfacet
-  facet normal -0.935475 0.353393 0
-    outer loop
-      vertex -29.288 11.5959 60
-      vertex -29.6377 10.6702 0
-      vertex -29.6377 10.6702 60
-    endloop
-  endfacet
-  facet normal 0.6495 0.760361 -0
-    outer loop
-      vertex 20.8313 23.6285 0
-      vertex 20.0789 24.2712 60
-      vertex 20.8313 23.6285 60
-    endloop
-  endfacet
-  facet normal 0.6495 0.760361 0
-    outer loop
-      vertex 20.0789 24.2712 60
-      vertex 20.8313 23.6285 0
-      vertex 20.0789 24.2712 0
-    endloop
-  endfacet
-  facet normal 0.522557 0.852604 -0
-    outer loop
+      vertex 17.7056 26.053 0
       vertex 16.8785 26.5963 0
-      vertex 16.0348 27.1134 60
-      vertex 16.8785 26.5963 60
+      vertex 17.9867 26.4666 60
     endloop
   endfacet
-  facet normal 0.522557 0.852604 0
+  facet normal 0.989981 0.140951 -0.0083313
     outer loop
-      vertex 16.0348 27.1134 60
-      vertex 16.8785 26.5963 0
-      vertex 16.0348 27.1134 0
+      vertex 31.7477 4.01066 60
+      vertex 31.1122 4.92768 0
+      vertex 31.606 5.0059 60
     endloop
   endfacet
-  facet normal -0.6495 -0.760361 0
+  facet normal 0.935394 0.353508 -0.00833312
     outer loop
-      vertex -20.8313 -23.6285 0
-      vertex -20.0789 -24.2712 60
-      vertex -20.8313 -23.6285 60
+      vertex 30.1082 10.8396 60
+      vertex 29.6377 10.6702 0
+      vertex 29.7528 11.78 60
     endloop
   endfacet
-  facet normal -0.6495 -0.760361 -0
+  facet normal 0.760335 0.649478 -0.00833307
     outer loop
-      vertex -20.0789 -24.2712 60
-      vertex -20.8313 -23.6285 0
+      vertex 24.2712 20.0789 0
+      vertex 23.6285 20.8313 0
+      vertex 24.0036 21.162 60
+    endloop
+  endfacet
+  facet normal -0.625203 -0.780418 -0.00833175
+    outer loop
+      vertex -19.613 -25.285 60
       vertex -20.0789 -24.2712 0
+      vertex -19.3066 -24.8899 0
     endloop
   endfacet
-  facet normal -0.835809 0.549021 0
+  facet normal -0.171889 -0.985081 -0.00833294
     outer loop
-      vertex -26.5963 16.8785 0
-      vertex -26.053 17.7056 60
-      vertex -26.053 17.7056 0
-    endloop
-  endfacet
-  facet normal -0.835809 0.549021 0
-    outer loop
-      vertex -26.053 17.7056 60
-      vertex -26.5963 16.8785 0
-      vertex -26.5963 16.8785 60
-    endloop
-  endfacet
-  facet normal -0.109745 0.99396 0
-    outer loop
-      vertex -2.96441 31.3602 0
-      vertex -3.948 31.2516 60
-      vertex -2.96441 31.3602 60
-    endloop
-  endfacet
-  facet normal -0.109745 0.99396 0
-    outer loop
-      vertex -3.948 31.2516 60
-      vertex -2.96441 31.3602 0
-      vertex -3.948 31.2516 0
-    endloop
-  endfacet
-  facet normal -0.202719 -0.979237 0
-    outer loop
-      vertex -6.87151 -30.7414 0
-      vertex -5.90251 -30.942 60
-      vertex -6.87151 -30.7414 60
-    endloop
-  endfacet
-  facet normal -0.202719 -0.979237 -0
-    outer loop
-      vertex -5.90251 -30.942 60
-      vertex -6.87151 -30.7414 0
+      vertex -5.0059 -31.606 60
+      vertex -5.9962 -31.4332 60
       vertex -5.90251 -30.942 0
     endloop
   endfacet
-  facet normal -0.0784189 -0.99692 0
+  facet normal 0.323976 -0.946029 -0.00833157
     outer loop
-      vertex -2.96441 -31.3602 0
-      vertex -1.9779 -31.4378 60
-      vertex -2.96441 -31.3602 60
+      vertex 9.88854 -30.4338 60
+      vertex 9.73403 -29.9583 0
+      vertex 10.6702 -29.6377 0
     endloop
   endfacet
-  facet normal -0.0784189 -0.99692 -0
+  facet normal -0.989981 0.140951 -0.0083313
     outer loop
-      vertex -1.9779 -31.4378 60
-      vertex -2.96441 -31.3602 0
+      vertex -31.1122 4.92768 0
+      vertex -31.7477 4.01066 60
+      vertex -31.606 5.0059 60
+    endloop
+  endfacet
+  facet normal 0.993928 0.109719 -0.00833234
+    outer loop
+      vertex 31.858 3.01147 60
+      vertex 31.3602 2.96441 0
+      vertex 31.7477 4.01066 60
+    endloop
+  endfacet
+  facet normal -0.625203 0.780418 -0.00833175
+    outer loop
+      vertex -19.3066 24.8899 0
+      vertex -20.0789 24.2712 0
+      vertex -19.613 25.285 60
+    endloop
+  endfacet
+  facet normal 0.911402 -0.411434 -0.00833034
+    outer loop
+      vertex 28.9545 -13.6249 60
+      vertex 28.9093 -12.5102 0
+      vertex 29.3681 -12.7087 60
+    endloop
+  endfacet
+  facet normal 0.695904 0.718086 -0.00833251
+    outer loop
+      vertex 22.6274 22.6274 60
+      vertex 21.5632 22.9625 0
+      vertex 21.9055 23.327 60
+    endloop
+  endfacet
+  facet normal -0.0470502 0.998858 -0.00833345
+    outer loop
+      vertex -1.9779 31.4378 0
+      vertex -2.0093 31.9369 60
+      vertex -1.00514 31.9842 60
+    endloop
+  endfacet
+  facet normal -0.263898 0.964515 -0.00833217
+    outer loop
+      vertex -7.83373 30.5104 0
+      vertex -8.92772 30.7294 60
+      vertex -7.95808 30.9947 60
+    endloop
+  endfacet
+  facet normal 0.0784162 0.996886 -0.00833233
+    outer loop
+      vertex 2.96441 31.3602 0
+      vertex 1.9779 31.4378 0
+      vertex 3.01147 31.858 60
+    endloop
+  endfacet
+  facet normal -0.323976 -0.946029 -0.00833157
+    outer loop
+      vertex -9.88854 -30.4338 60
+      vertex -10.6702 -29.6377 0
+      vertex -9.73403 -29.9583 0
+    endloop
+  endfacet
+  facet normal -0.439949 -0.897984 -0.00833201
+    outer loop
+      vertex -13.412 -28.5021 0
+      vertex -14.5277 -28.5122 60
+      vertex -14.3007 -28.0667 0
+    endloop
+  endfacet
+  facet normal 0.495436 0.868604 -0.00833144
+    outer loop
+      vertex 16.0348 27.1134 0
+      vertex 15.1752 27.6037 0
+      vertex 15.4161 28.0418 60
+    endloop
+  endfacet
+  facet normal 0.993925 0.109741 -0.00833271
+    outer loop
+      vertex 31.3602 2.96441 0
+      vertex 31.2516 3.948 0
+      vertex 31.7477 4.01066 60
+    endloop
+  endfacet
+  facet normal 0.323888 -0.946059 -0.00833312
+    outer loop
+      vertex 10.8396 -30.1082 60
+      vertex 9.88854 -30.4338 60
+      vertex 10.6702 -29.6377 0
+    endloop
+  endfacet
+  facet normal 0.353508 -0.935394 -0.00833312
+    outer loop
+      vertex 10.8396 -30.1082 60
+      vertex 10.6702 -29.6377 0
+      vertex 11.78 -29.7528 60
+    endloop
+  endfacet
+  facet normal 0.323888 0.946059 -0.00833312
+    outer loop
+      vertex 10.6702 29.6377 0
+      vertex 9.88854 30.4338 60
+      vertex 10.8396 30.1082 60
+    endloop
+  endfacet
+  facet normal 0.411434 -0.911402 -0.00833034
+    outer loop
+      vertex 12.7087 -29.3681 60
+      vertex 12.5102 -28.9093 0
+      vertex 13.6249 -28.9545 60
+    endloop
+  endfacet
+  facet normal 0.695904 -0.718086 -0.00833251
+    outer loop
+      vertex 21.9055 -23.327 60
+      vertex 21.5632 -22.9625 0
+      vertex 22.6274 -22.6274 60
+    endloop
+  endfacet
+  facet normal 0.985081 -0.171889 -0.00833294
+    outer loop
+      vertex 31.4332 -5.9962 60
+      vertex 30.942 -5.90251 0
+      vertex 31.606 -5.0059 60
+    endloop
+  endfacet
+  facet normal 0.522413 -0.852652 -0.00833084
+    outer loop
+      vertex 16.2893 -27.5437 60
+      vertex 16.0348 -27.1134 0
+      vertex 17.1465 -27.0185 60
+    endloop
+  endfacet
+  facet normal -0.263846 0.964529 -0.00833128
+    outer loop
+      vertex -8.78822 30.2493 0
+      vertex -8.92772 30.7294 60
+      vertex -7.83373 30.5104 0
+    endloop
+  endfacet
+  facet normal -0.0784836 -0.996881 -0.00833346
+    outer loop
+      vertex -2.0093 -31.9369 60
+      vertex -3.01147 -31.858 60
       vertex -1.9779 -31.4378 0
     endloop
   endfacet
-  facet normal 0.575008 -0.818148 0
+  facet normal 0.852652 0.522413 -0.00833084
     outer loop
-      vertex 17.7056 -26.053 0
-      vertex 18.5152 -25.484 60
-      vertex 17.7056 -26.053 60
+      vertex 27.1134 16.0348 0
+      vertex 27.0185 17.1465 60
+      vertex 27.5437 16.2893 60
     endloop
   endfacet
-  facet normal 0.575008 -0.818148 0
+  facet normal 0.109719 -0.993928 -0.00833234
     outer loop
-      vertex 18.5152 -25.484 60
-      vertex 17.7056 -26.053 0
-      vertex 18.5152 -25.484 0
+      vertex 3.01147 -31.858 60
+      vertex 2.96441 -31.3602 0
+      vertex 4.01066 -31.7477 60
     endloop
   endfacet
-  facet normal -0.868635 0.495453 0
+  facet normal 0.81812 -0.574988 -0.00833197
     outer loop
-      vertex -27.6037 15.1752 0
-      vertex -27.1134 16.0348 60
-      vertex -27.1134 16.0348 0
+      vertex 25.8885 -18.8091 60
+      vertex 25.484 -18.5152 0
+      vertex 26.053 -17.7056 0
     endloop
   endfacet
-  facet normal -0.868635 0.495453 0
+  facet normal -0.71816 0.695828 -0.00833075
     outer loop
-      vertex -27.1134 16.0348 60
-      vertex -27.6037 15.1752 0
-      vertex -27.6037 15.1752 60
+      vertex -22.2739 22.2739 0
+      vertex -22.9625 21.5632 0
+      vertex -22.6274 22.6274 60
     endloop
   endfacet
-  facet normal -0.439964 -0.898015 0
+  facet normal -0.852575 -0.522539 -0.00833329
     outer loop
-      vertex -14.3007 -28.0667 0
-      vertex -13.412 -28.5021 60
-      vertex -14.3007 -28.0667 60
+      vertex -27.0185 -17.1465 60
+      vertex -27.1134 -16.0348 0
+      vertex -26.5963 -16.8785 0
     endloop
   endfacet
-  facet normal -0.439964 -0.898015 -0
+  facet normal -0.0157167 0.999842 -0.00833113
     outer loop
-      vertex -13.412 -28.5021 60
-      vertex -14.3007 -28.0667 0
-      vertex -13.412 -28.5021 0
+      vertex -0.989438 31.4845 0
+      vertex -1.00514 31.9842 60
+      vertex 0 32 60
     endloop
   endfacet
-  facet normal 0.883776 -0.467911 0
+  facet normal 0.985064 -0.171987 -0.00833129
     outer loop
-      vertex 27.6037 -15.1752 60
-      vertex 28.0667 -14.3007 0
-      vertex 28.0667 -14.3007 60
+      vertex 31.606 -5.0059 60
+      vertex 30.942 -5.90251 0
+      vertex 31.1122 -4.92768 0
     endloop
   endfacet
-  facet normal 0.883776 -0.467911 0
+  facet normal -0.71816 -0.695828 -0.00833075
     outer loop
-      vertex 28.0667 -14.3007 0
-      vertex 27.6037 -15.1752 60
-      vertex 27.6037 -15.1752 0
+      vertex -22.6274 -22.6274 60
+      vertex -22.9625 -21.5632 0
+      vertex -22.2739 -22.2739 0
     endloop
   endfacet
-  facet normal -0.600356 -0.799733 0
+  facet normal 0.673026 -0.739572 -0.00833305
     outer loop
-      vertex -19.3066 -24.8899 0
-      vertex -18.5152 -25.484 60
-      vertex -19.3066 -24.8899 60
+      vertex 21.162 -24.0036 60
+      vertex 20.8313 -23.6285 0
+      vertex 21.9055 -23.327 60
     endloop
   endfacet
-  facet normal -0.600356 -0.799733 -0
+  facet normal -0.989981 -0.140951 -0.0083313
     outer loop
-      vertex -18.5152 -25.484 60
-      vertex -19.3066 -24.8899 0
-      vertex -18.5152 -25.484 0
+      vertex -31.606 -5.0059 60
+      vertex -31.7477 -4.01066 60
+      vertex -31.1122 -4.92768 0
     endloop
   endfacet
-  facet normal -0.439964 0.898015 0
+  facet normal 0.923853 -0.382657 -0.00833035
     outer loop
-      vertex -13.412 28.5021 0
-      vertex -14.3007 28.0667 60
-      vertex -13.412 28.5021 60
-    endloop
-  endfacet
-  facet normal -0.439964 0.898015 0
-    outer loop
-      vertex -14.3007 28.0667 60
-      vertex -13.412 28.5021 0
-      vertex -14.3007 28.0667 0
-    endloop
-  endfacet
-  facet normal 0.911395 -0.411533 0
-    outer loop
-      vertex 28.5021 -13.412 60
+      vertex 29.3681 -12.7087 60
       vertex 28.9093 -12.5102 0
-      vertex 28.9093 -12.5102 60
-    endloop
-  endfacet
-  facet normal 0.911395 -0.411533 0
-    outer loop
-      vertex 28.9093 -12.5102 0
-      vertex 28.5021 -13.412 60
-      vertex 28.5021 -13.412 0
-    endloop
-  endfacet
-  facet normal -0.99692 0.0784189 0
-    outer loop
-      vertex -31.4378 1.9779 0
-      vertex -31.3602 2.96441 60
-      vertex -31.3602 2.96441 0
-    endloop
-  endfacet
-  facet normal -0.99692 0.0784189 0
-    outer loop
-      vertex -31.3602 2.96441 60
-      vertex -31.4378 1.9779 0
-      vertex -31.4378 1.9779 60
-    endloop
-  endfacet
-  facet normal 0.935475 -0.353393 0
-    outer loop
-      vertex 29.288 -11.5959 60
-      vertex 29.6377 -10.6702 0
-      vertex 29.6377 -10.6702 60
-    endloop
-  endfacet
-  facet normal 0.935475 -0.353393 0
-    outer loop
-      vertex 29.6377 -10.6702 0
-      vertex 29.288 -11.5959 60
       vertex 29.288 -11.5959 0
     endloop
   endfacet
-  facet normal -0.0471925 -0.998886 0
+  facet normal 0.83578 -0.549002 -0.00833338
     outer loop
-      vertex -1.9779 -31.4378 0
-      vertex -0.989438 -31.4845 60
-      vertex -1.9779 -31.4378 60
+      vertex 26.4666 -17.9867 60
+      vertex 26.053 -17.7056 0
+      vertex 26.5963 -16.8785 0
     endloop
   endfacet
-  facet normal -0.0471925 -0.998886 -0
+  facet normal -0.649391 -0.760409 -0.00833117
     outer loop
-      vertex -0.989438 -31.4845 60
-      vertex -1.9779 -31.4378 0
-      vertex -0.989438 -31.4845 0
+      vertex -20.3976 -24.6564 60
+      vertex -21.162 -24.0036 60
+      vertex -20.0789 -24.2712 0
     endloop
   endfacet
-  facet normal 0.109745 -0.99396 0
+  facet normal -0.996881 0.0784836 -0.00833346
     outer loop
-      vertex 2.96441 -31.3602 0
-      vertex 3.948 -31.2516 60
-      vertex 2.96441 -31.3602 60
+      vertex -31.4378 1.9779 0
+      vertex -31.9369 2.0093 60
+      vertex -31.858 3.01147 60
     endloop
   endfacet
-  facet normal 0.109745 -0.99396 0
+  facet normal 0.972338 -0.233429 -0.00833106
     outer loop
-      vertex 3.948 -31.2516 60
+      vertex 31.2293 -6.98058 60
+      vertex 30.5104 -7.83373 0
+      vertex 30.7414 -6.87151 0
+    endloop
+  endfacet
+  facet normal 0.495436 -0.868604 -0.00833144
+    outer loop
+      vertex 15.4161 -28.0418 60
+      vertex 15.1752 -27.6037 0
+      vertex 16.0348 -27.1134 0
+    endloop
+  endfacet
+  facet normal 0.897984 -0.439949 -0.00833201
+    outer loop
+      vertex 28.5122 -14.5277 60
+      vertex 28.0667 -14.3007 0
+      vertex 28.5021 -13.412 0
+    endloop
+  endfacet
+  facet normal 0.996886 -0.0784162 -0.00833233
+    outer loop
+      vertex 31.858 -3.01147 60
+      vertex 31.3602 -2.96441 0
+      vertex 31.4378 -1.9779 0
+    endloop
+  endfacet
+  facet normal 0.989993 -0.140868 -0.00833271
+    outer loop
+      vertex 31.7477 -4.01066 60
+      vertex 31.1122 -4.92768 0
+      vertex 31.2516 -3.948 0
+    endloop
+  endfacet
+  facet normal -0.897984 0.439949 -0.00833201
+    outer loop
+      vertex -28.5021 13.412 0
+      vertex -28.5122 14.5277 60
+      vertex -28.0667 14.3007 0
+    endloop
+  endfacet
+  facet normal 0.989993 0.140868 -0.00833271
+    outer loop
+      vertex 31.2516 3.948 0
+      vertex 31.1122 4.92768 0
+      vertex 31.7477 4.01066 60
+    endloop
+  endfacet
+  facet normal 0.993925 -0.109741 -0.00833271
+    outer loop
+      vertex 31.7477 -4.01066 60
+      vertex 31.2516 -3.948 0
+      vertex 31.3602 -2.96441 0
+    endloop
+  endfacet
+  facet normal -0.382687 -0.92384 -0.0083309
+    outer loop
+      vertex -11.78 -29.7528 60
+      vertex -12.7087 -29.3681 60
+      vertex -11.5959 -29.288 0
+    endloop
+  endfacet
+  facet normal 0.998851 -0.0471908 -0.00833112
+    outer loop
+      vertex 31.9842 -1.00514 60
+      vertex 31.4378 -1.9779 0
+      vertex 31.4845 -0.989438 0
+    endloop
+  endfacet
+  facet normal -0.015663 0.999843 -0.00833202
+    outer loop
+      vertex 0 31.5 0
+      vertex -0.989438 31.4845 0
+      vertex 0 32 60
+    endloop
+  endfacet
+  facet normal -0.522539 -0.852575 -0.00833329
+    outer loop
+      vertex -16.0348 -27.1134 0
+      vertex -17.1465 -27.0185 60
+      vertex -16.8785 -26.5963 0
+    endloop
+  endfacet
+  facet normal 0.71816 -0.695828 -0.00833075
+    outer loop
+      vertex 22.6274 -22.6274 60
+      vertex 22.2739 -22.2739 0
+      vertex 22.9625 -21.5632 0
+    endloop
+  endfacet
+  facet normal 0.718086 -0.695904 -0.00833251
+    outer loop
+      vertex 23.327 -21.9055 60
+      vertex 22.6274 -22.6274 60
+      vertex 22.9625 -21.5632 0
+    endloop
+  endfacet
+  facet normal -0.972338 0.233429 -0.00833106
+    outer loop
+      vertex -30.7414 6.87151 0
+      vertex -31.2293 6.98058 60
+      vertex -30.5104 7.83373 0
+    endloop
+  endfacet
+  facet normal 0.109741 -0.993925 -0.00833271
+    outer loop
+      vertex 4.01066 -31.7477 60
       vertex 2.96441 -31.3602 0
       vertex 3.948 -31.2516 0
     endloop
   endfacet
-  facet normal 0.600356 -0.799733 0
+  facet normal 0.955751 0.294059 -0.00833129
     outer loop
-      vertex 18.5152 -25.484 0
-      vertex 19.3066 -24.8899 60
-      vertex 18.5152 -25.484 60
+      vertex 30.2493 8.78822 0
+      vertex 29.9583 9.73403 0
+      vertex 30.7294 8.92772 60
     endloop
   endfacet
-  facet normal 0.600356 -0.799733 0
+  facet normal 0.467926 -0.883728 -0.00833141
     outer loop
-      vertex 19.3066 -24.8899 60
-      vertex 18.5152 -25.484 0
-      vertex 19.3066 -24.8899 0
+      vertex 15.4161 -28.0418 60
+      vertex 14.5277 -28.5122 60
+      vertex 15.1752 -27.6037 0
     endloop
   endfacet
-  facet normal -0.955784 0.294069 0
+  facet normal 0.625231 -0.780395 -0.00833116
+    outer loop
+      vertex 20.3976 -24.6564 60
+      vertex 19.613 -25.285 60
+      vertex 20.0789 -24.2712 0
+    endloop
+  endfacet
+  facet normal 0.171889 0.985081 -0.00833294
+    outer loop
+      vertex 5.90251 30.942 0
+      vertex 5.0059 31.606 60
+      vertex 5.9962 31.4332 60
+    endloop
+  endfacet
+  facet normal -0.897987 0.439942 -0.00833189
+    outer loop
+      vertex -28.5021 13.412 0
+      vertex -28.9545 13.6249 60
+      vertex -28.5122 14.5277 60
+    endloop
+  endfacet
+  facet normal -0.955751 -0.294059 -0.00833129
+    outer loop
+      vertex -29.9583 -9.73403 0
+      vertex -30.7294 -8.92772 60
+      vertex -30.2493 -8.78822 0
+    endloop
+  endfacet
+  facet normal -0.522413 -0.852652 -0.00833084
+    outer loop
+      vertex -16.2893 -27.5437 60
+      vertex -17.1465 -27.0185 60
+      vertex -16.0348 -27.1134 0
+    endloop
+  endfacet
+  facet normal 0.923853 0.382657 -0.00833035
+    outer loop
+      vertex 29.288 11.5959 0
+      vertex 28.9093 12.5102 0
+      vertex 29.3681 12.7087 60
+    endloop
+  endfacet
+  facet normal -0.739572 -0.673026 -0.00833305
+    outer loop
+      vertex -23.327 -21.9055 60
+      vertex -24.0036 -21.162 60
+      vertex -23.6285 -20.8313 0
+    endloop
+  endfacet
+  facet normal -0.467926 -0.883728 -0.00833141
+    outer loop
+      vertex -14.5277 -28.5122 60
+      vertex -15.4161 -28.0418 60
+      vertex -15.1752 -27.6037 0
+    endloop
+  endfacet
+  facet normal -0.985081 0.171889 -0.00833294
+    outer loop
+      vertex -30.942 5.90251 0
+      vertex -31.606 5.0059 60
+      vertex -31.4332 5.9962 60
+    endloop
+  endfacet
+  facet normal 0.935394 -0.353508 -0.00833312
+    outer loop
+      vertex 29.7528 -11.78 60
+      vertex 29.6377 -10.6702 0
+      vertex 30.1082 -10.8396 60
+    endloop
+  endfacet
+  facet normal 0.495468 -0.868586 -0.00833082
+    outer loop
+      vertex 16.2893 -27.5437 60
+      vertex 15.4161 -28.0418 60
+      vertex 16.0348 -27.1134 0
+    endloop
+  endfacet
+  facet normal -0.923853 0.382657 -0.00833035
+    outer loop
+      vertex -29.288 11.5959 0
+      vertex -29.3681 12.7087 60
+      vertex -28.9093 12.5102 0
+    endloop
+  endfacet
+  facet normal 0.996881 0.0784836 -0.00833346
+    outer loop
+      vertex 31.9369 2.0093 60
+      vertex 31.4378 1.9779 0
+      vertex 31.858 3.01147 60
+    endloop
+  endfacet
+  facet normal 0.964529 0.263846 -0.00833128
+    outer loop
+      vertex 30.5104 7.83373 0
+      vertex 30.2493 8.78822 0
+      vertex 30.7294 8.92772 60
+    endloop
+  endfacet
+  facet normal -0.835782 0.548998 -0.00833331
+    outer loop
+      vertex -26.5963 16.8785 0
+      vertex -27.0185 17.1465 60
+      vertex -26.4666 17.9867 60
+    endloop
+  endfacet
+  facet normal -0.911402 0.411434 -0.00833034
+    outer loop
+      vertex -28.9093 12.5102 0
+      vertex -29.3681 12.7087 60
+      vertex -28.9545 13.6249 60
+    endloop
+  endfacet
+  facet normal 0.955756 0.294042 -0.00833157
+    outer loop
+      vertex 30.7294 8.92772 60
+      vertex 29.9583 9.73403 0
+      vertex 30.4338 9.88854 60
+    endloop
+  endfacet
+  facet normal 0.263898 0.964515 -0.00833217
+    outer loop
+      vertex 8.92772 30.7294 60
+      vertex 7.83373 30.5104 0
+      vertex 7.95808 30.9947 60
+    endloop
+  endfacet
+  facet normal -0.83578 0.549002 -0.00833338
+    outer loop
+      vertex -26.053 17.7056 0
+      vertex -26.5963 16.8785 0
+      vertex -26.4666 17.9867 60
+    endloop
+  endfacet
+  facet normal -0.760335 -0.649478 -0.00833307
+    outer loop
+      vertex -24.0036 -21.162 60
+      vertex -24.2712 -20.0789 0
+      vertex -23.6285 -20.8313 0
+    endloop
+  endfacet
+  facet normal -0.673026 0.739572 -0.00833305
+    outer loop
+      vertex -20.8313 23.6285 0
+      vertex -21.9055 23.327 60
+      vertex -21.162 24.0036 60
+    endloop
+  endfacet
+  facet normal -0.323888 -0.946059 -0.00833312
+    outer loop
+      vertex -9.88854 -30.4338 60
+      vertex -10.8396 -30.1082 60
+      vertex -10.6702 -29.6377 0
+    endloop
+  endfacet
+  facet normal -0.109719 0.993928 -0.00833234
+    outer loop
+      vertex -2.96441 31.3602 0
+      vertex -4.01066 31.7477 60
+      vertex -3.01147 31.858 60
+    endloop
+  endfacet
+  facet normal -0.625231 -0.780395 -0.00833116
+    outer loop
+      vertex -19.613 -25.285 60
+      vertex -20.3976 -24.6564 60
+      vertex -20.0789 -24.2712 0
+    endloop
+  endfacet
+  facet normal -0.911402 -0.411434 -0.00833034
+    outer loop
+      vertex -28.9545 -13.6249 60
+      vertex -29.3681 -12.7087 60
+      vertex -28.9093 -12.5102 0
+    endloop
+  endfacet
+  facet normal -0.996886 0.0784162 -0.00833233
+    outer loop
+      vertex -31.4378 1.9779 0
+      vertex -31.858 3.01147 60
+      vertex -31.3602 2.96441 0
+    endloop
+  endfacet
+  facet normal 0.799705 -0.600335 -0.00833177
+    outer loop
+      vertex 25.285 -19.613 60
+      vertex 24.8899 -19.3066 0
+      vertex 25.484 -18.5152 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.7 0 60
+      vertex 32 0 60
+      vertex 31.9842 1.00514 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.6757 1.15996 60
+      vertex 31.9842 1.00514 60
+      vertex 31.9369 2.0093 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 32 0 60
+      vertex 27.7 0 60
+      vertex 31.9842 -1.00514 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.6029 2.31788 60
+      vertex 31.9369 2.0093 60
+      vertex 31.858 3.01147 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.6757 -1.15996 60
+      vertex 31.9842 -1.00514 60
+      vertex 27.7 0 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.4816 3.47173 60
+      vertex 31.858 3.01147 60
+      vertex 31.7477 4.01066 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.9842 -1.00514 60
+      vertex 27.6757 -1.15996 60
+      vertex 31.9369 -2.0093 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.4816 3.47173 60
+      vertex 31.7477 4.01066 60
+      vertex 31.606 5.0059 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.6029 -2.31788 60
+      vertex 31.9369 -2.0093 60
+      vertex 27.6757 -1.15996 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.3121 4.61949 60
+      vertex 31.606 5.0059 60
+      vertex 31.4332 5.9962 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.9369 -2.0093 60
+      vertex 27.6029 -2.31788 60
+      vertex 31.858 -3.01147 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.0947 5.75915 60
+      vertex 31.4332 5.9962 60
+      vertex 31.2293 6.98058 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.4816 -3.47173 60
+      vertex 31.858 -3.01147 60
+      vertex 27.6029 -2.31788 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.8298 6.88871 60
+      vertex 31.2293 6.98058 60
+      vertex 30.9947 7.95808 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.858 -3.01147 60
+      vertex 27.4816 -3.47173 60
+      vertex 31.7477 -4.01066 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.8298 6.88871 60
+      vertex 30.9947 7.95808 60
+      vertex 30.7294 8.92772 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.7477 -4.01066 60
+      vertex 27.4816 -3.47173 60
+      vertex 31.606 -5.0059 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.5177 8.00618 60
+      vertex 30.7294 8.92772 60
+      vertex 30.4338 9.88854 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.3121 -4.61949 60
+      vertex 31.606 -5.0059 60
+      vertex 27.4816 -3.47173 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.1592 9.10961 60
+      vertex 30.4338 9.88854 60
+      vertex 30.1082 10.8396 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.606 -5.0059 60
+      vertex 27.3121 -4.61949 60
+      vertex 31.4332 -5.9962 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.7548 10.1971 60
+      vertex 30.1082 10.8396 60
+      vertex 29.7528 11.78 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.0947 -5.75915 60
+      vertex 31.4332 -5.9962 60
+      vertex 27.3121 -4.61949 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.7548 10.1971 60
+      vertex 29.7528 11.78 60
+      vertex 29.3681 12.7087 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.4332 -5.9962 60
+      vertex 27.0947 -5.75915 60
+      vertex 31.2293 -6.98058 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.3052 11.2666 60
+      vertex 29.3681 12.7087 60
+      vertex 28.9545 13.6249 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.8298 -6.88871 60
+      vertex 31.2293 -6.98058 60
+      vertex 27.0947 -5.75915 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8112 12.3164 60
+      vertex 28.9545 13.6249 60
+      vertex 28.5122 14.5277 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.2293 -6.98058 60
+      vertex 26.8298 -6.88871 60
+      vertex 30.9947 -7.95808 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.2737 13.3446 60
+      vertex 28.5122 14.5277 60
+      vertex 28.0418 15.4161 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.9947 -7.95808 60
+      vertex 26.8298 -6.88871 60
+      vertex 30.7294 -8.92772 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.5177 -8.00618 60
+      vertex 30.7294 -8.92772 60
+      vertex 26.8298 -6.88871 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.9842 1.00514 60
+      vertex 27.6757 1.15996 60
+      vertex 27.7 0 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.9369 2.0093 60
+      vertex 27.6029 2.31788 60
+      vertex 27.6757 1.15996 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.2737 13.3446 60
+      vertex 28.0418 15.4161 60
+      vertex 27.5437 16.2893 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.858 3.01147 60
+      vertex 27.4816 3.47173 60
+      vertex 27.6029 2.31788 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.606 5.0059 60
+      vertex 27.3121 4.61949 60
+      vertex 27.4816 3.47173 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.4332 5.9962 60
+      vertex 27.0947 5.75915 60
+      vertex 27.3121 4.61949 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.6936 14.3493 60
+      vertex 27.5437 16.2893 60
+      vertex 27.0185 17.1465 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.2293 6.98058 60
+      vertex 26.8298 6.88871 60
+      vertex 27.0947 5.75915 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.7294 8.92772 60
+      vertex 26.5177 8.00618 60
+      vertex 26.8298 6.88871 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.0719 15.3289 60
+      vertex 27.0185 17.1465 60
+      vertex 26.4666 17.9867 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.4338 9.88854 60
+      vertex 26.1592 9.10961 60
+      vertex 26.5177 8.00618 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.4098 16.2817 60
+      vertex 26.4666 17.9867 60
+      vertex 25.8885 18.8091 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.1082 10.8396 60
+      vertex 25.7548 10.1971 60
+      vertex 26.1592 9.10961 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.3681 12.7087 60
+      vertex 25.3052 11.2666 60
+      vertex 25.7548 10.1971 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.4098 16.2817 60
+      vertex 25.8885 18.8091 60
+      vertex 25.285 19.613 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.9545 13.6249 60
+      vertex 24.8112 12.3164 60
+      vertex 25.3052 11.2666 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.7083 17.2058 60
+      vertex 25.285 19.613 60
+      vertex 24.6564 20.3976 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.5122 14.5277 60
+      vertex 24.2737 13.3446 60
+      vertex 24.8112 12.3164 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.9688 18.0998 60
+      vertex 24.6564 20.3976 60
+      vertex 24.0036 21.162 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.5437 16.2893 60
+      vertex 23.6936 14.3493 60
+      vertex 24.2737 13.3446 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1924 18.962 60
+      vertex 24.0036 21.162 60
+      vertex 23.327 21.9055 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.0185 17.1465 60
+      vertex 23.0719 15.3289 60
+      vertex 23.6936 14.3493 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1924 18.962 60
+      vertex 23.327 21.9055 60
+      vertex 22.6274 22.6274 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.4666 17.9867 60
+      vertex 22.4098 16.2817 60
+      vertex 23.0719 15.3289 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3807 19.7909 60
+      vertex 22.6274 22.6274 60
+      vertex 21.9055 23.327 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.285 19.613 60
+      vertex 21.7083 17.2058 60
+      vertex 22.4098 16.2817 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5349 20.5851 60
+      vertex 21.9055 23.327 60
+      vertex 21.162 24.0036 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.6564 20.3976 60
+      vertex 20.9688 18.0998 60
+      vertex 21.7083 17.2058 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6566 21.3432 60
+      vertex 21.162 24.0036 60
+      vertex 20.3976 24.6564 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.0036 21.162 60
+      vertex 20.1924 18.962 60
+      vertex 20.9688 18.0998 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6566 21.3432 60
+      vertex 20.3976 24.6564 60
+      vertex 19.613 25.285 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.6274 22.6274 60
+      vertex 19.3807 19.7909 60
+      vertex 20.1924 18.962 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.7474 22.0639 60
+      vertex 19.613 25.285 60
+      vertex 18.8091 25.8885 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.9055 23.327 60
+      vertex 18.5349 20.5851 60
+      vertex 19.3807 19.7909 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.8088 22.7458 60
+      vertex 18.8091 25.8885 60
+      vertex 17.9867 26.4666 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.162 24.0036 60
+      vertex 17.6566 21.3432 60
+      vertex 18.5349 20.5851 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8424 23.3879 60
+      vertex 17.9867 26.4666 60
+      vertex 17.1465 27.0185 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.613 25.285 60
+      vertex 16.7474 22.0639 60
+      vertex 17.6566 21.3432 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8424 23.3879 60
+      vertex 17.1465 27.0185 60
+      vertex 16.2893 27.5437 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.8091 25.8885 60
+      vertex 15.8088 22.7458 60
+      vertex 16.7474 22.0639 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.85 23.9889 60
+      vertex 16.2893 27.5437 60
+      vertex 15.4161 28.0418 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.9867 26.4666 60
+      vertex 14.8424 23.3879 60
+      vertex 15.8088 22.7458 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.8333 24.5478 60
+      vertex 15.4161 28.0418 60
+      vertex 14.5277 28.5122 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.2893 27.5437 60
+      vertex 13.85 23.9889 60
+      vertex 14.8424 23.3879 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7941 25.0637 60
+      vertex 14.5277 28.5122 60
+      vertex 13.6249 28.9545 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4161 28.0418 60
+      vertex 12.8333 24.5478 60
+      vertex 13.85 23.9889 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7941 25.0637 60
+      vertex 13.6249 28.9545 60
+      vertex 12.7087 29.3681 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.5277 28.5122 60
+      vertex 11.7941 25.0637 60
+      vertex 12.8333 24.5478 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.7342 25.5356 60
+      vertex 12.7087 29.3681 60
+      vertex 11.78 29.7528 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.65545 25.9627 60
+      vertex 11.78 29.7528 60
+      vertex 10.8396 30.1082 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7087 29.3681 60
+      vertex 10.7342 25.5356 60
+      vertex 11.7941 25.0637 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.55977 26.3443 60
+      vertex 10.8396 30.1082 60
+      vertex 9.88854 30.4338 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.78 29.7528 60
+      vertex 9.65545 25.9627 60
+      vertex 10.7342 25.5356 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.55977 26.3443 60
+      vertex 9.88854 30.4338 60
+      vertex 8.92772 30.7294 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.8396 30.1082 60
+      vertex 8.55977 26.3443 60
+      vertex 9.65545 25.9627 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.44908 26.6796 60
+      vertex 8.92772 30.7294 60
+      vertex 7.95808 30.9947 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.92772 30.7294 60
+      vertex 7.44908 26.6796 60
+      vertex 8.55977 26.3443 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.32532 26.9681 60
+      vertex 7.95808 30.9947 60
+      vertex 6.98058 31.2293 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.95808 30.9947 60
+      vertex 6.32532 26.9681 60
+      vertex 7.44908 26.6796 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.19046 27.2094 60
+      vertex 6.98058 31.2293 60
+      vertex 5.9962 31.4332 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.98058 31.2293 60
+      vertex 5.19046 27.2094 60
+      vertex 6.32532 26.9681 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.0059 31.606 60
+      vertex 5.19046 27.2094 60
+      vertex 5.9962 31.4332 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.0059 31.606 60
+      vertex 4.0465 27.4028 60
+      vertex 5.19046 27.2094 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.01066 31.7477 60
+      vertex 4.0465 27.4028 60
+      vertex 5.0059 31.606 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.89544 27.5483 60
+      vertex 4.01066 31.7477 60
+      vertex 3.01147 31.858 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.01066 31.7477 60
+      vertex 2.89544 27.5483 60
+      vertex 4.0465 27.4028 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.7393 27.6453 60
+      vertex 3.01147 31.858 60
+      vertex 2.0093 31.9369 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.01147 31.858 60
+      vertex 1.7393 27.6453 60
+      vertex 2.89544 27.5483 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.00514 31.9842 60
+      vertex 1.7393 27.6453 60
+      vertex 2.0093 31.9369 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.00514 31.9842 60
+      vertex 0.580105 27.6939 60
+      vertex 1.7393 27.6453 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 32 60
+      vertex 0.580105 27.6939 60
+      vertex 1.00514 31.9842 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 32 60
+      vertex -0.580105 27.6939 60
+      vertex 0.580105 27.6939 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.00514 31.9842 60
+      vertex -0.580105 27.6939 60
+      vertex 0 32 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.00514 31.9842 60
+      vertex -1.7393 27.6453 60
+      vertex -0.580105 27.6939 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.0093 31.9369 60
+      vertex -1.7393 27.6453 60
+      vertex -1.00514 31.9842 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3.01147 31.858 60
+      vertex -1.7393 27.6453 60
+      vertex -2.0093 31.9369 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.7393 27.6453 60
+      vertex -3.01147 31.858 60
+      vertex -2.89544 27.5483 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -4.01066 31.7477 60
+      vertex -2.89544 27.5483 60
+      vertex -3.01147 31.858 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.01066 31.7477 60
+      vertex -4.0465 27.4028 60
+      vertex -2.89544 27.5483 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.0059 31.606 60
+      vertex -4.0465 27.4028 60
+      vertex -4.01066 31.7477 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.0059 31.606 60
+      vertex -5.19046 27.2094 60
+      vertex -4.0465 27.4028 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.9962 31.4332 60
+      vertex -5.19046 27.2094 60
+      vertex -5.0059 31.606 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -6.98058 31.2293 60
+      vertex -5.19046 27.2094 60
+      vertex -5.9962 31.4332 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.19046 27.2094 60
+      vertex -6.98058 31.2293 60
+      vertex -6.32532 26.9681 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -7.95808 30.9947 60
+      vertex -6.32532 26.9681 60
+      vertex -6.98058 31.2293 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.32532 26.9681 60
+      vertex -7.95808 30.9947 60
+      vertex -7.44908 26.6796 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -8.92772 30.7294 60
+      vertex -7.44908 26.6796 60
+      vertex -7.95808 30.9947 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.44908 26.6796 60
+      vertex -8.92772 30.7294 60
+      vertex -8.55977 26.3443 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.88854 30.4338 60
+      vertex -8.55977 26.3443 60
+      vertex -8.92772 30.7294 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.8396 30.1082 60
+      vertex -8.55977 26.3443 60
+      vertex -9.88854 30.4338 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.55977 26.3443 60
+      vertex -10.8396 30.1082 60
+      vertex -9.65545 25.9627 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.78 29.7528 60
+      vertex -9.65545 25.9627 60
+      vertex -10.8396 30.1082 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.65545 25.9627 60
+      vertex -11.78 29.7528 60
+      vertex -10.7342 25.5356 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.7087 29.3681 60
+      vertex -10.7342 25.5356 60
+      vertex -11.78 29.7528 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.7342 25.5356 60
+      vertex -12.7087 29.3681 60
+      vertex -11.7941 25.0637 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.6249 28.9545 60
+      vertex -11.7941 25.0637 60
+      vertex -12.7087 29.3681 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.5277 28.5122 60
+      vertex -11.7941 25.0637 60
+      vertex -13.6249 28.9545 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7941 25.0637 60
+      vertex -14.5277 28.5122 60
+      vertex -12.8333 24.5478 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.4161 28.0418 60
+      vertex -12.8333 24.5478 60
+      vertex -14.5277 28.5122 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.8333 24.5478 60
+      vertex -15.4161 28.0418 60
+      vertex -13.85 23.9889 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.2893 27.5437 60
+      vertex -13.85 23.9889 60
+      vertex -15.4161 28.0418 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.85 23.9889 60
+      vertex -16.2893 27.5437 60
+      vertex -14.8424 23.3879 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.1465 27.0185 60
+      vertex -14.8424 23.3879 60
+      vertex -16.2893 27.5437 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.9867 26.4666 60
+      vertex -14.8424 23.3879 60
+      vertex -17.1465 27.0185 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8424 23.3879 60
+      vertex -17.9867 26.4666 60
+      vertex -15.8088 22.7458 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.8091 25.8885 60
+      vertex -15.8088 22.7458 60
+      vertex -17.9867 26.4666 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.8088 22.7458 60
+      vertex -18.8091 25.8885 60
+      vertex -16.7474 22.0639 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.613 25.285 60
+      vertex -16.7474 22.0639 60
+      vertex -18.8091 25.8885 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.7474 22.0639 60
+      vertex -19.613 25.285 60
+      vertex -17.6566 21.3432 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.3976 24.6564 60
+      vertex -17.6566 21.3432 60
+      vertex -19.613 25.285 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.162 24.0036 60
+      vertex -17.6566 21.3432 60
+      vertex -20.3976 24.6564 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6566 21.3432 60
+      vertex -21.162 24.0036 60
+      vertex -18.5349 20.5851 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.9055 23.327 60
+      vertex -18.5349 20.5851 60
+      vertex -21.162 24.0036 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5349 20.5851 60
+      vertex -21.9055 23.327 60
+      vertex -19.3807 19.7909 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.6274 22.6274 60
+      vertex -19.3807 19.7909 60
+      vertex -21.9055 23.327 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3807 19.7909 60
+      vertex -22.6274 22.6274 60
+      vertex -20.1924 18.962 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.327 21.9055 60
+      vertex -20.1924 18.962 60
+      vertex -22.6274 22.6274 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.0036 21.162 60
+      vertex -20.1924 18.962 60
+      vertex -23.327 21.9055 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1924 18.962 60
+      vertex -24.0036 21.162 60
+      vertex -20.9688 18.0998 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.6564 20.3976 60
+      vertex -20.9688 18.0998 60
+      vertex -24.0036 21.162 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.9688 18.0998 60
+      vertex -24.6564 20.3976 60
+      vertex -21.7083 17.2058 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -25.285 19.613 60
+      vertex -21.7083 17.2058 60
+      vertex -24.6564 20.3976 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.7083 17.2058 60
+      vertex -25.285 19.613 60
+      vertex -22.4098 16.2817 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -25.8885 18.8091 60
+      vertex -22.4098 16.2817 60
+      vertex -25.285 19.613 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -26.4666 17.9867 60
+      vertex -22.4098 16.2817 60
+      vertex -25.8885 18.8091 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.4098 16.2817 60
+      vertex -26.4666 17.9867 60
+      vertex -23.0719 15.3289 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.0185 17.1465 60
+      vertex -23.0719 15.3289 60
+      vertex -26.4666 17.9867 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0719 15.3289 60
+      vertex -27.0185 17.1465 60
+      vertex -23.6936 14.3493 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.5437 16.2893 60
+      vertex -23.6936 14.3493 60
+      vertex -27.0185 17.1465 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.6936 14.3493 60
+      vertex -27.5437 16.2893 60
+      vertex -24.2737 13.3446 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.0418 15.4161 60
+      vertex -24.2737 13.3446 60
+      vertex -27.5437 16.2893 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.5122 14.5277 60
+      vertex -24.2737 13.3446 60
+      vertex -28.0418 15.4161 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.2737 13.3446 60
+      vertex -28.5122 14.5277 60
+      vertex -24.8112 12.3164 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.9545 13.6249 60
+      vertex -24.8112 12.3164 60
+      vertex -28.5122 14.5277 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8112 12.3164 60
+      vertex -28.9545 13.6249 60
+      vertex -25.3052 11.2666 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -29.3681 12.7087 60
+      vertex -25.3052 11.2666 60
+      vertex -28.9545 13.6249 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3052 11.2666 60
+      vertex -29.3681 12.7087 60
+      vertex -25.7548 10.1971 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -29.7528 11.78 60
+      vertex -25.7548 10.1971 60
+      vertex -29.3681 12.7087 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.1082 10.8396 60
+      vertex -25.7548 10.1971 60
+      vertex -29.7528 11.78 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.7548 10.1971 60
+      vertex -30.1082 10.8396 60
+      vertex -26.1592 9.10961 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.4338 9.88854 60
+      vertex -26.1592 9.10961 60
+      vertex -30.1082 10.8396 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1592 9.10961 60
+      vertex -30.4338 9.88854 60
+      vertex -26.5177 8.00618 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.7294 8.92772 60
+      vertex -26.5177 8.00618 60
+      vertex -30.4338 9.88854 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.7294 -8.92772 60
+      vertex 26.5177 -8.00618 60
+      vertex 30.4338 -9.88854 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.1592 -9.10961 60
+      vertex 30.4338 -9.88854 60
+      vertex 26.5177 -8.00618 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.4338 -9.88854 60
+      vertex 26.1592 -9.10961 60
+      vertex 30.1082 -10.8396 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.7548 -10.1971 60
+      vertex 30.1082 -10.8396 60
+      vertex 26.1592 -9.10961 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.1082 -10.8396 60
+      vertex 25.7548 -10.1971 60
+      vertex 29.7528 -11.78 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.7528 -11.78 60
+      vertex 25.7548 -10.1971 60
+      vertex 29.3681 -12.7087 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.3052 -11.2666 60
+      vertex 29.3681 -12.7087 60
+      vertex 25.7548 -10.1971 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.3681 -12.7087 60
+      vertex 25.3052 -11.2666 60
+      vertex 28.9545 -13.6249 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.8112 -12.3164 60
+      vertex 28.9545 -13.6249 60
+      vertex 25.3052 -11.2666 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.9545 -13.6249 60
+      vertex 24.8112 -12.3164 60
+      vertex 28.5122 -14.5277 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.2737 -13.3446 60
+      vertex 28.5122 -14.5277 60
+      vertex 24.8112 -12.3164 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.5122 -14.5277 60
+      vertex 24.2737 -13.3446 60
+      vertex 28.0418 -15.4161 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.0418 -15.4161 60
+      vertex 24.2737 -13.3446 60
+      vertex 27.5437 -16.2893 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.6936 -14.3493 60
+      vertex 27.5437 -16.2893 60
+      vertex 24.2737 -13.3446 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.5437 -16.2893 60
+      vertex 23.6936 -14.3493 60
+      vertex 27.0185 -17.1465 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.0719 -15.3289 60
+      vertex 27.0185 -17.1465 60
+      vertex 23.6936 -14.3493 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.0185 -17.1465 60
+      vertex 23.0719 -15.3289 60
+      vertex 26.4666 -17.9867 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.4098 -16.2817 60
+      vertex 26.4666 -17.9867 60
+      vertex 23.0719 -15.3289 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.4666 -17.9867 60
+      vertex 22.4098 -16.2817 60
+      vertex 25.8885 -18.8091 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.8885 -18.8091 60
+      vertex 22.4098 -16.2817 60
+      vertex 25.285 -19.613 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.7083 -17.2058 60
+      vertex 25.285 -19.613 60
+      vertex 22.4098 -16.2817 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.285 -19.613 60
+      vertex 21.7083 -17.2058 60
+      vertex 24.6564 -20.3976 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.9688 -18.0998 60
+      vertex 24.6564 -20.3976 60
+      vertex 21.7083 -17.2058 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.6564 -20.3976 60
+      vertex 20.9688 -18.0998 60
+      vertex 24.0036 -21.162 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.1924 -18.962 60
+      vertex 24.0036 -21.162 60
+      vertex 20.9688 -18.0998 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.0036 -21.162 60
+      vertex 20.1924 -18.962 60
+      vertex 23.327 -21.9055 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.327 -21.9055 60
+      vertex 20.1924 -18.962 60
+      vertex 22.6274 -22.6274 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.3807 -19.7909 60
+      vertex 22.6274 -22.6274 60
+      vertex 20.1924 -18.962 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.6274 -22.6274 60
+      vertex 19.3807 -19.7909 60
+      vertex 21.9055 -23.327 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.5349 -20.5851 60
+      vertex 21.9055 -23.327 60
+      vertex 19.3807 -19.7909 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.9055 -23.327 60
+      vertex 18.5349 -20.5851 60
+      vertex 21.162 -24.0036 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.6566 -21.3432 60
+      vertex 21.162 -24.0036 60
+      vertex 18.5349 -20.5851 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.162 -24.0036 60
+      vertex 17.6566 -21.3432 60
+      vertex 20.3976 -24.6564 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.3976 -24.6564 60
+      vertex 17.6566 -21.3432 60
+      vertex 19.613 -25.285 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.7474 -22.0639 60
+      vertex 19.613 -25.285 60
+      vertex 17.6566 -21.3432 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.613 -25.285 60
+      vertex 16.7474 -22.0639 60
+      vertex 18.8091 -25.8885 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.8088 -22.7458 60
+      vertex 18.8091 -25.8885 60
+      vertex 16.7474 -22.0639 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.8091 -25.8885 60
+      vertex 15.8088 -22.7458 60
+      vertex 17.9867 -26.4666 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.8424 -23.3879 60
+      vertex 17.9867 -26.4666 60
+      vertex 15.8088 -22.7458 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.9867 -26.4666 60
+      vertex 14.8424 -23.3879 60
+      vertex 17.1465 -27.0185 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.1465 -27.0185 60
+      vertex 14.8424 -23.3879 60
+      vertex 16.2893 -27.5437 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.85 -23.9889 60
+      vertex 16.2893 -27.5437 60
+      vertex 14.8424 -23.3879 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.2893 -27.5437 60
+      vertex 13.85 -23.9889 60
+      vertex 15.4161 -28.0418 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.8333 -24.5478 60
+      vertex 15.4161 -28.0418 60
+      vertex 13.85 -23.9889 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4161 -28.0418 60
+      vertex 12.8333 -24.5478 60
+      vertex 14.5277 -28.5122 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.7941 -25.0637 60
+      vertex 14.5277 -28.5122 60
+      vertex 12.8333 -24.5478 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.5277 -28.5122 60
+      vertex 11.7941 -25.0637 60
+      vertex 13.6249 -28.9545 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6249 -28.9545 60
+      vertex 11.7941 -25.0637 60
+      vertex 12.7087 -29.3681 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.7342 -25.5356 60
+      vertex 12.7087 -29.3681 60
+      vertex 11.7941 -25.0637 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7087 -29.3681 60
+      vertex 10.7342 -25.5356 60
+      vertex 11.78 -29.7528 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.65545 -25.9627 60
+      vertex 11.78 -29.7528 60
+      vertex 10.7342 -25.5356 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.78 -29.7528 60
+      vertex 9.65545 -25.9627 60
+      vertex 10.8396 -30.1082 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 8.55977 -26.3443 60
+      vertex 10.8396 -30.1082 60
+      vertex 9.65545 -25.9627 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.8396 -30.1082 60
+      vertex 8.55977 -26.3443 60
+      vertex 9.88854 -30.4338 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.88854 -30.4338 60
+      vertex 8.55977 -26.3443 60
+      vertex 8.92772 -30.7294 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 7.44908 -26.6796 60
+      vertex 8.92772 -30.7294 60
+      vertex 8.55977 -26.3443 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.92772 -30.7294 60
+      vertex 7.44908 -26.6796 60
+      vertex 7.95808 -30.9947 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 6.32532 -26.9681 60
+      vertex 7.95808 -30.9947 60
+      vertex 7.44908 -26.6796 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.95808 -30.9947 60
+      vertex 6.32532 -26.9681 60
+      vertex 6.98058 -31.2293 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.19046 -27.2094 60
+      vertex 6.98058 -31.2293 60
+      vertex 6.32532 -26.9681 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.98058 -31.2293 60
+      vertex 5.19046 -27.2094 60
+      vertex 5.9962 -31.4332 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.19046 -27.2094 60
+      vertex 5.0059 -31.606 60
+      vertex 5.9962 -31.4332 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.0465 -27.4028 60
+      vertex 5.0059 -31.606 60
+      vertex 5.19046 -27.2094 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.0465 -27.4028 60
+      vertex 4.01066 -31.7477 60
+      vertex 5.0059 -31.606 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.89544 -27.5483 60
+      vertex 4.01066 -31.7477 60
+      vertex 4.0465 -27.4028 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.01066 -31.7477 60
+      vertex 2.89544 -27.5483 60
+      vertex 3.01147 -31.858 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.7393 -27.6453 60
+      vertex 3.01147 -31.858 60
+      vertex 2.89544 -27.5483 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.01147 -31.858 60
+      vertex 1.7393 -27.6453 60
+      vertex 2.0093 -31.9369 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.7393 -27.6453 60
+      vertex 1.00514 -31.9842 60
+      vertex 2.0093 -31.9369 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.580105 -27.6939 60
+      vertex 1.00514 -31.9842 60
+      vertex 1.7393 -27.6453 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.580105 -27.6939 60
+      vertex 0 -32 60
+      vertex 1.00514 -31.9842 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.580105 -27.6939 60
+      vertex 0 -32 60
+      vertex 0.580105 -27.6939 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.580105 -27.6939 60
+      vertex -1.00514 -31.9842 60
+      vertex 0 -32 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.7393 -27.6453 60
+      vertex -1.00514 -31.9842 60
+      vertex -0.580105 -27.6939 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.7393 -27.6453 60
+      vertex -2.0093 -31.9369 60
+      vertex -1.00514 -31.9842 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.01147 -31.858 60
+      vertex -1.7393 -27.6453 60
+      vertex -2.89544 -27.5483 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.7393 -27.6453 60
+      vertex -3.01147 -31.858 60
+      vertex -2.0093 -31.9369 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.89544 -27.5483 60
+      vertex -4.01066 -31.7477 60
+      vertex -3.01147 -31.858 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.0465 -27.4028 60
+      vertex -4.01066 -31.7477 60
+      vertex -2.89544 -27.5483 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.0465 -27.4028 60
+      vertex -5.0059 -31.606 60
+      vertex -4.01066 -31.7477 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.19046 -27.2094 60
+      vertex -5.0059 -31.606 60
+      vertex -4.0465 -27.4028 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.19046 -27.2094 60
+      vertex -5.9962 -31.4332 60
+      vertex -5.0059 -31.606 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.98058 -31.2293 60
+      vertex -5.19046 -27.2094 60
+      vertex -6.32532 -26.9681 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.19046 -27.2094 60
+      vertex -6.98058 -31.2293 60
+      vertex -5.9962 -31.4332 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.95808 -30.9947 60
+      vertex -6.32532 -26.9681 60
+      vertex -7.44908 -26.6796 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.32532 -26.9681 60
+      vertex -7.95808 -30.9947 60
+      vertex -6.98058 -31.2293 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.92772 -30.7294 60
+      vertex -7.44908 -26.6796 60
+      vertex -8.55977 -26.3443 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.44908 -26.6796 60
+      vertex -8.92772 -30.7294 60
+      vertex -7.95808 -30.9947 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.8396 -30.1082 60
+      vertex -8.55977 -26.3443 60
+      vertex -9.65545 -25.9627 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.55977 -26.3443 60
+      vertex -9.88854 -30.4338 60
+      vertex -8.92772 -30.7294 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.78 -29.7528 60
+      vertex -9.65545 -25.9627 60
+      vertex -10.7342 -25.5356 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.55977 -26.3443 60
+      vertex -10.8396 -30.1082 60
+      vertex -9.88854 -30.4338 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.65545 -25.9627 60
+      vertex -11.78 -29.7528 60
+      vertex -10.8396 -30.1082 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.7087 -29.3681 60
+      vertex -10.7342 -25.5356 60
+      vertex -11.7941 -25.0637 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.7342 -25.5356 60
+      vertex -12.7087 -29.3681 60
+      vertex -11.78 -29.7528 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.5277 -28.5122 60
+      vertex -11.7941 -25.0637 60
+      vertex -12.8333 -24.5478 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7941 -25.0637 60
+      vertex -13.6249 -28.9545 60
+      vertex -12.7087 -29.3681 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.4161 -28.0418 60
+      vertex -12.8333 -24.5478 60
+      vertex -13.85 -23.9889 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7941 -25.0637 60
+      vertex -14.5277 -28.5122 60
+      vertex -13.6249 -28.9545 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.2893 -27.5437 60
+      vertex -13.85 -23.9889 60
+      vertex -14.8424 -23.3879 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.8333 -24.5478 60
+      vertex -15.4161 -28.0418 60
+      vertex -14.5277 -28.5122 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.9867 -26.4666 60
+      vertex -14.8424 -23.3879 60
+      vertex -15.8088 -22.7458 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.85 -23.9889 60
+      vertex -16.2893 -27.5437 60
+      vertex -15.4161 -28.0418 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.8091 -25.8885 60
+      vertex -15.8088 -22.7458 60
+      vertex -16.7474 -22.0639 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8424 -23.3879 60
+      vertex -17.1465 -27.0185 60
+      vertex -16.2893 -27.5437 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.613 -25.285 60
+      vertex -16.7474 -22.0639 60
+      vertex -17.6566 -21.3432 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8424 -23.3879 60
+      vertex -17.9867 -26.4666 60
+      vertex -17.1465 -27.0185 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.162 -24.0036 60
+      vertex -17.6566 -21.3432 60
+      vertex -18.5349 -20.5851 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.8088 -22.7458 60
+      vertex -18.8091 -25.8885 60
+      vertex -17.9867 -26.4666 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.9055 -23.327 60
+      vertex -18.5349 -20.5851 60
+      vertex -19.3807 -19.7909 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.7474 -22.0639 60
+      vertex -19.613 -25.285 60
+      vertex -18.8091 -25.8885 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.6274 -22.6274 60
+      vertex -19.3807 -19.7909 60
+      vertex -20.1924 -18.962 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6566 -21.3432 60
+      vertex -20.3976 -24.6564 60
+      vertex -19.613 -25.285 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.0036 -21.162 60
+      vertex -20.1924 -18.962 60
+      vertex -20.9688 -18.0998 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6566 -21.3432 60
+      vertex -21.162 -24.0036 60
+      vertex -20.3976 -24.6564 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.6564 -20.3976 60
+      vertex -20.9688 -18.0998 60
+      vertex -21.7083 -17.2058 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5349 -20.5851 60
+      vertex -21.9055 -23.327 60
+      vertex -21.162 -24.0036 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.285 -19.613 60
+      vertex -21.7083 -17.2058 60
+      vertex -22.4098 -16.2817 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3807 -19.7909 60
+      vertex -22.6274 -22.6274 60
+      vertex -21.9055 -23.327 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.4666 -17.9867 60
+      vertex -22.4098 -16.2817 60
+      vertex -23.0719 -15.3289 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1924 -18.962 60
+      vertex -23.327 -21.9055 60
+      vertex -22.6274 -22.6274 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0185 -17.1465 60
+      vertex -23.0719 -15.3289 60
+      vertex -23.6936 -14.3493 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1924 -18.962 60
+      vertex -24.0036 -21.162 60
+      vertex -23.327 -21.9055 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.5437 -16.2893 60
+      vertex -23.6936 -14.3493 60
+      vertex -24.2737 -13.3446 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.9688 -18.0998 60
+      vertex -24.6564 -20.3976 60
+      vertex -24.0036 -21.162 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.5122 -14.5277 60
+      vertex -24.2737 -13.3446 60
+      vertex -24.8112 -12.3164 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.7083 -17.2058 60
+      vertex -25.285 -19.613 60
+      vertex -24.6564 -20.3976 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.9545 -13.6249 60
+      vertex -24.8112 -12.3164 60
+      vertex -25.3052 -11.2666 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -29.3681 -12.7087 60
+      vertex -25.3052 -11.2666 60
+      vertex -25.7548 -10.1971 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.4098 -16.2817 60
+      vertex -25.8885 -18.8091 60
+      vertex -25.285 -19.613 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.1082 -10.8396 60
+      vertex -25.7548 -10.1971 60
+      vertex -26.1592 -9.10961 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.4098 -16.2817 60
+      vertex -26.4666 -17.9867 60
+      vertex -25.8885 -18.8091 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.4338 -9.88854 60
+      vertex -26.1592 -9.10961 60
+      vertex -26.5177 -8.00618 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.7294 -8.92772 60
+      vertex -26.5177 -8.00618 60
+      vertex -26.8298 -6.88871 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0719 -15.3289 60
+      vertex -27.0185 -17.1465 60
+      vertex -26.4666 -17.9867 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.2293 -6.98058 60
+      vertex -26.8298 -6.88871 60
+      vertex -27.0947 -5.75915 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.4332 -5.9962 60
+      vertex -27.0947 -5.75915 60
+      vertex -27.3121 -4.61949 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.606 -5.0059 60
+      vertex -27.3121 -4.61949 60
+      vertex -27.4816 -3.47173 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.6936 -14.3493 60
+      vertex -27.5437 -16.2893 60
+      vertex -27.0185 -17.1465 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.858 -3.01147 60
+      vertex -27.4816 -3.47173 60
+      vertex -27.6029 -2.31788 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.9369 -2.0093 60
+      vertex -27.6029 -2.31788 60
+      vertex -27.6757 -1.15996 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.9842 -1.00514 60
+      vertex -27.6757 -1.15996 60
+      vertex -27.7 0 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.5177 8.00618 60
+      vertex -30.7294 8.92772 60
+      vertex -26.8298 6.88871 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.2737 -13.3446 60
+      vertex -28.0418 -15.4161 60
+      vertex -27.5437 -16.2893 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.9947 7.95808 60
+      vertex -26.8298 6.88871 60
+      vertex -30.7294 8.92772 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.2737 -13.3446 60
+      vertex -28.5122 -14.5277 60
+      vertex -28.0418 -15.4161 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.2293 6.98058 60
+      vertex -26.8298 6.88871 60
+      vertex -30.9947 7.95808 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8112 -12.3164 60
+      vertex -28.9545 -13.6249 60
+      vertex -28.5122 -14.5277 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8298 6.88871 60
+      vertex -31.2293 6.98058 60
+      vertex -27.0947 5.75915 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3052 -11.2666 60
+      vertex -29.3681 -12.7087 60
+      vertex -28.9545 -13.6249 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.4332 5.9962 60
+      vertex -27.0947 5.75915 60
+      vertex -31.2293 6.98058 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.7548 -10.1971 60
+      vertex -29.7528 -11.78 60
+      vertex -29.3681 -12.7087 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0947 5.75915 60
+      vertex -31.4332 5.9962 60
+      vertex -27.3121 4.61949 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.7548 -10.1971 60
+      vertex -30.1082 -10.8396 60
+      vertex -29.7528 -11.78 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.606 5.0059 60
+      vertex -27.3121 4.61949 60
+      vertex -31.4332 5.9962 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1592 -9.10961 60
+      vertex -30.4338 -9.88854 60
+      vertex -30.1082 -10.8396 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3121 4.61949 60
+      vertex -31.606 5.0059 60
+      vertex -27.4816 3.47173 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.5177 -8.00618 60
+      vertex -30.7294 -8.92772 60
+      vertex -30.4338 -9.88854 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.7477 4.01066 60
+      vertex -27.4816 3.47173 60
+      vertex -31.606 5.0059 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8298 -6.88871 60
+      vertex -30.9947 -7.95808 60
+      vertex -30.7294 -8.92772 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.858 3.01147 60
+      vertex -27.4816 3.47173 60
+      vertex -31.7477 4.01066 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8298 -6.88871 60
+      vertex -31.2293 -6.98058 60
+      vertex -30.9947 -7.95808 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.4816 3.47173 60
+      vertex -31.858 3.01147 60
+      vertex -27.6029 2.31788 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0947 -5.75915 60
+      vertex -31.4332 -5.9962 60
+      vertex -31.2293 -6.98058 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.9369 2.0093 60
+      vertex -27.6029 2.31788 60
+      vertex -31.858 3.01147 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3121 -4.61949 60
+      vertex -31.606 -5.0059 60
+      vertex -31.4332 -5.9962 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6029 2.31788 60
+      vertex -31.9369 2.0093 60
+      vertex -27.6757 1.15996 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.4816 -3.47173 60
+      vertex -31.7477 -4.01066 60
+      vertex -31.606 -5.0059 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.9842 1.00514 60
+      vertex -27.6757 1.15996 60
+      vertex -31.9369 2.0093 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.4816 -3.47173 60
+      vertex -31.858 -3.01147 60
+      vertex -31.7477 -4.01066 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6757 1.15996 60
+      vertex -31.9842 1.00514 60
+      vertex -27.7 0 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6029 -2.31788 60
+      vertex -31.9369 -2.0093 60
+      vertex -31.858 -3.01147 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -32 0 60
+      vertex -27.7 0 60
+      vertex -31.9842 1.00514 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6757 -1.15996 60
+      vertex -31.9842 -1.00514 60
+      vertex -31.9369 -2.0093 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.7 0 60
+      vertex -32 0 60
+      vertex -31.9842 -1.00514 60
+    endloop
+  endfacet
+  facet normal -0.202823 0.97918 -0.00833106
+    outer loop
+      vertex -6.87151 30.7414 0
+      vertex -6.98058 31.2293 60
+      vertex -5.9962 31.4332 60
+    endloop
+  endfacet
+  facet normal -0.999842 0.0157167 -0.00833113
+    outer loop
+      vertex -31.4845 0.989438 0
+      vertex -32 0 60
+      vertex -31.9842 1.00514 60
+    endloop
+  endfacet
+  facet normal 0.897987 0.439942 -0.00833189
+    outer loop
+      vertex 28.9545 13.6249 60
+      vertex 28.5021 13.412 0
+      vertex 28.5122 14.5277 60
+    endloop
+  endfacet
+  facet normal -0.964515 0.263898 -0.00833217
+    outer loop
+      vertex -30.5104 7.83373 0
+      vertex -30.9947 7.95808 60
+      vertex -30.7294 8.92772 60
+    endloop
+  endfacet
+  facet normal -0.760335 0.649478 -0.00833307
+    outer loop
+      vertex -23.6285 20.8313 0
+      vertex -24.2712 20.0789 0
+      vertex -24.0036 21.162 60
+    endloop
+  endfacet
+  facet normal 0.263846 0.964529 -0.00833128
+    outer loop
+      vertex 8.78822 30.2493 0
+      vertex 7.83373 30.5104 0
+      vertex 8.92772 30.7294 60
+    endloop
+  endfacet
+  facet normal 0.411518 0.911363 -0.00833188
+    outer loop
+      vertex 13.412 28.5021 0
+      vertex 12.5102 28.9093 0
+      vertex 13.6249 28.9545 60
+    endloop
+  endfacet
+  facet normal 0.964515 -0.263898 -0.00833217
+    outer loop
+      vertex 30.7294 -8.92772 60
+      vertex 30.5104 -7.83373 0
+      vertex 30.9947 -7.95808 60
+    endloop
+  endfacet
+  facet normal 0.171987 0.985064 -0.00833129
+    outer loop
+      vertex 5.90251 30.942 0
+      vertex 4.92768 31.1122 0
+      vertex 5.0059 31.606 60
+    endloop
+  endfacet
+  facet normal 0.202712 0.979203 -0.00833294
+    outer loop
+      vertex 6.87151 30.7414 0
+      vertex 5.90251 30.942 0
+      vertex 5.9962 31.4332 60
+    endloop
+  endfacet
+  facet normal 0.600345 -0.799698 -0.00833199
+    outer loop
+      vertex 18.8091 -25.8885 60
+      vertex 18.5152 -25.484 0
+      vertex 19.613 -25.285 60
+    endloop
+  endfacet
+  facet normal 0.574988 -0.81812 -0.00833197
+    outer loop
+      vertex 18.8091 -25.8885 60
+      vertex 17.7056 -26.053 0
+      vertex 18.5152 -25.484 0
+    endloop
+  endfacet
+  facet normal -0.993925 -0.109741 -0.00833271
+    outer loop
+      vertex -31.2516 -3.948 0
+      vertex -31.7477 -4.01066 60
+      vertex -31.3602 -2.96441 0
+    endloop
+  endfacet
+  facet normal -0.780395 -0.625231 -0.00833116
+    outer loop
+      vertex -24.6564 -20.3976 60
+      vertex -25.285 -19.613 60
+      vertex -24.2712 -20.0789 0
+    endloop
+  endfacet
+  facet normal -0.574988 0.81812 -0.00833197
+    outer loop
+      vertex -18.5152 25.484 0
+      vertex -18.8091 25.8885 60
+      vertex -17.7056 26.053 0
+    endloop
+  endfacet
+  facet normal -0.294042 0.955756 -0.00833157
+    outer loop
+      vertex -9.73403 29.9583 0
+      vertex -9.88854 30.4338 60
+      vertex -8.92772 30.7294 60
+    endloop
+  endfacet
+  facet normal 0.0784836 -0.996881 -0.00833346
+    outer loop
+      vertex 2.0093 -31.9369 60
+      vertex 1.9779 -31.4378 0
+      vertex 3.01147 -31.858 60
+    endloop
+  endfacet
+  facet normal -0.955751 0.294059 -0.00833129
     outer loop
       vertex -30.2493 8.78822 0
-      vertex -29.9583 9.73403 60
+      vertex -30.7294 8.92772 60
       vertex -29.9583 9.73403 0
     endloop
   endfacet
-  facet normal -0.955784 0.294069 0
+  facet normal -0.467926 0.883728 -0.00833141
     outer loop
-      vertex -29.9583 9.73403 60
-      vertex -30.2493 8.78822 0
-      vertex -30.2493 8.78822 60
+      vertex -15.1752 27.6037 0
+      vertex -15.4161 28.0418 60
+      vertex -14.5277 28.5122 60
     endloop
   endfacet
-  facet normal -0.898015 -0.439964 0
+  facet normal -0.625231 0.780395 -0.00833116
     outer loop
-      vertex -28.0667 -14.3007 0
-      vertex -28.5021 -13.412 60
-      vertex -28.5021 -13.412 0
+      vertex -20.0789 24.2712 0
+      vertex -20.3976 24.6564 60
+      vertex -19.613 25.285 60
     endloop
   endfacet
-  facet normal -0.898015 -0.439964 0
+  facet normal 0.718086 0.695904 -0.00833251
     outer loop
-      vertex -28.5021 -13.412 60
-      vertex -28.0667 -14.3007 0
-      vertex -28.0667 -14.3007 60
+      vertex 22.9625 21.5632 0
+      vertex 22.6274 22.6274 60
+      vertex 23.327 21.9055 60
     endloop
   endfacet
-  facet normal -0.998886 -0.0471925 0
+  facet normal 0.739594 0.673001 -0.00833251
+    outer loop
+      vertex 23.6285 20.8313 0
+      vertex 22.9625 21.5632 0
+      vertex 23.327 21.9055 60
+    endloop
+  endfacet
+  facet normal 0.439949 0.897984 -0.00833201
+    outer loop
+      vertex 14.3007 28.0667 0
+      vertex 13.412 28.5021 0
+      vertex 14.5277 28.5122 60
+    endloop
+  endfacet
+  facet normal 0.818071 -0.575057 -0.00833338
+    outer loop
+      vertex 26.4666 -17.9867 60
+      vertex 25.8885 -18.8091 60
+      vertex 26.053 -17.7056 0
+    endloop
+  endfacet
+  facet normal 0.382657 -0.923853 -0.00833035
+    outer loop
+      vertex 12.7087 -29.3681 60
+      vertex 11.5959 -29.288 0
+      vertex 12.5102 -28.9093 0
+    endloop
+  endfacet
+  facet normal 0.382687 -0.92384 -0.0083309
+    outer loop
+      vertex 11.78 -29.7528 60
+      vertex 11.5959 -29.288 0
+      vertex 12.7087 -29.3681 60
+    endloop
+  endfacet
+  facet normal -0.673001 -0.739594 -0.00833251
+    outer loop
+      vertex -20.8313 -23.6285 0
+      vertex -21.9055 -23.327 60
+      vertex -21.5632 -22.9625 0
+    endloop
+  endfacet
+  facet normal -0.695904 0.718086 -0.00833251
+    outer loop
+      vertex -21.5632 22.9625 0
+      vertex -22.6274 22.6274 60
+      vertex -21.9055 23.327 60
+    endloop
+  endfacet
+  facet normal 0.972354 -0.233365 -0.00833216
+    outer loop
+      vertex 30.9947 -7.95808 60
+      vertex 30.5104 -7.83373 0
+      vertex 31.2293 -6.98058 60
+    endloop
+  endfacet
+  facet normal -0.495468 0.868586 -0.00833082
+    outer loop
+      vertex -16.0348 27.1134 0
+      vertex -16.2893 27.5437 60
+      vertex -15.4161 28.0418 60
+    endloop
+  endfacet
+  facet normal -0.780418 -0.625203 -0.00833175
+    outer loop
+      vertex -24.2712 -20.0789 0
+      vertex -25.285 -19.613 60
+      vertex -24.8899 -19.3066 0
+    endloop
+  endfacet
+  facet normal -0.575057 -0.818071 -0.00833338
+    outer loop
+      vertex -17.9867 -26.4666 60
+      vertex -18.8091 -25.8885 60
+      vertex -17.7056 -26.053 0
+    endloop
+  endfacet
+  facet normal 0.0470502 0.998858 -0.00833345
+    outer loop
+      vertex 1.9779 31.4378 0
+      vertex 1.00514 31.9842 60
+      vertex 2.0093 31.9369 60
+    endloop
+  endfacet
+  facet normal 0.0784836 0.996881 -0.00833346
+    outer loop
+      vertex 3.01147 31.858 60
+      vertex 1.9779 31.4378 0
+      vertex 2.0093 31.9369 60
+    endloop
+  endfacet
+  facet normal 0.695828 0.71816 -0.00833075
+    outer loop
+      vertex 22.2739 22.2739 0
+      vertex 21.5632 22.9625 0
+      vertex 22.6274 22.6274 60
+    endloop
+  endfacet
+  facet normal 0.972354 0.233365 -0.00833216
+    outer loop
+      vertex 31.2293 6.98058 60
+      vertex 30.5104 7.83373 0
+      vertex 30.9947 7.95808 60
+    endloop
+  endfacet
+  facet normal -0.439942 -0.897987 -0.00833189
+    outer loop
+      vertex -13.6249 -28.9545 60
+      vertex -14.5277 -28.5122 60
+      vertex -13.412 -28.5021 0
+    endloop
+  endfacet
+  facet normal -0.649478 0.760335 -0.00833307
+    outer loop
+      vertex -20.8313 23.6285 0
+      vertex -21.162 24.0036 60
+      vertex -20.0789 24.2712 0
+    endloop
+  endfacet
+  facet normal -0.868604 0.495436 -0.00833144
+    outer loop
+      vertex -27.6037 15.1752 0
+      vertex -28.0418 15.4161 60
+      vertex -27.1134 16.0348 0
+    endloop
+  endfacet
+  facet normal 0.109741 0.993925 -0.00833271
+    outer loop
+      vertex 3.948 31.2516 0
+      vertex 2.96441 31.3602 0
+      vertex 4.01066 31.7477 60
+    endloop
+  endfacet
+  facet normal -0.998851 -0.0471908 -0.00833112
     outer loop
       vertex -31.4378 -1.9779 0
-      vertex -31.4845 -0.989438 60
+      vertex -31.9842 -1.00514 60
       vertex -31.4845 -0.989438 0
     endloop
   endfacet
-  facet normal -0.998886 -0.0471925 0
+  facet normal 0.382687 0.92384 -0.0083309
     outer loop
-      vertex -31.4845 -0.989438 60
-      vertex -31.4378 -1.9779 0
-      vertex -31.4378 -1.9779 60
+      vertex 12.7087 29.3681 60
+      vertex 11.5959 29.288 0
+      vertex 11.78 29.7528 60
     endloop
   endfacet
-  facet normal 0.439964 -0.898015 0
+  facet normal 0.780395 -0.625231 -0.00833116
     outer loop
-      vertex 13.412 -28.5021 0
-      vertex 14.3007 -28.0667 60
-      vertex 13.412 -28.5021 60
+      vertex 24.6564 -20.3976 60
+      vertex 24.2712 -20.0789 0
+      vertex 25.285 -19.613 60
     endloop
   endfacet
-  facet normal 0.439964 -0.898015 0
+  facet normal 0.780418 -0.625203 -0.00833175
     outer loop
-      vertex 14.3007 -28.0667 60
-      vertex 13.412 -28.5021 0
-      vertex 14.3007 -28.0667 0
+      vertex 25.285 -19.613 60
+      vertex 24.2712 -20.0789 0
+      vertex 24.8899 -19.3066 0
     endloop
   endfacet
-  facet normal 0.411533 -0.911395 0
+  facet normal 0.911363 0.411518 -0.00833188
     outer loop
-      vertex 12.5102 -28.9093 0
-      vertex 13.412 -28.5021 60
-      vertex 12.5102 -28.9093 60
+      vertex 28.9093 12.5102 0
+      vertex 28.5021 13.412 0
+      vertex 28.9545 13.6249 60
     endloop
   endfacet
-  facet normal 0.411533 -0.911395 0
+  facet normal -0.946029 0.323976 -0.00833157
     outer loop
-      vertex 13.412 -28.5021 60
-      vertex 12.5102 -28.9093 0
-      vertex 13.412 -28.5021 0
+      vertex -29.9583 9.73403 0
+      vertex -30.4338 9.88854 60
+      vertex -29.6377 10.6702 0
     endloop
   endfacet
-  facet normal -0.799733 -0.600356 0
+  facet normal -0.35338 0.935443 -0.00833085
     outer loop
-      vertex -24.8899 -19.3066 0
-      vertex -25.484 -18.5152 60
-      vertex -25.484 -18.5152 0
+      vertex -11.5959 29.288 0
+      vertex -11.78 29.7528 60
+      vertex -10.6702 29.6377 0
     endloop
   endfacet
-  facet normal -0.799733 -0.600356 0
+  facet normal 0.294059 -0.955751 -0.00833129
     outer loop
-      vertex -25.484 -18.5152 60
-      vertex -24.8899 -19.3066 0
-      vertex -24.8899 -19.3066 60
-    endloop
-  endfacet
-  facet normal -0.979237 -0.202719 0
-    outer loop
-      vertex -30.7414 -6.87151 0
-      vertex -30.942 -5.90251 60
-      vertex -30.942 -5.90251 0
-    endloop
-  endfacet
-  facet normal -0.979237 -0.202719 0
-    outer loop
-      vertex -30.942 -5.90251 60
-      vertex -30.7414 -6.87151 0
-      vertex -30.7414 -6.87151 60
-    endloop
-  endfacet
-  facet normal 0.411533 0.911395 -0
-    outer loop
-      vertex 13.412 28.5021 0
-      vertex 12.5102 28.9093 60
-      vertex 13.412 28.5021 60
-    endloop
-  endfacet
-  facet normal 0.411533 0.911395 0
-    outer loop
-      vertex 12.5102 28.9093 60
-      vertex 13.412 28.5021 0
-      vertex 12.5102 28.9093 0
-    endloop
-  endfacet
-  facet normal -0.99396 0.109745 0
-    outer loop
-      vertex -31.3602 2.96441 0
-      vertex -31.2516 3.948 60
-      vertex -31.2516 3.948 0
-    endloop
-  endfacet
-  facet normal -0.99396 0.109745 0
-    outer loop
-      vertex -31.2516 3.948 60
-      vertex -31.3602 2.96441 0
-      vertex -31.3602 2.96441 60
-    endloop
-  endfacet
-  facet normal 0.718185 -0.695852 0
-    outer loop
-      vertex 22.2739 -22.2739 60
-      vertex 22.9625 -21.5632 0
-      vertex 22.9625 -21.5632 60
-    endloop
-  endfacet
-  facet normal 0.718185 -0.695852 0
-    outer loop
-      vertex 22.9625 -21.5632 0
-      vertex 22.2739 -22.2739 60
-      vertex 22.2739 -22.2739 0
-    endloop
-  endfacet
-  facet normal 0.999877 -0.0156635 0
-    outer loop
-      vertex 31.4845 -0.989438 60
-      vertex 31.5 0 0
-      vertex 31.5 0 60
-    endloop
-  endfacet
-  facet normal 0.999877 -0.0156635 0
-    outer loop
-      vertex 31.5 0 0
-      vertex 31.4845 -0.989438 60
-      vertex 31.4845 -0.989438 0
-    endloop
-  endfacet
-  facet normal 0.294069 -0.955784 0
-    outer loop
-      vertex 8.78822 -30.2493 0
-      vertex 9.73403 -29.9583 60
-      vertex 8.78822 -30.2493 60
-    endloop
-  endfacet
-  facet normal 0.294069 -0.955784 0
-    outer loop
-      vertex 9.73403 -29.9583 60
+      vertex 8.92772 -30.7294 60
       vertex 8.78822 -30.2493 0
       vertex 9.73403 -29.9583 0
     endloop
   endfacet
-  facet normal 0.233437 0.972372 -0
+  facet normal 0.868604 -0.495436 -0.00833144
     outer loop
-      vertex 7.83373 30.5104 0
-      vertex 6.87151 30.7414 60
-      vertex 7.83373 30.5104 60
+      vertex 28.0418 -15.4161 60
+      vertex 27.1134 -16.0348 0
+      vertex 27.6037 -15.1752 0
     endloop
   endfacet
-  facet normal 0.233437 0.972372 0
+  facet normal -0.495436 -0.868604 -0.00833144
     outer loop
-      vertex 6.87151 30.7414 60
-      vertex 7.83373 30.5104 0
-      vertex 6.87151 30.7414 0
+      vertex -15.4161 -28.0418 60
+      vertex -16.0348 -27.1134 0
+      vertex -15.1752 -27.6037 0
     endloop
   endfacet
-  facet normal -0.233437 -0.972372 0
+  facet normal 0.0471908 0.998851 -0.00833112
     outer loop
-      vertex -7.83373 -30.5104 0
-      vertex -6.87151 -30.7414 60
-      vertex -7.83373 -30.5104 60
+      vertex 1.9779 31.4378 0
+      vertex 0.989438 31.4845 0
+      vertex 1.00514 31.9842 60
     endloop
   endfacet
-  facet normal -0.233437 -0.972372 -0
+  facet normal -0.799698 -0.600345 -0.00833199
     outer loop
-      vertex -6.87151 -30.7414 60
-      vertex -7.83373 -30.5104 0
-      vertex -6.87151 -30.7414 0
+      vertex -25.285 -19.613 60
+      vertex -25.8885 -18.8091 60
+      vertex -25.484 -18.5152 0
     endloop
   endfacet
-  facet normal 0.73962 0.673025 0
+  facet normal -0.294059 -0.955751 -0.00833129
     outer loop
-      vertex 23.6285 20.8313 60
-      vertex 22.9625 21.5632 0
-      vertex 22.9625 21.5632 60
+      vertex -8.92772 -30.7294 60
+      vertex -9.73403 -29.9583 0
+      vertex -8.78822 -30.2493 0
     endloop
   endfacet
-  facet normal 0.73962 0.673025 0
+  facet normal 0.852575 -0.522539 -0.00833329
     outer loop
-      vertex 22.9625 21.5632 0
-      vertex 23.6285 20.8313 60
-      vertex 23.6285 20.8313 0
+      vertex 27.0185 -17.1465 60
+      vertex 26.5963 -16.8785 0
+      vertex 27.1134 -16.0348 0
     endloop
   endfacet
-  facet normal 0.0156635 0.999877 -0
+  facet normal -0.439942 0.897987 -0.00833189
+    outer loop
+      vertex -13.412 28.5021 0
+      vertex -14.5277 28.5122 60
+      vertex -13.6249 28.9545 60
+    endloop
+  endfacet
+  facet normal 0.868604 0.495436 -0.00833144
+    outer loop
+      vertex 27.6037 15.1752 0
+      vertex 27.1134 16.0348 0
+      vertex 28.0418 15.4161 60
+    endloop
+  endfacet
+  facet normal -0.0471908 -0.998851 -0.00833112
+    outer loop
+      vertex -1.00514 -31.9842 60
+      vertex -1.9779 -31.4378 0
+      vertex -0.989438 -31.4845 0
+    endloop
+  endfacet
+  facet normal -0.818071 0.575057 -0.00833338
+    outer loop
+      vertex -26.053 17.7056 0
+      vertex -26.4666 17.9867 60
+      vertex -25.8885 18.8091 60
+    endloop
+  endfacet
+  facet normal 0.946029 0.323976 -0.00833157
+    outer loop
+      vertex 29.9583 9.73403 0
+      vertex 29.6377 10.6702 0
+      vertex 30.4338 9.88854 60
+    endloop
+  endfacet
+  facet normal 0.985064 0.171987 -0.00833129
+    outer loop
+      vertex 31.1122 4.92768 0
+      vertex 30.942 5.90251 0
+      vertex 31.606 5.0059 60
+    endloop
+  endfacet
+  facet normal -0.649391 0.760409 -0.00833117
+    outer loop
+      vertex -20.0789 24.2712 0
+      vertex -21.162 24.0036 60
+      vertex -20.3976 24.6564 60
+    endloop
+  endfacet
+  facet normal 0.911363 -0.411518 -0.00833188
+    outer loop
+      vertex 28.9545 -13.6249 60
+      vertex 28.5021 -13.412 0
+      vertex 28.9093 -12.5102 0
+    endloop
+  endfacet
+  facet normal 0.897987 -0.439942 -0.00833189
+    outer loop
+      vertex 28.5122 -14.5277 60
+      vertex 28.5021 -13.412 0
+      vertex 28.9545 -13.6249 60
+    endloop
+  endfacet
+  facet normal -0.600345 -0.799698 -0.00833199
+    outer loop
+      vertex -18.8091 -25.8885 60
+      vertex -19.613 -25.285 60
+      vertex -18.5152 -25.484 0
+    endloop
+  endfacet
+  facet normal 0.574988 0.81812 -0.00833197
+    outer loop
+      vertex 18.5152 25.484 0
+      vertex 17.7056 26.053 0
+      vertex 18.8091 25.8885 60
+    endloop
+  endfacet
+  facet normal 0.522539 -0.852575 -0.00833329
+    outer loop
+      vertex 17.1465 -27.0185 60
+      vertex 16.0348 -27.1134 0
+      vertex 16.8785 -26.5963 0
+    endloop
+  endfacet
+  facet normal -0.549002 -0.83578 -0.00833338
+    outer loop
+      vertex -16.8785 -26.5963 0
+      vertex -17.9867 -26.4666 60
+      vertex -17.7056 -26.053 0
+    endloop
+  endfacet
+  facet normal -0.868586 0.495468 -0.00833082
+    outer loop
+      vertex -27.1134 16.0348 0
+      vertex -28.0418 15.4161 60
+      vertex -27.5437 16.2893 60
+    endloop
+  endfacet
+  facet normal 0.411518 -0.911363 -0.00833188
+    outer loop
+      vertex 13.6249 -28.9545 60
+      vertex 12.5102 -28.9093 0
+      vertex 13.412 -28.5021 0
+    endloop
+  endfacet
+  facet normal -0.985081 -0.171889 -0.00833294
+    outer loop
+      vertex -31.4332 -5.9962 60
+      vertex -31.606 -5.0059 60
+      vertex -30.942 -5.90251 0
+    endloop
+  endfacet
+  facet normal 0.835782 -0.548998 -0.00833331
+    outer loop
+      vertex 27.0185 -17.1465 60
+      vertex 26.4666 -17.9867 60
+      vertex 26.5963 -16.8785 0
+    endloop
+  endfacet
+  facet normal -0.964515 -0.263898 -0.00833217
+    outer loop
+      vertex -30.7294 -8.92772 60
+      vertex -30.9947 -7.95808 60
+      vertex -30.5104 -7.83373 0
+    endloop
+  endfacet
+  facet normal 0.439942 -0.897987 -0.00833189
+    outer loop
+      vertex 13.6249 -28.9545 60
+      vertex 13.412 -28.5021 0
+      vertex 14.5277 -28.5122 60
+    endloop
+  endfacet
+  facet normal -0.989993 -0.140868 -0.00833271
+    outer loop
+      vertex -31.1122 -4.92768 0
+      vertex -31.7477 -4.01066 60
+      vertex -31.2516 -3.948 0
+    endloop
+  endfacet
+  facet normal -0.109719 -0.993928 -0.00833234
+    outer loop
+      vertex -3.01147 -31.858 60
+      vertex -4.01066 -31.7477 60
+      vertex -2.96441 -31.3602 0
+    endloop
+  endfacet
+  facet normal 0.548998 -0.835782 -0.00833331
+    outer loop
+      vertex 17.1465 -27.0185 60
+      vertex 16.8785 -26.5963 0
+      vertex 17.9867 -26.4666 60
+    endloop
+  endfacet
+  facet normal -0.999843 0.015663 -0.00833202
+    outer loop
+      vertex -31.5 0 0
+      vertex -32 0 60
+      vertex -31.4845 0.989438 0
+    endloop
+  endfacet
+  facet normal 0.439949 -0.897984 -0.00833201
+    outer loop
+      vertex 14.5277 -28.5122 60
+      vertex 13.412 -28.5021 0
+      vertex 14.3007 -28.0667 0
+    endloop
+  endfacet
+  facet normal -0.171889 0.985081 -0.00833294
+    outer loop
+      vertex -5.90251 30.942 0
+      vertex -5.9962 31.4332 60
+      vertex -5.0059 31.606 60
+    endloop
+  endfacet
+  facet normal -0.600345 0.799698 -0.00833199
+    outer loop
+      vertex -18.5152 25.484 0
+      vertex -19.613 25.285 60
+      vertex -18.8091 25.8885 60
+    endloop
+  endfacet
+  facet normal -0.83578 -0.549002 -0.00833338
+    outer loop
+      vertex -26.4666 -17.9867 60
+      vertex -26.5963 -16.8785 0
+      vertex -26.053 -17.7056 0
+    endloop
+  endfacet
+  facet normal -0.171987 -0.985064 -0.00833129
+    outer loop
+      vertex -5.0059 -31.606 60
+      vertex -5.90251 -30.942 0
+      vertex -4.92768 -31.1122 0
+    endloop
+  endfacet
+  facet normal -0.985064 -0.171987 -0.00833129
+    outer loop
+      vertex -30.942 -5.90251 0
+      vertex -31.606 -5.0059 60
+      vertex -31.1122 -4.92768 0
+    endloop
+  endfacet
+  facet normal 0.649391 0.760409 -0.00833117
+    outer loop
+      vertex 21.162 24.0036 60
+      vertex 20.0789 24.2712 0
+      vertex 20.3976 24.6564 60
+    endloop
+  endfacet
+  facet normal -0.883745 -0.467895 -0.00833201
+    outer loop
+      vertex -27.6037 -15.1752 0
+      vertex -28.5122 -14.5277 60
+      vertex -28.0667 -14.3007 0
+    endloop
+  endfacet
+  facet normal -0.964529 -0.263846 -0.00833128
+    outer loop
+      vertex -30.2493 -8.78822 0
+      vertex -30.7294 -8.92772 60
+      vertex -30.5104 -7.83373 0
+    endloop
+  endfacet
+  facet normal -0.964529 0.263846 -0.00833128
+    outer loop
+      vertex -30.5104 7.83373 0
+      vertex -30.7294 8.92772 60
+      vertex -30.2493 8.78822 0
+    endloop
+  endfacet
+  facet normal -0.999842 -0.0157167 -0.00833113
+    outer loop
+      vertex -31.9842 -1.00514 60
+      vertex -32 0 60
+      vertex -31.4845 -0.989438 0
+    endloop
+  endfacet
+  facet normal -0.999843 -0.015663 -0.00833202
+    outer loop
+      vertex -31.4845 -0.989438 0
+      vertex -32 0 60
+      vertex -31.5 0 0
+    endloop
+  endfacet
+  facet normal -0.972338 -0.233429 -0.00833106
+    outer loop
+      vertex -30.5104 -7.83373 0
+      vertex -31.2293 -6.98058 60
+      vertex -30.7414 -6.87151 0
+    endloop
+  endfacet
+  facet normal 0.233365 -0.972354 -0.00833216
+    outer loop
+      vertex 7.95808 -30.9947 60
+      vertex 6.98058 -31.2293 60
+      vertex 7.83373 -30.5104 0
+    endloop
+  endfacet
+  facet normal -0.946059 0.323888 -0.00833312
+    outer loop
+      vertex -29.6377 10.6702 0
+      vertex -30.4338 9.88854 60
+      vertex -30.1082 10.8396 60
+    endloop
+  endfacet
+  facet normal -0.695828 0.71816 -0.00833075
+    outer loop
+      vertex -22.2739 22.2739 0
+      vertex -22.6274 22.6274 60
+      vertex -21.5632 22.9625 0
+    endloop
+  endfacet
+  facet normal 0.0157167 0.999842 -0.00833113
     outer loop
       vertex 0.989438 31.4845 0
-      vertex 0 31.5 60
-      vertex 0.989438 31.4845 60
+      vertex 0 32 60
+      vertex 1.00514 31.9842 60
     endloop
   endfacet
-  facet normal 0.0156635 0.999877 0
+  facet normal -0.323976 0.946029 -0.00833157
     outer loop
-      vertex 0 31.5 60
-      vertex 0.989438 31.4845 0
-      vertex 0 31.5 0
+      vertex -9.73403 29.9583 0
+      vertex -10.6702 29.6377 0
+      vertex -9.88854 30.4338 60
     endloop
   endfacet
-  facet normal -0.673025 -0.73962 0
+  facet normal -0.294059 0.955751 -0.00833129
     outer loop
-      vertex -21.5632 -22.9625 0
-      vertex -20.8313 -23.6285 60
-      vertex -21.5632 -22.9625 60
+      vertex -8.78822 30.2493 0
+      vertex -9.73403 29.9583 0
+      vertex -8.92772 30.7294 60
     endloop
   endfacet
-  facet normal -0.673025 -0.73962 -0
+  facet normal 0.972338 0.233429 -0.00833106
     outer loop
-      vertex -20.8313 -23.6285 60
-      vertex -21.5632 -22.9625 0
+      vertex 30.7414 6.87151 0
+      vertex 30.5104 7.83373 0
+      vertex 31.2293 6.98058 60
+    endloop
+  endfacet
+  facet normal 0.202712 -0.979203 -0.00833294
+    outer loop
+      vertex 5.9962 -31.4332 60
+      vertex 5.90251 -30.942 0
+      vertex 6.87151 -30.7414 0
+    endloop
+  endfacet
+  facet normal -0.883728 0.467926 -0.00833141
+    outer loop
+      vertex -27.6037 15.1752 0
+      vertex -28.5122 14.5277 60
+      vertex -28.0418 15.4161 60
+    endloop
+  endfacet
+  facet normal 0.935443 -0.35338 -0.00833085
+    outer loop
+      vertex 29.7528 -11.78 60
+      vertex 29.288 -11.5959 0
+      vertex 29.6377 -10.6702 0
+    endloop
+  endfacet
+  facet normal 0.695828 -0.71816 -0.00833075
+    outer loop
+      vertex 22.6274 -22.6274 60
+      vertex 21.5632 -22.9625 0
+      vertex 22.2739 -22.2739 0
+    endloop
+  endfacet
+  facet normal 0.852652 -0.522413 -0.00833084
+    outer loop
+      vertex 27.5437 -16.2893 60
+      vertex 27.0185 -17.1465 60
+      vertex 27.1134 -16.0348 0
+    endloop
+  endfacet
+  facet normal -0.760409 -0.649391 -0.00833117
+    outer loop
+      vertex -24.0036 -21.162 60
+      vertex -24.6564 -20.3976 60
+      vertex -24.2712 -20.0789 0
+    endloop
+  endfacet
+  facet normal 0.548998 0.835782 -0.00833331
+    outer loop
+      vertex 17.9867 26.4666 60
+      vertex 16.8785 26.5963 0
+      vertex 17.1465 27.0185 60
+    endloop
+  endfacet
+  facet normal -0.972354 -0.233365 -0.00833216
+    outer loop
+      vertex -30.9947 -7.95808 60
+      vertex -31.2293 -6.98058 60
+      vertex -30.5104 -7.83373 0
+    endloop
+  endfacet
+  facet normal 0.233429 -0.972338 -0.00833106
+    outer loop
+      vertex 6.98058 -31.2293 60
+      vertex 6.87151 -30.7414 0
+      vertex 7.83373 -30.5104 0
+    endloop
+  endfacet
+  facet normal -0.852652 -0.522413 -0.00833084
+    outer loop
+      vertex -27.0185 -17.1465 60
+      vertex -27.5437 -16.2893 60
+      vertex -27.1134 -16.0348 0
+    endloop
+  endfacet
+  facet normal 0.799705 0.600335 -0.00833177
+    outer loop
+      vertex 25.484 18.5152 0
+      vertex 24.8899 19.3066 0
+      vertex 25.285 19.613 60
+    endloop
+  endfacet
+  facet normal 0.81812 0.574988 -0.00833197
+    outer loop
+      vertex 26.053 17.7056 0
+      vertex 25.484 18.5152 0
+      vertex 25.8885 18.8091 60
+    endloop
+  endfacet
+  facet normal 0.883745 -0.467895 -0.00833201
+    outer loop
+      vertex 28.5122 -14.5277 60
+      vertex 27.6037 -15.1752 0
+      vertex 28.0667 -14.3007 0
+    endloop
+  endfacet
+  facet normal -0.233365 0.972354 -0.00833216
+    outer loop
+      vertex -7.83373 30.5104 0
+      vertex -7.95808 30.9947 60
+      vertex -6.98058 31.2293 60
+    endloop
+  endfacet
+  facet normal 0.868586 -0.495468 -0.00833082
+    outer loop
+      vertex 27.5437 -16.2893 60
+      vertex 27.1134 -16.0348 0
+      vertex 28.0418 -15.4161 60
+    endloop
+  endfacet
+  facet normal 0.799698 0.600345 -0.00833199
+    outer loop
+      vertex 25.484 18.5152 0
+      vertex 25.285 19.613 60
+      vertex 25.8885 18.8091 60
+    endloop
+  endfacet
+  facet normal -0.835782 -0.548998 -0.00833331
+    outer loop
+      vertex -26.4666 -17.9867 60
+      vertex -27.0185 -17.1465 60
+      vertex -26.5963 -16.8785 0
+    endloop
+  endfacet
+  facet normal -0.294042 -0.955756 -0.00833157
+    outer loop
+      vertex -8.92772 -30.7294 60
+      vertex -9.88854 -30.4338 60
+      vertex -9.73403 -29.9583 0
+    endloop
+  endfacet
+  facet normal -0.996886 -0.0784162 -0.00833233
+    outer loop
+      vertex -31.3602 -2.96441 0
+      vertex -31.858 -3.01147 60
+      vertex -31.4378 -1.9779 0
+    endloop
+  endfacet
+  facet normal -0.233365 -0.972354 -0.00833216
+    outer loop
+      vertex -6.98058 -31.2293 60
+      vertex -7.95808 -30.9947 60
+      vertex -7.83373 -30.5104 0
+    endloop
+  endfacet
+  facet normal 0.263898 -0.964515 -0.00833217
+    outer loop
+      vertex 7.95808 -30.9947 60
+      vertex 7.83373 -30.5104 0
+      vertex 8.92772 -30.7294 60
+    endloop
+  endfacet
+  facet normal 0.263846 -0.964529 -0.00833128
+    outer loop
+      vertex 8.92772 -30.7294 60
+      vertex 7.83373 -30.5104 0
+      vertex 8.78822 -30.2493 0
+    endloop
+  endfacet
+  facet normal -0.935443 -0.35338 -0.00833085
+    outer loop
+      vertex -29.288 -11.5959 0
+      vertex -29.7528 -11.78 60
+      vertex -29.6377 -10.6702 0
+    endloop
+  endfacet
+  facet normal -0.718086 -0.695904 -0.00833251
+    outer loop
+      vertex -22.6274 -22.6274 60
+      vertex -23.327 -21.9055 60
+      vertex -22.9625 -21.5632 0
+    endloop
+  endfacet
+  facet normal 0.600345 0.799698 -0.00833199
+    outer loop
+      vertex 19.613 25.285 60
+      vertex 18.5152 25.484 0
+      vertex 18.8091 25.8885 60
+    endloop
+  endfacet
+  facet normal -0.600335 -0.799705 -0.00833177
+    outer loop
+      vertex -18.5152 -25.484 0
+      vertex -19.613 -25.285 60
+      vertex -19.3066 -24.8899 0
+    endloop
+  endfacet
+  facet normal -0.0157167 -0.999842 -0.00833113
+    outer loop
+      vertex 0 -32 60
+      vertex -1.00514 -31.9842 60
+      vertex -0.989438 -31.4845 0
+    endloop
+  endfacet
+  facet normal 0.998858 0.0470502 -0.00833345
+    outer loop
+      vertex 31.9842 1.00514 60
+      vertex 31.4378 1.9779 0
+      vertex 31.9369 2.0093 60
+    endloop
+  endfacet
+  facet normal 0.998851 0.0471908 -0.00833112
+    outer loop
+      vertex 31.4845 0.989438 0
+      vertex 31.4378 1.9779 0
+      vertex 31.9842 1.00514 60
+    endloop
+  endfacet
+  facet normal -0.883745 0.467895 -0.00833201
+    outer loop
+      vertex -28.0667 14.3007 0
+      vertex -28.5122 14.5277 60
+      vertex -27.6037 15.1752 0
+    endloop
+  endfacet
+  facet normal -0.140868 -0.989993 -0.00833271
+    outer loop
+      vertex -4.01066 -31.7477 60
+      vertex -4.92768 -31.1122 0
+      vertex -3.948 -31.2516 0
+    endloop
+  endfacet
+  facet normal -0.109741 -0.993925 -0.00833271
+    outer loop
+      vertex -2.96441 -31.3602 0
+      vertex -4.01066 -31.7477 60
+      vertex -3.948 -31.2516 0
+    endloop
+  endfacet
+  facet normal -0.935394 0.353508 -0.00833312
+    outer loop
+      vertex -29.6377 10.6702 0
+      vertex -30.1082 10.8396 60
+      vertex -29.7528 11.78 60
+    endloop
+  endfacet
+  facet normal 0.495468 0.868586 -0.00833082
+    outer loop
+      vertex 16.0348 27.1134 0
+      vertex 15.4161 28.0418 60
+      vertex 16.2893 27.5437 60
+    endloop
+  endfacet
+  facet normal 0.600335 0.799705 -0.00833177
+    outer loop
+      vertex 19.3066 24.8899 0
+      vertex 18.5152 25.484 0
+      vertex 19.613 25.285 60
+    endloop
+  endfacet
+  facet normal 0.467926 0.883728 -0.00833141
+    outer loop
+      vertex 15.1752 27.6037 0
+      vertex 14.5277 28.5122 60
+      vertex 15.4161 28.0418 60
+    endloop
+  endfacet
+  facet normal -0.263898 -0.964515 -0.00833217
+    outer loop
+      vertex -7.95808 -30.9947 60
+      vertex -8.92772 -30.7294 60
+      vertex -7.83373 -30.5104 0
+    endloop
+  endfacet
+  facet normal -0.0470502 -0.998858 -0.00833345
+    outer loop
+      vertex -1.00514 -31.9842 60
+      vertex -2.0093 -31.9369 60
+      vertex -1.9779 -31.4378 0
+    endloop
+  endfacet
+  facet normal -0.171987 0.985064 -0.00833129
+    outer loop
+      vertex -4.92768 31.1122 0
+      vertex -5.90251 30.942 0
+      vertex -5.0059 31.606 60
+    endloop
+  endfacet
+  facet normal -0.35338 -0.935443 -0.00833085
+    outer loop
+      vertex -10.6702 -29.6377 0
+      vertex -11.78 -29.7528 60
+      vertex -11.5959 -29.288 0
+    endloop
+  endfacet
+  facet normal -0.353508 -0.935394 -0.00833312
+    outer loop
+      vertex -10.8396 -30.1082 60
+      vertex -11.78 -29.7528 60
+      vertex -10.6702 -29.6377 0
+    endloop
+  endfacet
+  facet normal -0.202712 0.979203 -0.00833294
+    outer loop
+      vertex -5.90251 30.942 0
+      vertex -6.87151 30.7414 0
+      vertex -5.9962 31.4332 60
+    endloop
+  endfacet
+  facet normal -0.799705 0.600335 -0.00833177
+    outer loop
+      vertex -24.8899 19.3066 0
+      vertex -25.484 18.5152 0
+      vertex -25.285 19.613 60
+    endloop
+  endfacet
+  facet normal -0.799698 0.600345 -0.00833199
+    outer loop
+      vertex -25.484 18.5152 0
+      vertex -25.8885 18.8091 60
+      vertex -25.285 19.613 60
+    endloop
+  endfacet
+  facet normal -0.760409 0.649391 -0.00833117
+    outer loop
+      vertex -24.2712 20.0789 0
+      vertex -24.6564 20.3976 60
+      vertex -24.0036 21.162 60
+    endloop
+  endfacet
+  facet normal -0.673026 -0.739572 -0.00833305
+    outer loop
+      vertex -21.162 -24.0036 60
+      vertex -21.9055 -23.327 60
       vertex -20.8313 -23.6285 0
     endloop
   endfacet
-  facet normal -0.898015 0.439964 0
+  facet normal -0.574988 -0.81812 -0.00833197
     outer loop
-      vertex -28.5021 13.412 0
-      vertex -28.0667 14.3007 60
-      vertex -28.0667 14.3007 0
+      vertex -17.7056 -26.053 0
+      vertex -18.8091 -25.8885 60
+      vertex -18.5152 -25.484 0
     endloop
   endfacet
-  facet normal -0.898015 0.439964 0
+  facet normal -0.739572 0.673026 -0.00833305
     outer loop
-      vertex -28.0667 14.3007 60
-      vertex -28.5021 13.412 0
-      vertex -28.5021 13.412 60
+      vertex -23.6285 20.8313 0
+      vertex -24.0036 21.162 60
+      vertex -23.327 21.9055 60
     endloop
   endfacet
-  facet normal -0.852604 0.522557 0
+  facet normal -0.467895 0.883745 -0.00833201
     outer loop
-      vertex -27.1134 16.0348 0
-      vertex -26.5963 16.8785 60
-      vertex -26.5963 16.8785 0
+      vertex -14.3007 28.0667 0
+      vertex -15.1752 27.6037 0
+      vertex -14.5277 28.5122 60
     endloop
   endfacet
-  facet normal -0.852604 0.522557 0
+  facet normal -0.549002 0.83578 -0.00833338
     outer loop
-      vertex -26.5963 16.8785 60
-      vertex -27.1134 16.0348 0
-      vertex -27.1134 16.0348 60
+      vertex -17.7056 26.053 0
+      vertex -17.9867 26.4666 60
+      vertex -16.8785 26.5963 0
     endloop
   endfacet
-  facet normal -0.0156635 -0.999877 0
+  facet normal -0.522539 0.852575 -0.00833329
     outer loop
-      vertex -0.989438 -31.4845 0
-      vertex 0 -31.5 60
-      vertex -0.989438 -31.4845 60
+      vertex -16.8785 26.5963 0
+      vertex -17.1465 27.0185 60
+      vertex -16.0348 27.1134 0
     endloop
   endfacet
-  facet normal -0.0156635 -0.999877 -0
+  facet normal -0.946029 -0.323976 -0.00833157
     outer loop
-      vertex 0 -31.5 60
+      vertex -29.6377 -10.6702 0
+      vertex -30.4338 -9.88854 60
+      vertex -29.9583 -9.73403 0
+    endloop
+  endfacet
+  facet normal -0.015663 -0.999843 -0.00833202
+    outer loop
+      vertex 0 -32 60
       vertex -0.989438 -31.4845 0
       vertex 0 -31.5 0
+    endloop
+  endfacet
+  facet normal 0.883728 -0.467926 -0.00833141
+    outer loop
+      vertex 28.0418 -15.4161 60
+      vertex 27.6037 -15.1752 0
+      vertex 28.5122 -14.5277 60
+    endloop
+  endfacet
+  facet normal -0.0784162 -0.996886 -0.00833233
+    outer loop
+      vertex -1.9779 -31.4378 0
+      vertex -3.01147 -31.858 60
+      vertex -2.96441 -31.3602 0
+    endloop
+  endfacet
+  facet normal 0.760335 -0.649478 -0.00833307
+    outer loop
+      vertex 24.0036 -21.162 60
+      vertex 23.6285 -20.8313 0
+      vertex 24.2712 -20.0789 0
+    endloop
+  endfacet
+  facet normal 0.467895 0.883745 -0.00833201
+    outer loop
+      vertex 15.1752 27.6037 0
+      vertex 14.3007 28.0667 0
+      vertex 14.5277 28.5122 60
+    endloop
+  endfacet
+  facet normal -0.649478 -0.760335 -0.00833307
+    outer loop
+      vertex -20.0789 -24.2712 0
+      vertex -21.162 -24.0036 60
+      vertex -20.8313 -23.6285 0
+    endloop
+  endfacet
+  facet normal -0.935394 -0.353508 -0.00833312
+    outer loop
+      vertex -29.7528 -11.78 60
+      vertex -30.1082 -10.8396 60
+      vertex -29.6377 -10.6702 0
+    endloop
+  endfacet
+  facet normal -0.600335 0.799705 -0.00833177
+    outer loop
+      vertex -19.3066 24.8899 0
+      vertex -19.613 25.285 60
+      vertex -18.5152 25.484 0
+    endloop
+  endfacet
+  facet normal -0.897987 -0.439942 -0.00833189
+    outer loop
+      vertex -28.5122 -14.5277 60
+      vertex -28.9545 -13.6249 60
+      vertex -28.5021 -13.412 0
+    endloop
+  endfacet
+  facet normal 0.649478 0.760335 -0.00833307
+    outer loop
+      vertex 20.8313 23.6285 0
+      vertex 20.0789 24.2712 0
+      vertex 21.162 24.0036 60
+    endloop
+  endfacet
+  facet normal 0.673001 0.739594 -0.00833251
+    outer loop
+      vertex 21.5632 22.9625 0
+      vertex 20.8313 23.6285 0
+      vertex 21.9055 23.327 60
     endloop
   endfacet
   facet normal 0 0 -1
@@ -4855,2848 +7697,6 @@ solid OpenSCAD_Model
       vertex -27.7 0 0
       vertex -31.5 0 0
       vertex -31.4845 0.989438 0
-    endloop
-  endfacet
-  facet normal -0.695852 -0.718185 0
-    outer loop
-      vertex -22.2739 -22.2739 0
-      vertex -21.5632 -22.9625 60
-      vertex -22.2739 -22.2739 60
-    endloop
-  endfacet
-  facet normal -0.695852 -0.718185 -0
-    outer loop
-      vertex -21.5632 -22.9625 60
-      vertex -22.2739 -22.2739 0
-      vertex -21.5632 -22.9625 0
-    endloop
-  endfacet
-  facet normal 0.695852 0.718185 -0
-    outer loop
-      vertex 22.2739 22.2739 0
-      vertex 21.5632 22.9625 60
-      vertex 22.2739 22.2739 60
-    endloop
-  endfacet
-  facet normal 0.695852 0.718185 0
-    outer loop
-      vertex 21.5632 22.9625 60
-      vertex 22.2739 22.2739 0
-      vertex 21.5632 22.9625 0
-    endloop
-  endfacet
-  facet normal -0.999877 0.0156635 0
-    outer loop
-      vertex -31.5 0 0
-      vertex -31.4845 0.989438 60
-      vertex -31.4845 0.989438 0
-    endloop
-  endfacet
-  facet normal -0.999877 0.0156635 0
-    outer loop
-      vertex -31.4845 0.989438 60
-      vertex -31.5 0 0
-      vertex -31.5 0 60
-    endloop
-  endfacet
-  facet normal 0.760361 0.6495 0
-    outer loop
-      vertex 24.2712 20.0789 60
-      vertex 23.6285 20.8313 0
-      vertex 23.6285 20.8313 60
-    endloop
-  endfacet
-  facet normal 0.760361 0.6495 0
-    outer loop
-      vertex 23.6285 20.8313 0
-      vertex 24.2712 20.0789 60
-      vertex 24.2712 20.0789 0
-    endloop
-  endfacet
-  facet normal 0.353393 0.935475 -0
-    outer loop
-      vertex 11.5959 29.288 0
-      vertex 10.6702 29.6377 60
-      vertex 11.5959 29.288 60
-    endloop
-  endfacet
-  facet normal 0.353393 0.935475 0
-    outer loop
-      vertex 10.6702 29.6377 60
-      vertex 11.5959 29.288 0
-      vertex 10.6702 29.6377 0
-    endloop
-  endfacet
-  facet normal 0.818148 -0.575008 0
-    outer loop
-      vertex 25.484 -18.5152 60
-      vertex 26.053 -17.7056 0
-      vertex 26.053 -17.7056 60
-    endloop
-  endfacet
-  facet normal 0.818148 -0.575008 0
-    outer loop
-      vertex 26.053 -17.7056 0
-      vertex 25.484 -18.5152 60
-      vertex 25.484 -18.5152 0
-    endloop
-  endfacet
-  facet normal -0.760361 0.6495 0
-    outer loop
-      vertex -24.2712 20.0789 0
-      vertex -23.6285 20.8313 60
-      vertex -23.6285 20.8313 0
-    endloop
-  endfacet
-  facet normal -0.760361 0.6495 0
-    outer loop
-      vertex -23.6285 20.8313 60
-      vertex -24.2712 20.0789 0
-      vertex -24.2712 20.0789 60
-    endloop
-  endfacet
-  facet normal -0.600356 0.799733 0
-    outer loop
-      vertex -18.5152 25.484 0
-      vertex -19.3066 24.8899 60
-      vertex -18.5152 25.484 60
-    endloop
-  endfacet
-  facet normal -0.600356 0.799733 0
-    outer loop
-      vertex -19.3066 24.8899 60
-      vertex -18.5152 25.484 0
-      vertex -19.3066 24.8899 0
-    endloop
-  endfacet
-  facet normal -0.625225 0.780445 0
-    outer loop
-      vertex -19.3066 24.8899 0
-      vertex -20.0789 24.2712 60
-      vertex -19.3066 24.8899 60
-    endloop
-  endfacet
-  facet normal -0.625225 0.780445 0
-    outer loop
-      vertex -20.0789 24.2712 60
-      vertex -19.3066 24.8899 0
-      vertex -20.0789 24.2712 0
-    endloop
-  endfacet
-  facet normal 0.109745 0.99396 -0
-    outer loop
-      vertex 3.948 31.2516 0
-      vertex 2.96441 31.3602 60
-      vertex 3.948 31.2516 60
-    endloop
-  endfacet
-  facet normal 0.109745 0.99396 0
-    outer loop
-      vertex 2.96441 31.3602 60
-      vertex 3.948 31.2516 0
-      vertex 2.96441 31.3602 0
-    endloop
-  endfacet
-  facet normal -0.411533 -0.911395 0
-    outer loop
-      vertex -13.412 -28.5021 0
-      vertex -12.5102 -28.9093 60
-      vertex -13.412 -28.5021 60
-    endloop
-  endfacet
-  facet normal -0.411533 -0.911395 -0
-    outer loop
-      vertex -12.5102 -28.9093 60
-      vertex -13.412 -28.5021 0
-      vertex -12.5102 -28.9093 0
-    endloop
-  endfacet
-  facet normal 0.799733 0.600356 0
-    outer loop
-      vertex 25.484 18.5152 60
-      vertex 24.8899 19.3066 0
-      vertex 24.8899 19.3066 60
-    endloop
-  endfacet
-  facet normal 0.799733 0.600356 0
-    outer loop
-      vertex 24.8899 19.3066 0
-      vertex 25.484 18.5152 60
-      vertex 25.484 18.5152 0
-    endloop
-  endfacet
-  facet normal 0.38267 -0.923885 0
-    outer loop
-      vertex 11.5959 -29.288 0
-      vertex 12.5102 -28.9093 60
-      vertex 11.5959 -29.288 60
-    endloop
-  endfacet
-  facet normal 0.38267 -0.923885 0
-    outer loop
-      vertex 12.5102 -28.9093 60
-      vertex 11.5959 -29.288 0
-      vertex 12.5102 -28.9093 0
-    endloop
-  endfacet
-  facet normal -0.467911 0.883776 0
-    outer loop
-      vertex -14.3007 28.0667 0
-      vertex -15.1752 27.6037 60
-      vertex -14.3007 28.0667 60
-    endloop
-  endfacet
-  facet normal -0.467911 0.883776 0
-    outer loop
-      vertex -15.1752 27.6037 60
-      vertex -14.3007 28.0667 0
-      vertex -15.1752 27.6037 0
-    endloop
-  endfacet
-  facet normal -0.985098 0.171993 0
-    outer loop
-      vertex -31.1122 4.92768 0
-      vertex -30.942 5.90251 60
-      vertex -30.942 5.90251 0
-    endloop
-  endfacet
-  facet normal -0.985098 0.171993 0
-    outer loop
-      vertex -30.942 5.90251 60
-      vertex -31.1122 4.92768 0
-      vertex -31.1122 4.92768 60
-    endloop
-  endfacet
-  facet normal -0.294069 0.955784 0
-    outer loop
-      vertex -8.78822 30.2493 0
-      vertex -9.73403 29.9583 60
-      vertex -8.78822 30.2493 60
-    endloop
-  endfacet
-  facet normal -0.294069 0.955784 0
-    outer loop
-      vertex -9.73403 29.9583 60
-      vertex -8.78822 30.2493 0
-      vertex -9.73403 29.9583 0
-    endloop
-  endfacet
-  facet normal 0.695852 -0.718185 0
-    outer loop
-      vertex 21.5632 -22.9625 0
-      vertex 22.2739 -22.2739 60
-      vertex 21.5632 -22.9625 60
-    endloop
-  endfacet
-  facet normal 0.695852 -0.718185 0
-    outer loop
-      vertex 22.2739 -22.2739 60
-      vertex 21.5632 -22.9625 0
-      vertex 22.2739 -22.2739 0
-    endloop
-  endfacet
-  facet normal -0.852604 -0.522557 0
-    outer loop
-      vertex -26.5963 -16.8785 0
-      vertex -27.1134 -16.0348 60
-      vertex -27.1134 -16.0348 0
-    endloop
-  endfacet
-  facet normal -0.852604 -0.522557 0
-    outer loop
-      vertex -27.1134 -16.0348 60
-      vertex -26.5963 -16.8785 0
-      vertex -26.5963 -16.8785 60
-    endloop
-  endfacet
-  facet normal -0.835809 -0.549021 0
-    outer loop
-      vertex -26.053 -17.7056 0
-      vertex -26.5963 -16.8785 60
-      vertex -26.5963 -16.8785 0
-    endloop
-  endfacet
-  facet normal -0.835809 -0.549021 0
-    outer loop
-      vertex -26.5963 -16.8785 60
-      vertex -26.053 -17.7056 0
-      vertex -26.053 -17.7056 60
-    endloop
-  endfacet
-  facet normal 0.673025 -0.73962 0
-    outer loop
-      vertex 20.8313 -23.6285 0
-      vertex 21.5632 -22.9625 60
-      vertex 20.8313 -23.6285 60
-    endloop
-  endfacet
-  facet normal 0.673025 -0.73962 0
-    outer loop
-      vertex 21.5632 -22.9625 60
-      vertex 20.8313 -23.6285 0
-      vertex 21.5632 -22.9625 0
-    endloop
-  endfacet
-  facet normal -0.109745 -0.99396 0
-    outer loop
-      vertex -3.948 -31.2516 0
-      vertex -2.96441 -31.3602 60
-      vertex -3.948 -31.2516 60
-    endloop
-  endfacet
-  facet normal -0.109745 -0.99396 -0
-    outer loop
-      vertex -2.96441 -31.3602 60
-      vertex -3.948 -31.2516 0
-      vertex -2.96441 -31.3602 0
-    endloop
-  endfacet
-  facet normal -0.780445 -0.625225 0
-    outer loop
-      vertex -24.2712 -20.0789 0
-      vertex -24.8899 -19.3066 60
-      vertex -24.8899 -19.3066 0
-    endloop
-  endfacet
-  facet normal -0.780445 -0.625225 0
-    outer loop
-      vertex -24.8899 -19.3066 60
-      vertex -24.2712 -20.0789 0
-      vertex -24.2712 -20.0789 60
-    endloop
-  endfacet
-  facet normal -0.99396 -0.109745 0
-    outer loop
-      vertex -31.2516 -3.948 0
-      vertex -31.3602 -2.96441 60
-      vertex -31.3602 -2.96441 0
-    endloop
-  endfacet
-  facet normal -0.99396 -0.109745 0
-    outer loop
-      vertex -31.3602 -2.96441 60
-      vertex -31.2516 -3.948 0
-      vertex -31.2516 -3.948 60
-    endloop
-  endfacet
-  facet normal -0.955784 -0.294069 0
-    outer loop
-      vertex -29.9583 -9.73403 0
-      vertex -30.2493 -8.78822 60
-      vertex -30.2493 -8.78822 0
-    endloop
-  endfacet
-  facet normal -0.955784 -0.294069 0
-    outer loop
-      vertex -30.2493 -8.78822 60
-      vertex -29.9583 -9.73403 0
-      vertex -29.9583 -9.73403 60
-    endloop
-  endfacet
-  facet normal -0.294069 -0.955784 0
-    outer loop
-      vertex -9.73403 -29.9583 0
-      vertex -8.78822 -30.2493 60
-      vertex -9.73403 -29.9583 60
-    endloop
-  endfacet
-  facet normal -0.294069 -0.955784 -0
-    outer loop
-      vertex -8.78822 -30.2493 60
-      vertex -9.73403 -29.9583 0
-      vertex -8.78822 -30.2493 0
-    endloop
-  endfacet
-  facet normal -0.799733 0.600356 0
-    outer loop
-      vertex -25.484 18.5152 0
-      vertex -24.8899 19.3066 60
-      vertex -24.8899 19.3066 0
-    endloop
-  endfacet
-  facet normal -0.799733 0.600356 0
-    outer loop
-      vertex -24.8899 19.3066 60
-      vertex -25.484 18.5152 0
-      vertex -25.484 18.5152 60
-    endloop
-  endfacet
-  facet normal -0.522557 -0.852604 0
-    outer loop
-      vertex -16.8785 -26.5963 0
-      vertex -16.0348 -27.1134 60
-      vertex -16.8785 -26.5963 60
-    endloop
-  endfacet
-  facet normal -0.522557 -0.852604 -0
-    outer loop
-      vertex -16.0348 -27.1134 60
-      vertex -16.8785 -26.5963 0
-      vertex -16.0348 -27.1134 0
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.7 0 60
-      vertex 31.5 0 60
-      vertex 31.4845 0.989438 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 27.6757 1.15996 60
-      vertex 31.4845 0.989438 60
-      vertex 31.4378 1.9779 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 31.5 0 60
-      vertex 27.7 0 60
-      vertex 31.4845 -0.989438 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 27.6029 2.31788 60
-      vertex 31.4378 1.9779 60
-      vertex 31.3602 2.96441 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.6757 -1.15996 60
-      vertex 31.4845 -0.989438 60
-      vertex 27.7 0 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 27.4816 3.47173 60
-      vertex 31.3602 2.96441 60
-      vertex 31.2516 3.948 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 31.4845 -0.989438 60
-      vertex 27.6757 -1.15996 60
-      vertex 31.4378 -1.9779 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.4816 3.47173 60
-      vertex 31.2516 3.948 60
-      vertex 31.1122 4.92768 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.6029 -2.31788 60
-      vertex 31.4378 -1.9779 60
-      vertex 27.6757 -1.15996 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.3121 4.61949 60
-      vertex 31.1122 4.92768 60
-      vertex 30.942 5.90251 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 31.4378 -1.9779 60
-      vertex 27.6029 -2.31788 60
-      vertex 31.3602 -2.96441 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.0947 5.75915 60
-      vertex 30.942 5.90251 60
-      vertex 30.7414 6.87151 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.4816 -3.47173 60
-      vertex 31.3602 -2.96441 60
-      vertex 27.6029 -2.31788 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 26.8298 6.88871 60
-      vertex 30.7414 6.87151 60
-      vertex 30.5104 7.83373 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 31.3602 -2.96441 60
-      vertex 27.4816 -3.47173 60
-      vertex 31.2516 -3.948 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 26.8298 6.88871 60
-      vertex 30.5104 7.83373 60
-      vertex 30.2493 8.78822 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 31.2516 -3.948 60
-      vertex 27.4816 -3.47173 60
-      vertex 31.1122 -4.92768 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 26.5177 8.00618 60
-      vertex 30.2493 8.78822 60
-      vertex 29.9583 9.73403 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 27.3121 -4.61949 60
-      vertex 31.1122 -4.92768 60
-      vertex 27.4816 -3.47173 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 26.1592 9.10961 60
-      vertex 29.9583 9.73403 60
-      vertex 29.6377 10.6702 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 31.1122 -4.92768 60
-      vertex 27.3121 -4.61949 60
-      vertex 30.942 -5.90251 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.7548 10.1971 60
-      vertex 29.6377 10.6702 60
-      vertex 29.288 11.5959 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 27.0947 -5.75915 60
-      vertex 30.942 -5.90251 60
-      vertex 27.3121 -4.61949 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.7548 10.1971 60
-      vertex 29.288 11.5959 60
-      vertex 28.9093 12.5102 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 30.942 -5.90251 60
-      vertex 27.0947 -5.75915 60
-      vertex 30.7414 -6.87151 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.3052 11.2666 60
-      vertex 28.9093 12.5102 60
-      vertex 28.5021 13.412 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 26.8298 -6.88871 60
-      vertex 30.7414 -6.87151 60
-      vertex 27.0947 -5.75915 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.8112 12.3164 60
-      vertex 28.5021 13.412 60
-      vertex 28.0667 14.3007 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 30.7414 -6.87151 60
-      vertex 26.8298 -6.88871 60
-      vertex 30.5104 -7.83373 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 30.5104 -7.83373 60
-      vertex 26.8298 -6.88871 60
-      vertex 30.2493 -8.78822 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 31.4845 0.989438 60
-      vertex 27.6757 1.15996 60
-      vertex 27.7 0 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.2737 13.3446 60
-      vertex 28.0667 14.3007 60
-      vertex 27.6037 15.1752 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 31.4378 1.9779 60
-      vertex 27.6029 2.31788 60
-      vertex 27.6757 1.15996 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 31.3602 2.96441 60
-      vertex 27.4816 3.47173 60
-      vertex 27.6029 2.31788 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 31.1122 4.92768 60
-      vertex 27.3121 4.61949 60
-      vertex 27.4816 3.47173 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.2737 13.3446 60
-      vertex 27.6037 15.1752 60
-      vertex 27.1134 16.0348 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 30.942 5.90251 60
-      vertex 27.0947 5.75915 60
-      vertex 27.3121 4.61949 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 30.7414 6.87151 60
-      vertex 26.8298 6.88871 60
-      vertex 27.0947 5.75915 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.6936 14.3493 60
-      vertex 27.1134 16.0348 60
-      vertex 26.5963 16.8785 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 30.2493 8.78822 60
-      vertex 26.5177 8.00618 60
-      vertex 26.8298 6.88871 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 29.9583 9.73403 60
-      vertex 26.1592 9.10961 60
-      vertex 26.5177 8.00618 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.0719 15.3289 60
-      vertex 26.5963 16.8785 60
-      vertex 26.053 17.7056 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 29.6377 10.6702 60
-      vertex 25.7548 10.1971 60
-      vertex 26.1592 9.10961 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.4098 16.2817 60
-      vertex 26.053 17.7056 60
-      vertex 25.484 18.5152 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 28.9093 12.5102 60
-      vertex 25.3052 11.2666 60
-      vertex 25.7548 10.1971 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.4098 16.2817 60
-      vertex 25.484 18.5152 60
-      vertex 24.8899 19.3066 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 28.5021 13.412 60
-      vertex 24.8112 12.3164 60
-      vertex 25.3052 11.2666 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 28.0667 14.3007 60
-      vertex 24.2737 13.3446 60
-      vertex 24.8112 12.3164 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.7083 17.2058 60
-      vertex 24.8899 19.3066 60
-      vertex 24.2712 20.0789 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.1134 16.0348 60
-      vertex 23.6936 14.3493 60
-      vertex 24.2737 13.3446 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.9688 18.0998 60
-      vertex 24.2712 20.0789 60
-      vertex 23.6285 20.8313 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 26.5963 16.8785 60
-      vertex 23.0719 15.3289 60
-      vertex 23.6936 14.3493 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.1924 18.962 60
-      vertex 23.6285 20.8313 60
-      vertex 22.9625 21.5632 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 26.053 17.7056 60
-      vertex 22.4098 16.2817 60
-      vertex 23.0719 15.3289 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.1924 18.962 60
-      vertex 22.9625 21.5632 60
-      vertex 22.2739 22.2739 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.8899 19.3066 60
-      vertex 21.7083 17.2058 60
-      vertex 22.4098 16.2817 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.3807 19.7909 60
-      vertex 22.2739 22.2739 60
-      vertex 21.5632 22.9625 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.2712 20.0789 60
-      vertex 20.9688 18.0998 60
-      vertex 21.7083 17.2058 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5349 20.5851 60
-      vertex 21.5632 22.9625 60
-      vertex 20.8313 23.6285 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.6285 20.8313 60
-      vertex 20.1924 18.962 60
-      vertex 20.9688 18.0998 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6566 21.3432 60
-      vertex 20.8313 23.6285 60
-      vertex 20.0789 24.2712 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.2739 22.2739 60
-      vertex 19.3807 19.7909 60
-      vertex 20.1924 18.962 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6566 21.3432 60
-      vertex 20.0789 24.2712 60
-      vertex 19.3066 24.8899 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.5632 22.9625 60
-      vertex 18.5349 20.5851 60
-      vertex 19.3807 19.7909 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.7474 22.0639 60
-      vertex 19.3066 24.8899 60
-      vertex 18.5152 25.484 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.8088 22.7458 60
-      vertex 18.5152 25.484 60
-      vertex 17.7056 26.053 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.8313 23.6285 60
-      vertex 17.6566 21.3432 60
-      vertex 18.5349 20.5851 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8424 23.3879 60
-      vertex 17.7056 26.053 60
-      vertex 16.8785 26.5963 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.3066 24.8899 60
-      vertex 16.7474 22.0639 60
-      vertex 17.6566 21.3432 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8424 23.3879 60
-      vertex 16.8785 26.5963 60
-      vertex 16.0348 27.1134 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5152 25.484 60
-      vertex 15.8088 22.7458 60
-      vertex 16.7474 22.0639 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.85 23.9889 60
-      vertex 16.0348 27.1134 60
-      vertex 15.1752 27.6037 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.7056 26.053 60
-      vertex 14.8424 23.3879 60
-      vertex 15.8088 22.7458 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.8333 24.5478 60
-      vertex 15.1752 27.6037 60
-      vertex 14.3007 28.0667 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0348 27.1134 60
-      vertex 13.85 23.9889 60
-      vertex 14.8424 23.3879 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.7941 25.0637 60
-      vertex 14.3007 28.0667 60
-      vertex 13.412 28.5021 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.1752 27.6037 60
-      vertex 12.8333 24.5478 60
-      vertex 13.85 23.9889 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.7941 25.0637 60
-      vertex 13.412 28.5021 60
-      vertex 12.5102 28.9093 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.3007 28.0667 60
-      vertex 11.7941 25.0637 60
-      vertex 12.8333 24.5478 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.7342 25.5356 60
-      vertex 12.5102 28.9093 60
-      vertex 11.5959 29.288 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.5102 28.9093 60
-      vertex 10.7342 25.5356 60
-      vertex 11.7941 25.0637 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.65545 25.9627 60
-      vertex 11.5959 29.288 60
-      vertex 10.6702 29.6377 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.55977 26.3443 60
-      vertex 10.6702 29.6377 60
-      vertex 9.73403 29.9583 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5959 29.288 60
-      vertex 9.65545 25.9627 60
-      vertex 10.7342 25.5356 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.55977 26.3443 60
-      vertex 9.73403 29.9583 60
-      vertex 8.78822 30.2493 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.6702 29.6377 60
-      vertex 8.55977 26.3443 60
-      vertex 9.65545 25.9627 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 7.44908 26.6796 60
-      vertex 8.78822 30.2493 60
-      vertex 7.83373 30.5104 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.78822 30.2493 60
-      vertex 7.44908 26.6796 60
-      vertex 8.55977 26.3443 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 6.32532 26.9681 60
-      vertex 7.83373 30.5104 60
-      vertex 6.87151 30.7414 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 7.83373 30.5104 60
-      vertex 6.32532 26.9681 60
-      vertex 7.44908 26.6796 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.19046 27.2094 60
-      vertex 6.87151 30.7414 60
-      vertex 5.90251 30.942 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 6.87151 30.7414 60
-      vertex 5.19046 27.2094 60
-      vertex 6.32532 26.9681 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 4.92768 31.1122 60
-      vertex 5.19046 27.2094 60
-      vertex 5.90251 30.942 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 4.92768 31.1122 60
-      vertex 4.0465 27.4028 60
-      vertex 5.19046 27.2094 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 3.948 31.2516 60
-      vertex 4.0465 27.4028 60
-      vertex 4.92768 31.1122 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.89544 27.5483 60
-      vertex 3.948 31.2516 60
-      vertex 2.96441 31.3602 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 3.948 31.2516 60
-      vertex 2.89544 27.5483 60
-      vertex 4.0465 27.4028 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 1.7393 27.6453 60
-      vertex 2.96441 31.3602 60
-      vertex 1.9779 31.4378 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.96441 31.3602 60
-      vertex 1.7393 27.6453 60
-      vertex 2.89544 27.5483 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.989438 31.4845 60
-      vertex 1.7393 27.6453 60
-      vertex 1.9779 31.4378 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.989438 31.4845 60
-      vertex 0.580105 27.6939 60
-      vertex 1.7393 27.6453 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0 31.5 60
-      vertex 0.580105 27.6939 60
-      vertex 0.989438 31.4845 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0 31.5 60
-      vertex -0.580105 27.6939 60
-      vertex 0.580105 27.6939 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -0.989438 31.4845 60
-      vertex -0.580105 27.6939 60
-      vertex 0 31.5 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.989438 31.4845 60
-      vertex -1.7393 27.6453 60
-      vertex -0.580105 27.6939 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -1.9779 31.4378 60
-      vertex -1.7393 27.6453 60
-      vertex -0.989438 31.4845 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -2.96441 31.3602 60
-      vertex -1.7393 27.6453 60
-      vertex -1.9779 31.4378 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.7393 27.6453 60
-      vertex -2.96441 31.3602 60
-      vertex -2.89544 27.5483 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -3.948 31.2516 60
-      vertex -2.89544 27.5483 60
-      vertex -2.96441 31.3602 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -3.948 31.2516 60
-      vertex -4.0465 27.4028 60
-      vertex -2.89544 27.5483 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -4.92768 31.1122 60
-      vertex -4.0465 27.4028 60
-      vertex -3.948 31.2516 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -4.92768 31.1122 60
-      vertex -5.19046 27.2094 60
-      vertex -4.0465 27.4028 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -5.90251 30.942 60
-      vertex -5.19046 27.2094 60
-      vertex -4.92768 31.1122 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -6.87151 30.7414 60
-      vertex -5.19046 27.2094 60
-      vertex -5.90251 30.942 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.19046 27.2094 60
-      vertex -6.87151 30.7414 60
-      vertex -6.32532 26.9681 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -7.83373 30.5104 60
-      vertex -6.32532 26.9681 60
-      vertex -6.87151 30.7414 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -6.32532 26.9681 60
-      vertex -7.83373 30.5104 60
-      vertex -7.44908 26.6796 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -8.78822 30.2493 60
-      vertex -7.44908 26.6796 60
-      vertex -7.83373 30.5104 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -7.44908 26.6796 60
-      vertex -8.78822 30.2493 60
-      vertex -8.55977 26.3443 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -9.73403 29.9583 60
-      vertex -8.55977 26.3443 60
-      vertex -8.78822 30.2493 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -10.6702 29.6377 60
-      vertex -8.55977 26.3443 60
-      vertex -9.73403 29.9583 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.55977 26.3443 60
-      vertex -10.6702 29.6377 60
-      vertex -9.65545 25.9627 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -11.5959 29.288 60
-      vertex -9.65545 25.9627 60
-      vertex -10.6702 29.6377 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.65545 25.9627 60
-      vertex -11.5959 29.288 60
-      vertex -10.7342 25.5356 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -12.5102 28.9093 60
-      vertex -10.7342 25.5356 60
-      vertex -11.5959 29.288 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.7342 25.5356 60
-      vertex -12.5102 28.9093 60
-      vertex -11.7941 25.0637 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.412 28.5021 60
-      vertex -11.7941 25.0637 60
-      vertex -12.5102 28.9093 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.3007 28.0667 60
-      vertex -11.7941 25.0637 60
-      vertex -13.412 28.5021 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.7941 25.0637 60
-      vertex -14.3007 28.0667 60
-      vertex -12.8333 24.5478 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -15.1752 27.6037 60
-      vertex -12.8333 24.5478 60
-      vertex -14.3007 28.0667 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.8333 24.5478 60
-      vertex -15.1752 27.6037 60
-      vertex -13.85 23.9889 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.0348 27.1134 60
-      vertex -13.85 23.9889 60
-      vertex -15.1752 27.6037 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.85 23.9889 60
-      vertex -16.0348 27.1134 60
-      vertex -14.8424 23.3879 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.8785 26.5963 60
-      vertex -14.8424 23.3879 60
-      vertex -16.0348 27.1134 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -17.7056 26.053 60
-      vertex -14.8424 23.3879 60
-      vertex -16.8785 26.5963 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8424 23.3879 60
-      vertex -17.7056 26.053 60
-      vertex -15.8088 22.7458 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -18.5152 25.484 60
-      vertex -15.8088 22.7458 60
-      vertex -17.7056 26.053 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.8088 22.7458 60
-      vertex -18.5152 25.484 60
-      vertex -16.7474 22.0639 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -19.3066 24.8899 60
-      vertex -16.7474 22.0639 60
-      vertex -18.5152 25.484 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.7474 22.0639 60
-      vertex -19.3066 24.8899 60
-      vertex -17.6566 21.3432 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -20.0789 24.2712 60
-      vertex -17.6566 21.3432 60
-      vertex -19.3066 24.8899 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -20.8313 23.6285 60
-      vertex -17.6566 21.3432 60
-      vertex -20.0789 24.2712 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.6566 21.3432 60
-      vertex -20.8313 23.6285 60
-      vertex -18.5349 20.5851 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -21.5632 22.9625 60
-      vertex -18.5349 20.5851 60
-      vertex -20.8313 23.6285 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5349 20.5851 60
-      vertex -21.5632 22.9625 60
-      vertex -19.3807 19.7909 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -22.2739 22.2739 60
-      vertex -19.3807 19.7909 60
-      vertex -21.5632 22.9625 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.3807 19.7909 60
-      vertex -22.2739 22.2739 60
-      vertex -20.1924 18.962 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -22.9625 21.5632 60
-      vertex -20.1924 18.962 60
-      vertex -22.2739 22.2739 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -23.6285 20.8313 60
-      vertex -20.1924 18.962 60
-      vertex -22.9625 21.5632 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.1924 18.962 60
-      vertex -23.6285 20.8313 60
-      vertex -20.9688 18.0998 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -24.2712 20.0789 60
-      vertex -20.9688 18.0998 60
-      vertex -23.6285 20.8313 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.9688 18.0998 60
-      vertex -24.2712 20.0789 60
-      vertex -21.7083 17.2058 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -24.8899 19.3066 60
-      vertex -21.7083 17.2058 60
-      vertex -24.2712 20.0789 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.7083 17.2058 60
-      vertex -24.8899 19.3066 60
-      vertex -22.4098 16.2817 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -25.484 18.5152 60
-      vertex -22.4098 16.2817 60
-      vertex -24.8899 19.3066 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -26.053 17.7056 60
-      vertex -22.4098 16.2817 60
-      vertex -25.484 18.5152 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.4098 16.2817 60
-      vertex -26.053 17.7056 60
-      vertex -23.0719 15.3289 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -26.5963 16.8785 60
-      vertex -23.0719 15.3289 60
-      vertex -26.053 17.7056 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.0719 15.3289 60
-      vertex -26.5963 16.8785 60
-      vertex -23.6936 14.3493 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -27.1134 16.0348 60
-      vertex -23.6936 14.3493 60
-      vertex -26.5963 16.8785 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.6936 14.3493 60
-      vertex -27.1134 16.0348 60
-      vertex -24.2737 13.3446 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -27.6037 15.1752 60
-      vertex -24.2737 13.3446 60
-      vertex -27.1134 16.0348 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -28.0667 14.3007 60
-      vertex -24.2737 13.3446 60
-      vertex -27.6037 15.1752 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.2737 13.3446 60
-      vertex -28.0667 14.3007 60
-      vertex -24.8112 12.3164 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -28.5021 13.412 60
-      vertex -24.8112 12.3164 60
-      vertex -28.0667 14.3007 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.8112 12.3164 60
-      vertex -28.5021 13.412 60
-      vertex -25.3052 11.2666 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -28.9093 12.5102 60
-      vertex -25.3052 11.2666 60
-      vertex -28.5021 13.412 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.3052 11.2666 60
-      vertex -28.9093 12.5102 60
-      vertex -25.7548 10.1971 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -29.288 11.5959 60
-      vertex -25.7548 10.1971 60
-      vertex -28.9093 12.5102 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -29.6377 10.6702 60
-      vertex -25.7548 10.1971 60
-      vertex -29.288 11.5959 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.7548 10.1971 60
-      vertex -29.6377 10.6702 60
-      vertex -26.1592 9.10961 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -29.9583 9.73403 60
-      vertex -26.1592 9.10961 60
-      vertex -29.6377 10.6702 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -26.1592 9.10961 60
-      vertex -29.9583 9.73403 60
-      vertex -26.5177 8.00618 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -30.2493 8.78822 60
-      vertex -26.5177 8.00618 60
-      vertex -29.9583 9.73403 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -26.5177 8.00618 60
-      vertex -30.2493 8.78822 60
-      vertex -26.8298 6.88871 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 26.5177 -8.00618 60
-      vertex 30.2493 -8.78822 60
-      vertex 26.8298 -6.88871 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 30.2493 -8.78822 60
-      vertex 26.5177 -8.00618 60
-      vertex 29.9583 -9.73403 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 26.1592 -9.10961 60
-      vertex 29.9583 -9.73403 60
-      vertex 26.5177 -8.00618 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 29.9583 -9.73403 60
-      vertex 26.1592 -9.10961 60
-      vertex 29.6377 -10.6702 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 25.7548 -10.1971 60
-      vertex 29.6377 -10.6702 60
-      vertex 26.1592 -9.10961 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 29.6377 -10.6702 60
-      vertex 25.7548 -10.1971 60
-      vertex 29.288 -11.5959 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 29.288 -11.5959 60
-      vertex 25.7548 -10.1971 60
-      vertex 28.9093 -12.5102 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 25.3052 -11.2666 60
-      vertex 28.9093 -12.5102 60
-      vertex 25.7548 -10.1971 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 28.9093 -12.5102 60
-      vertex 25.3052 -11.2666 60
-      vertex 28.5021 -13.412 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 24.8112 -12.3164 60
-      vertex 28.5021 -13.412 60
-      vertex 25.3052 -11.2666 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 28.5021 -13.412 60
-      vertex 24.8112 -12.3164 60
-      vertex 28.0667 -14.3007 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 24.2737 -13.3446 60
-      vertex 28.0667 -14.3007 60
-      vertex 24.8112 -12.3164 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 28.0667 -14.3007 60
-      vertex 24.2737 -13.3446 60
-      vertex 27.6037 -15.1752 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.6037 -15.1752 60
-      vertex 24.2737 -13.3446 60
-      vertex 27.1134 -16.0348 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.6936 -14.3493 60
-      vertex 27.1134 -16.0348 60
-      vertex 24.2737 -13.3446 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.1134 -16.0348 60
-      vertex 23.6936 -14.3493 60
-      vertex 26.5963 -16.8785 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.0719 -15.3289 60
-      vertex 26.5963 -16.8785 60
-      vertex 23.6936 -14.3493 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 26.5963 -16.8785 60
-      vertex 23.0719 -15.3289 60
-      vertex 26.053 -17.7056 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 22.4098 -16.2817 60
-      vertex 26.053 -17.7056 60
-      vertex 23.0719 -15.3289 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 26.053 -17.7056 60
-      vertex 22.4098 -16.2817 60
-      vertex 25.484 -18.5152 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.484 -18.5152 60
-      vertex 22.4098 -16.2817 60
-      vertex 24.8899 -19.3066 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 21.7083 -17.2058 60
-      vertex 24.8899 -19.3066 60
-      vertex 22.4098 -16.2817 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.8899 -19.3066 60
-      vertex 21.7083 -17.2058 60
-      vertex 24.2712 -20.0789 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 20.9688 -18.0998 60
-      vertex 24.2712 -20.0789 60
-      vertex 21.7083 -17.2058 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.2712 -20.0789 60
-      vertex 20.9688 -18.0998 60
-      vertex 23.6285 -20.8313 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 20.1924 -18.962 60
-      vertex 23.6285 -20.8313 60
-      vertex 20.9688 -18.0998 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.6285 -20.8313 60
-      vertex 20.1924 -18.962 60
-      vertex 22.9625 -21.5632 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.9625 -21.5632 60
-      vertex 20.1924 -18.962 60
-      vertex 22.2739 -22.2739 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 19.3807 -19.7909 60
-      vertex 22.2739 -22.2739 60
-      vertex 20.1924 -18.962 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.2739 -22.2739 60
-      vertex 19.3807 -19.7909 60
-      vertex 21.5632 -22.9625 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.5349 -20.5851 60
-      vertex 21.5632 -22.9625 60
-      vertex 19.3807 -19.7909 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.5632 -22.9625 60
-      vertex 18.5349 -20.5851 60
-      vertex 20.8313 -23.6285 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 17.6566 -21.3432 60
-      vertex 20.8313 -23.6285 60
-      vertex 18.5349 -20.5851 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.8313 -23.6285 60
-      vertex 17.6566 -21.3432 60
-      vertex 20.0789 -24.2712 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.0789 -24.2712 60
-      vertex 17.6566 -21.3432 60
-      vertex 19.3066 -24.8899 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.7474 -22.0639 60
-      vertex 19.3066 -24.8899 60
-      vertex 17.6566 -21.3432 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.3066 -24.8899 60
-      vertex 16.7474 -22.0639 60
-      vertex 18.5152 -25.484 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.8088 -22.7458 60
-      vertex 18.5152 -25.484 60
-      vertex 16.7474 -22.0639 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5152 -25.484 60
-      vertex 15.8088 -22.7458 60
-      vertex 17.7056 -26.053 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.8424 -23.3879 60
-      vertex 17.7056 -26.053 60
-      vertex 15.8088 -22.7458 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.7056 -26.053 60
-      vertex 14.8424 -23.3879 60
-      vertex 16.8785 -26.5963 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.8785 -26.5963 60
-      vertex 14.8424 -23.3879 60
-      vertex 16.0348 -27.1134 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.85 -23.9889 60
-      vertex 16.0348 -27.1134 60
-      vertex 14.8424 -23.3879 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0348 -27.1134 60
-      vertex 13.85 -23.9889 60
-      vertex 15.1752 -27.6037 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 12.8333 -24.5478 60
-      vertex 15.1752 -27.6037 60
-      vertex 13.85 -23.9889 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.1752 -27.6037 60
-      vertex 12.8333 -24.5478 60
-      vertex 14.3007 -28.0667 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.7941 -25.0637 60
-      vertex 14.3007 -28.0667 60
-      vertex 12.8333 -24.5478 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.3007 -28.0667 60
-      vertex 11.7941 -25.0637 60
-      vertex 13.412 -28.5021 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.412 -28.5021 60
-      vertex 11.7941 -25.0637 60
-      vertex 12.5102 -28.9093 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.7342 -25.5356 60
-      vertex 12.5102 -28.9093 60
-      vertex 11.7941 -25.0637 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.5102 -28.9093 60
-      vertex 10.7342 -25.5356 60
-      vertex 11.5959 -29.288 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 9.65545 -25.9627 60
-      vertex 11.5959 -29.288 60
-      vertex 10.7342 -25.5356 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5959 -29.288 60
-      vertex 9.65545 -25.9627 60
-      vertex 10.6702 -29.6377 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 8.55977 -26.3443 60
-      vertex 10.6702 -29.6377 60
-      vertex 9.65545 -25.9627 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.6702 -29.6377 60
-      vertex 8.55977 -26.3443 60
-      vertex 9.73403 -29.9583 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.73403 -29.9583 60
-      vertex 8.55977 -26.3443 60
-      vertex 8.78822 -30.2493 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 7.44908 -26.6796 60
-      vertex 8.78822 -30.2493 60
-      vertex 8.55977 -26.3443 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.78822 -30.2493 60
-      vertex 7.44908 -26.6796 60
-      vertex 7.83373 -30.5104 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 6.32532 -26.9681 60
-      vertex 7.83373 -30.5104 60
-      vertex 7.44908 -26.6796 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 7.83373 -30.5104 60
-      vertex 6.32532 -26.9681 60
-      vertex 6.87151 -30.7414 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 5.19046 -27.2094 60
-      vertex 6.87151 -30.7414 60
-      vertex 6.32532 -26.9681 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 6.87151 -30.7414 60
-      vertex 5.19046 -27.2094 60
-      vertex 5.90251 -30.942 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.19046 -27.2094 60
-      vertex 4.92768 -31.1122 60
-      vertex 5.90251 -30.942 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 4.0465 -27.4028 60
-      vertex 4.92768 -31.1122 60
-      vertex 5.19046 -27.2094 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 4.0465 -27.4028 60
-      vertex 3.948 -31.2516 60
-      vertex 4.92768 -31.1122 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 2.89544 -27.5483 60
-      vertex 3.948 -31.2516 60
-      vertex 4.0465 -27.4028 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 3.948 -31.2516 60
-      vertex 2.89544 -27.5483 60
-      vertex 2.96441 -31.3602 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 1.7393 -27.6453 60
-      vertex 2.96441 -31.3602 60
-      vertex 2.89544 -27.5483 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.96441 -31.3602 60
-      vertex 1.7393 -27.6453 60
-      vertex 1.9779 -31.4378 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 1.7393 -27.6453 60
-      vertex 0.989438 -31.4845 60
-      vertex 1.9779 -31.4378 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.580105 -27.6939 60
-      vertex 0.989438 -31.4845 60
-      vertex 1.7393 -27.6453 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.580105 -27.6939 60
-      vertex 0 -31.5 60
-      vertex 0.989438 -31.4845 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -0.580105 -27.6939 60
-      vertex 0 -31.5 60
-      vertex 0.580105 -27.6939 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.580105 -27.6939 60
-      vertex -0.989438 -31.4845 60
-      vertex 0 -31.5 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.7393 -27.6453 60
-      vertex -0.989438 -31.4845 60
-      vertex -0.580105 -27.6939 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.7393 -27.6453 60
-      vertex -1.9779 -31.4378 60
-      vertex -0.989438 -31.4845 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.96441 -31.3602 60
-      vertex -1.7393 -27.6453 60
-      vertex -2.89544 -27.5483 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.7393 -27.6453 60
-      vertex -2.96441 -31.3602 60
-      vertex -1.9779 -31.4378 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.89544 -27.5483 60
-      vertex -3.948 -31.2516 60
-      vertex -2.96441 -31.3602 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -4.0465 -27.4028 60
-      vertex -3.948 -31.2516 60
-      vertex -2.89544 -27.5483 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -4.0465 -27.4028 60
-      vertex -4.92768 -31.1122 60
-      vertex -3.948 -31.2516 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.19046 -27.2094 60
-      vertex -4.92768 -31.1122 60
-      vertex -4.0465 -27.4028 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.19046 -27.2094 60
-      vertex -5.90251 -30.942 60
-      vertex -4.92768 -31.1122 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -6.87151 -30.7414 60
-      vertex -5.19046 -27.2094 60
-      vertex -6.32532 -26.9681 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.19046 -27.2094 60
-      vertex -6.87151 -30.7414 60
-      vertex -5.90251 -30.942 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -7.83373 -30.5104 60
-      vertex -6.32532 -26.9681 60
-      vertex -7.44908 -26.6796 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -6.32532 -26.9681 60
-      vertex -7.83373 -30.5104 60
-      vertex -6.87151 -30.7414 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.78822 -30.2493 60
-      vertex -7.44908 -26.6796 60
-      vertex -8.55977 -26.3443 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -7.44908 -26.6796 60
-      vertex -8.78822 -30.2493 60
-      vertex -7.83373 -30.5104 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.6702 -29.6377 60
-      vertex -8.55977 -26.3443 60
-      vertex -9.65545 -25.9627 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.55977 -26.3443 60
-      vertex -9.73403 -29.9583 60
-      vertex -8.78822 -30.2493 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.55977 -26.3443 60
-      vertex -10.6702 -29.6377 60
-      vertex -9.73403 -29.9583 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5959 -29.288 60
-      vertex -9.65545 -25.9627 60
-      vertex -10.7342 -25.5356 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.65545 -25.9627 60
-      vertex -11.5959 -29.288 60
-      vertex -10.6702 -29.6377 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.5102 -28.9093 60
-      vertex -10.7342 -25.5356 60
-      vertex -11.7941 -25.0637 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.7342 -25.5356 60
-      vertex -12.5102 -28.9093 60
-      vertex -11.5959 -29.288 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.3007 -28.0667 60
-      vertex -11.7941 -25.0637 60
-      vertex -12.8333 -24.5478 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.7941 -25.0637 60
-      vertex -13.412 -28.5021 60
-      vertex -12.5102 -28.9093 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.1752 -27.6037 60
-      vertex -12.8333 -24.5478 60
-      vertex -13.85 -23.9889 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.7941 -25.0637 60
-      vertex -14.3007 -28.0667 60
-      vertex -13.412 -28.5021 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0348 -27.1134 60
-      vertex -13.85 -23.9889 60
-      vertex -14.8424 -23.3879 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.8333 -24.5478 60
-      vertex -15.1752 -27.6037 60
-      vertex -14.3007 -28.0667 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.7056 -26.053 60
-      vertex -14.8424 -23.3879 60
-      vertex -15.8088 -22.7458 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.85 -23.9889 60
-      vertex -16.0348 -27.1134 60
-      vertex -15.1752 -27.6037 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5152 -25.484 60
-      vertex -15.8088 -22.7458 60
-      vertex -16.7474 -22.0639 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8424 -23.3879 60
-      vertex -16.8785 -26.5963 60
-      vertex -16.0348 -27.1134 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.3066 -24.8899 60
-      vertex -16.7474 -22.0639 60
-      vertex -17.6566 -21.3432 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8424 -23.3879 60
-      vertex -17.7056 -26.053 60
-      vertex -16.8785 -26.5963 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.8088 -22.7458 60
-      vertex -18.5152 -25.484 60
-      vertex -17.7056 -26.053 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.8313 -23.6285 60
-      vertex -17.6566 -21.3432 60
-      vertex -18.5349 -20.5851 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.7474 -22.0639 60
-      vertex -19.3066 -24.8899 60
-      vertex -18.5152 -25.484 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.5632 -22.9625 60
-      vertex -18.5349 -20.5851 60
-      vertex -19.3807 -19.7909 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.6566 -21.3432 60
-      vertex -20.0789 -24.2712 60
-      vertex -19.3066 -24.8899 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.2739 -22.2739 60
-      vertex -19.3807 -19.7909 60
-      vertex -20.1924 -18.962 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.6566 -21.3432 60
-      vertex -20.8313 -23.6285 60
-      vertex -20.0789 -24.2712 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.6285 -20.8313 60
-      vertex -20.1924 -18.962 60
-      vertex -20.9688 -18.0998 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5349 -20.5851 60
-      vertex -21.5632 -22.9625 60
-      vertex -20.8313 -23.6285 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.2712 -20.0789 60
-      vertex -20.9688 -18.0998 60
-      vertex -21.7083 -17.2058 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -19.3807 -19.7909 60
-      vertex -22.2739 -22.2739 60
-      vertex -21.5632 -22.9625 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.8899 -19.3066 60
-      vertex -21.7083 -17.2058 60
-      vertex -22.4098 -16.2817 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.1924 -18.962 60
-      vertex -22.9625 -21.5632 60
-      vertex -22.2739 -22.2739 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -26.053 -17.7056 60
-      vertex -22.4098 -16.2817 60
-      vertex -23.0719 -15.3289 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.1924 -18.962 60
-      vertex -23.6285 -20.8313 60
-      vertex -22.9625 -21.5632 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -26.5963 -16.8785 60
-      vertex -23.0719 -15.3289 60
-      vertex -23.6936 -14.3493 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -20.9688 -18.0998 60
-      vertex -24.2712 -20.0789 60
-      vertex -23.6285 -20.8313 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -27.1134 -16.0348 60
-      vertex -23.6936 -14.3493 60
-      vertex -24.2737 -13.3446 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -28.0667 -14.3007 60
-      vertex -24.2737 -13.3446 60
-      vertex -24.8112 -12.3164 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -21.7083 -17.2058 60
-      vertex -24.8899 -19.3066 60
-      vertex -24.2712 -20.0789 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -28.5021 -13.412 60
-      vertex -24.8112 -12.3164 60
-      vertex -25.3052 -11.2666 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.4098 -16.2817 60
-      vertex -25.484 -18.5152 60
-      vertex -24.8899 -19.3066 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -28.9093 -12.5102 60
-      vertex -25.3052 -11.2666 60
-      vertex -25.7548 -10.1971 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -22.4098 -16.2817 60
-      vertex -26.053 -17.7056 60
-      vertex -25.484 -18.5152 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -29.6377 -10.6702 60
-      vertex -25.7548 -10.1971 60
-      vertex -26.1592 -9.10961 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -29.9583 -9.73403 60
-      vertex -26.1592 -9.10961 60
-      vertex -26.5177 -8.00618 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.0719 -15.3289 60
-      vertex -26.5963 -16.8785 60
-      vertex -26.053 -17.7056 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -30.2493 -8.78822 60
-      vertex -26.5177 -8.00618 60
-      vertex -26.8298 -6.88871 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -30.7414 -6.87151 60
-      vertex -26.8298 -6.88871 60
-      vertex -27.0947 -5.75915 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -23.6936 -14.3493 60
-      vertex -27.1134 -16.0348 60
-      vertex -26.5963 -16.8785 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -30.942 -5.90251 60
-      vertex -27.0947 -5.75915 60
-      vertex -27.3121 -4.61949 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -31.1122 -4.92768 60
-      vertex -27.3121 -4.61949 60
-      vertex -27.4816 -3.47173 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -31.3602 -2.96441 60
-      vertex -27.4816 -3.47173 60
-      vertex -27.6029 -2.31788 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.2737 -13.3446 60
-      vertex -27.6037 -15.1752 60
-      vertex -27.1134 -16.0348 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -31.4378 -1.9779 60
-      vertex -27.6029 -2.31788 60
-      vertex -27.6757 -1.15996 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -31.4845 -0.989438 60
-      vertex -27.6757 -1.15996 60
-      vertex -27.7 0 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -30.5104 7.83373 60
-      vertex -26.8298 6.88871 60
-      vertex -30.2493 8.78822 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.2737 -13.3446 60
-      vertex -28.0667 -14.3007 60
-      vertex -27.6037 -15.1752 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -30.7414 6.87151 60
-      vertex -26.8298 6.88871 60
-      vertex -30.5104 7.83373 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -24.8112 -12.3164 60
-      vertex -28.5021 -13.412 60
-      vertex -28.0667 -14.3007 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -26.8298 6.88871 60
-      vertex -30.7414 6.87151 60
-      vertex -27.0947 5.75915 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.3052 -11.2666 60
-      vertex -28.9093 -12.5102 60
-      vertex -28.5021 -13.412 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -30.942 5.90251 60
-      vertex -27.0947 5.75915 60
-      vertex -30.7414 6.87151 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.7548 -10.1971 60
-      vertex -29.288 -11.5959 60
-      vertex -28.9093 -12.5102 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -27.0947 5.75915 60
-      vertex -30.942 5.90251 60
-      vertex -27.3121 4.61949 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -25.7548 -10.1971 60
-      vertex -29.6377 -10.6702 60
-      vertex -29.288 -11.5959 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -31.1122 4.92768 60
-      vertex -27.3121 4.61949 60
-      vertex -30.942 5.90251 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -26.1592 -9.10961 60
-      vertex -29.9583 -9.73403 60
-      vertex -29.6377 -10.6702 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -27.3121 4.61949 60
-      vertex -31.1122 4.92768 60
-      vertex -27.4816 3.47173 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -26.5177 -8.00618 60
-      vertex -30.2493 -8.78822 60
-      vertex -29.9583 -9.73403 60
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -31.2516 3.948 60
-      vertex -27.4816 3.47173 60
-      vertex -31.1122 4.92768 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -26.8298 -6.88871 60
-      vertex -30.5104 -7.83373 60
-      vertex -30.2493 -8.78822 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -31.3602 2.96441 60
-      vertex -27.4816 3.47173 60
-      vertex -31.2516 3.948 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -26.8298 -6.88871 60
-      vertex -30.7414 -6.87151 60
-      vertex -30.5104 -7.83373 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -27.4816 3.47173 60
-      vertex -31.3602 2.96441 60
-      vertex -27.6029 2.31788 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -27.0947 -5.75915 60
-      vertex -30.942 -5.90251 60
-      vertex -30.7414 -6.87151 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -31.4378 1.9779 60
-      vertex -27.6029 2.31788 60
-      vertex -31.3602 2.96441 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -27.3121 -4.61949 60
-      vertex -31.1122 -4.92768 60
-      vertex -30.942 -5.90251 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -27.6029 2.31788 60
-      vertex -31.4378 1.9779 60
-      vertex -27.6757 1.15996 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -27.4816 -3.47173 60
-      vertex -31.2516 -3.948 60
-      vertex -31.1122 -4.92768 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -31.4845 0.989438 60
-      vertex -27.6757 1.15996 60
-      vertex -31.4378 1.9779 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -27.4816 -3.47173 60
-      vertex -31.3602 -2.96441 60
-      vertex -31.2516 -3.948 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -27.6757 1.15996 60
-      vertex -31.4845 0.989438 60
-      vertex -27.7 0 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -27.6029 -2.31788 60
-      vertex -31.4378 -1.9779 60
-      vertex -31.3602 -2.96441 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -31.5 0 60
-      vertex -27.7 0 60
-      vertex -31.4845 0.989438 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -27.6757 -1.15996 60
-      vertex -31.4845 -0.989438 60
-      vertex -31.4378 -1.9779 60
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -27.7 0 60
-      vertex -31.5 0 60
-      vertex -31.4845 -0.989438 60
-    endloop
-  endfacet
-  facet normal -0.625225 -0.780445 0
-    outer loop
-      vertex -20.0789 -24.2712 0
-      vertex -19.3066 -24.8899 60
-      vertex -20.0789 -24.2712 60
-    endloop
-  endfacet
-  facet normal -0.625225 -0.780445 -0
-    outer loop
-      vertex -19.3066 -24.8899 60
-      vertex -20.0789 -24.2712 0
-      vertex -19.3066 -24.8899 0
     endloop
   endfacet
   facet normal 0.48173 0.87632 -0
@@ -7811,20 +7811,6 @@ solid OpenSCAD_Model
       vertex 1.7393 -27.6453 0
     endloop
   endfacet
-  facet normal 0.921856 -0.387533 0
-    outer loop
-      vertex -25.7548 10.1971 60
-      vertex -25.3052 11.2666 0
-      vertex -25.3052 11.2666 60
-    endloop
-  endfacet
-  facet normal 0.921856 -0.387533 0
-    outer loop
-      vertex -25.3052 11.2666 0
-      vertex -25.7548 10.1971 60
-      vertex -25.7548 10.1971 0
-    endloop
-  endfacet
   facet normal 0 -1 0
     outer loop
       vertex -0.580105 27.6939 0
@@ -7851,6 +7837,20 @@ solid OpenSCAD_Model
       vertex -19.3807 -19.7909 60
       vertex -18.5349 -20.5851 0
       vertex -19.3807 -19.7909 0
+    endloop
+  endfacet
+  facet normal 0.587767 -0.80903 0
+    outer loop
+      vertex -16.7474 22.0639 0
+      vertex -15.8088 22.7458 60
+      vertex -16.7474 22.0639 60
+    endloop
+  endfacet
+  facet normal 0.587767 -0.80903 0
+    outer loop
+      vertex -15.8088 22.7458 60
+      vertex -16.7474 22.0639 0
+      vertex -15.8088 22.7458 0
     endloop
   endfacet
   facet normal -0.653407 -0.757007 0
@@ -8033,20 +8033,6 @@ solid OpenSCAD_Model
       vertex 23.0719 -15.3289 60
       vertex 22.4098 -16.2817 0
       vertex 22.4098 -16.2817 60
-    endloop
-  endfacet
-  facet normal -0.48173 -0.87632 0
-    outer loop
-      vertex 12.8333 24.5478 0
-      vertex 13.85 23.9889 60
-      vertex 12.8333 24.5478 60
-    endloop
-  endfacet
-  facet normal -0.48173 -0.87632 -0
-    outer loop
-      vertex 13.85 23.9889 60
-      vertex 12.8333 24.5478 0
-      vertex 13.85 23.9889 0
     endloop
   endfacet
   facet normal -0.951063 -0.308997 0
@@ -8497,6 +8483,20 @@ solid OpenSCAD_Model
       vertex 12.8333 24.5478 0
     endloop
   endfacet
+  facet normal 0.989271 -0.146094 0
+    outer loop
+      vertex -27.4816 3.47173 60
+      vertex -27.3121 4.61949 0
+      vertex -27.3121 4.61949 60
+    endloop
+  endfacet
+  facet normal 0.989271 -0.146094 0
+    outer loop
+      vertex -27.3121 4.61949 0
+      vertex -27.4816 3.47173 60
+      vertex -27.4816 3.47173 0
+    endloop
+  endfacet
   facet normal -0.289003 0.957328 0
     outer loop
       vertex 8.55977 -26.3443 0
@@ -8509,20 +8509,6 @@ solid OpenSCAD_Model
       vertex 7.44908 -26.6796 60
       vertex 8.55977 -26.3443 0
       vertex 7.44908 -26.6796 0
-    endloop
-  endfacet
-  facet normal 0.951063 -0.308997 0
-    outer loop
-      vertex -26.5177 8.00618 60
-      vertex -26.1592 9.10961 0
-      vertex -26.1592 9.10961 60
-    endloop
-  endfacet
-  facet normal 0.951063 -0.308997 0
-    outer loop
-      vertex -26.1592 9.10961 0
-      vertex -26.5177 8.00618 60
-      vertex -26.5177 8.00618 0
     endloop
   endfacet
   facet normal -0.0418888 0.999122 0
@@ -9169,6 +9155,20 @@ solid OpenSCAD_Model
       vertex -20.9688 -18.0998 0
     endloop
   endfacet
+  facet normal 0.951063 -0.308997 0
+    outer loop
+      vertex -26.5177 8.00618 60
+      vertex -26.1592 9.10961 0
+      vertex -26.1592 9.10961 60
+    endloop
+  endfacet
+  facet normal 0.951063 -0.308997 0
+    outer loop
+      vertex -26.1592 9.10961 0
+      vertex -26.5177 8.00618 60
+      vertex -26.5177 8.00618 0
+    endloop
+  endfacet
   facet normal 0.999781 -0.0209444 0
     outer loop
       vertex -27.7 0 60
@@ -9223,20 +9223,6 @@ solid OpenSCAD_Model
       vertex -8.55977 26.3443 60
       vertex -9.65545 25.9627 0
       vertex -8.55977 26.3443 0
-    endloop
-  endfacet
-  facet normal 0.587767 -0.80903 0
-    outer loop
-      vertex -16.7474 22.0639 0
-      vertex -15.8088 22.7458 60
-      vertex -16.7474 22.0639 60
-    endloop
-  endfacet
-  facet normal 0.587767 -0.80903 0
-    outer loop
-      vertex -15.8088 22.7458 60
-      vertex -16.7474 22.0639 0
-      vertex -15.8088 22.7458 0
     endloop
   endfacet
   facet normal -0.444661 0.895699 0
@@ -9309,6 +9295,20 @@ solid OpenSCAD_Model
       vertex 20.9688 18.0998 60
     endloop
   endfacet
+  facet normal -0.48173 -0.87632 0
+    outer loop
+      vertex 12.8333 24.5478 0
+      vertex 13.85 23.9889 60
+      vertex 12.8333 24.5478 60
+    endloop
+  endfacet
+  facet normal -0.48173 -0.87632 -0
+    outer loop
+      vertex 13.85 23.9889 60
+      vertex 12.8333 24.5478 0
+      vertex 13.85 23.9889 0
+    endloop
+  endfacet
   facet normal -0.621189 0.783661 0
     outer loop
       vertex 17.6566 -21.3432 0
@@ -9351,6 +9351,20 @@ solid OpenSCAD_Model
       vertex -9.65545 25.9627 0
     endloop
   endfacet
+  facet normal 0.248664 -0.96859 0
+    outer loop
+      vertex -7.44908 26.6796 0
+      vertex -6.32532 26.9681 60
+      vertex -7.44908 26.6796 60
+    endloop
+  endfacet
+  facet normal 0.248664 -0.96859 0
+    outer loop
+      vertex -6.32532 26.9681 60
+      vertex -7.44908 26.6796 0
+      vertex -6.32532 26.9681 0
+    endloop
+  endfacet
   facet normal 0.207976 -0.978134 0
     outer loop
       vertex -6.32532 26.9681 0
@@ -9377,20 +9391,6 @@ solid OpenSCAD_Model
       vertex -27.0947 5.75915 0
       vertex -27.3121 4.61949 60
       vertex -27.3121 4.61949 0
-    endloop
-  endfacet
-  facet normal 0.989271 -0.146094 0
-    outer loop
-      vertex -27.4816 3.47173 60
-      vertex -27.3121 4.61949 0
-      vertex -27.3121 4.61949 60
-    endloop
-  endfacet
-  facet normal 0.989271 -0.146094 0
-    outer loop
-      vertex -27.3121 4.61949 0
-      vertex -27.4816 3.47173 60
-      vertex -27.4816 3.47173 0
     endloop
   endfacet
   facet normal 0.714481 -0.699655 0
@@ -9477,20 +9477,6 @@ solid OpenSCAD_Model
       vertex 13.85 -23.9889 0
     endloop
   endfacet
-  facet normal 0.248664 -0.96859 0
-    outer loop
-      vertex -7.44908 26.6796 0
-      vertex -6.32532 26.9681 60
-      vertex -7.44908 26.6796 60
-    endloop
-  endfacet
-  facet normal 0.248664 -0.96859 0
-    outer loop
-      vertex -6.32532 26.9681 60
-      vertex -7.44908 26.6796 0
-      vertex -6.32532 26.9681 0
-    endloop
-  endfacet
   facet normal -0.982288 0.18738 0
     outer loop
       vertex 27.0947 -5.75915 0
@@ -9503,6 +9489,20 @@ solid OpenSCAD_Model
       vertex 27.3121 -4.61949 60
       vertex 27.0947 -5.75915 0
       vertex 27.0947 -5.75915 60
+    endloop
+  endfacet
+  facet normal 0.921856 -0.387533 0
+    outer loop
+      vertex -25.7548 10.1971 60
+      vertex -25.3052 11.2666 0
+      vertex -25.3052 11.2666 60
+    endloop
+  endfacet
+  facet normal 0.921856 -0.387533 0
+    outer loop
+      vertex -25.3052 11.2666 0
+      vertex -25.7548 10.1971 60
+      vertex -25.7548 10.1971 0
     endloop
   endfacet
   facet normal 0.999781 0.0209444 0
@@ -9545,20 +9545,6 @@ solid OpenSCAD_Model
       vertex -16.7474 -22.0639 60
       vertex -15.8088 -22.7458 0
       vertex -16.7474 -22.0639 0
-    endloop
-  endfacet
-  facet normal 0.904827 -0.42578 0
-    outer loop
-      vertex -25.3052 11.2666 60
-      vertex -24.8112 12.3164 0
-      vertex -24.8112 12.3164 60
-    endloop
-  endfacet
-  facet normal 0.904827 -0.42578 0
-    outer loop
-      vertex -24.8112 12.3164 0
-      vertex -25.3052 11.2666 60
-      vertex -25.3052 11.2666 0
     endloop
   endfacet
   facet normal -0.821195 -0.570648 0
@@ -9643,6 +9629,20 @@ solid OpenSCAD_Model
       vertex -22.4098 16.2817 0
       vertex -23.0719 15.3289 60
       vertex -23.0719 15.3289 0
+    endloop
+  endfacet
+  facet normal 0.904827 -0.42578 0
+    outer loop
+      vertex -25.3052 11.2666 60
+      vertex -24.8112 12.3164 0
+      vertex -24.8112 12.3164 60
+    endloop
+  endfacet
+  facet normal 0.904827 -0.42578 0
+    outer loop
+      vertex -24.8112 12.3164 0
+      vertex -25.3052 11.2666 60
+      vertex -25.3052 11.2666 0
     endloop
   endfacet
   facet normal -0.207976 0.978134 0

--- a/tests/cad/test_spool_core_sleeve.sh
+++ b/tests/cad/test_spool_core_sleeve.sh
@@ -14,8 +14,8 @@ STL="${REPO_ROOT}/stl/spool_core_sleeve/${PRESET}.stl"
 
 [[ -s "${STL}" ]] || { echo "FAIL: STL missing"; exit 1; }
 
-# Expect wall thickness = (63-55)/2 = 4 mm (allow simple string match)
-grep -E 'Radial wall thickness: +4(.0+)? +mm' "${LOG}" >/dev/null \
+# Expect wall thickness start/end = 4 mm -> 4.5 mm
+grep -E 'Radial wall thickness: +4(\.0+)? +mm -> +4\.5(\.0+)? +mm' "${LOG}" >/dev/null \
     || { echo "FAIL: unexpected wall thickness (see ${LOG})"; exit 1; }
 
 echo "All checks passed."


### PR DESCRIPTION
## Summary
- allow spool_core_sleeve to specify different end diameters for a linear taper
- regenerate Sunlu 55 mm preset as 63→64 mm sleeve and document new target_od_end parameter
- wire taper support into CLI renderer, tests, and docs

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash tests/cad/test_spool_core_sleeve.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a79450a020832f9763c961533ffa71