### PR TITLE
🔩 : add wedge removal Sunlu spool core sleeve

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ or skip end-to-end tests by prefixing commands with `SKIP_E2E=1`.
 - CI troubleshooting tips in `docs/ci-guide.md`
 - Nightly STL exports are committed back to `stl/` after each run
 - Sunlu spool core sleeve adapter (63→64 mm) [STL](./stl/spool_core_sleeve/sunlu55_to63_len60.stl)
+  and matching wedge-removal cylinder [STL](./stl/spool_core_sleeve/sunlu55_to63cyl_len60.stl)
 - Flywheel construction guide in `docs/flywheel-construction.md` with CAD files in `cad/`
   including `stand.scad`, `shaft.scad`, and `adapter.scad`. Assembly details live in `docs/flywheel-stand.md`, clamp instructions in `docs/flywheel-adapter.md`, and physics in `docs/flywheel-physics.md`
 

--- a/cad/README.md
+++ b/cad/README.md
@@ -20,10 +20,11 @@ sudo apt-get install openscad
   bore clearance
 - `flywheel.scad` – cylindrical flywheel with center bore and optional shaft clearance
   (override `$fs` via the `resolution_fs` variable for finer meshes)
-- `utils/spool_core_sleeve.scad` – parametric spool core sleeve library
-  (see `examples/spool_core_sleeve_example.scad`; a pre-generated
-  `sunlu55_to63_len60` 63→64 mm tapered sleeve lives in
-  `stl/spool_core_sleeve/`)
+- `utils/spool_core_sleeve.scad` – parametric spool core sleeve library.
+  Ready-to-print presets live in `spool_core_sleeve/` with matching STLs in
+  `../stl/spool_core_sleeve/`, including a `sunlu55_to63_len60` 63→64 mm
+  tapered adapter and a `sunlu55_to63cyl_len60` straight 63 mm cylinder for
+  wedge removal.
 - `examples/spool_core_sleeve_example.scad` – demo spool core sleeve; the
   corresponding OBJ lives in `webapp/static/models/examples/` and the
   pre-generated 63→64 mm sleeve's OBJ is at

--- a/cad/spool_core_sleeve/sunlu55_to63_len60.scad
+++ b/cad/spool_core_sleeve/sunlu55_to63_len60.scad
@@ -1,0 +1,3 @@
+use <../utils/spool_core_sleeve.scad>;
+
+spool_core_sleeve_preset("sunlu55_to63_len60");

--- a/cad/spool_core_sleeve/sunlu55_to63cyl_len60.scad
+++ b/cad/spool_core_sleeve/sunlu55_to63cyl_len60.scad
@@ -1,0 +1,3 @@
+use <../utils/spool_core_sleeve.scad>;
+
+spool_core_sleeve_preset("sunlu55_to63cyl_len60");

--- a/cad/utils/spool_core_sleeve.scad
+++ b/cad/utils/spool_core_sleeve.scad
@@ -59,7 +59,9 @@ module spool_core_sleeve(
 
 // Optional named presets (extend as you collect measurements)
 function _spool_core_sleeve_preset(preset) =
-    (preset == "sunlu55_to63_len60") ? [55, 63, 64, 60, 0.20] : undef;
+    (preset == "sunlu55_to63_len60") ? [55, 63, 64, 60, 0.20] :
+    (preset == "sunlu55_to63cyl_len60") ? [55, 63, 63, 60, 0.20] :
+    undef;
 
 module spool_core_sleeve_preset(
     preset = "sunlu55_to63_len60", $fn_outer = 200, $fn_inner = 150

--- a/docs/spool-core-sleeve.md
+++ b/docs/spool-core-sleeve.md
@@ -17,6 +17,9 @@ spool_core_sleeve(inner_id=55, target_od=63, target_od_end=64,
 
 // or via named preset
 spool_core_sleeve_preset("sunlu55_to63_len60");
+
+// straight 63 mm cylinder (works as a wedge removal tool)
+spool_core_sleeve_preset("sunlu55_to63cyl_len60");
 ```
 
 ### Parameters
@@ -52,6 +55,14 @@ openscad -o stl/spool_core_sleeve/sunlu55_to63_len60.stl \
   -D PRESET="sunlu55_to63_len60" \
   cad/examples/spool_core_sleeve_example.scad
 ```
+
+## Ready-to-print files
+
+Two preset SCAD files live in `cad/spool_core_sleeve/` with matching STLs in
+`stl/spool_core_sleeve/`. The tapered adapter (`sunlu55_to63_len60`) expands from
+63 mm to 64 mm, while the straight cylinder (`sunlu55_to63cyl_len60`) serves as a
+wedge-removal tool so the adapter can be reused across many spools.
+
 
 ## Printing notes
 

--- a/stl/spool_core_sleeve/.gitignore
+++ b/stl/spool_core_sleeve/.gitignore
@@ -1,3 +1,4 @@
 *.stl
 *.log
 !sunlu55_to63_len60.stl
+!sunlu55_to63cyl_len60.stl

--- a/stl/spool_core_sleeve/sunlu55_to63_len60.stl
+++ b/stl/spool_core_sleeve/sunlu55_to63_len60.stl
@@ -7839,20 +7839,6 @@ solid OpenSCAD_Model
       vertex -19.3807 -19.7909 0
     endloop
   endfacet
-  facet normal 0.587767 -0.80903 0
-    outer loop
-      vertex -16.7474 22.0639 0
-      vertex -15.8088 22.7458 60
-      vertex -16.7474 22.0639 60
-    endloop
-  endfacet
-  facet normal 0.587767 -0.80903 0
-    outer loop
-      vertex -15.8088 22.7458 60
-      vertex -16.7474 22.0639 0
-      vertex -15.8088 22.7458 0
-    endloop
-  endfacet
   facet normal -0.653407 -0.757007 0
     outer loop
       vertex 17.6566 21.3432 0
@@ -7921,20 +7907,6 @@ solid OpenSCAD_Model
       vertex -20.1924 -18.962 0
       vertex -19.3807 -19.7909 60
       vertex -19.3807 -19.7909 0
-    endloop
-  endfacet
-  facet normal -0.921856 0.387533 0
-    outer loop
-      vertex 25.3052 -11.2666 0
-      vertex 25.7548 -10.1971 60
-      vertex 25.7548 -10.1971 0
-    endloop
-  endfacet
-  facet normal -0.921856 0.387533 0
-    outer loop
-      vertex 25.7548 -10.1971 60
-      vertex 25.3052 -11.2666 0
-      vertex 25.3052 -11.2666 60
     endloop
   endfacet
   facet normal -0.963141 -0.268997 0
@@ -8763,6 +8735,20 @@ solid OpenSCAD_Model
       vertex 15.8088 22.7458 0
     endloop
   endfacet
+  facet normal -0.743114 0.669165 0
+    outer loop
+      vertex 20.1924 -18.962 0
+      vertex 20.9688 -18.0998 60
+      vertex 20.9688 -18.0998 0
+    endloop
+  endfacet
+  facet normal -0.743114 0.669165 0
+    outer loop
+      vertex 20.9688 -18.0998 60
+      vertex 20.1924 -18.962 0
+      vertex 20.1924 -18.962 60
+    endloop
+  endfacet
   facet normal -0.99452 0.10455 0
     outer loop
       vertex 27.4816 -3.47173 0
@@ -8915,20 +8901,6 @@ solid OpenSCAD_Model
       vertex 6.32532 -26.9681 60
       vertex 7.44908 -26.6796 0
       vertex 6.32532 -26.9681 0
-    endloop
-  endfacet
-  facet normal -0.743114 0.669165 0
-    outer loop
-      vertex 20.1924 -18.962 0
-      vertex 20.9688 -18.0998 60
-      vertex 20.9688 -18.0998 0
-    endloop
-  endfacet
-  facet normal -0.743114 0.669165 0
-    outer loop
-      vertex 20.9688 -18.0998 60
-      vertex 20.1924 -18.962 0
-      vertex 20.1924 -18.962 60
     endloop
   endfacet
   facet normal 0.68452 -0.728994 0
@@ -9225,6 +9197,20 @@ solid OpenSCAD_Model
       vertex -8.55977 26.3443 0
     endloop
   endfacet
+  facet normal 0.587767 -0.80903 0
+    outer loop
+      vertex -16.7474 22.0639 0
+      vertex -15.8088 22.7458 60
+      vertex -16.7474 22.0639 60
+    endloop
+  endfacet
+  facet normal 0.587767 -0.80903 0
+    outer loop
+      vertex -15.8088 22.7458 60
+      vertex -16.7474 22.0639 0
+      vertex -15.8088 22.7458 0
+    endloop
+  endfacet
   facet normal -0.444661 0.895699 0
     outer loop
       vertex 12.8333 -24.5478 0
@@ -9491,6 +9477,20 @@ solid OpenSCAD_Model
       vertex 27.0947 -5.75915 60
     endloop
   endfacet
+  facet normal -0.921856 0.387533 0
+    outer loop
+      vertex 25.3052 -11.2666 0
+      vertex 25.7548 -10.1971 60
+      vertex 25.7548 -10.1971 0
+    endloop
+  endfacet
+  facet normal -0.921856 0.387533 0
+    outer loop
+      vertex 25.7548 -10.1971 60
+      vertex 25.3052 -11.2666 0
+      vertex 25.3052 -11.2666 60
+    endloop
+  endfacet
   facet normal 0.921856 -0.387533 0
     outer loop
       vertex -25.7548 10.1971 60
@@ -9545,6 +9545,20 @@ solid OpenSCAD_Model
       vertex -16.7474 -22.0639 60
       vertex -15.8088 -22.7458 0
       vertex -16.7474 -22.0639 0
+    endloop
+  endfacet
+  facet normal 0.904827 -0.42578 0
+    outer loop
+      vertex -25.3052 11.2666 60
+      vertex -24.8112 12.3164 0
+      vertex -24.8112 12.3164 60
+    endloop
+  endfacet
+  facet normal 0.904827 -0.42578 0
+    outer loop
+      vertex -24.8112 12.3164 0
+      vertex -25.3052 11.2666 60
+      vertex -25.3052 11.2666 0
     endloop
   endfacet
   facet normal -0.821195 -0.570648 0
@@ -9629,20 +9643,6 @@ solid OpenSCAD_Model
       vertex -22.4098 16.2817 0
       vertex -23.0719 15.3289 60
       vertex -23.0719 15.3289 0
-    endloop
-  endfacet
-  facet normal 0.904827 -0.42578 0
-    outer loop
-      vertex -25.3052 11.2666 60
-      vertex -24.8112 12.3164 0
-      vertex -24.8112 12.3164 60
-    endloop
-  endfacet
-  facet normal 0.904827 -0.42578 0
-    outer loop
-      vertex -24.8112 12.3164 0
-      vertex -25.3052 11.2666 60
-      vertex -25.3052 11.2666 0
     endloop
   endfacet
   facet normal -0.207976 0.978134 0

--- a/stl/spool_core_sleeve/sunlu55_to63cyl_len60.stl
+++ b/stl/spool_core_sleeve/sunlu55_to63cyl_len60.stl
@@ -1,0 +1,9802 @@
+solid OpenSCAD_Model
+  facet normal 0.998886 0.0471925 0
+    outer loop
+      vertex 31.4845 0.989438 60
+      vertex 31.4378 1.9779 0
+      vertex 31.4378 1.9779 60
+    endloop
+  endfacet
+  facet normal 0.998886 0.0471925 0
+    outer loop
+      vertex 31.4378 1.9779 0
+      vertex 31.4845 0.989438 60
+      vertex 31.4845 0.989438 0
+    endloop
+  endfacet
+  facet normal 0.999877 0.0156635 0
+    outer loop
+      vertex 31.5 0 60
+      vertex 31.4845 0.989438 0
+      vertex 31.4845 0.989438 60
+    endloop
+  endfacet
+  facet normal 0.999877 0.0156635 0
+    outer loop
+      vertex 31.4845 0.989438 0
+      vertex 31.5 0 60
+      vertex 31.5 0 0
+    endloop
+  endfacet
+  facet normal 0.99692 0.0784189 0
+    outer loop
+      vertex 31.4378 1.9779 60
+      vertex 31.3602 2.96441 0
+      vertex 31.3602 2.96441 60
+    endloop
+  endfacet
+  facet normal 0.99692 0.0784189 0
+    outer loop
+      vertex 31.3602 2.96441 0
+      vertex 31.4378 1.9779 60
+      vertex 31.4378 1.9779 0
+    endloop
+  endfacet
+  facet normal -0.979237 0.202719 0
+    outer loop
+      vertex -30.942 5.90251 0
+      vertex -30.7414 6.87151 60
+      vertex -30.7414 6.87151 0
+    endloop
+  endfacet
+  facet normal -0.979237 0.202719 0
+    outer loop
+      vertex -30.7414 6.87151 60
+      vertex -30.942 5.90251 0
+      vertex -30.942 5.90251 60
+    endloop
+  endfacet
+  facet normal -0.140872 -0.990028 0
+    outer loop
+      vertex -4.92768 -31.1122 0
+      vertex -3.948 -31.2516 60
+      vertex -4.92768 -31.1122 60
+    endloop
+  endfacet
+  facet normal -0.140872 -0.990028 -0
+    outer loop
+      vertex -3.948 -31.2516 60
+      vertex -4.92768 -31.1122 0
+      vertex -3.948 -31.2516 0
+    endloop
+  endfacet
+  facet normal 0.38267 0.923885 -0
+    outer loop
+      vertex 12.5102 28.9093 0
+      vertex 11.5959 29.288 60
+      vertex 12.5102 28.9093 60
+    endloop
+  endfacet
+  facet normal 0.38267 0.923885 0
+    outer loop
+      vertex 11.5959 29.288 60
+      vertex 12.5102 28.9093 0
+      vertex 11.5959 29.288 0
+    endloop
+  endfacet
+  facet normal 0.0784189 -0.99692 0
+    outer loop
+      vertex 1.9779 -31.4378 0
+      vertex 2.96441 -31.3602 60
+      vertex 1.9779 -31.4378 60
+    endloop
+  endfacet
+  facet normal 0.0784189 -0.99692 0
+    outer loop
+      vertex 2.96441 -31.3602 60
+      vertex 1.9779 -31.4378 0
+      vertex 2.96441 -31.3602 0
+    endloop
+  endfacet
+  facet normal -0.99692 -0.0784189 0
+    outer loop
+      vertex -31.3602 -2.96441 0
+      vertex -31.4378 -1.9779 60
+      vertex -31.4378 -1.9779 0
+    endloop
+  endfacet
+  facet normal -0.99692 -0.0784189 0
+    outer loop
+      vertex -31.4378 -1.9779 60
+      vertex -31.3602 -2.96441 0
+      vertex -31.3602 -2.96441 60
+    endloop
+  endfacet
+  facet normal 0.99396 0.109745 0
+    outer loop
+      vertex 31.3602 2.96441 60
+      vertex 31.2516 3.948 0
+      vertex 31.2516 3.948 60
+    endloop
+  endfacet
+  facet normal 0.99396 0.109745 0
+    outer loop
+      vertex 31.2516 3.948 0
+      vertex 31.3602 2.96441 60
+      vertex 31.3602 2.96441 0
+    endloop
+  endfacet
+  facet normal 0.835809 -0.549021 0
+    outer loop
+      vertex 26.053 -17.7056 60
+      vertex 26.5963 -16.8785 0
+      vertex 26.5963 -16.8785 60
+    endloop
+  endfacet
+  facet normal 0.835809 -0.549021 0
+    outer loop
+      vertex 26.5963 -16.8785 0
+      vertex 26.053 -17.7056 60
+      vertex 26.053 -17.7056 0
+    endloop
+  endfacet
+  facet normal -0.263855 0.964562 0
+    outer loop
+      vertex -7.83373 30.5104 0
+      vertex -8.78822 30.2493 60
+      vertex -7.83373 30.5104 60
+    endloop
+  endfacet
+  facet normal -0.263855 0.964562 0
+    outer loop
+      vertex -8.78822 30.2493 60
+      vertex -7.83373 30.5104 0
+      vertex -8.78822 30.2493 0
+    endloop
+  endfacet
+  facet normal -0.73962 0.673025 0
+    outer loop
+      vertex -23.6285 20.8313 0
+      vertex -22.9625 21.5632 60
+      vertex -22.9625 21.5632 0
+    endloop
+  endfacet
+  facet normal -0.73962 0.673025 0
+    outer loop
+      vertex -22.9625 21.5632 60
+      vertex -23.6285 20.8313 0
+      vertex -23.6285 20.8313 60
+    endloop
+  endfacet
+  facet normal -0.411533 0.911395 0
+    outer loop
+      vertex -12.5102 28.9093 0
+      vertex -13.412 28.5021 60
+      vertex -12.5102 28.9093 60
+    endloop
+  endfacet
+  facet normal -0.411533 0.911395 0
+    outer loop
+      vertex -13.412 28.5021 60
+      vertex -12.5102 28.9093 0
+      vertex -13.412 28.5021 0
+    endloop
+  endfacet
+  facet normal 0.549021 0.835809 -0
+    outer loop
+      vertex 17.7056 26.053 0
+      vertex 16.8785 26.5963 60
+      vertex 17.7056 26.053 60
+    endloop
+  endfacet
+  facet normal 0.549021 0.835809 0
+    outer loop
+      vertex 16.8785 26.5963 60
+      vertex 17.7056 26.053 0
+      vertex 16.8785 26.5963 0
+    endloop
+  endfacet
+  facet normal -0.522557 0.852604 0
+    outer loop
+      vertex -16.0348 27.1134 0
+      vertex -16.8785 26.5963 60
+      vertex -16.0348 27.1134 60
+    endloop
+  endfacet
+  facet normal -0.522557 0.852604 0
+    outer loop
+      vertex -16.8785 26.5963 60
+      vertex -16.0348 27.1134 0
+      vertex -16.8785 26.5963 0
+    endloop
+  endfacet
+  facet normal -0.964562 -0.263855 0
+    outer loop
+      vertex -30.2493 -8.78822 0
+      vertex -30.5104 -7.83373 60
+      vertex -30.5104 -7.83373 0
+    endloop
+  endfacet
+  facet normal -0.964562 -0.263855 0
+    outer loop
+      vertex -30.5104 -7.83373 60
+      vertex -30.2493 -8.78822 0
+      vertex -30.2493 -8.78822 60
+    endloop
+  endfacet
+  facet normal 0.73962 -0.673025 0
+    outer loop
+      vertex 22.9625 -21.5632 60
+      vertex 23.6285 -20.8313 0
+      vertex 23.6285 -20.8313 60
+    endloop
+  endfacet
+  facet normal 0.73962 -0.673025 0
+    outer loop
+      vertex 23.6285 -20.8313 0
+      vertex 22.9625 -21.5632 60
+      vertex 22.9625 -21.5632 0
+    endloop
+  endfacet
+  facet normal -0.0784189 0.99692 0
+    outer loop
+      vertex -1.9779 31.4378 0
+      vertex -2.96441 31.3602 60
+      vertex -1.9779 31.4378 60
+    endloop
+  endfacet
+  facet normal -0.0784189 0.99692 0
+    outer loop
+      vertex -2.96441 31.3602 60
+      vertex -1.9779 31.4378 0
+      vertex -2.96441 31.3602 0
+    endloop
+  endfacet
+  facet normal 0.99692 -0.0784189 0
+    outer loop
+      vertex 31.3602 -2.96441 60
+      vertex 31.4378 -1.9779 0
+      vertex 31.4378 -1.9779 60
+    endloop
+  endfacet
+  facet normal 0.99692 -0.0784189 0
+    outer loop
+      vertex 31.4378 -1.9779 0
+      vertex 31.3602 -2.96441 60
+      vertex 31.3602 -2.96441 0
+    endloop
+  endfacet
+  facet normal 0.946061 0.323987 0
+    outer loop
+      vertex 29.9583 9.73403 60
+      vertex 29.6377 10.6702 0
+      vertex 29.6377 10.6702 60
+    endloop
+  endfacet
+  facet normal 0.946061 0.323987 0
+    outer loop
+      vertex 29.6377 10.6702 0
+      vertex 29.9583 9.73403 60
+      vertex 29.9583 9.73403 0
+    endloop
+  endfacet
+  facet normal -0.883776 0.467911 0
+    outer loop
+      vertex -28.0667 14.3007 0
+      vertex -27.6037 15.1752 60
+      vertex -27.6037 15.1752 0
+    endloop
+  endfacet
+  facet normal -0.883776 0.467911 0
+    outer loop
+      vertex -27.6037 15.1752 60
+      vertex -28.0667 14.3007 0
+      vertex -28.0667 14.3007 60
+    endloop
+  endfacet
+  facet normal -0.760361 -0.6495 0
+    outer loop
+      vertex -23.6285 -20.8313 0
+      vertex -24.2712 -20.0789 60
+      vertex -24.2712 -20.0789 0
+    endloop
+  endfacet
+  facet normal -0.760361 -0.6495 0
+    outer loop
+      vertex -24.2712 -20.0789 60
+      vertex -23.6285 -20.8313 0
+      vertex -23.6285 -20.8313 60
+    endloop
+  endfacet
+  facet normal 0.868635 0.495453 0
+    outer loop
+      vertex 27.6037 15.1752 60
+      vertex 27.1134 16.0348 0
+      vertex 27.1134 16.0348 60
+    endloop
+  endfacet
+  facet normal 0.868635 0.495453 0
+    outer loop
+      vertex 27.1134 16.0348 0
+      vertex 27.6037 15.1752 60
+      vertex 27.6037 15.1752 0
+    endloop
+  endfacet
+  facet normal -0.38267 0.923885 0
+    outer loop
+      vertex -11.5959 29.288 0
+      vertex -12.5102 28.9093 60
+      vertex -11.5959 29.288 60
+    endloop
+  endfacet
+  facet normal -0.38267 0.923885 0
+    outer loop
+      vertex -12.5102 28.9093 60
+      vertex -11.5959 29.288 0
+      vertex -12.5102 28.9093 0
+    endloop
+  endfacet
+  facet normal -0.549021 0.835809 0
+    outer loop
+      vertex -16.8785 26.5963 0
+      vertex -17.7056 26.053 60
+      vertex -16.8785 26.5963 60
+    endloop
+  endfacet
+  facet normal -0.549021 0.835809 0
+    outer loop
+      vertex -17.7056 26.053 60
+      vertex -16.8785 26.5963 0
+      vertex -17.7056 26.053 0
+    endloop
+  endfacet
+  facet normal 0.780445 0.625225 0
+    outer loop
+      vertex 24.8899 19.3066 60
+      vertex 24.2712 20.0789 0
+      vertex 24.2712 20.0789 60
+    endloop
+  endfacet
+  facet normal 0.780445 0.625225 0
+    outer loop
+      vertex 24.2712 20.0789 0
+      vertex 24.8899 19.3066 60
+      vertex 24.8899 19.3066 0
+    endloop
+  endfacet
+  facet normal 0.625225 0.780445 -0
+    outer loop
+      vertex 20.0789 24.2712 0
+      vertex 19.3066 24.8899 60
+      vertex 20.0789 24.2712 60
+    endloop
+  endfacet
+  facet normal 0.625225 0.780445 0
+    outer loop
+      vertex 19.3066 24.8899 60
+      vertex 20.0789 24.2712 0
+      vertex 19.3066 24.8899 0
+    endloop
+  endfacet
+  facet normal 0.955784 0.294069 0
+    outer loop
+      vertex 30.2493 8.78822 60
+      vertex 29.9583 9.73403 0
+      vertex 29.9583 9.73403 60
+    endloop
+  endfacet
+  facet normal 0.955784 0.294069 0
+    outer loop
+      vertex 29.9583 9.73403 0
+      vertex 30.2493 8.78822 60
+      vertex 30.2493 8.78822 0
+    endloop
+  endfacet
+  facet normal -0.263855 -0.964562 0
+    outer loop
+      vertex -8.78822 -30.2493 0
+      vertex -7.83373 -30.5104 60
+      vertex -8.78822 -30.2493 60
+    endloop
+  endfacet
+  facet normal -0.263855 -0.964562 -0
+    outer loop
+      vertex -7.83373 -30.5104 60
+      vertex -8.78822 -30.2493 0
+      vertex -7.83373 -30.5104 0
+    endloop
+  endfacet
+  facet normal 0.985098 0.171993 0
+    outer loop
+      vertex 31.1122 4.92768 60
+      vertex 30.942 5.90251 0
+      vertex 30.942 5.90251 60
+    endloop
+  endfacet
+  facet normal 0.985098 0.171993 0
+    outer loop
+      vertex 30.942 5.90251 0
+      vertex 31.1122 4.92768 60
+      vertex 31.1122 4.92768 0
+    endloop
+  endfacet
+  facet normal -0.323987 -0.946061 0
+    outer loop
+      vertex -10.6702 -29.6377 0
+      vertex -9.73403 -29.9583 60
+      vertex -10.6702 -29.6377 60
+    endloop
+  endfacet
+  facet normal -0.323987 -0.946061 -0
+    outer loop
+      vertex -9.73403 -29.9583 60
+      vertex -10.6702 -29.6377 0
+      vertex -9.73403 -29.9583 0
+    endloop
+  endfacet
+  facet normal 0.294069 0.955784 -0
+    outer loop
+      vertex 9.73403 29.9583 0
+      vertex 8.78822 30.2493 60
+      vertex 9.73403 29.9583 60
+    endloop
+  endfacet
+  facet normal 0.294069 0.955784 0
+    outer loop
+      vertex 8.78822 30.2493 60
+      vertex 9.73403 29.9583 0
+      vertex 8.78822 30.2493 0
+    endloop
+  endfacet
+  facet normal -0.868635 -0.495453 0
+    outer loop
+      vertex -27.1134 -16.0348 0
+      vertex -27.6037 -15.1752 60
+      vertex -27.6037 -15.1752 0
+    endloop
+  endfacet
+  facet normal -0.868635 -0.495453 0
+    outer loop
+      vertex -27.6037 -15.1752 60
+      vertex -27.1134 -16.0348 0
+      vertex -27.1134 -16.0348 60
+    endloop
+  endfacet
+  facet normal 0.760361 -0.6495 0
+    outer loop
+      vertex 23.6285 -20.8313 60
+      vertex 24.2712 -20.0789 0
+      vertex 24.2712 -20.0789 60
+    endloop
+  endfacet
+  facet normal 0.760361 -0.6495 0
+    outer loop
+      vertex 24.2712 -20.0789 0
+      vertex 23.6285 -20.8313 60
+      vertex 23.6285 -20.8313 0
+    endloop
+  endfacet
+  facet normal 0.202719 -0.979237 0
+    outer loop
+      vertex 5.90251 -30.942 0
+      vertex 6.87151 -30.7414 60
+      vertex 5.90251 -30.942 60
+    endloop
+  endfacet
+  facet normal 0.202719 -0.979237 0
+    outer loop
+      vertex 6.87151 -30.7414 60
+      vertex 5.90251 -30.942 0
+      vertex 6.87151 -30.7414 0
+    endloop
+  endfacet
+  facet normal -0.575008 -0.818148 0
+    outer loop
+      vertex -18.5152 -25.484 0
+      vertex -17.7056 -26.053 60
+      vertex -18.5152 -25.484 60
+    endloop
+  endfacet
+  facet normal -0.575008 -0.818148 -0
+    outer loop
+      vertex -17.7056 -26.053 60
+      vertex -18.5152 -25.484 0
+      vertex -17.7056 -26.053 0
+    endloop
+  endfacet
+  facet normal 0.979237 -0.202719 0
+    outer loop
+      vertex 30.7414 -6.87151 60
+      vertex 30.942 -5.90251 0
+      vertex 30.942 -5.90251 60
+    endloop
+  endfacet
+  facet normal 0.979237 -0.202719 0
+    outer loop
+      vertex 30.942 -5.90251 0
+      vertex 30.7414 -6.87151 60
+      vertex 30.7414 -6.87151 0
+    endloop
+  endfacet
+  facet normal -0.695852 0.718185 0
+    outer loop
+      vertex -21.5632 22.9625 0
+      vertex -22.2739 22.2739 60
+      vertex -21.5632 22.9625 60
+    endloop
+  endfacet
+  facet normal -0.695852 0.718185 0
+    outer loop
+      vertex -22.2739 22.2739 60
+      vertex -21.5632 22.9625 0
+      vertex -22.2739 22.2739 0
+    endloop
+  endfacet
+  facet normal -0.998886 0.0471925 0
+    outer loop
+      vertex -31.4845 0.989438 0
+      vertex -31.4378 1.9779 60
+      vertex -31.4378 1.9779 0
+    endloop
+  endfacet
+  facet normal -0.998886 0.0471925 0
+    outer loop
+      vertex -31.4378 1.9779 60
+      vertex -31.4845 0.989438 0
+      vertex -31.4845 0.989438 60
+    endloop
+  endfacet
+  facet normal -0.818148 0.575008 0
+    outer loop
+      vertex -26.053 17.7056 0
+      vertex -25.484 18.5152 60
+      vertex -25.484 18.5152 0
+    endloop
+  endfacet
+  facet normal -0.818148 0.575008 0
+    outer loop
+      vertex -25.484 18.5152 60
+      vertex -26.053 17.7056 0
+      vertex -26.053 17.7056 60
+    endloop
+  endfacet
+  facet normal -0.0156635 0.999877 0
+    outer loop
+      vertex 0 31.5 0
+      vertex -0.989438 31.4845 60
+      vertex 0 31.5 60
+    endloop
+  endfacet
+  facet normal -0.0156635 0.999877 0
+    outer loop
+      vertex -0.989438 31.4845 60
+      vertex 0 31.5 0
+      vertex -0.989438 31.4845 0
+    endloop
+  endfacet
+  facet normal 0.353393 -0.935475 0
+    outer loop
+      vertex 10.6702 -29.6377 0
+      vertex 11.5959 -29.288 60
+      vertex 10.6702 -29.6377 60
+    endloop
+  endfacet
+  facet normal 0.353393 -0.935475 0
+    outer loop
+      vertex 11.5959 -29.288 60
+      vertex 10.6702 -29.6377 0
+      vertex 11.5959 -29.288 0
+    endloop
+  endfacet
+  facet normal -0.985098 -0.171993 0
+    outer loop
+      vertex -30.942 -5.90251 0
+      vertex -31.1122 -4.92768 60
+      vertex -31.1122 -4.92768 0
+    endloop
+  endfacet
+  facet normal -0.985098 -0.171993 0
+    outer loop
+      vertex -31.1122 -4.92768 60
+      vertex -30.942 -5.90251 0
+      vertex -30.942 -5.90251 60
+    endloop
+  endfacet
+  facet normal 0.0471925 -0.998886 0
+    outer loop
+      vertex 0.989438 -31.4845 0
+      vertex 1.9779 -31.4378 60
+      vertex 0.989438 -31.4845 60
+    endloop
+  endfacet
+  facet normal 0.0471925 -0.998886 0
+    outer loop
+      vertex 1.9779 -31.4378 60
+      vertex 0.989438 -31.4845 0
+      vertex 1.9779 -31.4378 0
+    endloop
+  endfacet
+  facet normal -0.353393 0.935475 0
+    outer loop
+      vertex -10.6702 29.6377 0
+      vertex -11.5959 29.288 60
+      vertex -10.6702 29.6377 60
+    endloop
+  endfacet
+  facet normal -0.353393 0.935475 0
+    outer loop
+      vertex -11.5959 29.288 60
+      vertex -10.6702 29.6377 0
+      vertex -11.5959 29.288 0
+    endloop
+  endfacet
+  facet normal -0.6495 0.760361 0
+    outer loop
+      vertex -20.0789 24.2712 0
+      vertex -20.8313 23.6285 60
+      vertex -20.0789 24.2712 60
+    endloop
+  endfacet
+  facet normal -0.6495 0.760361 0
+    outer loop
+      vertex -20.8313 23.6285 60
+      vertex -20.0789 24.2712 0
+      vertex -20.8313 23.6285 0
+    endloop
+  endfacet
+  facet normal 0.171993 -0.985098 0
+    outer loop
+      vertex 4.92768 -31.1122 0
+      vertex 5.90251 -30.942 60
+      vertex 4.92768 -31.1122 60
+    endloop
+  endfacet
+  facet normal 0.171993 -0.985098 0
+    outer loop
+      vertex 5.90251 -30.942 60
+      vertex 4.92768 -31.1122 0
+      vertex 5.90251 -30.942 0
+    endloop
+  endfacet
+  facet normal 0.140872 0.990028 -0
+    outer loop
+      vertex 4.92768 31.1122 0
+      vertex 3.948 31.2516 60
+      vertex 4.92768 31.1122 60
+    endloop
+  endfacet
+  facet normal 0.140872 0.990028 0
+    outer loop
+      vertex 3.948 31.2516 60
+      vertex 4.92768 31.1122 0
+      vertex 3.948 31.2516 0
+    endloop
+  endfacet
+  facet normal 0.852604 -0.522557 0
+    outer loop
+      vertex 26.5963 -16.8785 60
+      vertex 27.1134 -16.0348 0
+      vertex 27.1134 -16.0348 60
+    endloop
+  endfacet
+  facet normal 0.852604 -0.522557 0
+    outer loop
+      vertex 27.1134 -16.0348 0
+      vertex 26.5963 -16.8785 60
+      vertex 26.5963 -16.8785 0
+    endloop
+  endfacet
+  facet normal 0.467911 0.883776 -0
+    outer loop
+      vertex 15.1752 27.6037 0
+      vertex 14.3007 28.0667 60
+      vertex 15.1752 27.6037 60
+    endloop
+  endfacet
+  facet normal 0.467911 0.883776 0
+    outer loop
+      vertex 14.3007 28.0667 60
+      vertex 15.1752 27.6037 0
+      vertex 14.3007 28.0667 0
+    endloop
+  endfacet
+  facet normal 0.935475 0.353393 0
+    outer loop
+      vertex 29.6377 10.6702 60
+      vertex 29.288 11.5959 0
+      vertex 29.288 11.5959 60
+    endloop
+  endfacet
+  facet normal 0.935475 0.353393 0
+    outer loop
+      vertex 29.288 11.5959 0
+      vertex 29.6377 10.6702 60
+      vertex 29.6377 10.6702 0
+    endloop
+  endfacet
+  facet normal 0.549021 -0.835809 0
+    outer loop
+      vertex 16.8785 -26.5963 0
+      vertex 17.7056 -26.053 60
+      vertex 16.8785 -26.5963 60
+    endloop
+  endfacet
+  facet normal 0.549021 -0.835809 0
+    outer loop
+      vertex 17.7056 -26.053 60
+      vertex 16.8785 -26.5963 0
+      vertex 17.7056 -26.053 0
+    endloop
+  endfacet
+  facet normal 0.955784 -0.294069 0
+    outer loop
+      vertex 29.9583 -9.73403 60
+      vertex 30.2493 -8.78822 0
+      vertex 30.2493 -8.78822 60
+    endloop
+  endfacet
+  facet normal 0.955784 -0.294069 0
+    outer loop
+      vertex 30.2493 -8.78822 0
+      vertex 29.9583 -9.73403 60
+      vertex 29.9583 -9.73403 0
+    endloop
+  endfacet
+  facet normal -0.883776 -0.467911 0
+    outer loop
+      vertex -27.6037 -15.1752 0
+      vertex -28.0667 -14.3007 60
+      vertex -28.0667 -14.3007 0
+    endloop
+  endfacet
+  facet normal -0.883776 -0.467911 0
+    outer loop
+      vertex -28.0667 -14.3007 60
+      vertex -27.6037 -15.1752 0
+      vertex -27.6037 -15.1752 60
+    endloop
+  endfacet
+  facet normal -0.233437 0.972372 0
+    outer loop
+      vertex -6.87151 30.7414 0
+      vertex -7.83373 30.5104 60
+      vertex -6.87151 30.7414 60
+    endloop
+  endfacet
+  facet normal -0.233437 0.972372 0
+    outer loop
+      vertex -7.83373 30.5104 60
+      vertex -6.87151 30.7414 0
+      vertex -7.83373 30.5104 0
+    endloop
+  endfacet
+  facet normal -0.972372 0.233437 0
+    outer loop
+      vertex -30.7414 6.87151 0
+      vertex -30.5104 7.83373 60
+      vertex -30.5104 7.83373 0
+    endloop
+  endfacet
+  facet normal -0.972372 0.233437 0
+    outer loop
+      vertex -30.5104 7.83373 60
+      vertex -30.7414 6.87151 0
+      vertex -30.7414 6.87151 60
+    endloop
+  endfacet
+  facet normal 0.923885 -0.38267 0
+    outer loop
+      vertex 28.9093 -12.5102 60
+      vertex 29.288 -11.5959 0
+      vertex 29.288 -11.5959 60
+    endloop
+  endfacet
+  facet normal 0.923885 -0.38267 0
+    outer loop
+      vertex 29.288 -11.5959 0
+      vertex 28.9093 -12.5102 60
+      vertex 28.9093 -12.5102 0
+    endloop
+  endfacet
+  facet normal 0.0156635 -0.999877 0
+    outer loop
+      vertex 0 -31.5 0
+      vertex 0.989438 -31.4845 60
+      vertex 0 -31.5 60
+    endloop
+  endfacet
+  facet normal 0.0156635 -0.999877 0
+    outer loop
+      vertex 0.989438 -31.4845 60
+      vertex 0 -31.5 0
+      vertex 0.989438 -31.4845 0
+    endloop
+  endfacet
+  facet normal 0.140872 -0.990028 0
+    outer loop
+      vertex 3.948 -31.2516 0
+      vertex 4.92768 -31.1122 60
+      vertex 3.948 -31.2516 60
+    endloop
+  endfacet
+  facet normal 0.140872 -0.990028 0
+    outer loop
+      vertex 4.92768 -31.1122 60
+      vertex 3.948 -31.2516 0
+      vertex 4.92768 -31.1122 0
+    endloop
+  endfacet
+  facet normal 0.964562 0.263855 0
+    outer loop
+      vertex 30.5104 7.83373 60
+      vertex 30.2493 8.78822 0
+      vertex 30.2493 8.78822 60
+    endloop
+  endfacet
+  facet normal 0.964562 0.263855 0
+    outer loop
+      vertex 30.2493 8.78822 0
+      vertex 30.5104 7.83373 60
+      vertex 30.5104 7.83373 0
+    endloop
+  endfacet
+  facet normal 0.202719 0.979237 -0
+    outer loop
+      vertex 6.87151 30.7414 0
+      vertex 5.90251 30.942 60
+      vertex 6.87151 30.7414 60
+    endloop
+  endfacet
+  facet normal 0.202719 0.979237 0
+    outer loop
+      vertex 5.90251 30.942 60
+      vertex 6.87151 30.7414 0
+      vertex 5.90251 30.942 0
+    endloop
+  endfacet
+  facet normal -0.780445 0.625225 0
+    outer loop
+      vertex -24.8899 19.3066 0
+      vertex -24.2712 20.0789 60
+      vertex -24.2712 20.0789 0
+    endloop
+  endfacet
+  facet normal -0.780445 0.625225 0
+    outer loop
+      vertex -24.2712 20.0789 60
+      vertex -24.8899 19.3066 0
+      vertex -24.8899 19.3066 60
+    endloop
+  endfacet
+  facet normal 0.6495 -0.760361 0
+    outer loop
+      vertex 20.0789 -24.2712 0
+      vertex 20.8313 -23.6285 60
+      vertex 20.0789 -24.2712 60
+    endloop
+  endfacet
+  facet normal 0.6495 -0.760361 0
+    outer loop
+      vertex 20.8313 -23.6285 60
+      vertex 20.0789 -24.2712 0
+      vertex 20.8313 -23.6285 0
+    endloop
+  endfacet
+  facet normal 0.0471925 0.998886 -0
+    outer loop
+      vertex 1.9779 31.4378 0
+      vertex 0.989438 31.4845 60
+      vertex 1.9779 31.4378 60
+    endloop
+  endfacet
+  facet normal 0.0471925 0.998886 0
+    outer loop
+      vertex 0.989438 31.4845 60
+      vertex 1.9779 31.4378 0
+      vertex 0.989438 31.4845 0
+    endloop
+  endfacet
+  facet normal -0.140872 0.990028 0
+    outer loop
+      vertex -3.948 31.2516 0
+      vertex -4.92768 31.1122 60
+      vertex -3.948 31.2516 60
+    endloop
+  endfacet
+  facet normal -0.140872 0.990028 0
+    outer loop
+      vertex -4.92768 31.1122 60
+      vertex -3.948 31.2516 0
+      vertex -4.92768 31.1122 0
+    endloop
+  endfacet
+  facet normal 0.233437 -0.972372 0
+    outer loop
+      vertex 6.87151 -30.7414 0
+      vertex 7.83373 -30.5104 60
+      vertex 6.87151 -30.7414 60
+    endloop
+  endfacet
+  facet normal 0.233437 -0.972372 0
+    outer loop
+      vertex 7.83373 -30.5104 60
+      vertex 6.87151 -30.7414 0
+      vertex 7.83373 -30.5104 0
+    endloop
+  endfacet
+  facet normal -0.171993 -0.985098 0
+    outer loop
+      vertex -5.90251 -30.942 0
+      vertex -4.92768 -31.1122 60
+      vertex -5.90251 -30.942 60
+    endloop
+  endfacet
+  facet normal -0.171993 -0.985098 -0
+    outer loop
+      vertex -4.92768 -31.1122 60
+      vertex -5.90251 -30.942 0
+      vertex -4.92768 -31.1122 0
+    endloop
+  endfacet
+  facet normal 0.673025 0.73962 -0
+    outer loop
+      vertex 21.5632 22.9625 0
+      vertex 20.8313 23.6285 60
+      vertex 21.5632 22.9625 60
+    endloop
+  endfacet
+  facet normal 0.673025 0.73962 0
+    outer loop
+      vertex 20.8313 23.6285 60
+      vertex 21.5632 22.9625 0
+      vertex 20.8313 23.6285 0
+    endloop
+  endfacet
+  facet normal 0.898015 0.439964 0
+    outer loop
+      vertex 28.5021 13.412 60
+      vertex 28.0667 14.3007 0
+      vertex 28.0667 14.3007 60
+    endloop
+  endfacet
+  facet normal 0.898015 0.439964 0
+    outer loop
+      vertex 28.0667 14.3007 0
+      vertex 28.5021 13.412 60
+      vertex 28.5021 13.412 0
+    endloop
+  endfacet
+  facet normal 0.600356 0.799733 -0
+    outer loop
+      vertex 19.3066 24.8899 0
+      vertex 18.5152 25.484 60
+      vertex 19.3066 24.8899 60
+    endloop
+  endfacet
+  facet normal 0.600356 0.799733 0
+    outer loop
+      vertex 18.5152 25.484 60
+      vertex 19.3066 24.8899 0
+      vertex 18.5152 25.484 0
+    endloop
+  endfacet
+  facet normal -0.0471925 0.998886 0
+    outer loop
+      vertex -0.989438 31.4845 0
+      vertex -1.9779 31.4378 60
+      vertex -0.989438 31.4845 60
+    endloop
+  endfacet
+  facet normal -0.0471925 0.998886 0
+    outer loop
+      vertex -1.9779 31.4378 60
+      vertex -0.989438 31.4845 0
+      vertex -1.9779 31.4378 0
+    endloop
+  endfacet
+  facet normal 0.495453 0.868635 -0
+    outer loop
+      vertex 16.0348 27.1134 0
+      vertex 15.1752 27.6037 60
+      vertex 16.0348 27.1134 60
+    endloop
+  endfacet
+  facet normal 0.495453 0.868635 0
+    outer loop
+      vertex 15.1752 27.6037 60
+      vertex 16.0348 27.1134 0
+      vertex 15.1752 27.6037 0
+    endloop
+  endfacet
+  facet normal -0.718185 0.695852 0
+    outer loop
+      vertex -22.9625 21.5632 0
+      vertex -22.2739 22.2739 60
+      vertex -22.2739 22.2739 0
+    endloop
+  endfacet
+  facet normal -0.718185 0.695852 0
+    outer loop
+      vertex -22.2739 22.2739 60
+      vertex -22.9625 21.5632 0
+      vertex -22.9625 21.5632 60
+    endloop
+  endfacet
+  facet normal -0.323987 0.946061 0
+    outer loop
+      vertex -9.73403 29.9583 0
+      vertex -10.6702 29.6377 60
+      vertex -9.73403 29.9583 60
+    endloop
+  endfacet
+  facet normal -0.323987 0.946061 0
+    outer loop
+      vertex -10.6702 29.6377 60
+      vertex -9.73403 29.9583 0
+      vertex -10.6702 29.6377 0
+    endloop
+  endfacet
+  facet normal -0.911395 -0.411533 0
+    outer loop
+      vertex -28.5021 -13.412 0
+      vertex -28.9093 -12.5102 60
+      vertex -28.9093 -12.5102 0
+    endloop
+  endfacet
+  facet normal -0.911395 -0.411533 0
+    outer loop
+      vertex -28.9093 -12.5102 60
+      vertex -28.5021 -13.412 0
+      vertex -28.5021 -13.412 60
+    endloop
+  endfacet
+  facet normal -0.990028 -0.140872 0
+    outer loop
+      vertex -31.1122 -4.92768 0
+      vertex -31.2516 -3.948 60
+      vertex -31.2516 -3.948 0
+    endloop
+  endfacet
+  facet normal -0.990028 -0.140872 0
+    outer loop
+      vertex -31.2516 -3.948 60
+      vertex -31.1122 -4.92768 0
+      vertex -31.1122 -4.92768 60
+    endloop
+  endfacet
+  facet normal -0.467911 -0.883776 0
+    outer loop
+      vertex -15.1752 -27.6037 0
+      vertex -14.3007 -28.0667 60
+      vertex -15.1752 -27.6037 60
+    endloop
+  endfacet
+  facet normal -0.467911 -0.883776 -0
+    outer loop
+      vertex -14.3007 -28.0667 60
+      vertex -15.1752 -27.6037 0
+      vertex -14.3007 -28.0667 0
+    endloop
+  endfacet
+  facet normal 0.99396 -0.109745 0
+    outer loop
+      vertex 31.2516 -3.948 60
+      vertex 31.3602 -2.96441 0
+      vertex 31.3602 -2.96441 60
+    endloop
+  endfacet
+  facet normal 0.99396 -0.109745 0
+    outer loop
+      vertex 31.3602 -2.96441 0
+      vertex 31.2516 -3.948 60
+      vertex 31.2516 -3.948 0
+    endloop
+  endfacet
+  facet normal -0.964562 0.263855 0
+    outer loop
+      vertex -30.5104 7.83373 0
+      vertex -30.2493 8.78822 60
+      vertex -30.2493 8.78822 0
+    endloop
+  endfacet
+  facet normal -0.964562 0.263855 0
+    outer loop
+      vertex -30.2493 8.78822 60
+      vertex -30.5104 7.83373 0
+      vertex -30.5104 7.83373 60
+    endloop
+  endfacet
+  facet normal 0.883776 0.467911 0
+    outer loop
+      vertex 28.0667 14.3007 60
+      vertex 27.6037 15.1752 0
+      vertex 27.6037 15.1752 60
+    endloop
+  endfacet
+  facet normal 0.883776 0.467911 0
+    outer loop
+      vertex 27.6037 15.1752 0
+      vertex 28.0667 14.3007 60
+      vertex 28.0667 14.3007 0
+    endloop
+  endfacet
+  facet normal 0.780445 -0.625225 0
+    outer loop
+      vertex 24.2712 -20.0789 60
+      vertex 24.8899 -19.3066 0
+      vertex 24.8899 -19.3066 60
+    endloop
+  endfacet
+  facet normal 0.780445 -0.625225 0
+    outer loop
+      vertex 24.8899 -19.3066 0
+      vertex 24.2712 -20.0789 60
+      vertex 24.2712 -20.0789 0
+    endloop
+  endfacet
+  facet normal 0.964562 -0.263855 0
+    outer loop
+      vertex 30.2493 -8.78822 60
+      vertex 30.5104 -7.83373 0
+      vertex 30.5104 -7.83373 60
+    endloop
+  endfacet
+  facet normal 0.964562 -0.263855 0
+    outer loop
+      vertex 30.5104 -7.83373 0
+      vertex 30.2493 -8.78822 60
+      vertex 30.2493 -8.78822 0
+    endloop
+  endfacet
+  facet normal -0.990028 0.140872 0
+    outer loop
+      vertex -31.2516 3.948 0
+      vertex -31.1122 4.92768 60
+      vertex -31.1122 4.92768 0
+    endloop
+  endfacet
+  facet normal -0.990028 0.140872 0
+    outer loop
+      vertex -31.1122 4.92768 60
+      vertex -31.2516 3.948 0
+      vertex -31.2516 3.948 60
+    endloop
+  endfacet
+  facet normal -0.999877 -0.0156635 0
+    outer loop
+      vertex -31.4845 -0.989438 0
+      vertex -31.5 0 60
+      vertex -31.5 0 0
+    endloop
+  endfacet
+  facet normal -0.999877 -0.0156635 0
+    outer loop
+      vertex -31.5 0 60
+      vertex -31.4845 -0.989438 0
+      vertex -31.4845 -0.989438 60
+    endloop
+  endfacet
+  facet normal 0.263855 -0.964562 0
+    outer loop
+      vertex 7.83373 -30.5104 0
+      vertex 8.78822 -30.2493 60
+      vertex 7.83373 -30.5104 60
+    endloop
+  endfacet
+  facet normal 0.263855 -0.964562 0
+    outer loop
+      vertex 8.78822 -30.2493 60
+      vertex 7.83373 -30.5104 0
+      vertex 8.78822 -30.2493 0
+    endloop
+  endfacet
+  facet normal 0.972372 0.233437 0
+    outer loop
+      vertex 30.7414 6.87151 60
+      vertex 30.5104 7.83373 0
+      vertex 30.5104 7.83373 60
+    endloop
+  endfacet
+  facet normal 0.972372 0.233437 0
+    outer loop
+      vertex 30.5104 7.83373 0
+      vertex 30.7414 6.87151 60
+      vertex 30.7414 6.87151 0
+    endloop
+  endfacet
+  facet normal 0.946061 -0.323987 0
+    outer loop
+      vertex 29.6377 -10.6702 60
+      vertex 29.9583 -9.73403 0
+      vertex 29.9583 -9.73403 60
+    endloop
+  endfacet
+  facet normal 0.946061 -0.323987 0
+    outer loop
+      vertex 29.9583 -9.73403 0
+      vertex 29.6377 -10.6702 60
+      vertex 29.6377 -10.6702 0
+    endloop
+  endfacet
+  facet normal 0.979237 0.202719 0
+    outer loop
+      vertex 30.942 5.90251 60
+      vertex 30.7414 6.87151 0
+      vertex 30.7414 6.87151 60
+    endloop
+  endfacet
+  facet normal 0.979237 0.202719 0
+    outer loop
+      vertex 30.7414 6.87151 0
+      vertex 30.942 5.90251 60
+      vertex 30.942 5.90251 0
+    endloop
+  endfacet
+  facet normal 0.990028 0.140872 0
+    outer loop
+      vertex 31.2516 3.948 60
+      vertex 31.1122 4.92768 0
+      vertex 31.1122 4.92768 60
+    endloop
+  endfacet
+  facet normal 0.990028 0.140872 0
+    outer loop
+      vertex 31.1122 4.92768 0
+      vertex 31.2516 3.948 60
+      vertex 31.2516 3.948 0
+    endloop
+  endfacet
+  facet normal 0.799733 -0.600356 0
+    outer loop
+      vertex 24.8899 -19.3066 60
+      vertex 25.484 -18.5152 0
+      vertex 25.484 -18.5152 60
+    endloop
+  endfacet
+  facet normal 0.799733 -0.600356 0
+    outer loop
+      vertex 25.484 -18.5152 0
+      vertex 24.8899 -19.3066 60
+      vertex 24.8899 -19.3066 0
+    endloop
+  endfacet
+  facet normal 0.998886 -0.0471925 0
+    outer loop
+      vertex 31.4378 -1.9779 60
+      vertex 31.4845 -0.989438 0
+      vertex 31.4845 -0.989438 60
+    endloop
+  endfacet
+  facet normal 0.998886 -0.0471925 0
+    outer loop
+      vertex 31.4845 -0.989438 0
+      vertex 31.4378 -1.9779 60
+      vertex 31.4378 -1.9779 0
+    endloop
+  endfacet
+  facet normal -0.946061 0.323987 0
+    outer loop
+      vertex -29.9583 9.73403 0
+      vertex -29.6377 10.6702 60
+      vertex -29.6377 10.6702 0
+    endloop
+  endfacet
+  facet normal -0.946061 0.323987 0
+    outer loop
+      vertex -29.6377 10.6702 60
+      vertex -29.9583 9.73403 0
+      vertex -29.9583 9.73403 60
+    endloop
+  endfacet
+  facet normal 0.898015 -0.439964 0
+    outer loop
+      vertex 28.0667 -14.3007 60
+      vertex 28.5021 -13.412 0
+      vertex 28.5021 -13.412 60
+    endloop
+  endfacet
+  facet normal 0.898015 -0.439964 0
+    outer loop
+      vertex 28.5021 -13.412 0
+      vertex 28.0667 -14.3007 60
+      vertex 28.0667 -14.3007 0
+    endloop
+  endfacet
+  facet normal -0.38267 -0.923885 0
+    outer loop
+      vertex -12.5102 -28.9093 0
+      vertex -11.5959 -29.288 60
+      vertex -12.5102 -28.9093 60
+    endloop
+  endfacet
+  facet normal -0.38267 -0.923885 -0
+    outer loop
+      vertex -11.5959 -29.288 60
+      vertex -12.5102 -28.9093 0
+      vertex -11.5959 -29.288 0
+    endloop
+  endfacet
+  facet normal -0.718185 -0.695852 0
+    outer loop
+      vertex -22.2739 -22.2739 0
+      vertex -22.9625 -21.5632 60
+      vertex -22.9625 -21.5632 0
+    endloop
+  endfacet
+  facet normal -0.718185 -0.695852 0
+    outer loop
+      vertex -22.9625 -21.5632 60
+      vertex -22.2739 -22.2739 0
+      vertex -22.2739 -22.2739 60
+    endloop
+  endfacet
+  facet normal 0.439964 0.898015 -0
+    outer loop
+      vertex 14.3007 28.0667 0
+      vertex 13.412 28.5021 60
+      vertex 14.3007 28.0667 60
+    endloop
+  endfacet
+  facet normal 0.439964 0.898015 0
+    outer loop
+      vertex 13.412 28.5021 60
+      vertex 14.3007 28.0667 0
+      vertex 13.412 28.5021 0
+    endloop
+  endfacet
+  facet normal -0.575008 0.818148 0
+    outer loop
+      vertex -17.7056 26.053 0
+      vertex -18.5152 25.484 60
+      vertex -17.7056 26.053 60
+    endloop
+  endfacet
+  facet normal -0.575008 0.818148 0
+    outer loop
+      vertex -18.5152 25.484 60
+      vertex -17.7056 26.053 0
+      vertex -18.5152 25.484 0
+    endloop
+  endfacet
+  facet normal -0.202719 0.979237 0
+    outer loop
+      vertex -5.90251 30.942 0
+      vertex -6.87151 30.7414 60
+      vertex -5.90251 30.942 60
+    endloop
+  endfacet
+  facet normal -0.202719 0.979237 0
+    outer loop
+      vertex -6.87151 30.7414 60
+      vertex -5.90251 30.942 0
+      vertex -6.87151 30.7414 0
+    endloop
+  endfacet
+  facet normal -0.73962 -0.673025 0
+    outer loop
+      vertex -22.9625 -21.5632 0
+      vertex -23.6285 -20.8313 60
+      vertex -23.6285 -20.8313 0
+    endloop
+  endfacet
+  facet normal -0.73962 -0.673025 0
+    outer loop
+      vertex -23.6285 -20.8313 60
+      vertex -22.9625 -21.5632 0
+      vertex -22.9625 -21.5632 60
+    endloop
+  endfacet
+  facet normal 0.972372 -0.233437 0
+    outer loop
+      vertex 30.5104 -7.83373 60
+      vertex 30.7414 -6.87151 0
+      vertex 30.7414 -6.87151 60
+    endloop
+  endfacet
+  facet normal 0.972372 -0.233437 0
+    outer loop
+      vertex 30.7414 -6.87151 0
+      vertex 30.5104 -7.83373 60
+      vertex 30.5104 -7.83373 0
+    endloop
+  endfacet
+  facet normal -0.946061 -0.323987 0
+    outer loop
+      vertex -29.6377 -10.6702 0
+      vertex -29.9583 -9.73403 60
+      vertex -29.9583 -9.73403 0
+    endloop
+  endfacet
+  facet normal -0.946061 -0.323987 0
+    outer loop
+      vertex -29.9583 -9.73403 60
+      vertex -29.6377 -10.6702 0
+      vertex -29.6377 -10.6702 60
+    endloop
+  endfacet
+  facet normal 0.495453 -0.868635 0
+    outer loop
+      vertex 15.1752 -27.6037 0
+      vertex 16.0348 -27.1134 60
+      vertex 15.1752 -27.6037 60
+    endloop
+  endfacet
+  facet normal 0.495453 -0.868635 0
+    outer loop
+      vertex 16.0348 -27.1134 60
+      vertex 15.1752 -27.6037 0
+      vertex 16.0348 -27.1134 0
+    endloop
+  endfacet
+  facet normal 0.923885 0.38267 0
+    outer loop
+      vertex 29.288 11.5959 60
+      vertex 28.9093 12.5102 0
+      vertex 28.9093 12.5102 60
+    endloop
+  endfacet
+  facet normal 0.923885 0.38267 0
+    outer loop
+      vertex 28.9093 12.5102 0
+      vertex 29.288 11.5959 60
+      vertex 29.288 11.5959 0
+    endloop
+  endfacet
+  facet normal 0.985098 -0.171993 0
+    outer loop
+      vertex 30.942 -5.90251 60
+      vertex 31.1122 -4.92768 0
+      vertex 31.1122 -4.92768 60
+    endloop
+  endfacet
+  facet normal 0.985098 -0.171993 0
+    outer loop
+      vertex 31.1122 -4.92768 0
+      vertex 30.942 -5.90251 60
+      vertex 30.942 -5.90251 0
+    endloop
+  endfacet
+  facet normal 0.323987 -0.946061 0
+    outer loop
+      vertex 9.73403 -29.9583 0
+      vertex 10.6702 -29.6377 60
+      vertex 9.73403 -29.9583 60
+    endloop
+  endfacet
+  facet normal 0.323987 -0.946061 0
+    outer loop
+      vertex 10.6702 -29.6377 60
+      vertex 9.73403 -29.9583 0
+      vertex 10.6702 -29.6377 0
+    endloop
+  endfacet
+  facet normal -0.171993 0.985098 0
+    outer loop
+      vertex -4.92768 31.1122 0
+      vertex -5.90251 30.942 60
+      vertex -4.92768 31.1122 60
+    endloop
+  endfacet
+  facet normal -0.171993 0.985098 0
+    outer loop
+      vertex -5.90251 30.942 60
+      vertex -4.92768 31.1122 0
+      vertex -5.90251 30.942 0
+    endloop
+  endfacet
+  facet normal 0.467911 -0.883776 0
+    outer loop
+      vertex 14.3007 -28.0667 0
+      vertex 15.1752 -27.6037 60
+      vertex 14.3007 -28.0667 60
+    endloop
+  endfacet
+  facet normal 0.467911 -0.883776 0
+    outer loop
+      vertex 15.1752 -27.6037 60
+      vertex 14.3007 -28.0667 0
+      vertex 15.1752 -27.6037 0
+    endloop
+  endfacet
+  facet normal 0.263855 0.964562 -0
+    outer loop
+      vertex 8.78822 30.2493 0
+      vertex 7.83373 30.5104 60
+      vertex 8.78822 30.2493 60
+    endloop
+  endfacet
+  facet normal 0.263855 0.964562 0
+    outer loop
+      vertex 7.83373 30.5104 60
+      vertex 8.78822 30.2493 0
+      vertex 7.83373 30.5104 0
+    endloop
+  endfacet
+  facet normal -0.923885 0.38267 0
+    outer loop
+      vertex -29.288 11.5959 0
+      vertex -28.9093 12.5102 60
+      vertex -28.9093 12.5102 0
+    endloop
+  endfacet
+  facet normal -0.923885 0.38267 0
+    outer loop
+      vertex -28.9093 12.5102 60
+      vertex -29.288 11.5959 0
+      vertex -29.288 11.5959 60
+    endloop
+  endfacet
+  facet normal 0.522557 -0.852604 0
+    outer loop
+      vertex 16.0348 -27.1134 0
+      vertex 16.8785 -26.5963 60
+      vertex 16.0348 -27.1134 60
+    endloop
+  endfacet
+  facet normal 0.522557 -0.852604 0
+    outer loop
+      vertex 16.8785 -26.5963 60
+      vertex 16.0348 -27.1134 0
+      vertex 16.8785 -26.5963 0
+    endloop
+  endfacet
+  facet normal -0.549021 -0.835809 0
+    outer loop
+      vertex -17.7056 -26.053 0
+      vertex -16.8785 -26.5963 60
+      vertex -17.7056 -26.053 60
+    endloop
+  endfacet
+  facet normal -0.549021 -0.835809 -0
+    outer loop
+      vertex -16.8785 -26.5963 60
+      vertex -17.7056 -26.053 0
+      vertex -16.8785 -26.5963 0
+    endloop
+  endfacet
+  facet normal 0.171993 0.985098 -0
+    outer loop
+      vertex 5.90251 30.942 0
+      vertex 4.92768 31.1122 60
+      vertex 5.90251 30.942 60
+    endloop
+  endfacet
+  facet normal 0.171993 0.985098 0
+    outer loop
+      vertex 4.92768 31.1122 60
+      vertex 5.90251 30.942 0
+      vertex 4.92768 31.1122 0
+    endloop
+  endfacet
+  facet normal 0.852604 0.522557 0
+    outer loop
+      vertex 27.1134 16.0348 60
+      vertex 26.5963 16.8785 0
+      vertex 26.5963 16.8785 60
+    endloop
+  endfacet
+  facet normal 0.852604 0.522557 0
+    outer loop
+      vertex 26.5963 16.8785 0
+      vertex 27.1134 16.0348 60
+      vertex 27.1134 16.0348 0
+    endloop
+  endfacet
+  facet normal 0.575008 0.818148 -0
+    outer loop
+      vertex 18.5152 25.484 0
+      vertex 17.7056 26.053 60
+      vertex 18.5152 25.484 60
+    endloop
+  endfacet
+  facet normal 0.575008 0.818148 0
+    outer loop
+      vertex 17.7056 26.053 60
+      vertex 18.5152 25.484 0
+      vertex 17.7056 26.053 0
+    endloop
+  endfacet
+  facet normal -0.818148 -0.575008 0
+    outer loop
+      vertex -25.484 -18.5152 0
+      vertex -26.053 -17.7056 60
+      vertex -26.053 -17.7056 0
+    endloop
+  endfacet
+  facet normal -0.818148 -0.575008 0
+    outer loop
+      vertex -26.053 -17.7056 60
+      vertex -25.484 -18.5152 0
+      vertex -25.484 -18.5152 60
+    endloop
+  endfacet
+  facet normal 0.818148 0.575008 0
+    outer loop
+      vertex 26.053 17.7056 60
+      vertex 25.484 18.5152 0
+      vertex 25.484 18.5152 60
+    endloop
+  endfacet
+  facet normal 0.818148 0.575008 0
+    outer loop
+      vertex 25.484 18.5152 0
+      vertex 26.053 17.7056 60
+      vertex 26.053 17.7056 0
+    endloop
+  endfacet
+  facet normal -0.935475 -0.353393 0
+    outer loop
+      vertex -29.288 -11.5959 0
+      vertex -29.6377 -10.6702 60
+      vertex -29.6377 -10.6702 0
+    endloop
+  endfacet
+  facet normal -0.935475 -0.353393 0
+    outer loop
+      vertex -29.6377 -10.6702 60
+      vertex -29.288 -11.5959 0
+      vertex -29.288 -11.5959 60
+    endloop
+  endfacet
+  facet normal 0.323987 0.946061 -0
+    outer loop
+      vertex 10.6702 29.6377 0
+      vertex 9.73403 29.9583 60
+      vertex 10.6702 29.6377 60
+    endloop
+  endfacet
+  facet normal 0.323987 0.946061 0
+    outer loop
+      vertex 9.73403 29.9583 60
+      vertex 10.6702 29.6377 0
+      vertex 9.73403 29.9583 0
+    endloop
+  endfacet
+  facet normal 0.625225 -0.780445 0
+    outer loop
+      vertex 19.3066 -24.8899 0
+      vertex 20.0789 -24.2712 60
+      vertex 19.3066 -24.8899 60
+    endloop
+  endfacet
+  facet normal 0.625225 -0.780445 0
+    outer loop
+      vertex 20.0789 -24.2712 60
+      vertex 19.3066 -24.8899 0
+      vertex 20.0789 -24.2712 0
+    endloop
+  endfacet
+  facet normal -0.495453 0.868635 0
+    outer loop
+      vertex -15.1752 27.6037 0
+      vertex -16.0348 27.1134 60
+      vertex -15.1752 27.6037 60
+    endloop
+  endfacet
+  facet normal -0.495453 0.868635 0
+    outer loop
+      vertex -16.0348 27.1134 60
+      vertex -15.1752 27.6037 0
+      vertex -16.0348 27.1134 0
+    endloop
+  endfacet
+  facet normal -0.495453 -0.868635 0
+    outer loop
+      vertex -16.0348 -27.1134 0
+      vertex -15.1752 -27.6037 60
+      vertex -16.0348 -27.1134 60
+    endloop
+  endfacet
+  facet normal -0.495453 -0.868635 -0
+    outer loop
+      vertex -15.1752 -27.6037 60
+      vertex -16.0348 -27.1134 0
+      vertex -15.1752 -27.6037 0
+    endloop
+  endfacet
+  facet normal 0.0784189 0.99692 -0
+    outer loop
+      vertex 2.96441 31.3602 0
+      vertex 1.9779 31.4378 60
+      vertex 2.96441 31.3602 60
+    endloop
+  endfacet
+  facet normal 0.0784189 0.99692 0
+    outer loop
+      vertex 1.9779 31.4378 60
+      vertex 2.96441 31.3602 0
+      vertex 1.9779 31.4378 0
+    endloop
+  endfacet
+  facet normal 0.835809 0.549021 0
+    outer loop
+      vertex 26.5963 16.8785 60
+      vertex 26.053 17.7056 0
+      vertex 26.053 17.7056 60
+    endloop
+  endfacet
+  facet normal 0.835809 0.549021 0
+    outer loop
+      vertex 26.053 17.7056 0
+      vertex 26.5963 16.8785 60
+      vertex 26.5963 16.8785 0
+    endloop
+  endfacet
+  facet normal 0.718185 0.695852 0
+    outer loop
+      vertex 22.9625 21.5632 60
+      vertex 22.2739 22.2739 0
+      vertex 22.2739 22.2739 60
+    endloop
+  endfacet
+  facet normal 0.718185 0.695852 0
+    outer loop
+      vertex 22.2739 22.2739 0
+      vertex 22.9625 21.5632 60
+      vertex 22.9625 21.5632 0
+    endloop
+  endfacet
+  facet normal -0.673025 0.73962 0
+    outer loop
+      vertex -20.8313 23.6285 0
+      vertex -21.5632 22.9625 60
+      vertex -20.8313 23.6285 60
+    endloop
+  endfacet
+  facet normal -0.673025 0.73962 0
+    outer loop
+      vertex -21.5632 22.9625 60
+      vertex -20.8313 23.6285 0
+      vertex -21.5632 22.9625 0
+    endloop
+  endfacet
+  facet normal -0.972372 -0.233437 0
+    outer loop
+      vertex -30.5104 -7.83373 0
+      vertex -30.7414 -6.87151 60
+      vertex -30.7414 -6.87151 0
+    endloop
+  endfacet
+  facet normal -0.972372 -0.233437 0
+    outer loop
+      vertex -30.7414 -6.87151 60
+      vertex -30.5104 -7.83373 0
+      vertex -30.5104 -7.83373 60
+    endloop
+  endfacet
+  facet normal 0.911395 0.411533 0
+    outer loop
+      vertex 28.9093 12.5102 60
+      vertex 28.5021 13.412 0
+      vertex 28.5021 13.412 60
+    endloop
+  endfacet
+  facet normal 0.911395 0.411533 0
+    outer loop
+      vertex 28.5021 13.412 0
+      vertex 28.9093 12.5102 60
+      vertex 28.9093 12.5102 0
+    endloop
+  endfacet
+  facet normal 0.868635 -0.495453 0
+    outer loop
+      vertex 27.1134 -16.0348 60
+      vertex 27.6037 -15.1752 0
+      vertex 27.6037 -15.1752 60
+    endloop
+  endfacet
+  facet normal 0.868635 -0.495453 0
+    outer loop
+      vertex 27.6037 -15.1752 0
+      vertex 27.1134 -16.0348 60
+      vertex 27.1134 -16.0348 0
+    endloop
+  endfacet
+  facet normal -0.911395 0.411533 0
+    outer loop
+      vertex -28.9093 12.5102 0
+      vertex -28.5021 13.412 60
+      vertex -28.5021 13.412 0
+    endloop
+  endfacet
+  facet normal -0.911395 0.411533 0
+    outer loop
+      vertex -28.5021 13.412 60
+      vertex -28.9093 12.5102 0
+      vertex -28.9093 12.5102 60
+    endloop
+  endfacet
+  facet normal 0.990028 -0.140872 0
+    outer loop
+      vertex 31.1122 -4.92768 60
+      vertex 31.2516 -3.948 0
+      vertex 31.2516 -3.948 60
+    endloop
+  endfacet
+  facet normal 0.990028 -0.140872 0
+    outer loop
+      vertex 31.2516 -3.948 0
+      vertex 31.1122 -4.92768 60
+      vertex 31.1122 -4.92768 0
+    endloop
+  endfacet
+  facet normal -0.923885 -0.38267 0
+    outer loop
+      vertex -28.9093 -12.5102 0
+      vertex -29.288 -11.5959 60
+      vertex -29.288 -11.5959 0
+    endloop
+  endfacet
+  facet normal -0.923885 -0.38267 0
+    outer loop
+      vertex -29.288 -11.5959 60
+      vertex -28.9093 -12.5102 0
+      vertex -28.9093 -12.5102 60
+    endloop
+  endfacet
+  facet normal -0.353393 -0.935475 0
+    outer loop
+      vertex -11.5959 -29.288 0
+      vertex -10.6702 -29.6377 60
+      vertex -11.5959 -29.288 60
+    endloop
+  endfacet
+  facet normal -0.353393 -0.935475 -0
+    outer loop
+      vertex -10.6702 -29.6377 60
+      vertex -11.5959 -29.288 0
+      vertex -10.6702 -29.6377 0
+    endloop
+  endfacet
+  facet normal -0.935475 0.353393 0
+    outer loop
+      vertex -29.6377 10.6702 0
+      vertex -29.288 11.5959 60
+      vertex -29.288 11.5959 0
+    endloop
+  endfacet
+  facet normal -0.935475 0.353393 0
+    outer loop
+      vertex -29.288 11.5959 60
+      vertex -29.6377 10.6702 0
+      vertex -29.6377 10.6702 60
+    endloop
+  endfacet
+  facet normal 0.6495 0.760361 -0
+    outer loop
+      vertex 20.8313 23.6285 0
+      vertex 20.0789 24.2712 60
+      vertex 20.8313 23.6285 60
+    endloop
+  endfacet
+  facet normal 0.6495 0.760361 0
+    outer loop
+      vertex 20.0789 24.2712 60
+      vertex 20.8313 23.6285 0
+      vertex 20.0789 24.2712 0
+    endloop
+  endfacet
+  facet normal 0.522557 0.852604 -0
+    outer loop
+      vertex 16.8785 26.5963 0
+      vertex 16.0348 27.1134 60
+      vertex 16.8785 26.5963 60
+    endloop
+  endfacet
+  facet normal 0.522557 0.852604 0
+    outer loop
+      vertex 16.0348 27.1134 60
+      vertex 16.8785 26.5963 0
+      vertex 16.0348 27.1134 0
+    endloop
+  endfacet
+  facet normal -0.6495 -0.760361 0
+    outer loop
+      vertex -20.8313 -23.6285 0
+      vertex -20.0789 -24.2712 60
+      vertex -20.8313 -23.6285 60
+    endloop
+  endfacet
+  facet normal -0.6495 -0.760361 -0
+    outer loop
+      vertex -20.0789 -24.2712 60
+      vertex -20.8313 -23.6285 0
+      vertex -20.0789 -24.2712 0
+    endloop
+  endfacet
+  facet normal -0.835809 0.549021 0
+    outer loop
+      vertex -26.5963 16.8785 0
+      vertex -26.053 17.7056 60
+      vertex -26.053 17.7056 0
+    endloop
+  endfacet
+  facet normal -0.835809 0.549021 0
+    outer loop
+      vertex -26.053 17.7056 60
+      vertex -26.5963 16.8785 0
+      vertex -26.5963 16.8785 60
+    endloop
+  endfacet
+  facet normal -0.109745 0.99396 0
+    outer loop
+      vertex -2.96441 31.3602 0
+      vertex -3.948 31.2516 60
+      vertex -2.96441 31.3602 60
+    endloop
+  endfacet
+  facet normal -0.109745 0.99396 0
+    outer loop
+      vertex -3.948 31.2516 60
+      vertex -2.96441 31.3602 0
+      vertex -3.948 31.2516 0
+    endloop
+  endfacet
+  facet normal -0.202719 -0.979237 0
+    outer loop
+      vertex -6.87151 -30.7414 0
+      vertex -5.90251 -30.942 60
+      vertex -6.87151 -30.7414 60
+    endloop
+  endfacet
+  facet normal -0.202719 -0.979237 -0
+    outer loop
+      vertex -5.90251 -30.942 60
+      vertex -6.87151 -30.7414 0
+      vertex -5.90251 -30.942 0
+    endloop
+  endfacet
+  facet normal -0.0784189 -0.99692 0
+    outer loop
+      vertex -2.96441 -31.3602 0
+      vertex -1.9779 -31.4378 60
+      vertex -2.96441 -31.3602 60
+    endloop
+  endfacet
+  facet normal -0.0784189 -0.99692 -0
+    outer loop
+      vertex -1.9779 -31.4378 60
+      vertex -2.96441 -31.3602 0
+      vertex -1.9779 -31.4378 0
+    endloop
+  endfacet
+  facet normal 0.575008 -0.818148 0
+    outer loop
+      vertex 17.7056 -26.053 0
+      vertex 18.5152 -25.484 60
+      vertex 17.7056 -26.053 60
+    endloop
+  endfacet
+  facet normal 0.575008 -0.818148 0
+    outer loop
+      vertex 18.5152 -25.484 60
+      vertex 17.7056 -26.053 0
+      vertex 18.5152 -25.484 0
+    endloop
+  endfacet
+  facet normal -0.868635 0.495453 0
+    outer loop
+      vertex -27.6037 15.1752 0
+      vertex -27.1134 16.0348 60
+      vertex -27.1134 16.0348 0
+    endloop
+  endfacet
+  facet normal -0.868635 0.495453 0
+    outer loop
+      vertex -27.1134 16.0348 60
+      vertex -27.6037 15.1752 0
+      vertex -27.6037 15.1752 60
+    endloop
+  endfacet
+  facet normal -0.439964 -0.898015 0
+    outer loop
+      vertex -14.3007 -28.0667 0
+      vertex -13.412 -28.5021 60
+      vertex -14.3007 -28.0667 60
+    endloop
+  endfacet
+  facet normal -0.439964 -0.898015 -0
+    outer loop
+      vertex -13.412 -28.5021 60
+      vertex -14.3007 -28.0667 0
+      vertex -13.412 -28.5021 0
+    endloop
+  endfacet
+  facet normal 0.883776 -0.467911 0
+    outer loop
+      vertex 27.6037 -15.1752 60
+      vertex 28.0667 -14.3007 0
+      vertex 28.0667 -14.3007 60
+    endloop
+  endfacet
+  facet normal 0.883776 -0.467911 0
+    outer loop
+      vertex 28.0667 -14.3007 0
+      vertex 27.6037 -15.1752 60
+      vertex 27.6037 -15.1752 0
+    endloop
+  endfacet
+  facet normal -0.600356 -0.799733 0
+    outer loop
+      vertex -19.3066 -24.8899 0
+      vertex -18.5152 -25.484 60
+      vertex -19.3066 -24.8899 60
+    endloop
+  endfacet
+  facet normal -0.600356 -0.799733 -0
+    outer loop
+      vertex -18.5152 -25.484 60
+      vertex -19.3066 -24.8899 0
+      vertex -18.5152 -25.484 0
+    endloop
+  endfacet
+  facet normal -0.439964 0.898015 0
+    outer loop
+      vertex -13.412 28.5021 0
+      vertex -14.3007 28.0667 60
+      vertex -13.412 28.5021 60
+    endloop
+  endfacet
+  facet normal -0.439964 0.898015 0
+    outer loop
+      vertex -14.3007 28.0667 60
+      vertex -13.412 28.5021 0
+      vertex -14.3007 28.0667 0
+    endloop
+  endfacet
+  facet normal 0.911395 -0.411533 0
+    outer loop
+      vertex 28.5021 -13.412 60
+      vertex 28.9093 -12.5102 0
+      vertex 28.9093 -12.5102 60
+    endloop
+  endfacet
+  facet normal 0.911395 -0.411533 0
+    outer loop
+      vertex 28.9093 -12.5102 0
+      vertex 28.5021 -13.412 60
+      vertex 28.5021 -13.412 0
+    endloop
+  endfacet
+  facet normal -0.99692 0.0784189 0
+    outer loop
+      vertex -31.4378 1.9779 0
+      vertex -31.3602 2.96441 60
+      vertex -31.3602 2.96441 0
+    endloop
+  endfacet
+  facet normal -0.99692 0.0784189 0
+    outer loop
+      vertex -31.3602 2.96441 60
+      vertex -31.4378 1.9779 0
+      vertex -31.4378 1.9779 60
+    endloop
+  endfacet
+  facet normal 0.935475 -0.353393 0
+    outer loop
+      vertex 29.288 -11.5959 60
+      vertex 29.6377 -10.6702 0
+      vertex 29.6377 -10.6702 60
+    endloop
+  endfacet
+  facet normal 0.935475 -0.353393 0
+    outer loop
+      vertex 29.6377 -10.6702 0
+      vertex 29.288 -11.5959 60
+      vertex 29.288 -11.5959 0
+    endloop
+  endfacet
+  facet normal -0.0471925 -0.998886 0
+    outer loop
+      vertex -1.9779 -31.4378 0
+      vertex -0.989438 -31.4845 60
+      vertex -1.9779 -31.4378 60
+    endloop
+  endfacet
+  facet normal -0.0471925 -0.998886 -0
+    outer loop
+      vertex -0.989438 -31.4845 60
+      vertex -1.9779 -31.4378 0
+      vertex -0.989438 -31.4845 0
+    endloop
+  endfacet
+  facet normal 0.109745 -0.99396 0
+    outer loop
+      vertex 2.96441 -31.3602 0
+      vertex 3.948 -31.2516 60
+      vertex 2.96441 -31.3602 60
+    endloop
+  endfacet
+  facet normal 0.109745 -0.99396 0
+    outer loop
+      vertex 3.948 -31.2516 60
+      vertex 2.96441 -31.3602 0
+      vertex 3.948 -31.2516 0
+    endloop
+  endfacet
+  facet normal 0.600356 -0.799733 0
+    outer loop
+      vertex 18.5152 -25.484 0
+      vertex 19.3066 -24.8899 60
+      vertex 18.5152 -25.484 60
+    endloop
+  endfacet
+  facet normal 0.600356 -0.799733 0
+    outer loop
+      vertex 19.3066 -24.8899 60
+      vertex 18.5152 -25.484 0
+      vertex 19.3066 -24.8899 0
+    endloop
+  endfacet
+  facet normal -0.955784 0.294069 0
+    outer loop
+      vertex -30.2493 8.78822 0
+      vertex -29.9583 9.73403 60
+      vertex -29.9583 9.73403 0
+    endloop
+  endfacet
+  facet normal -0.955784 0.294069 0
+    outer loop
+      vertex -29.9583 9.73403 60
+      vertex -30.2493 8.78822 0
+      vertex -30.2493 8.78822 60
+    endloop
+  endfacet
+  facet normal -0.898015 -0.439964 0
+    outer loop
+      vertex -28.0667 -14.3007 0
+      vertex -28.5021 -13.412 60
+      vertex -28.5021 -13.412 0
+    endloop
+  endfacet
+  facet normal -0.898015 -0.439964 0
+    outer loop
+      vertex -28.5021 -13.412 60
+      vertex -28.0667 -14.3007 0
+      vertex -28.0667 -14.3007 60
+    endloop
+  endfacet
+  facet normal -0.998886 -0.0471925 0
+    outer loop
+      vertex -31.4378 -1.9779 0
+      vertex -31.4845 -0.989438 60
+      vertex -31.4845 -0.989438 0
+    endloop
+  endfacet
+  facet normal -0.998886 -0.0471925 0
+    outer loop
+      vertex -31.4845 -0.989438 60
+      vertex -31.4378 -1.9779 0
+      vertex -31.4378 -1.9779 60
+    endloop
+  endfacet
+  facet normal 0.439964 -0.898015 0
+    outer loop
+      vertex 13.412 -28.5021 0
+      vertex 14.3007 -28.0667 60
+      vertex 13.412 -28.5021 60
+    endloop
+  endfacet
+  facet normal 0.439964 -0.898015 0
+    outer loop
+      vertex 14.3007 -28.0667 60
+      vertex 13.412 -28.5021 0
+      vertex 14.3007 -28.0667 0
+    endloop
+  endfacet
+  facet normal 0.411533 -0.911395 0
+    outer loop
+      vertex 12.5102 -28.9093 0
+      vertex 13.412 -28.5021 60
+      vertex 12.5102 -28.9093 60
+    endloop
+  endfacet
+  facet normal 0.411533 -0.911395 0
+    outer loop
+      vertex 13.412 -28.5021 60
+      vertex 12.5102 -28.9093 0
+      vertex 13.412 -28.5021 0
+    endloop
+  endfacet
+  facet normal -0.799733 -0.600356 0
+    outer loop
+      vertex -24.8899 -19.3066 0
+      vertex -25.484 -18.5152 60
+      vertex -25.484 -18.5152 0
+    endloop
+  endfacet
+  facet normal -0.799733 -0.600356 0
+    outer loop
+      vertex -25.484 -18.5152 60
+      vertex -24.8899 -19.3066 0
+      vertex -24.8899 -19.3066 60
+    endloop
+  endfacet
+  facet normal -0.979237 -0.202719 0
+    outer loop
+      vertex -30.7414 -6.87151 0
+      vertex -30.942 -5.90251 60
+      vertex -30.942 -5.90251 0
+    endloop
+  endfacet
+  facet normal -0.979237 -0.202719 0
+    outer loop
+      vertex -30.942 -5.90251 60
+      vertex -30.7414 -6.87151 0
+      vertex -30.7414 -6.87151 60
+    endloop
+  endfacet
+  facet normal 0.411533 0.911395 -0
+    outer loop
+      vertex 13.412 28.5021 0
+      vertex 12.5102 28.9093 60
+      vertex 13.412 28.5021 60
+    endloop
+  endfacet
+  facet normal 0.411533 0.911395 0
+    outer loop
+      vertex 12.5102 28.9093 60
+      vertex 13.412 28.5021 0
+      vertex 12.5102 28.9093 0
+    endloop
+  endfacet
+  facet normal -0.99396 0.109745 0
+    outer loop
+      vertex -31.3602 2.96441 0
+      vertex -31.2516 3.948 60
+      vertex -31.2516 3.948 0
+    endloop
+  endfacet
+  facet normal -0.99396 0.109745 0
+    outer loop
+      vertex -31.2516 3.948 60
+      vertex -31.3602 2.96441 0
+      vertex -31.3602 2.96441 60
+    endloop
+  endfacet
+  facet normal 0.718185 -0.695852 0
+    outer loop
+      vertex 22.2739 -22.2739 60
+      vertex 22.9625 -21.5632 0
+      vertex 22.9625 -21.5632 60
+    endloop
+  endfacet
+  facet normal 0.718185 -0.695852 0
+    outer loop
+      vertex 22.9625 -21.5632 0
+      vertex 22.2739 -22.2739 60
+      vertex 22.2739 -22.2739 0
+    endloop
+  endfacet
+  facet normal 0.999877 -0.0156635 0
+    outer loop
+      vertex 31.4845 -0.989438 60
+      vertex 31.5 0 0
+      vertex 31.5 0 60
+    endloop
+  endfacet
+  facet normal 0.999877 -0.0156635 0
+    outer loop
+      vertex 31.5 0 0
+      vertex 31.4845 -0.989438 60
+      vertex 31.4845 -0.989438 0
+    endloop
+  endfacet
+  facet normal 0.294069 -0.955784 0
+    outer loop
+      vertex 8.78822 -30.2493 0
+      vertex 9.73403 -29.9583 60
+      vertex 8.78822 -30.2493 60
+    endloop
+  endfacet
+  facet normal 0.294069 -0.955784 0
+    outer loop
+      vertex 9.73403 -29.9583 60
+      vertex 8.78822 -30.2493 0
+      vertex 9.73403 -29.9583 0
+    endloop
+  endfacet
+  facet normal 0.233437 0.972372 -0
+    outer loop
+      vertex 7.83373 30.5104 0
+      vertex 6.87151 30.7414 60
+      vertex 7.83373 30.5104 60
+    endloop
+  endfacet
+  facet normal 0.233437 0.972372 0
+    outer loop
+      vertex 6.87151 30.7414 60
+      vertex 7.83373 30.5104 0
+      vertex 6.87151 30.7414 0
+    endloop
+  endfacet
+  facet normal -0.233437 -0.972372 0
+    outer loop
+      vertex -7.83373 -30.5104 0
+      vertex -6.87151 -30.7414 60
+      vertex -7.83373 -30.5104 60
+    endloop
+  endfacet
+  facet normal -0.233437 -0.972372 -0
+    outer loop
+      vertex -6.87151 -30.7414 60
+      vertex -7.83373 -30.5104 0
+      vertex -6.87151 -30.7414 0
+    endloop
+  endfacet
+  facet normal 0.73962 0.673025 0
+    outer loop
+      vertex 23.6285 20.8313 60
+      vertex 22.9625 21.5632 0
+      vertex 22.9625 21.5632 60
+    endloop
+  endfacet
+  facet normal 0.73962 0.673025 0
+    outer loop
+      vertex 22.9625 21.5632 0
+      vertex 23.6285 20.8313 60
+      vertex 23.6285 20.8313 0
+    endloop
+  endfacet
+  facet normal 0.0156635 0.999877 -0
+    outer loop
+      vertex 0.989438 31.4845 0
+      vertex 0 31.5 60
+      vertex 0.989438 31.4845 60
+    endloop
+  endfacet
+  facet normal 0.0156635 0.999877 0
+    outer loop
+      vertex 0 31.5 60
+      vertex 0.989438 31.4845 0
+      vertex 0 31.5 0
+    endloop
+  endfacet
+  facet normal -0.673025 -0.73962 0
+    outer loop
+      vertex -21.5632 -22.9625 0
+      vertex -20.8313 -23.6285 60
+      vertex -21.5632 -22.9625 60
+    endloop
+  endfacet
+  facet normal -0.673025 -0.73962 -0
+    outer loop
+      vertex -20.8313 -23.6285 60
+      vertex -21.5632 -22.9625 0
+      vertex -20.8313 -23.6285 0
+    endloop
+  endfacet
+  facet normal -0.898015 0.439964 0
+    outer loop
+      vertex -28.5021 13.412 0
+      vertex -28.0667 14.3007 60
+      vertex -28.0667 14.3007 0
+    endloop
+  endfacet
+  facet normal -0.898015 0.439964 0
+    outer loop
+      vertex -28.0667 14.3007 60
+      vertex -28.5021 13.412 0
+      vertex -28.5021 13.412 60
+    endloop
+  endfacet
+  facet normal -0.852604 0.522557 0
+    outer loop
+      vertex -27.1134 16.0348 0
+      vertex -26.5963 16.8785 60
+      vertex -26.5963 16.8785 0
+    endloop
+  endfacet
+  facet normal -0.852604 0.522557 0
+    outer loop
+      vertex -26.5963 16.8785 60
+      vertex -27.1134 16.0348 0
+      vertex -27.1134 16.0348 60
+    endloop
+  endfacet
+  facet normal -0.0156635 -0.999877 0
+    outer loop
+      vertex -0.989438 -31.4845 0
+      vertex 0 -31.5 60
+      vertex -0.989438 -31.4845 60
+    endloop
+  endfacet
+  facet normal -0.0156635 -0.999877 -0
+    outer loop
+      vertex 0 -31.5 60
+      vertex -0.989438 -31.4845 0
+      vertex 0 -31.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.7 0 0
+      vertex 31.5 0 0
+      vertex 31.4845 -0.989438 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.6757 -1.15996 0
+      vertex 31.4845 -0.989438 0
+      vertex 31.4378 -1.9779 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31.5 0 0
+      vertex 27.7 0 0
+      vertex 31.4845 0.989438 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.6029 -2.31788 0
+      vertex 31.4378 -1.9779 0
+      vertex 31.3602 -2.96441 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.6757 1.15996 0
+      vertex 31.4845 0.989438 0
+      vertex 27.7 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.4816 -3.47173 0
+      vertex 31.3602 -2.96441 0
+      vertex 31.2516 -3.948 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31.4845 0.989438 0
+      vertex 27.6757 1.15996 0
+      vertex 31.4378 1.9779 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.4816 -3.47173 0
+      vertex 31.2516 -3.948 0
+      vertex 31.1122 -4.92768 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.6029 2.31788 0
+      vertex 31.4378 1.9779 0
+      vertex 27.6757 1.15996 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3121 -4.61949 0
+      vertex 31.1122 -4.92768 0
+      vertex 30.942 -5.90251 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31.4378 1.9779 0
+      vertex 27.6029 2.31788 0
+      vertex 31.3602 2.96441 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0947 -5.75915 0
+      vertex 30.942 -5.90251 0
+      vertex 30.7414 -6.87151 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.4816 3.47173 0
+      vertex 31.3602 2.96441 0
+      vertex 27.6029 2.31788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8298 -6.88871 0
+      vertex 30.7414 -6.87151 0
+      vertex 30.5104 -7.83373 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31.3602 2.96441 0
+      vertex 27.4816 3.47173 0
+      vertex 31.2516 3.948 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8298 -6.88871 0
+      vertex 30.5104 -7.83373 0
+      vertex 30.2493 -8.78822 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 31.2516 3.948 0
+      vertex 27.4816 3.47173 0
+      vertex 31.1122 4.92768 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.5177 -8.00618 0
+      vertex 30.2493 -8.78822 0
+      vertex 29.9583 -9.73403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3121 4.61949 0
+      vertex 31.1122 4.92768 0
+      vertex 27.4816 3.47173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1592 -9.10961 0
+      vertex 29.9583 -9.73403 0
+      vertex 29.6377 -10.6702 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 31.1122 4.92768 0
+      vertex 27.3121 4.61949 0
+      vertex 30.942 5.90251 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.7548 -10.1971 0
+      vertex 29.6377 -10.6702 0
+      vertex 29.288 -11.5959 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0947 5.75915 0
+      vertex 30.942 5.90251 0
+      vertex 27.3121 4.61949 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.7548 -10.1971 0
+      vertex 29.288 -11.5959 0
+      vertex 28.9093 -12.5102 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 30.942 5.90251 0
+      vertex 27.0947 5.75915 0
+      vertex 30.7414 6.87151 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.3052 -11.2666 0
+      vertex 28.9093 -12.5102 0
+      vertex 28.5021 -13.412 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8298 6.88871 0
+      vertex 30.7414 6.87151 0
+      vertex 27.0947 5.75915 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8112 -12.3164 0
+      vertex 28.5021 -13.412 0
+      vertex 28.0667 -14.3007 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.7414 6.87151 0
+      vertex 26.8298 6.88871 0
+      vertex 30.5104 7.83373 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 30.5104 7.83373 0
+      vertex 26.8298 6.88871 0
+      vertex 30.2493 8.78822 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 31.4845 -0.989438 0
+      vertex 27.6757 -1.15996 0
+      vertex 27.7 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.2737 -13.3446 0
+      vertex 28.0667 -14.3007 0
+      vertex 27.6037 -15.1752 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 31.4378 -1.9779 0
+      vertex 27.6029 -2.31788 0
+      vertex 27.6757 -1.15996 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 31.3602 -2.96441 0
+      vertex 27.4816 -3.47173 0
+      vertex 27.6029 -2.31788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31.1122 -4.92768 0
+      vertex 27.3121 -4.61949 0
+      vertex 27.4816 -3.47173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.2737 -13.3446 0
+      vertex 27.6037 -15.1752 0
+      vertex 27.1134 -16.0348 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.942 -5.90251 0
+      vertex 27.0947 -5.75915 0
+      vertex 27.3121 -4.61949 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 30.7414 -6.87151 0
+      vertex 26.8298 -6.88871 0
+      vertex 27.0947 -5.75915 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.6936 -14.3493 0
+      vertex 27.1134 -16.0348 0
+      vertex 26.5963 -16.8785 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.2493 -8.78822 0
+      vertex 26.5177 -8.00618 0
+      vertex 26.8298 -6.88871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 29.9583 -9.73403 0
+      vertex 26.1592 -9.10961 0
+      vertex 26.5177 -8.00618 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.0719 -15.3289 0
+      vertex 26.5963 -16.8785 0
+      vertex 26.053 -17.7056 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 29.6377 -10.6702 0
+      vertex 25.7548 -10.1971 0
+      vertex 26.1592 -9.10961 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.4098 -16.2817 0
+      vertex 26.053 -17.7056 0
+      vertex 25.484 -18.5152 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.9093 -12.5102 0
+      vertex 25.3052 -11.2666 0
+      vertex 25.7548 -10.1971 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.4098 -16.2817 0
+      vertex 25.484 -18.5152 0
+      vertex 24.8899 -19.3066 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.5021 -13.412 0
+      vertex 24.8112 -12.3164 0
+      vertex 25.3052 -11.2666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.0667 -14.3007 0
+      vertex 24.2737 -13.3446 0
+      vertex 24.8112 -12.3164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.7083 -17.2058 0
+      vertex 24.8899 -19.3066 0
+      vertex 24.2712 -20.0789 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.1134 -16.0348 0
+      vertex 23.6936 -14.3493 0
+      vertex 24.2737 -13.3446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.9688 -18.0998 0
+      vertex 24.2712 -20.0789 0
+      vertex 23.6285 -20.8313 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.5963 -16.8785 0
+      vertex 23.0719 -15.3289 0
+      vertex 23.6936 -14.3493 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1924 -18.962 0
+      vertex 23.6285 -20.8313 0
+      vertex 22.9625 -21.5632 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.053 -17.7056 0
+      vertex 22.4098 -16.2817 0
+      vertex 23.0719 -15.3289 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1924 -18.962 0
+      vertex 22.9625 -21.5632 0
+      vertex 22.2739 -22.2739 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8899 -19.3066 0
+      vertex 21.7083 -17.2058 0
+      vertex 22.4098 -16.2817 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3807 -19.7909 0
+      vertex 22.2739 -22.2739 0
+      vertex 21.5632 -22.9625 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.2712 -20.0789 0
+      vertex 20.9688 -18.0998 0
+      vertex 21.7083 -17.2058 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5349 -20.5851 0
+      vertex 21.5632 -22.9625 0
+      vertex 20.8313 -23.6285 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.6285 -20.8313 0
+      vertex 20.1924 -18.962 0
+      vertex 20.9688 -18.0998 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.6566 -21.3432 0
+      vertex 20.8313 -23.6285 0
+      vertex 20.0789 -24.2712 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.2739 -22.2739 0
+      vertex 19.3807 -19.7909 0
+      vertex 20.1924 -18.962 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.6566 -21.3432 0
+      vertex 20.0789 -24.2712 0
+      vertex 19.3066 -24.8899 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.5632 -22.9625 0
+      vertex 18.5349 -20.5851 0
+      vertex 19.3807 -19.7909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.7474 -22.0639 0
+      vertex 19.3066 -24.8899 0
+      vertex 18.5152 -25.484 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8088 -22.7458 0
+      vertex 18.5152 -25.484 0
+      vertex 17.7056 -26.053 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.8313 -23.6285 0
+      vertex 17.6566 -21.3432 0
+      vertex 18.5349 -20.5851 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8424 -23.3879 0
+      vertex 17.7056 -26.053 0
+      vertex 16.8785 -26.5963 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3066 -24.8899 0
+      vertex 16.7474 -22.0639 0
+      vertex 17.6566 -21.3432 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8424 -23.3879 0
+      vertex 16.8785 -26.5963 0
+      vertex 16.0348 -27.1134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5152 -25.484 0
+      vertex 15.8088 -22.7458 0
+      vertex 16.7474 -22.0639 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.85 -23.9889 0
+      vertex 16.0348 -27.1134 0
+      vertex 15.1752 -27.6037 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.7056 -26.053 0
+      vertex 14.8424 -23.3879 0
+      vertex 15.8088 -22.7458 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.8333 -24.5478 0
+      vertex 15.1752 -27.6037 0
+      vertex 14.3007 -28.0667 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.0348 -27.1134 0
+      vertex 13.85 -23.9889 0
+      vertex 14.8424 -23.3879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.7941 -25.0637 0
+      vertex 14.3007 -28.0667 0
+      vertex 13.412 -28.5021 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.1752 -27.6037 0
+      vertex 12.8333 -24.5478 0
+      vertex 13.85 -23.9889 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.7941 -25.0637 0
+      vertex 13.412 -28.5021 0
+      vertex 12.5102 -28.9093 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.3007 -28.0667 0
+      vertex 11.7941 -25.0637 0
+      vertex 12.8333 -24.5478 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.7342 -25.5356 0
+      vertex 12.5102 -28.9093 0
+      vertex 11.5959 -29.288 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.5102 -28.9093 0
+      vertex 10.7342 -25.5356 0
+      vertex 11.7941 -25.0637 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.65545 -25.9627 0
+      vertex 11.5959 -29.288 0
+      vertex 10.6702 -29.6377 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.55977 -26.3443 0
+      vertex 10.6702 -29.6377 0
+      vertex 9.73403 -29.9583 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.5959 -29.288 0
+      vertex 9.65545 -25.9627 0
+      vertex 10.7342 -25.5356 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.55977 -26.3443 0
+      vertex 9.73403 -29.9583 0
+      vertex 8.78822 -30.2493 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6702 -29.6377 0
+      vertex 8.55977 -26.3443 0
+      vertex 9.65545 -25.9627 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.44908 -26.6796 0
+      vertex 8.78822 -30.2493 0
+      vertex 7.83373 -30.5104 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.78822 -30.2493 0
+      vertex 7.44908 -26.6796 0
+      vertex 8.55977 -26.3443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.32532 -26.9681 0
+      vertex 7.83373 -30.5104 0
+      vertex 6.87151 -30.7414 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.83373 -30.5104 0
+      vertex 6.32532 -26.9681 0
+      vertex 7.44908 -26.6796 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.19046 -27.2094 0
+      vertex 6.87151 -30.7414 0
+      vertex 5.90251 -30.942 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.87151 -30.7414 0
+      vertex 5.19046 -27.2094 0
+      vertex 6.32532 -26.9681 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.92768 -31.1122 0
+      vertex 5.19046 -27.2094 0
+      vertex 5.90251 -30.942 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.92768 -31.1122 0
+      vertex 4.0465 -27.4028 0
+      vertex 5.19046 -27.2094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.948 -31.2516 0
+      vertex 4.0465 -27.4028 0
+      vertex 4.92768 -31.1122 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.89544 -27.5483 0
+      vertex 3.948 -31.2516 0
+      vertex 2.96441 -31.3602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.948 -31.2516 0
+      vertex 2.89544 -27.5483 0
+      vertex 4.0465 -27.4028 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.7393 -27.6453 0
+      vertex 2.96441 -31.3602 0
+      vertex 1.9779 -31.4378 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.96441 -31.3602 0
+      vertex 1.7393 -27.6453 0
+      vertex 2.89544 -27.5483 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.989438 -31.4845 0
+      vertex 1.7393 -27.6453 0
+      vertex 1.9779 -31.4378 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.989438 -31.4845 0
+      vertex 0.580105 -27.6939 0
+      vertex 1.7393 -27.6453 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -31.5 0
+      vertex 0.580105 -27.6939 0
+      vertex 0.989438 -31.4845 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -31.5 0
+      vertex -0.580105 -27.6939 0
+      vertex 0.580105 -27.6939 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.989438 -31.4845 0
+      vertex -0.580105 -27.6939 0
+      vertex 0 -31.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.989438 -31.4845 0
+      vertex -1.7393 -27.6453 0
+      vertex -0.580105 -27.6939 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.9779 -31.4378 0
+      vertex -1.7393 -27.6453 0
+      vertex -0.989438 -31.4845 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.96441 -31.3602 0
+      vertex -1.7393 -27.6453 0
+      vertex -1.9779 -31.4378 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.7393 -27.6453 0
+      vertex -2.96441 -31.3602 0
+      vertex -2.89544 -27.5483 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.948 -31.2516 0
+      vertex -2.89544 -27.5483 0
+      vertex -2.96441 -31.3602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.948 -31.2516 0
+      vertex -4.0465 -27.4028 0
+      vertex -2.89544 -27.5483 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.92768 -31.1122 0
+      vertex -4.0465 -27.4028 0
+      vertex -3.948 -31.2516 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.92768 -31.1122 0
+      vertex -5.19046 -27.2094 0
+      vertex -4.0465 -27.4028 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.90251 -30.942 0
+      vertex -5.19046 -27.2094 0
+      vertex -4.92768 -31.1122 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.87151 -30.7414 0
+      vertex -5.19046 -27.2094 0
+      vertex -5.90251 -30.942 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.19046 -27.2094 0
+      vertex -6.87151 -30.7414 0
+      vertex -6.32532 -26.9681 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.83373 -30.5104 0
+      vertex -6.32532 -26.9681 0
+      vertex -6.87151 -30.7414 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -6.32532 -26.9681 0
+      vertex -7.83373 -30.5104 0
+      vertex -7.44908 -26.6796 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.78822 -30.2493 0
+      vertex -7.44908 -26.6796 0
+      vertex -7.83373 -30.5104 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -7.44908 -26.6796 0
+      vertex -8.78822 -30.2493 0
+      vertex -8.55977 -26.3443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.73403 -29.9583 0
+      vertex -8.55977 -26.3443 0
+      vertex -8.78822 -30.2493 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6702 -29.6377 0
+      vertex -8.55977 -26.3443 0
+      vertex -9.73403 -29.9583 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.55977 -26.3443 0
+      vertex -10.6702 -29.6377 0
+      vertex -9.65545 -25.9627 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.5959 -29.288 0
+      vertex -9.65545 -25.9627 0
+      vertex -10.6702 -29.6377 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.65545 -25.9627 0
+      vertex -11.5959 -29.288 0
+      vertex -10.7342 -25.5356 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.5102 -28.9093 0
+      vertex -10.7342 -25.5356 0
+      vertex -11.5959 -29.288 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -10.7342 -25.5356 0
+      vertex -12.5102 -28.9093 0
+      vertex -11.7941 -25.0637 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.412 -28.5021 0
+      vertex -11.7941 -25.0637 0
+      vertex -12.5102 -28.9093 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.3007 -28.0667 0
+      vertex -11.7941 -25.0637 0
+      vertex -13.412 -28.5021 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -11.7941 -25.0637 0
+      vertex -14.3007 -28.0667 0
+      vertex -12.8333 -24.5478 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.1752 -27.6037 0
+      vertex -12.8333 -24.5478 0
+      vertex -14.3007 -28.0667 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -12.8333 -24.5478 0
+      vertex -15.1752 -27.6037 0
+      vertex -13.85 -23.9889 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.0348 -27.1134 0
+      vertex -13.85 -23.9889 0
+      vertex -15.1752 -27.6037 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.85 -23.9889 0
+      vertex -16.0348 -27.1134 0
+      vertex -14.8424 -23.3879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.8785 -26.5963 0
+      vertex -14.8424 -23.3879 0
+      vertex -16.0348 -27.1134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.7056 -26.053 0
+      vertex -14.8424 -23.3879 0
+      vertex -16.8785 -26.5963 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.8424 -23.3879 0
+      vertex -17.7056 -26.053 0
+      vertex -15.8088 -22.7458 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5152 -25.484 0
+      vertex -15.8088 -22.7458 0
+      vertex -17.7056 -26.053 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.8088 -22.7458 0
+      vertex -18.5152 -25.484 0
+      vertex -16.7474 -22.0639 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3066 -24.8899 0
+      vertex -16.7474 -22.0639 0
+      vertex -18.5152 -25.484 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.7474 -22.0639 0
+      vertex -19.3066 -24.8899 0
+      vertex -17.6566 -21.3432 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.0789 -24.2712 0
+      vertex -17.6566 -21.3432 0
+      vertex -19.3066 -24.8899 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.8313 -23.6285 0
+      vertex -17.6566 -21.3432 0
+      vertex -20.0789 -24.2712 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -17.6566 -21.3432 0
+      vertex -20.8313 -23.6285 0
+      vertex -18.5349 -20.5851 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5632 -22.9625 0
+      vertex -18.5349 -20.5851 0
+      vertex -20.8313 -23.6285 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.5349 -20.5851 0
+      vertex -21.5632 -22.9625 0
+      vertex -19.3807 -19.7909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.2739 -22.2739 0
+      vertex -19.3807 -19.7909 0
+      vertex -21.5632 -22.9625 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.3807 -19.7909 0
+      vertex -22.2739 -22.2739 0
+      vertex -20.1924 -18.962 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.9625 -21.5632 0
+      vertex -20.1924 -18.962 0
+      vertex -22.2739 -22.2739 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.6285 -20.8313 0
+      vertex -20.1924 -18.962 0
+      vertex -22.9625 -21.5632 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -20.1924 -18.962 0
+      vertex -23.6285 -20.8313 0
+      vertex -20.9688 -18.0998 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.2712 -20.0789 0
+      vertex -20.9688 -18.0998 0
+      vertex -23.6285 -20.8313 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -20.9688 -18.0998 0
+      vertex -24.2712 -20.0789 0
+      vertex -21.7083 -17.2058 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.8899 -19.3066 0
+      vertex -21.7083 -17.2058 0
+      vertex -24.2712 -20.0789 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -21.7083 -17.2058 0
+      vertex -24.8899 -19.3066 0
+      vertex -22.4098 -16.2817 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.484 -18.5152 0
+      vertex -22.4098 -16.2817 0
+      vertex -24.8899 -19.3066 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.053 -17.7056 0
+      vertex -22.4098 -16.2817 0
+      vertex -25.484 -18.5152 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -22.4098 -16.2817 0
+      vertex -26.053 -17.7056 0
+      vertex -23.0719 -15.3289 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.5963 -16.8785 0
+      vertex -23.0719 -15.3289 0
+      vertex -26.053 -17.7056 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.0719 -15.3289 0
+      vertex -26.5963 -16.8785 0
+      vertex -23.6936 -14.3493 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.1134 -16.0348 0
+      vertex -23.6936 -14.3493 0
+      vertex -26.5963 -16.8785 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.6936 -14.3493 0
+      vertex -27.1134 -16.0348 0
+      vertex -24.2737 -13.3446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6037 -15.1752 0
+      vertex -24.2737 -13.3446 0
+      vertex -27.1134 -16.0348 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.0667 -14.3007 0
+      vertex -24.2737 -13.3446 0
+      vertex -27.6037 -15.1752 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.2737 -13.3446 0
+      vertex -28.0667 -14.3007 0
+      vertex -24.8112 -12.3164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.5021 -13.412 0
+      vertex -24.8112 -12.3164 0
+      vertex -28.0667 -14.3007 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.8112 -12.3164 0
+      vertex -28.5021 -13.412 0
+      vertex -25.3052 -11.2666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.9093 -12.5102 0
+      vertex -25.3052 -11.2666 0
+      vertex -28.5021 -13.412 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.3052 -11.2666 0
+      vertex -28.9093 -12.5102 0
+      vertex -25.7548 -10.1971 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.288 -11.5959 0
+      vertex -25.7548 -10.1971 0
+      vertex -28.9093 -12.5102 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.6377 -10.6702 0
+      vertex -25.7548 -10.1971 0
+      vertex -29.288 -11.5959 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.7548 -10.1971 0
+      vertex -29.6377 -10.6702 0
+      vertex -26.1592 -9.10961 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.9583 -9.73403 0
+      vertex -26.1592 -9.10961 0
+      vertex -29.6377 -10.6702 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.1592 -9.10961 0
+      vertex -29.9583 -9.73403 0
+      vertex -26.5177 -8.00618 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.2493 -8.78822 0
+      vertex -26.5177 -8.00618 0
+      vertex -29.9583 -9.73403 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.5177 -8.00618 0
+      vertex -30.2493 -8.78822 0
+      vertex -26.8298 -6.88871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.5177 8.00618 0
+      vertex 30.2493 8.78822 0
+      vertex 26.8298 6.88871 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 30.2493 8.78822 0
+      vertex 26.5177 8.00618 0
+      vertex 29.9583 9.73403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1592 9.10961 0
+      vertex 29.9583 9.73403 0
+      vertex 26.5177 8.00618 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 29.9583 9.73403 0
+      vertex 26.1592 9.10961 0
+      vertex 29.6377 10.6702 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.7548 10.1971 0
+      vertex 29.6377 10.6702 0
+      vertex 26.1592 9.10961 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 29.6377 10.6702 0
+      vertex 25.7548 10.1971 0
+      vertex 29.288 11.5959 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 29.288 11.5959 0
+      vertex 25.7548 10.1971 0
+      vertex 28.9093 12.5102 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.3052 11.2666 0
+      vertex 28.9093 12.5102 0
+      vertex 25.7548 10.1971 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.9093 12.5102 0
+      vertex 25.3052 11.2666 0
+      vertex 28.5021 13.412 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8112 12.3164 0
+      vertex 28.5021 13.412 0
+      vertex 25.3052 11.2666 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.5021 13.412 0
+      vertex 24.8112 12.3164 0
+      vertex 28.0667 14.3007 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.2737 13.3446 0
+      vertex 28.0667 14.3007 0
+      vertex 24.8112 12.3164 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.0667 14.3007 0
+      vertex 24.2737 13.3446 0
+      vertex 27.6037 15.1752 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 27.6037 15.1752 0
+      vertex 24.2737 13.3446 0
+      vertex 27.1134 16.0348 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.6936 14.3493 0
+      vertex 27.1134 16.0348 0
+      vertex 24.2737 13.3446 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 27.1134 16.0348 0
+      vertex 23.6936 14.3493 0
+      vertex 26.5963 16.8785 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.0719 15.3289 0
+      vertex 26.5963 16.8785 0
+      vertex 23.6936 14.3493 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 26.5963 16.8785 0
+      vertex 23.0719 15.3289 0
+      vertex 26.053 17.7056 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.4098 16.2817 0
+      vertex 26.053 17.7056 0
+      vertex 23.0719 15.3289 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 26.053 17.7056 0
+      vertex 22.4098 16.2817 0
+      vertex 25.484 18.5152 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 25.484 18.5152 0
+      vertex 22.4098 16.2817 0
+      vertex 24.8899 19.3066 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.7083 17.2058 0
+      vertex 24.8899 19.3066 0
+      vertex 22.4098 16.2817 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 24.8899 19.3066 0
+      vertex 21.7083 17.2058 0
+      vertex 24.2712 20.0789 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.9688 18.0998 0
+      vertex 24.2712 20.0789 0
+      vertex 21.7083 17.2058 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 24.2712 20.0789 0
+      vertex 20.9688 18.0998 0
+      vertex 23.6285 20.8313 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1924 18.962 0
+      vertex 23.6285 20.8313 0
+      vertex 20.9688 18.0998 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 23.6285 20.8313 0
+      vertex 20.1924 18.962 0
+      vertex 22.9625 21.5632 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 22.9625 21.5632 0
+      vertex 20.1924 18.962 0
+      vertex 22.2739 22.2739 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3807 19.7909 0
+      vertex 22.2739 22.2739 0
+      vertex 20.1924 18.962 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 22.2739 22.2739 0
+      vertex 19.3807 19.7909 0
+      vertex 21.5632 22.9625 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5349 20.5851 0
+      vertex 21.5632 22.9625 0
+      vertex 19.3807 19.7909 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 21.5632 22.9625 0
+      vertex 18.5349 20.5851 0
+      vertex 20.8313 23.6285 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.6566 21.3432 0
+      vertex 20.8313 23.6285 0
+      vertex 18.5349 20.5851 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.8313 23.6285 0
+      vertex 17.6566 21.3432 0
+      vertex 20.0789 24.2712 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.0789 24.2712 0
+      vertex 17.6566 21.3432 0
+      vertex 19.3066 24.8899 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.7474 22.0639 0
+      vertex 19.3066 24.8899 0
+      vertex 17.6566 21.3432 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.3066 24.8899 0
+      vertex 16.7474 22.0639 0
+      vertex 18.5152 25.484 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8088 22.7458 0
+      vertex 18.5152 25.484 0
+      vertex 16.7474 22.0639 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 18.5152 25.484 0
+      vertex 15.8088 22.7458 0
+      vertex 17.7056 26.053 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8424 23.3879 0
+      vertex 17.7056 26.053 0
+      vertex 15.8088 22.7458 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.7056 26.053 0
+      vertex 14.8424 23.3879 0
+      vertex 16.8785 26.5963 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 16.8785 26.5963 0
+      vertex 14.8424 23.3879 0
+      vertex 16.0348 27.1134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.85 23.9889 0
+      vertex 16.0348 27.1134 0
+      vertex 14.8424 23.3879 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 16.0348 27.1134 0
+      vertex 13.85 23.9889 0
+      vertex 15.1752 27.6037 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.8333 24.5478 0
+      vertex 15.1752 27.6037 0
+      vertex 13.85 23.9889 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.1752 27.6037 0
+      vertex 12.8333 24.5478 0
+      vertex 14.3007 28.0667 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.7941 25.0637 0
+      vertex 14.3007 28.0667 0
+      vertex 12.8333 24.5478 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14.3007 28.0667 0
+      vertex 11.7941 25.0637 0
+      vertex 13.412 28.5021 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 13.412 28.5021 0
+      vertex 11.7941 25.0637 0
+      vertex 12.5102 28.9093 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.7342 25.5356 0
+      vertex 12.5102 28.9093 0
+      vertex 11.7941 25.0637 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 12.5102 28.9093 0
+      vertex 10.7342 25.5356 0
+      vertex 11.5959 29.288 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.65545 25.9627 0
+      vertex 11.5959 29.288 0
+      vertex 10.7342 25.5356 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.5959 29.288 0
+      vertex 9.65545 25.9627 0
+      vertex 10.6702 29.6377 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.55977 26.3443 0
+      vertex 10.6702 29.6377 0
+      vertex 9.65545 25.9627 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.6702 29.6377 0
+      vertex 8.55977 26.3443 0
+      vertex 9.73403 29.9583 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 9.73403 29.9583 0
+      vertex 8.55977 26.3443 0
+      vertex 8.78822 30.2493 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.44908 26.6796 0
+      vertex 8.78822 30.2493 0
+      vertex 8.55977 26.3443 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 8.78822 30.2493 0
+      vertex 7.44908 26.6796 0
+      vertex 7.83373 30.5104 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.32532 26.9681 0
+      vertex 7.83373 30.5104 0
+      vertex 7.44908 26.6796 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 7.83373 30.5104 0
+      vertex 6.32532 26.9681 0
+      vertex 6.87151 30.7414 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.19046 27.2094 0
+      vertex 6.87151 30.7414 0
+      vertex 6.32532 26.9681 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 6.87151 30.7414 0
+      vertex 5.19046 27.2094 0
+      vertex 5.90251 30.942 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.19046 27.2094 0
+      vertex 4.92768 31.1122 0
+      vertex 5.90251 30.942 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.0465 27.4028 0
+      vertex 4.92768 31.1122 0
+      vertex 5.19046 27.2094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.0465 27.4028 0
+      vertex 3.948 31.2516 0
+      vertex 4.92768 31.1122 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.89544 27.5483 0
+      vertex 3.948 31.2516 0
+      vertex 4.0465 27.4028 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 3.948 31.2516 0
+      vertex 2.89544 27.5483 0
+      vertex 2.96441 31.3602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.7393 27.6453 0
+      vertex 2.96441 31.3602 0
+      vertex 2.89544 27.5483 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 2.96441 31.3602 0
+      vertex 1.7393 27.6453 0
+      vertex 1.9779 31.4378 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.7393 27.6453 0
+      vertex 0.989438 31.4845 0
+      vertex 1.9779 31.4378 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.580105 27.6939 0
+      vertex 0.989438 31.4845 0
+      vertex 1.7393 27.6453 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.580105 27.6939 0
+      vertex 0 31.5 0
+      vertex 0.989438 31.4845 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.580105 27.6939 0
+      vertex 0 31.5 0
+      vertex 0.580105 27.6939 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.580105 27.6939 0
+      vertex -0.989438 31.4845 0
+      vertex 0 31.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.7393 27.6453 0
+      vertex -0.989438 31.4845 0
+      vertex -0.580105 27.6939 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.7393 27.6453 0
+      vertex -1.9779 31.4378 0
+      vertex -0.989438 31.4845 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.96441 31.3602 0
+      vertex -1.7393 27.6453 0
+      vertex -2.89544 27.5483 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.7393 27.6453 0
+      vertex -2.96441 31.3602 0
+      vertex -1.9779 31.4378 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.89544 27.5483 0
+      vertex -3.948 31.2516 0
+      vertex -2.96441 31.3602 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.0465 27.4028 0
+      vertex -3.948 31.2516 0
+      vertex -2.89544 27.5483 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.0465 27.4028 0
+      vertex -4.92768 31.1122 0
+      vertex -3.948 31.2516 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.19046 27.2094 0
+      vertex -4.92768 31.1122 0
+      vertex -4.0465 27.4028 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.19046 27.2094 0
+      vertex -5.90251 30.942 0
+      vertex -4.92768 31.1122 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.87151 30.7414 0
+      vertex -5.19046 27.2094 0
+      vertex -6.32532 26.9681 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.19046 27.2094 0
+      vertex -6.87151 30.7414 0
+      vertex -5.90251 30.942 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.83373 30.5104 0
+      vertex -6.32532 26.9681 0
+      vertex -7.44908 26.6796 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.32532 26.9681 0
+      vertex -7.83373 30.5104 0
+      vertex -6.87151 30.7414 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.78822 30.2493 0
+      vertex -7.44908 26.6796 0
+      vertex -8.55977 26.3443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.44908 26.6796 0
+      vertex -8.78822 30.2493 0
+      vertex -7.83373 30.5104 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6702 29.6377 0
+      vertex -8.55977 26.3443 0
+      vertex -9.65545 25.9627 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.55977 26.3443 0
+      vertex -9.73403 29.9583 0
+      vertex -8.78822 30.2493 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.55977 26.3443 0
+      vertex -10.6702 29.6377 0
+      vertex -9.73403 29.9583 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.5959 29.288 0
+      vertex -9.65545 25.9627 0
+      vertex -10.7342 25.5356 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.65545 25.9627 0
+      vertex -11.5959 29.288 0
+      vertex -10.6702 29.6377 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.5102 28.9093 0
+      vertex -10.7342 25.5356 0
+      vertex -11.7941 25.0637 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.7342 25.5356 0
+      vertex -12.5102 28.9093 0
+      vertex -11.5959 29.288 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.3007 28.0667 0
+      vertex -11.7941 25.0637 0
+      vertex -12.8333 24.5478 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7941 25.0637 0
+      vertex -13.412 28.5021 0
+      vertex -12.5102 28.9093 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.1752 27.6037 0
+      vertex -12.8333 24.5478 0
+      vertex -13.85 23.9889 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7941 25.0637 0
+      vertex -14.3007 28.0667 0
+      vertex -13.412 28.5021 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.0348 27.1134 0
+      vertex -13.85 23.9889 0
+      vertex -14.8424 23.3879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.8333 24.5478 0
+      vertex -15.1752 27.6037 0
+      vertex -14.3007 28.0667 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.7056 26.053 0
+      vertex -14.8424 23.3879 0
+      vertex -15.8088 22.7458 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.85 23.9889 0
+      vertex -16.0348 27.1134 0
+      vertex -15.1752 27.6037 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5152 25.484 0
+      vertex -15.8088 22.7458 0
+      vertex -16.7474 22.0639 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8424 23.3879 0
+      vertex -16.8785 26.5963 0
+      vertex -16.0348 27.1134 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3066 24.8899 0
+      vertex -16.7474 22.0639 0
+      vertex -17.6566 21.3432 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8424 23.3879 0
+      vertex -17.7056 26.053 0
+      vertex -16.8785 26.5963 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8088 22.7458 0
+      vertex -18.5152 25.484 0
+      vertex -17.7056 26.053 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.8313 23.6285 0
+      vertex -17.6566 21.3432 0
+      vertex -18.5349 20.5851 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.7474 22.0639 0
+      vertex -19.3066 24.8899 0
+      vertex -18.5152 25.484 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5632 22.9625 0
+      vertex -18.5349 20.5851 0
+      vertex -19.3807 19.7909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.6566 21.3432 0
+      vertex -20.0789 24.2712 0
+      vertex -19.3066 24.8899 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.2739 22.2739 0
+      vertex -19.3807 19.7909 0
+      vertex -20.1924 18.962 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.6566 21.3432 0
+      vertex -20.8313 23.6285 0
+      vertex -20.0789 24.2712 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.6285 20.8313 0
+      vertex -20.1924 18.962 0
+      vertex -20.9688 18.0998 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5349 20.5851 0
+      vertex -21.5632 22.9625 0
+      vertex -20.8313 23.6285 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.2712 20.0789 0
+      vertex -20.9688 18.0998 0
+      vertex -21.7083 17.2058 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3807 19.7909 0
+      vertex -22.2739 22.2739 0
+      vertex -21.5632 22.9625 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.8899 19.3066 0
+      vertex -21.7083 17.2058 0
+      vertex -22.4098 16.2817 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1924 18.962 0
+      vertex -22.9625 21.5632 0
+      vertex -22.2739 22.2739 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.053 17.7056 0
+      vertex -22.4098 16.2817 0
+      vertex -23.0719 15.3289 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1924 18.962 0
+      vertex -23.6285 20.8313 0
+      vertex -22.9625 21.5632 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.5963 16.8785 0
+      vertex -23.0719 15.3289 0
+      vertex -23.6936 14.3493 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.9688 18.0998 0
+      vertex -24.2712 20.0789 0
+      vertex -23.6285 20.8313 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.1134 16.0348 0
+      vertex -23.6936 14.3493 0
+      vertex -24.2737 13.3446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.0667 14.3007 0
+      vertex -24.2737 13.3446 0
+      vertex -24.8112 12.3164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.7083 17.2058 0
+      vertex -24.8899 19.3066 0
+      vertex -24.2712 20.0789 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.5021 13.412 0
+      vertex -24.8112 12.3164 0
+      vertex -25.3052 11.2666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.4098 16.2817 0
+      vertex -25.484 18.5152 0
+      vertex -24.8899 19.3066 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.9093 12.5102 0
+      vertex -25.3052 11.2666 0
+      vertex -25.7548 10.1971 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.4098 16.2817 0
+      vertex -26.053 17.7056 0
+      vertex -25.484 18.5152 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.6377 10.6702 0
+      vertex -25.7548 10.1971 0
+      vertex -26.1592 9.10961 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.9583 9.73403 0
+      vertex -26.1592 9.10961 0
+      vertex -26.5177 8.00618 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.0719 15.3289 0
+      vertex -26.5963 16.8785 0
+      vertex -26.053 17.7056 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.2493 8.78822 0
+      vertex -26.5177 8.00618 0
+      vertex -26.8298 6.88871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.7414 6.87151 0
+      vertex -26.8298 6.88871 0
+      vertex -27.0947 5.75915 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.6936 14.3493 0
+      vertex -27.1134 16.0348 0
+      vertex -26.5963 16.8785 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.942 5.90251 0
+      vertex -27.0947 5.75915 0
+      vertex -27.3121 4.61949 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.1122 4.92768 0
+      vertex -27.3121 4.61949 0
+      vertex -27.4816 3.47173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.3602 2.96441 0
+      vertex -27.4816 3.47173 0
+      vertex -27.6029 2.31788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.2737 13.3446 0
+      vertex -27.6037 15.1752 0
+      vertex -27.1134 16.0348 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.4378 1.9779 0
+      vertex -27.6029 2.31788 0
+      vertex -27.6757 1.15996 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.4845 0.989438 0
+      vertex -27.6757 1.15996 0
+      vertex -27.7 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.5104 -7.83373 0
+      vertex -26.8298 -6.88871 0
+      vertex -30.2493 -8.78822 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.2737 13.3446 0
+      vertex -28.0667 14.3007 0
+      vertex -27.6037 15.1752 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.7414 -6.87151 0
+      vertex -26.8298 -6.88871 0
+      vertex -30.5104 -7.83373 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.8112 12.3164 0
+      vertex -28.5021 13.412 0
+      vertex -28.0667 14.3007 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.8298 -6.88871 0
+      vertex -30.7414 -6.87151 0
+      vertex -27.0947 -5.75915 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.3052 11.2666 0
+      vertex -28.9093 12.5102 0
+      vertex -28.5021 13.412 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.942 -5.90251 0
+      vertex -27.0947 -5.75915 0
+      vertex -30.7414 -6.87151 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.7548 10.1971 0
+      vertex -29.288 11.5959 0
+      vertex -28.9093 12.5102 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.0947 -5.75915 0
+      vertex -30.942 -5.90251 0
+      vertex -27.3121 -4.61949 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.7548 10.1971 0
+      vertex -29.6377 10.6702 0
+      vertex -29.288 11.5959 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.1122 -4.92768 0
+      vertex -27.3121 -4.61949 0
+      vertex -30.942 -5.90251 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.1592 9.10961 0
+      vertex -29.9583 9.73403 0
+      vertex -29.6377 10.6702 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.3121 -4.61949 0
+      vertex -31.1122 -4.92768 0
+      vertex -27.4816 -3.47173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.5177 8.00618 0
+      vertex -30.2493 8.78822 0
+      vertex -29.9583 9.73403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.2516 -3.948 0
+      vertex -27.4816 -3.47173 0
+      vertex -31.1122 -4.92768 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.8298 6.88871 0
+      vertex -30.5104 7.83373 0
+      vertex -30.2493 8.78822 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.3602 -2.96441 0
+      vertex -27.4816 -3.47173 0
+      vertex -31.2516 -3.948 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.8298 6.88871 0
+      vertex -30.7414 6.87151 0
+      vertex -30.5104 7.83373 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.4816 -3.47173 0
+      vertex -31.3602 -2.96441 0
+      vertex -27.6029 -2.31788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0947 5.75915 0
+      vertex -30.942 5.90251 0
+      vertex -30.7414 6.87151 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.4378 -1.9779 0
+      vertex -27.6029 -2.31788 0
+      vertex -31.3602 -2.96441 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.3121 4.61949 0
+      vertex -31.1122 4.92768 0
+      vertex -30.942 5.90251 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6029 -2.31788 0
+      vertex -31.4378 -1.9779 0
+      vertex -27.6757 -1.15996 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.4816 3.47173 0
+      vertex -31.2516 3.948 0
+      vertex -31.1122 4.92768 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.4845 -0.989438 0
+      vertex -27.6757 -1.15996 0
+      vertex -31.4378 -1.9779 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.4816 3.47173 0
+      vertex -31.3602 2.96441 0
+      vertex -31.2516 3.948 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6757 -1.15996 0
+      vertex -31.4845 -0.989438 0
+      vertex -27.7 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.6029 2.31788 0
+      vertex -31.4378 1.9779 0
+      vertex -31.3602 2.96441 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.5 0 0
+      vertex -27.7 0 0
+      vertex -31.4845 -0.989438 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.6757 1.15996 0
+      vertex -31.4845 0.989438 0
+      vertex -31.4378 1.9779 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.7 0 0
+      vertex -31.5 0 0
+      vertex -31.4845 0.989438 0
+    endloop
+  endfacet
+  facet normal -0.695852 -0.718185 0
+    outer loop
+      vertex -22.2739 -22.2739 0
+      vertex -21.5632 -22.9625 60
+      vertex -22.2739 -22.2739 60
+    endloop
+  endfacet
+  facet normal -0.695852 -0.718185 -0
+    outer loop
+      vertex -21.5632 -22.9625 60
+      vertex -22.2739 -22.2739 0
+      vertex -21.5632 -22.9625 0
+    endloop
+  endfacet
+  facet normal 0.695852 0.718185 -0
+    outer loop
+      vertex 22.2739 22.2739 0
+      vertex 21.5632 22.9625 60
+      vertex 22.2739 22.2739 60
+    endloop
+  endfacet
+  facet normal 0.695852 0.718185 0
+    outer loop
+      vertex 21.5632 22.9625 60
+      vertex 22.2739 22.2739 0
+      vertex 21.5632 22.9625 0
+    endloop
+  endfacet
+  facet normal -0.999877 0.0156635 0
+    outer loop
+      vertex -31.5 0 0
+      vertex -31.4845 0.989438 60
+      vertex -31.4845 0.989438 0
+    endloop
+  endfacet
+  facet normal -0.999877 0.0156635 0
+    outer loop
+      vertex -31.4845 0.989438 60
+      vertex -31.5 0 0
+      vertex -31.5 0 60
+    endloop
+  endfacet
+  facet normal 0.760361 0.6495 0
+    outer loop
+      vertex 24.2712 20.0789 60
+      vertex 23.6285 20.8313 0
+      vertex 23.6285 20.8313 60
+    endloop
+  endfacet
+  facet normal 0.760361 0.6495 0
+    outer loop
+      vertex 23.6285 20.8313 0
+      vertex 24.2712 20.0789 60
+      vertex 24.2712 20.0789 0
+    endloop
+  endfacet
+  facet normal 0.353393 0.935475 -0
+    outer loop
+      vertex 11.5959 29.288 0
+      vertex 10.6702 29.6377 60
+      vertex 11.5959 29.288 60
+    endloop
+  endfacet
+  facet normal 0.353393 0.935475 0
+    outer loop
+      vertex 10.6702 29.6377 60
+      vertex 11.5959 29.288 0
+      vertex 10.6702 29.6377 0
+    endloop
+  endfacet
+  facet normal 0.818148 -0.575008 0
+    outer loop
+      vertex 25.484 -18.5152 60
+      vertex 26.053 -17.7056 0
+      vertex 26.053 -17.7056 60
+    endloop
+  endfacet
+  facet normal 0.818148 -0.575008 0
+    outer loop
+      vertex 26.053 -17.7056 0
+      vertex 25.484 -18.5152 60
+      vertex 25.484 -18.5152 0
+    endloop
+  endfacet
+  facet normal -0.760361 0.6495 0
+    outer loop
+      vertex -24.2712 20.0789 0
+      vertex -23.6285 20.8313 60
+      vertex -23.6285 20.8313 0
+    endloop
+  endfacet
+  facet normal -0.760361 0.6495 0
+    outer loop
+      vertex -23.6285 20.8313 60
+      vertex -24.2712 20.0789 0
+      vertex -24.2712 20.0789 60
+    endloop
+  endfacet
+  facet normal -0.600356 0.799733 0
+    outer loop
+      vertex -18.5152 25.484 0
+      vertex -19.3066 24.8899 60
+      vertex -18.5152 25.484 60
+    endloop
+  endfacet
+  facet normal -0.600356 0.799733 0
+    outer loop
+      vertex -19.3066 24.8899 60
+      vertex -18.5152 25.484 0
+      vertex -19.3066 24.8899 0
+    endloop
+  endfacet
+  facet normal -0.625225 0.780445 0
+    outer loop
+      vertex -19.3066 24.8899 0
+      vertex -20.0789 24.2712 60
+      vertex -19.3066 24.8899 60
+    endloop
+  endfacet
+  facet normal -0.625225 0.780445 0
+    outer loop
+      vertex -20.0789 24.2712 60
+      vertex -19.3066 24.8899 0
+      vertex -20.0789 24.2712 0
+    endloop
+  endfacet
+  facet normal 0.109745 0.99396 -0
+    outer loop
+      vertex 3.948 31.2516 0
+      vertex 2.96441 31.3602 60
+      vertex 3.948 31.2516 60
+    endloop
+  endfacet
+  facet normal 0.109745 0.99396 0
+    outer loop
+      vertex 2.96441 31.3602 60
+      vertex 3.948 31.2516 0
+      vertex 2.96441 31.3602 0
+    endloop
+  endfacet
+  facet normal -0.411533 -0.911395 0
+    outer loop
+      vertex -13.412 -28.5021 0
+      vertex -12.5102 -28.9093 60
+      vertex -13.412 -28.5021 60
+    endloop
+  endfacet
+  facet normal -0.411533 -0.911395 -0
+    outer loop
+      vertex -12.5102 -28.9093 60
+      vertex -13.412 -28.5021 0
+      vertex -12.5102 -28.9093 0
+    endloop
+  endfacet
+  facet normal 0.799733 0.600356 0
+    outer loop
+      vertex 25.484 18.5152 60
+      vertex 24.8899 19.3066 0
+      vertex 24.8899 19.3066 60
+    endloop
+  endfacet
+  facet normal 0.799733 0.600356 0
+    outer loop
+      vertex 24.8899 19.3066 0
+      vertex 25.484 18.5152 60
+      vertex 25.484 18.5152 0
+    endloop
+  endfacet
+  facet normal 0.38267 -0.923885 0
+    outer loop
+      vertex 11.5959 -29.288 0
+      vertex 12.5102 -28.9093 60
+      vertex 11.5959 -29.288 60
+    endloop
+  endfacet
+  facet normal 0.38267 -0.923885 0
+    outer loop
+      vertex 12.5102 -28.9093 60
+      vertex 11.5959 -29.288 0
+      vertex 12.5102 -28.9093 0
+    endloop
+  endfacet
+  facet normal -0.467911 0.883776 0
+    outer loop
+      vertex -14.3007 28.0667 0
+      vertex -15.1752 27.6037 60
+      vertex -14.3007 28.0667 60
+    endloop
+  endfacet
+  facet normal -0.467911 0.883776 0
+    outer loop
+      vertex -15.1752 27.6037 60
+      vertex -14.3007 28.0667 0
+      vertex -15.1752 27.6037 0
+    endloop
+  endfacet
+  facet normal -0.985098 0.171993 0
+    outer loop
+      vertex -31.1122 4.92768 0
+      vertex -30.942 5.90251 60
+      vertex -30.942 5.90251 0
+    endloop
+  endfacet
+  facet normal -0.985098 0.171993 0
+    outer loop
+      vertex -30.942 5.90251 60
+      vertex -31.1122 4.92768 0
+      vertex -31.1122 4.92768 60
+    endloop
+  endfacet
+  facet normal -0.294069 0.955784 0
+    outer loop
+      vertex -8.78822 30.2493 0
+      vertex -9.73403 29.9583 60
+      vertex -8.78822 30.2493 60
+    endloop
+  endfacet
+  facet normal -0.294069 0.955784 0
+    outer loop
+      vertex -9.73403 29.9583 60
+      vertex -8.78822 30.2493 0
+      vertex -9.73403 29.9583 0
+    endloop
+  endfacet
+  facet normal 0.695852 -0.718185 0
+    outer loop
+      vertex 21.5632 -22.9625 0
+      vertex 22.2739 -22.2739 60
+      vertex 21.5632 -22.9625 60
+    endloop
+  endfacet
+  facet normal 0.695852 -0.718185 0
+    outer loop
+      vertex 22.2739 -22.2739 60
+      vertex 21.5632 -22.9625 0
+      vertex 22.2739 -22.2739 0
+    endloop
+  endfacet
+  facet normal -0.852604 -0.522557 0
+    outer loop
+      vertex -26.5963 -16.8785 0
+      vertex -27.1134 -16.0348 60
+      vertex -27.1134 -16.0348 0
+    endloop
+  endfacet
+  facet normal -0.852604 -0.522557 0
+    outer loop
+      vertex -27.1134 -16.0348 60
+      vertex -26.5963 -16.8785 0
+      vertex -26.5963 -16.8785 60
+    endloop
+  endfacet
+  facet normal -0.835809 -0.549021 0
+    outer loop
+      vertex -26.053 -17.7056 0
+      vertex -26.5963 -16.8785 60
+      vertex -26.5963 -16.8785 0
+    endloop
+  endfacet
+  facet normal -0.835809 -0.549021 0
+    outer loop
+      vertex -26.5963 -16.8785 60
+      vertex -26.053 -17.7056 0
+      vertex -26.053 -17.7056 60
+    endloop
+  endfacet
+  facet normal 0.673025 -0.73962 0
+    outer loop
+      vertex 20.8313 -23.6285 0
+      vertex 21.5632 -22.9625 60
+      vertex 20.8313 -23.6285 60
+    endloop
+  endfacet
+  facet normal 0.673025 -0.73962 0
+    outer loop
+      vertex 21.5632 -22.9625 60
+      vertex 20.8313 -23.6285 0
+      vertex 21.5632 -22.9625 0
+    endloop
+  endfacet
+  facet normal -0.109745 -0.99396 0
+    outer loop
+      vertex -3.948 -31.2516 0
+      vertex -2.96441 -31.3602 60
+      vertex -3.948 -31.2516 60
+    endloop
+  endfacet
+  facet normal -0.109745 -0.99396 -0
+    outer loop
+      vertex -2.96441 -31.3602 60
+      vertex -3.948 -31.2516 0
+      vertex -2.96441 -31.3602 0
+    endloop
+  endfacet
+  facet normal -0.780445 -0.625225 0
+    outer loop
+      vertex -24.2712 -20.0789 0
+      vertex -24.8899 -19.3066 60
+      vertex -24.8899 -19.3066 0
+    endloop
+  endfacet
+  facet normal -0.780445 -0.625225 0
+    outer loop
+      vertex -24.8899 -19.3066 60
+      vertex -24.2712 -20.0789 0
+      vertex -24.2712 -20.0789 60
+    endloop
+  endfacet
+  facet normal -0.99396 -0.109745 0
+    outer loop
+      vertex -31.2516 -3.948 0
+      vertex -31.3602 -2.96441 60
+      vertex -31.3602 -2.96441 0
+    endloop
+  endfacet
+  facet normal -0.99396 -0.109745 0
+    outer loop
+      vertex -31.3602 -2.96441 60
+      vertex -31.2516 -3.948 0
+      vertex -31.2516 -3.948 60
+    endloop
+  endfacet
+  facet normal -0.955784 -0.294069 0
+    outer loop
+      vertex -29.9583 -9.73403 0
+      vertex -30.2493 -8.78822 60
+      vertex -30.2493 -8.78822 0
+    endloop
+  endfacet
+  facet normal -0.955784 -0.294069 0
+    outer loop
+      vertex -30.2493 -8.78822 60
+      vertex -29.9583 -9.73403 0
+      vertex -29.9583 -9.73403 60
+    endloop
+  endfacet
+  facet normal -0.294069 -0.955784 0
+    outer loop
+      vertex -9.73403 -29.9583 0
+      vertex -8.78822 -30.2493 60
+      vertex -9.73403 -29.9583 60
+    endloop
+  endfacet
+  facet normal -0.294069 -0.955784 -0
+    outer loop
+      vertex -8.78822 -30.2493 60
+      vertex -9.73403 -29.9583 0
+      vertex -8.78822 -30.2493 0
+    endloop
+  endfacet
+  facet normal -0.799733 0.600356 0
+    outer loop
+      vertex -25.484 18.5152 0
+      vertex -24.8899 19.3066 60
+      vertex -24.8899 19.3066 0
+    endloop
+  endfacet
+  facet normal -0.799733 0.600356 0
+    outer loop
+      vertex -24.8899 19.3066 60
+      vertex -25.484 18.5152 0
+      vertex -25.484 18.5152 60
+    endloop
+  endfacet
+  facet normal -0.522557 -0.852604 0
+    outer loop
+      vertex -16.8785 -26.5963 0
+      vertex -16.0348 -27.1134 60
+      vertex -16.8785 -26.5963 60
+    endloop
+  endfacet
+  facet normal -0.522557 -0.852604 -0
+    outer loop
+      vertex -16.0348 -27.1134 60
+      vertex -16.8785 -26.5963 0
+      vertex -16.0348 -27.1134 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.7 0 60
+      vertex 31.5 0 60
+      vertex 31.4845 0.989438 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.6757 1.15996 60
+      vertex 31.4845 0.989438 60
+      vertex 31.4378 1.9779 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.5 0 60
+      vertex 27.7 0 60
+      vertex 31.4845 -0.989438 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.6029 2.31788 60
+      vertex 31.4378 1.9779 60
+      vertex 31.3602 2.96441 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.6757 -1.15996 60
+      vertex 31.4845 -0.989438 60
+      vertex 27.7 0 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.4816 3.47173 60
+      vertex 31.3602 2.96441 60
+      vertex 31.2516 3.948 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.4845 -0.989438 60
+      vertex 27.6757 -1.15996 60
+      vertex 31.4378 -1.9779 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.4816 3.47173 60
+      vertex 31.2516 3.948 60
+      vertex 31.1122 4.92768 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.6029 -2.31788 60
+      vertex 31.4378 -1.9779 60
+      vertex 27.6757 -1.15996 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.3121 4.61949 60
+      vertex 31.1122 4.92768 60
+      vertex 30.942 5.90251 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.4378 -1.9779 60
+      vertex 27.6029 -2.31788 60
+      vertex 31.3602 -2.96441 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.0947 5.75915 60
+      vertex 30.942 5.90251 60
+      vertex 30.7414 6.87151 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.4816 -3.47173 60
+      vertex 31.3602 -2.96441 60
+      vertex 27.6029 -2.31788 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.8298 6.88871 60
+      vertex 30.7414 6.87151 60
+      vertex 30.5104 7.83373 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.3602 -2.96441 60
+      vertex 27.4816 -3.47173 60
+      vertex 31.2516 -3.948 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.8298 6.88871 60
+      vertex 30.5104 7.83373 60
+      vertex 30.2493 8.78822 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.2516 -3.948 60
+      vertex 27.4816 -3.47173 60
+      vertex 31.1122 -4.92768 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.5177 8.00618 60
+      vertex 30.2493 8.78822 60
+      vertex 29.9583 9.73403 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.3121 -4.61949 60
+      vertex 31.1122 -4.92768 60
+      vertex 27.4816 -3.47173 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.1592 9.10961 60
+      vertex 29.9583 9.73403 60
+      vertex 29.6377 10.6702 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.1122 -4.92768 60
+      vertex 27.3121 -4.61949 60
+      vertex 30.942 -5.90251 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.7548 10.1971 60
+      vertex 29.6377 10.6702 60
+      vertex 29.288 11.5959 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.0947 -5.75915 60
+      vertex 30.942 -5.90251 60
+      vertex 27.3121 -4.61949 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.7548 10.1971 60
+      vertex 29.288 11.5959 60
+      vertex 28.9093 12.5102 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.942 -5.90251 60
+      vertex 27.0947 -5.75915 60
+      vertex 30.7414 -6.87151 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.3052 11.2666 60
+      vertex 28.9093 12.5102 60
+      vertex 28.5021 13.412 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.8298 -6.88871 60
+      vertex 30.7414 -6.87151 60
+      vertex 27.0947 -5.75915 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8112 12.3164 60
+      vertex 28.5021 13.412 60
+      vertex 28.0667 14.3007 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.7414 -6.87151 60
+      vertex 26.8298 -6.88871 60
+      vertex 30.5104 -7.83373 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.5104 -7.83373 60
+      vertex 26.8298 -6.88871 60
+      vertex 30.2493 -8.78822 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.4845 0.989438 60
+      vertex 27.6757 1.15996 60
+      vertex 27.7 0 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.2737 13.3446 60
+      vertex 28.0667 14.3007 60
+      vertex 27.6037 15.1752 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.4378 1.9779 60
+      vertex 27.6029 2.31788 60
+      vertex 27.6757 1.15996 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.3602 2.96441 60
+      vertex 27.4816 3.47173 60
+      vertex 27.6029 2.31788 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.1122 4.92768 60
+      vertex 27.3121 4.61949 60
+      vertex 27.4816 3.47173 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.2737 13.3446 60
+      vertex 27.6037 15.1752 60
+      vertex 27.1134 16.0348 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.942 5.90251 60
+      vertex 27.0947 5.75915 60
+      vertex 27.3121 4.61949 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.7414 6.87151 60
+      vertex 26.8298 6.88871 60
+      vertex 27.0947 5.75915 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.6936 14.3493 60
+      vertex 27.1134 16.0348 60
+      vertex 26.5963 16.8785 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.2493 8.78822 60
+      vertex 26.5177 8.00618 60
+      vertex 26.8298 6.88871 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.9583 9.73403 60
+      vertex 26.1592 9.10961 60
+      vertex 26.5177 8.00618 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.0719 15.3289 60
+      vertex 26.5963 16.8785 60
+      vertex 26.053 17.7056 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.6377 10.6702 60
+      vertex 25.7548 10.1971 60
+      vertex 26.1592 9.10961 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.4098 16.2817 60
+      vertex 26.053 17.7056 60
+      vertex 25.484 18.5152 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.9093 12.5102 60
+      vertex 25.3052 11.2666 60
+      vertex 25.7548 10.1971 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.4098 16.2817 60
+      vertex 25.484 18.5152 60
+      vertex 24.8899 19.3066 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.5021 13.412 60
+      vertex 24.8112 12.3164 60
+      vertex 25.3052 11.2666 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.0667 14.3007 60
+      vertex 24.2737 13.3446 60
+      vertex 24.8112 12.3164 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.7083 17.2058 60
+      vertex 24.8899 19.3066 60
+      vertex 24.2712 20.0789 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.1134 16.0348 60
+      vertex 23.6936 14.3493 60
+      vertex 24.2737 13.3446 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.9688 18.0998 60
+      vertex 24.2712 20.0789 60
+      vertex 23.6285 20.8313 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.5963 16.8785 60
+      vertex 23.0719 15.3289 60
+      vertex 23.6936 14.3493 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1924 18.962 60
+      vertex 23.6285 20.8313 60
+      vertex 22.9625 21.5632 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.053 17.7056 60
+      vertex 22.4098 16.2817 60
+      vertex 23.0719 15.3289 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1924 18.962 60
+      vertex 22.9625 21.5632 60
+      vertex 22.2739 22.2739 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8899 19.3066 60
+      vertex 21.7083 17.2058 60
+      vertex 22.4098 16.2817 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3807 19.7909 60
+      vertex 22.2739 22.2739 60
+      vertex 21.5632 22.9625 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.2712 20.0789 60
+      vertex 20.9688 18.0998 60
+      vertex 21.7083 17.2058 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5349 20.5851 60
+      vertex 21.5632 22.9625 60
+      vertex 20.8313 23.6285 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.6285 20.8313 60
+      vertex 20.1924 18.962 60
+      vertex 20.9688 18.0998 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6566 21.3432 60
+      vertex 20.8313 23.6285 60
+      vertex 20.0789 24.2712 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.2739 22.2739 60
+      vertex 19.3807 19.7909 60
+      vertex 20.1924 18.962 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6566 21.3432 60
+      vertex 20.0789 24.2712 60
+      vertex 19.3066 24.8899 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5632 22.9625 60
+      vertex 18.5349 20.5851 60
+      vertex 19.3807 19.7909 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.7474 22.0639 60
+      vertex 19.3066 24.8899 60
+      vertex 18.5152 25.484 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.8088 22.7458 60
+      vertex 18.5152 25.484 60
+      vertex 17.7056 26.053 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8313 23.6285 60
+      vertex 17.6566 21.3432 60
+      vertex 18.5349 20.5851 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8424 23.3879 60
+      vertex 17.7056 26.053 60
+      vertex 16.8785 26.5963 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3066 24.8899 60
+      vertex 16.7474 22.0639 60
+      vertex 17.6566 21.3432 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8424 23.3879 60
+      vertex 16.8785 26.5963 60
+      vertex 16.0348 27.1134 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5152 25.484 60
+      vertex 15.8088 22.7458 60
+      vertex 16.7474 22.0639 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.85 23.9889 60
+      vertex 16.0348 27.1134 60
+      vertex 15.1752 27.6037 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.7056 26.053 60
+      vertex 14.8424 23.3879 60
+      vertex 15.8088 22.7458 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.8333 24.5478 60
+      vertex 15.1752 27.6037 60
+      vertex 14.3007 28.0667 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0348 27.1134 60
+      vertex 13.85 23.9889 60
+      vertex 14.8424 23.3879 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7941 25.0637 60
+      vertex 14.3007 28.0667 60
+      vertex 13.412 28.5021 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.1752 27.6037 60
+      vertex 12.8333 24.5478 60
+      vertex 13.85 23.9889 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7941 25.0637 60
+      vertex 13.412 28.5021 60
+      vertex 12.5102 28.9093 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.3007 28.0667 60
+      vertex 11.7941 25.0637 60
+      vertex 12.8333 24.5478 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.7342 25.5356 60
+      vertex 12.5102 28.9093 60
+      vertex 11.5959 29.288 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.5102 28.9093 60
+      vertex 10.7342 25.5356 60
+      vertex 11.7941 25.0637 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.65545 25.9627 60
+      vertex 11.5959 29.288 60
+      vertex 10.6702 29.6377 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.55977 26.3443 60
+      vertex 10.6702 29.6377 60
+      vertex 9.73403 29.9583 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5959 29.288 60
+      vertex 9.65545 25.9627 60
+      vertex 10.7342 25.5356 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.55977 26.3443 60
+      vertex 9.73403 29.9583 60
+      vertex 8.78822 30.2493 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.6702 29.6377 60
+      vertex 8.55977 26.3443 60
+      vertex 9.65545 25.9627 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.44908 26.6796 60
+      vertex 8.78822 30.2493 60
+      vertex 7.83373 30.5104 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.78822 30.2493 60
+      vertex 7.44908 26.6796 60
+      vertex 8.55977 26.3443 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.32532 26.9681 60
+      vertex 7.83373 30.5104 60
+      vertex 6.87151 30.7414 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.83373 30.5104 60
+      vertex 6.32532 26.9681 60
+      vertex 7.44908 26.6796 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.19046 27.2094 60
+      vertex 6.87151 30.7414 60
+      vertex 5.90251 30.942 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.87151 30.7414 60
+      vertex 5.19046 27.2094 60
+      vertex 6.32532 26.9681 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.92768 31.1122 60
+      vertex 5.19046 27.2094 60
+      vertex 5.90251 30.942 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.92768 31.1122 60
+      vertex 4.0465 27.4028 60
+      vertex 5.19046 27.2094 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.948 31.2516 60
+      vertex 4.0465 27.4028 60
+      vertex 4.92768 31.1122 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.89544 27.5483 60
+      vertex 3.948 31.2516 60
+      vertex 2.96441 31.3602 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.948 31.2516 60
+      vertex 2.89544 27.5483 60
+      vertex 4.0465 27.4028 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.7393 27.6453 60
+      vertex 2.96441 31.3602 60
+      vertex 1.9779 31.4378 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.96441 31.3602 60
+      vertex 1.7393 27.6453 60
+      vertex 2.89544 27.5483 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.989438 31.4845 60
+      vertex 1.7393 27.6453 60
+      vertex 1.9779 31.4378 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.989438 31.4845 60
+      vertex 0.580105 27.6939 60
+      vertex 1.7393 27.6453 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 31.5 60
+      vertex 0.580105 27.6939 60
+      vertex 0.989438 31.4845 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 31.5 60
+      vertex -0.580105 27.6939 60
+      vertex 0.580105 27.6939 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.989438 31.4845 60
+      vertex -0.580105 27.6939 60
+      vertex 0 31.5 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.989438 31.4845 60
+      vertex -1.7393 27.6453 60
+      vertex -0.580105 27.6939 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.9779 31.4378 60
+      vertex -1.7393 27.6453 60
+      vertex -0.989438 31.4845 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.96441 31.3602 60
+      vertex -1.7393 27.6453 60
+      vertex -1.9779 31.4378 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.7393 27.6453 60
+      vertex -2.96441 31.3602 60
+      vertex -2.89544 27.5483 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3.948 31.2516 60
+      vertex -2.89544 27.5483 60
+      vertex -2.96441 31.3602 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.948 31.2516 60
+      vertex -4.0465 27.4028 60
+      vertex -2.89544 27.5483 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -4.92768 31.1122 60
+      vertex -4.0465 27.4028 60
+      vertex -3.948 31.2516 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.92768 31.1122 60
+      vertex -5.19046 27.2094 60
+      vertex -4.0465 27.4028 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.90251 30.942 60
+      vertex -5.19046 27.2094 60
+      vertex -4.92768 31.1122 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -6.87151 30.7414 60
+      vertex -5.19046 27.2094 60
+      vertex -5.90251 30.942 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.19046 27.2094 60
+      vertex -6.87151 30.7414 60
+      vertex -6.32532 26.9681 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -7.83373 30.5104 60
+      vertex -6.32532 26.9681 60
+      vertex -6.87151 30.7414 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.32532 26.9681 60
+      vertex -7.83373 30.5104 60
+      vertex -7.44908 26.6796 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -8.78822 30.2493 60
+      vertex -7.44908 26.6796 60
+      vertex -7.83373 30.5104 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.44908 26.6796 60
+      vertex -8.78822 30.2493 60
+      vertex -8.55977 26.3443 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.73403 29.9583 60
+      vertex -8.55977 26.3443 60
+      vertex -8.78822 30.2493 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.6702 29.6377 60
+      vertex -8.55977 26.3443 60
+      vertex -9.73403 29.9583 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.55977 26.3443 60
+      vertex -10.6702 29.6377 60
+      vertex -9.65545 25.9627 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.5959 29.288 60
+      vertex -9.65545 25.9627 60
+      vertex -10.6702 29.6377 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.65545 25.9627 60
+      vertex -11.5959 29.288 60
+      vertex -10.7342 25.5356 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.5102 28.9093 60
+      vertex -10.7342 25.5356 60
+      vertex -11.5959 29.288 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.7342 25.5356 60
+      vertex -12.5102 28.9093 60
+      vertex -11.7941 25.0637 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.412 28.5021 60
+      vertex -11.7941 25.0637 60
+      vertex -12.5102 28.9093 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.3007 28.0667 60
+      vertex -11.7941 25.0637 60
+      vertex -13.412 28.5021 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7941 25.0637 60
+      vertex -14.3007 28.0667 60
+      vertex -12.8333 24.5478 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.1752 27.6037 60
+      vertex -12.8333 24.5478 60
+      vertex -14.3007 28.0667 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.8333 24.5478 60
+      vertex -15.1752 27.6037 60
+      vertex -13.85 23.9889 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.0348 27.1134 60
+      vertex -13.85 23.9889 60
+      vertex -15.1752 27.6037 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.85 23.9889 60
+      vertex -16.0348 27.1134 60
+      vertex -14.8424 23.3879 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.8785 26.5963 60
+      vertex -14.8424 23.3879 60
+      vertex -16.0348 27.1134 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.7056 26.053 60
+      vertex -14.8424 23.3879 60
+      vertex -16.8785 26.5963 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8424 23.3879 60
+      vertex -17.7056 26.053 60
+      vertex -15.8088 22.7458 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.5152 25.484 60
+      vertex -15.8088 22.7458 60
+      vertex -17.7056 26.053 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.8088 22.7458 60
+      vertex -18.5152 25.484 60
+      vertex -16.7474 22.0639 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.3066 24.8899 60
+      vertex -16.7474 22.0639 60
+      vertex -18.5152 25.484 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.7474 22.0639 60
+      vertex -19.3066 24.8899 60
+      vertex -17.6566 21.3432 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.0789 24.2712 60
+      vertex -17.6566 21.3432 60
+      vertex -19.3066 24.8899 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.8313 23.6285 60
+      vertex -17.6566 21.3432 60
+      vertex -20.0789 24.2712 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6566 21.3432 60
+      vertex -20.8313 23.6285 60
+      vertex -18.5349 20.5851 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.5632 22.9625 60
+      vertex -18.5349 20.5851 60
+      vertex -20.8313 23.6285 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5349 20.5851 60
+      vertex -21.5632 22.9625 60
+      vertex -19.3807 19.7909 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.2739 22.2739 60
+      vertex -19.3807 19.7909 60
+      vertex -21.5632 22.9625 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3807 19.7909 60
+      vertex -22.2739 22.2739 60
+      vertex -20.1924 18.962 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.9625 21.5632 60
+      vertex -20.1924 18.962 60
+      vertex -22.2739 22.2739 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.6285 20.8313 60
+      vertex -20.1924 18.962 60
+      vertex -22.9625 21.5632 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1924 18.962 60
+      vertex -23.6285 20.8313 60
+      vertex -20.9688 18.0998 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.2712 20.0789 60
+      vertex -20.9688 18.0998 60
+      vertex -23.6285 20.8313 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.9688 18.0998 60
+      vertex -24.2712 20.0789 60
+      vertex -21.7083 17.2058 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.8899 19.3066 60
+      vertex -21.7083 17.2058 60
+      vertex -24.2712 20.0789 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.7083 17.2058 60
+      vertex -24.8899 19.3066 60
+      vertex -22.4098 16.2817 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -25.484 18.5152 60
+      vertex -22.4098 16.2817 60
+      vertex -24.8899 19.3066 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -26.053 17.7056 60
+      vertex -22.4098 16.2817 60
+      vertex -25.484 18.5152 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.4098 16.2817 60
+      vertex -26.053 17.7056 60
+      vertex -23.0719 15.3289 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -26.5963 16.8785 60
+      vertex -23.0719 15.3289 60
+      vertex -26.053 17.7056 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0719 15.3289 60
+      vertex -26.5963 16.8785 60
+      vertex -23.6936 14.3493 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.1134 16.0348 60
+      vertex -23.6936 14.3493 60
+      vertex -26.5963 16.8785 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.6936 14.3493 60
+      vertex -27.1134 16.0348 60
+      vertex -24.2737 13.3446 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.6037 15.1752 60
+      vertex -24.2737 13.3446 60
+      vertex -27.1134 16.0348 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.0667 14.3007 60
+      vertex -24.2737 13.3446 60
+      vertex -27.6037 15.1752 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.2737 13.3446 60
+      vertex -28.0667 14.3007 60
+      vertex -24.8112 12.3164 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.5021 13.412 60
+      vertex -24.8112 12.3164 60
+      vertex -28.0667 14.3007 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8112 12.3164 60
+      vertex -28.5021 13.412 60
+      vertex -25.3052 11.2666 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.9093 12.5102 60
+      vertex -25.3052 11.2666 60
+      vertex -28.5021 13.412 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3052 11.2666 60
+      vertex -28.9093 12.5102 60
+      vertex -25.7548 10.1971 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -29.288 11.5959 60
+      vertex -25.7548 10.1971 60
+      vertex -28.9093 12.5102 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -29.6377 10.6702 60
+      vertex -25.7548 10.1971 60
+      vertex -29.288 11.5959 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.7548 10.1971 60
+      vertex -29.6377 10.6702 60
+      vertex -26.1592 9.10961 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -29.9583 9.73403 60
+      vertex -26.1592 9.10961 60
+      vertex -29.6377 10.6702 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1592 9.10961 60
+      vertex -29.9583 9.73403 60
+      vertex -26.5177 8.00618 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.2493 8.78822 60
+      vertex -26.5177 8.00618 60
+      vertex -29.9583 9.73403 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.5177 8.00618 60
+      vertex -30.2493 8.78822 60
+      vertex -26.8298 6.88871 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.5177 -8.00618 60
+      vertex 30.2493 -8.78822 60
+      vertex 26.8298 -6.88871 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.2493 -8.78822 60
+      vertex 26.5177 -8.00618 60
+      vertex 29.9583 -9.73403 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.1592 -9.10961 60
+      vertex 29.9583 -9.73403 60
+      vertex 26.5177 -8.00618 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.9583 -9.73403 60
+      vertex 26.1592 -9.10961 60
+      vertex 29.6377 -10.6702 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.7548 -10.1971 60
+      vertex 29.6377 -10.6702 60
+      vertex 26.1592 -9.10961 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.6377 -10.6702 60
+      vertex 25.7548 -10.1971 60
+      vertex 29.288 -11.5959 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.288 -11.5959 60
+      vertex 25.7548 -10.1971 60
+      vertex 28.9093 -12.5102 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.3052 -11.2666 60
+      vertex 28.9093 -12.5102 60
+      vertex 25.7548 -10.1971 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.9093 -12.5102 60
+      vertex 25.3052 -11.2666 60
+      vertex 28.5021 -13.412 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.8112 -12.3164 60
+      vertex 28.5021 -13.412 60
+      vertex 25.3052 -11.2666 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.5021 -13.412 60
+      vertex 24.8112 -12.3164 60
+      vertex 28.0667 -14.3007 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.2737 -13.3446 60
+      vertex 28.0667 -14.3007 60
+      vertex 24.8112 -12.3164 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.0667 -14.3007 60
+      vertex 24.2737 -13.3446 60
+      vertex 27.6037 -15.1752 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.6037 -15.1752 60
+      vertex 24.2737 -13.3446 60
+      vertex 27.1134 -16.0348 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.6936 -14.3493 60
+      vertex 27.1134 -16.0348 60
+      vertex 24.2737 -13.3446 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.1134 -16.0348 60
+      vertex 23.6936 -14.3493 60
+      vertex 26.5963 -16.8785 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.0719 -15.3289 60
+      vertex 26.5963 -16.8785 60
+      vertex 23.6936 -14.3493 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.5963 -16.8785 60
+      vertex 23.0719 -15.3289 60
+      vertex 26.053 -17.7056 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.4098 -16.2817 60
+      vertex 26.053 -17.7056 60
+      vertex 23.0719 -15.3289 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.053 -17.7056 60
+      vertex 22.4098 -16.2817 60
+      vertex 25.484 -18.5152 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.484 -18.5152 60
+      vertex 22.4098 -16.2817 60
+      vertex 24.8899 -19.3066 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.7083 -17.2058 60
+      vertex 24.8899 -19.3066 60
+      vertex 22.4098 -16.2817 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8899 -19.3066 60
+      vertex 21.7083 -17.2058 60
+      vertex 24.2712 -20.0789 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.9688 -18.0998 60
+      vertex 24.2712 -20.0789 60
+      vertex 21.7083 -17.2058 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.2712 -20.0789 60
+      vertex 20.9688 -18.0998 60
+      vertex 23.6285 -20.8313 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.1924 -18.962 60
+      vertex 23.6285 -20.8313 60
+      vertex 20.9688 -18.0998 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.6285 -20.8313 60
+      vertex 20.1924 -18.962 60
+      vertex 22.9625 -21.5632 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.9625 -21.5632 60
+      vertex 20.1924 -18.962 60
+      vertex 22.2739 -22.2739 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.3807 -19.7909 60
+      vertex 22.2739 -22.2739 60
+      vertex 20.1924 -18.962 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.2739 -22.2739 60
+      vertex 19.3807 -19.7909 60
+      vertex 21.5632 -22.9625 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.5349 -20.5851 60
+      vertex 21.5632 -22.9625 60
+      vertex 19.3807 -19.7909 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.5632 -22.9625 60
+      vertex 18.5349 -20.5851 60
+      vertex 20.8313 -23.6285 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.6566 -21.3432 60
+      vertex 20.8313 -23.6285 60
+      vertex 18.5349 -20.5851 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8313 -23.6285 60
+      vertex 17.6566 -21.3432 60
+      vertex 20.0789 -24.2712 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.0789 -24.2712 60
+      vertex 17.6566 -21.3432 60
+      vertex 19.3066 -24.8899 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.7474 -22.0639 60
+      vertex 19.3066 -24.8899 60
+      vertex 17.6566 -21.3432 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3066 -24.8899 60
+      vertex 16.7474 -22.0639 60
+      vertex 18.5152 -25.484 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.8088 -22.7458 60
+      vertex 18.5152 -25.484 60
+      vertex 16.7474 -22.0639 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5152 -25.484 60
+      vertex 15.8088 -22.7458 60
+      vertex 17.7056 -26.053 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.8424 -23.3879 60
+      vertex 17.7056 -26.053 60
+      vertex 15.8088 -22.7458 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.7056 -26.053 60
+      vertex 14.8424 -23.3879 60
+      vertex 16.8785 -26.5963 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.8785 -26.5963 60
+      vertex 14.8424 -23.3879 60
+      vertex 16.0348 -27.1134 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.85 -23.9889 60
+      vertex 16.0348 -27.1134 60
+      vertex 14.8424 -23.3879 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0348 -27.1134 60
+      vertex 13.85 -23.9889 60
+      vertex 15.1752 -27.6037 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.8333 -24.5478 60
+      vertex 15.1752 -27.6037 60
+      vertex 13.85 -23.9889 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.1752 -27.6037 60
+      vertex 12.8333 -24.5478 60
+      vertex 14.3007 -28.0667 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.7941 -25.0637 60
+      vertex 14.3007 -28.0667 60
+      vertex 12.8333 -24.5478 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.3007 -28.0667 60
+      vertex 11.7941 -25.0637 60
+      vertex 13.412 -28.5021 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.412 -28.5021 60
+      vertex 11.7941 -25.0637 60
+      vertex 12.5102 -28.9093 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.7342 -25.5356 60
+      vertex 12.5102 -28.9093 60
+      vertex 11.7941 -25.0637 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.5102 -28.9093 60
+      vertex 10.7342 -25.5356 60
+      vertex 11.5959 -29.288 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.65545 -25.9627 60
+      vertex 11.5959 -29.288 60
+      vertex 10.7342 -25.5356 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5959 -29.288 60
+      vertex 9.65545 -25.9627 60
+      vertex 10.6702 -29.6377 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 8.55977 -26.3443 60
+      vertex 10.6702 -29.6377 60
+      vertex 9.65545 -25.9627 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.6702 -29.6377 60
+      vertex 8.55977 -26.3443 60
+      vertex 9.73403 -29.9583 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.73403 -29.9583 60
+      vertex 8.55977 -26.3443 60
+      vertex 8.78822 -30.2493 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 7.44908 -26.6796 60
+      vertex 8.78822 -30.2493 60
+      vertex 8.55977 -26.3443 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.78822 -30.2493 60
+      vertex 7.44908 -26.6796 60
+      vertex 7.83373 -30.5104 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 6.32532 -26.9681 60
+      vertex 7.83373 -30.5104 60
+      vertex 7.44908 -26.6796 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.83373 -30.5104 60
+      vertex 6.32532 -26.9681 60
+      vertex 6.87151 -30.7414 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.19046 -27.2094 60
+      vertex 6.87151 -30.7414 60
+      vertex 6.32532 -26.9681 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.87151 -30.7414 60
+      vertex 5.19046 -27.2094 60
+      vertex 5.90251 -30.942 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.19046 -27.2094 60
+      vertex 4.92768 -31.1122 60
+      vertex 5.90251 -30.942 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.0465 -27.4028 60
+      vertex 4.92768 -31.1122 60
+      vertex 5.19046 -27.2094 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.0465 -27.4028 60
+      vertex 3.948 -31.2516 60
+      vertex 4.92768 -31.1122 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.89544 -27.5483 60
+      vertex 3.948 -31.2516 60
+      vertex 4.0465 -27.4028 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.948 -31.2516 60
+      vertex 2.89544 -27.5483 60
+      vertex 2.96441 -31.3602 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.7393 -27.6453 60
+      vertex 2.96441 -31.3602 60
+      vertex 2.89544 -27.5483 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.96441 -31.3602 60
+      vertex 1.7393 -27.6453 60
+      vertex 1.9779 -31.4378 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.7393 -27.6453 60
+      vertex 0.989438 -31.4845 60
+      vertex 1.9779 -31.4378 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.580105 -27.6939 60
+      vertex 0.989438 -31.4845 60
+      vertex 1.7393 -27.6453 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.580105 -27.6939 60
+      vertex 0 -31.5 60
+      vertex 0.989438 -31.4845 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.580105 -27.6939 60
+      vertex 0 -31.5 60
+      vertex 0.580105 -27.6939 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.580105 -27.6939 60
+      vertex -0.989438 -31.4845 60
+      vertex 0 -31.5 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.7393 -27.6453 60
+      vertex -0.989438 -31.4845 60
+      vertex -0.580105 -27.6939 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.7393 -27.6453 60
+      vertex -1.9779 -31.4378 60
+      vertex -0.989438 -31.4845 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.96441 -31.3602 60
+      vertex -1.7393 -27.6453 60
+      vertex -2.89544 -27.5483 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.7393 -27.6453 60
+      vertex -2.96441 -31.3602 60
+      vertex -1.9779 -31.4378 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.89544 -27.5483 60
+      vertex -3.948 -31.2516 60
+      vertex -2.96441 -31.3602 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.0465 -27.4028 60
+      vertex -3.948 -31.2516 60
+      vertex -2.89544 -27.5483 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.0465 -27.4028 60
+      vertex -4.92768 -31.1122 60
+      vertex -3.948 -31.2516 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.19046 -27.2094 60
+      vertex -4.92768 -31.1122 60
+      vertex -4.0465 -27.4028 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.19046 -27.2094 60
+      vertex -5.90251 -30.942 60
+      vertex -4.92768 -31.1122 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.87151 -30.7414 60
+      vertex -5.19046 -27.2094 60
+      vertex -6.32532 -26.9681 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.19046 -27.2094 60
+      vertex -6.87151 -30.7414 60
+      vertex -5.90251 -30.942 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.83373 -30.5104 60
+      vertex -6.32532 -26.9681 60
+      vertex -7.44908 -26.6796 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.32532 -26.9681 60
+      vertex -7.83373 -30.5104 60
+      vertex -6.87151 -30.7414 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.78822 -30.2493 60
+      vertex -7.44908 -26.6796 60
+      vertex -8.55977 -26.3443 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.44908 -26.6796 60
+      vertex -8.78822 -30.2493 60
+      vertex -7.83373 -30.5104 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.6702 -29.6377 60
+      vertex -8.55977 -26.3443 60
+      vertex -9.65545 -25.9627 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.55977 -26.3443 60
+      vertex -9.73403 -29.9583 60
+      vertex -8.78822 -30.2493 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.55977 -26.3443 60
+      vertex -10.6702 -29.6377 60
+      vertex -9.73403 -29.9583 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5959 -29.288 60
+      vertex -9.65545 -25.9627 60
+      vertex -10.7342 -25.5356 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.65545 -25.9627 60
+      vertex -11.5959 -29.288 60
+      vertex -10.6702 -29.6377 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.5102 -28.9093 60
+      vertex -10.7342 -25.5356 60
+      vertex -11.7941 -25.0637 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.7342 -25.5356 60
+      vertex -12.5102 -28.9093 60
+      vertex -11.5959 -29.288 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.3007 -28.0667 60
+      vertex -11.7941 -25.0637 60
+      vertex -12.8333 -24.5478 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7941 -25.0637 60
+      vertex -13.412 -28.5021 60
+      vertex -12.5102 -28.9093 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.1752 -27.6037 60
+      vertex -12.8333 -24.5478 60
+      vertex -13.85 -23.9889 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7941 -25.0637 60
+      vertex -14.3007 -28.0667 60
+      vertex -13.412 -28.5021 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0348 -27.1134 60
+      vertex -13.85 -23.9889 60
+      vertex -14.8424 -23.3879 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.8333 -24.5478 60
+      vertex -15.1752 -27.6037 60
+      vertex -14.3007 -28.0667 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.7056 -26.053 60
+      vertex -14.8424 -23.3879 60
+      vertex -15.8088 -22.7458 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.85 -23.9889 60
+      vertex -16.0348 -27.1134 60
+      vertex -15.1752 -27.6037 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5152 -25.484 60
+      vertex -15.8088 -22.7458 60
+      vertex -16.7474 -22.0639 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8424 -23.3879 60
+      vertex -16.8785 -26.5963 60
+      vertex -16.0348 -27.1134 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3066 -24.8899 60
+      vertex -16.7474 -22.0639 60
+      vertex -17.6566 -21.3432 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8424 -23.3879 60
+      vertex -17.7056 -26.053 60
+      vertex -16.8785 -26.5963 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.8088 -22.7458 60
+      vertex -18.5152 -25.484 60
+      vertex -17.7056 -26.053 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.8313 -23.6285 60
+      vertex -17.6566 -21.3432 60
+      vertex -18.5349 -20.5851 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.7474 -22.0639 60
+      vertex -19.3066 -24.8899 60
+      vertex -18.5152 -25.484 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.5632 -22.9625 60
+      vertex -18.5349 -20.5851 60
+      vertex -19.3807 -19.7909 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6566 -21.3432 60
+      vertex -20.0789 -24.2712 60
+      vertex -19.3066 -24.8899 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.2739 -22.2739 60
+      vertex -19.3807 -19.7909 60
+      vertex -20.1924 -18.962 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6566 -21.3432 60
+      vertex -20.8313 -23.6285 60
+      vertex -20.0789 -24.2712 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.6285 -20.8313 60
+      vertex -20.1924 -18.962 60
+      vertex -20.9688 -18.0998 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5349 -20.5851 60
+      vertex -21.5632 -22.9625 60
+      vertex -20.8313 -23.6285 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.2712 -20.0789 60
+      vertex -20.9688 -18.0998 60
+      vertex -21.7083 -17.2058 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3807 -19.7909 60
+      vertex -22.2739 -22.2739 60
+      vertex -21.5632 -22.9625 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8899 -19.3066 60
+      vertex -21.7083 -17.2058 60
+      vertex -22.4098 -16.2817 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1924 -18.962 60
+      vertex -22.9625 -21.5632 60
+      vertex -22.2739 -22.2739 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.053 -17.7056 60
+      vertex -22.4098 -16.2817 60
+      vertex -23.0719 -15.3289 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1924 -18.962 60
+      vertex -23.6285 -20.8313 60
+      vertex -22.9625 -21.5632 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.5963 -16.8785 60
+      vertex -23.0719 -15.3289 60
+      vertex -23.6936 -14.3493 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.9688 -18.0998 60
+      vertex -24.2712 -20.0789 60
+      vertex -23.6285 -20.8313 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.1134 -16.0348 60
+      vertex -23.6936 -14.3493 60
+      vertex -24.2737 -13.3446 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.0667 -14.3007 60
+      vertex -24.2737 -13.3446 60
+      vertex -24.8112 -12.3164 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.7083 -17.2058 60
+      vertex -24.8899 -19.3066 60
+      vertex -24.2712 -20.0789 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.5021 -13.412 60
+      vertex -24.8112 -12.3164 60
+      vertex -25.3052 -11.2666 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.4098 -16.2817 60
+      vertex -25.484 -18.5152 60
+      vertex -24.8899 -19.3066 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.9093 -12.5102 60
+      vertex -25.3052 -11.2666 60
+      vertex -25.7548 -10.1971 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.4098 -16.2817 60
+      vertex -26.053 -17.7056 60
+      vertex -25.484 -18.5152 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -29.6377 -10.6702 60
+      vertex -25.7548 -10.1971 60
+      vertex -26.1592 -9.10961 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -29.9583 -9.73403 60
+      vertex -26.1592 -9.10961 60
+      vertex -26.5177 -8.00618 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0719 -15.3289 60
+      vertex -26.5963 -16.8785 60
+      vertex -26.053 -17.7056 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.2493 -8.78822 60
+      vertex -26.5177 -8.00618 60
+      vertex -26.8298 -6.88871 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.7414 -6.87151 60
+      vertex -26.8298 -6.88871 60
+      vertex -27.0947 -5.75915 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.6936 -14.3493 60
+      vertex -27.1134 -16.0348 60
+      vertex -26.5963 -16.8785 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.942 -5.90251 60
+      vertex -27.0947 -5.75915 60
+      vertex -27.3121 -4.61949 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.1122 -4.92768 60
+      vertex -27.3121 -4.61949 60
+      vertex -27.4816 -3.47173 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.3602 -2.96441 60
+      vertex -27.4816 -3.47173 60
+      vertex -27.6029 -2.31788 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.2737 -13.3446 60
+      vertex -27.6037 -15.1752 60
+      vertex -27.1134 -16.0348 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.4378 -1.9779 60
+      vertex -27.6029 -2.31788 60
+      vertex -27.6757 -1.15996 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.4845 -0.989438 60
+      vertex -27.6757 -1.15996 60
+      vertex -27.7 0 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.5104 7.83373 60
+      vertex -26.8298 6.88871 60
+      vertex -30.2493 8.78822 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.2737 -13.3446 60
+      vertex -28.0667 -14.3007 60
+      vertex -27.6037 -15.1752 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.7414 6.87151 60
+      vertex -26.8298 6.88871 60
+      vertex -30.5104 7.83373 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8112 -12.3164 60
+      vertex -28.5021 -13.412 60
+      vertex -28.0667 -14.3007 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8298 6.88871 60
+      vertex -30.7414 6.87151 60
+      vertex -27.0947 5.75915 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3052 -11.2666 60
+      vertex -28.9093 -12.5102 60
+      vertex -28.5021 -13.412 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.942 5.90251 60
+      vertex -27.0947 5.75915 60
+      vertex -30.7414 6.87151 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.7548 -10.1971 60
+      vertex -29.288 -11.5959 60
+      vertex -28.9093 -12.5102 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0947 5.75915 60
+      vertex -30.942 5.90251 60
+      vertex -27.3121 4.61949 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.7548 -10.1971 60
+      vertex -29.6377 -10.6702 60
+      vertex -29.288 -11.5959 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.1122 4.92768 60
+      vertex -27.3121 4.61949 60
+      vertex -30.942 5.90251 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1592 -9.10961 60
+      vertex -29.9583 -9.73403 60
+      vertex -29.6377 -10.6702 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3121 4.61949 60
+      vertex -31.1122 4.92768 60
+      vertex -27.4816 3.47173 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.5177 -8.00618 60
+      vertex -30.2493 -8.78822 60
+      vertex -29.9583 -9.73403 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.2516 3.948 60
+      vertex -27.4816 3.47173 60
+      vertex -31.1122 4.92768 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8298 -6.88871 60
+      vertex -30.5104 -7.83373 60
+      vertex -30.2493 -8.78822 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.3602 2.96441 60
+      vertex -27.4816 3.47173 60
+      vertex -31.2516 3.948 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8298 -6.88871 60
+      vertex -30.7414 -6.87151 60
+      vertex -30.5104 -7.83373 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.4816 3.47173 60
+      vertex -31.3602 2.96441 60
+      vertex -27.6029 2.31788 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0947 -5.75915 60
+      vertex -30.942 -5.90251 60
+      vertex -30.7414 -6.87151 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.4378 1.9779 60
+      vertex -27.6029 2.31788 60
+      vertex -31.3602 2.96441 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3121 -4.61949 60
+      vertex -31.1122 -4.92768 60
+      vertex -30.942 -5.90251 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6029 2.31788 60
+      vertex -31.4378 1.9779 60
+      vertex -27.6757 1.15996 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.4816 -3.47173 60
+      vertex -31.2516 -3.948 60
+      vertex -31.1122 -4.92768 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.4845 0.989438 60
+      vertex -27.6757 1.15996 60
+      vertex -31.4378 1.9779 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.4816 -3.47173 60
+      vertex -31.3602 -2.96441 60
+      vertex -31.2516 -3.948 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6757 1.15996 60
+      vertex -31.4845 0.989438 60
+      vertex -27.7 0 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6029 -2.31788 60
+      vertex -31.4378 -1.9779 60
+      vertex -31.3602 -2.96441 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.5 0 60
+      vertex -27.7 0 60
+      vertex -31.4845 0.989438 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6757 -1.15996 60
+      vertex -31.4845 -0.989438 60
+      vertex -31.4378 -1.9779 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.7 0 60
+      vertex -31.5 0 60
+      vertex -31.4845 -0.989438 60
+    endloop
+  endfacet
+  facet normal -0.625225 -0.780445 0
+    outer loop
+      vertex -20.0789 -24.2712 0
+      vertex -19.3066 -24.8899 60
+      vertex -20.0789 -24.2712 60
+    endloop
+  endfacet
+  facet normal -0.625225 -0.780445 -0
+    outer loop
+      vertex -19.3066 -24.8899 60
+      vertex -20.0789 -24.2712 0
+      vertex -19.3066 -24.8899 0
+    endloop
+  endfacet
+  facet normal 0.48173 0.87632 -0
+    outer loop
+      vertex -12.8333 -24.5478 0
+      vertex -13.85 -23.9889 60
+      vertex -12.8333 -24.5478 60
+    endloop
+  endfacet
+  facet normal 0.48173 0.87632 0
+    outer loop
+      vertex -13.85 -23.9889 60
+      vertex -12.8333 -24.5478 0
+      vertex -13.85 -23.9889 0
+    endloop
+  endfacet
+  facet normal 0.951063 0.308997 0
+    outer loop
+      vertex -26.1592 -9.10961 60
+      vertex -26.5177 -8.00618 0
+      vertex -26.5177 -8.00618 60
+    endloop
+  endfacet
+  facet normal 0.951063 0.308997 0
+    outer loop
+      vertex -26.5177 -8.00618 0
+      vertex -26.1592 -9.10961 60
+      vertex -26.1592 -9.10961 0
+    endloop
+  endfacet
+  facet normal -0.998029 -0.0627475 0
+    outer loop
+      vertex 27.6757 1.15996 0
+      vertex 27.6029 2.31788 60
+      vertex 27.6029 2.31788 0
+    endloop
+  endfacet
+  facet normal -0.998029 -0.0627475 0
+    outer loop
+      vertex 27.6029 2.31788 60
+      vertex 27.6757 1.15996 0
+      vertex 27.6757 1.15996 60
+    endloop
+  endfacet
+  facet normal -0.999781 -0.0209444 0
+    outer loop
+      vertex 27.7 0 0
+      vertex 27.6757 1.15996 60
+      vertex 27.6757 1.15996 0
+    endloop
+  endfacet
+  facet normal -0.999781 -0.0209444 0
+    outer loop
+      vertex 27.6757 1.15996 60
+      vertex 27.7 0 0
+      vertex 27.7 0 60
+    endloop
+  endfacet
+  facet normal -0.99452 -0.10455 0
+    outer loop
+      vertex 27.6029 2.31788 0
+      vertex 27.4816 3.47173 60
+      vertex 27.4816 3.47173 0
+    endloop
+  endfacet
+  facet normal -0.99452 -0.10455 0
+    outer loop
+      vertex 27.4816 3.47173 60
+      vertex 27.6029 2.31788 0
+      vertex 27.6029 2.31788 60
+    endloop
+  endfacet
+  facet normal -0.844317 0.535843 0
+    outer loop
+      vertex 23.0719 -15.3289 0
+      vertex 23.6936 -14.3493 60
+      vertex 23.6936 -14.3493 0
+    endloop
+  endfacet
+  facet normal -0.844317 0.535843 0
+    outer loop
+      vertex 23.6936 -14.3493 60
+      vertex 23.0719 -15.3289 0
+      vertex 23.0719 -15.3289 60
+    endloop
+  endfacet
+  facet normal -0.714481 0.699655 0
+    outer loop
+      vertex 19.3807 -19.7909 0
+      vertex 20.1924 -18.962 60
+      vertex 20.1924 -18.962 0
+    endloop
+  endfacet
+  facet normal -0.714481 0.699655 0
+    outer loop
+      vertex 20.1924 -18.962 60
+      vertex 19.3807 -19.7909 0
+      vertex 19.3807 -19.7909 60
+    endloop
+  endfacet
+  facet normal -0.0836061 0.996499 0
+    outer loop
+      vertex 2.89544 -27.5483 0
+      vertex 1.7393 -27.6453 60
+      vertex 2.89544 -27.5483 60
+    endloop
+  endfacet
+  facet normal -0.0836061 0.996499 0
+    outer loop
+      vertex 1.7393 -27.6453 60
+      vertex 2.89544 -27.5483 0
+      vertex 1.7393 -27.6453 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.580105 27.6939 0
+      vertex 0.580105 27.6939 60
+      vertex -0.580105 27.6939 60
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 0.580105 27.6939 60
+      vertex -0.580105 27.6939 0
+      vertex 0.580105 27.6939 0
+    endloop
+  endfacet
+  facet normal 0.68452 0.728994 -0
+    outer loop
+      vertex -18.5349 -20.5851 0
+      vertex -19.3807 -19.7909 60
+      vertex -18.5349 -20.5851 60
+    endloop
+  endfacet
+  facet normal 0.68452 0.728994 0
+    outer loop
+      vertex -19.3807 -19.7909 60
+      vertex -18.5349 -20.5851 0
+      vertex -19.3807 -19.7909 0
+    endloop
+  endfacet
+  facet normal -0.653407 -0.757007 0
+    outer loop
+      vertex 17.6566 21.3432 0
+      vertex 18.5349 20.5851 60
+      vertex 17.6566 21.3432 60
+    endloop
+  endfacet
+  facet normal -0.653407 -0.757007 -0
+    outer loop
+      vertex 18.5349 20.5851 60
+      vertex 17.6566 21.3432 0
+      vertex 18.5349 20.5851 0
+    endloop
+  endfacet
+  facet normal -0.368119 0.929779 0
+    outer loop
+      vertex 10.7342 -25.5356 0
+      vertex 9.65545 -25.9627 60
+      vertex 10.7342 -25.5356 60
+    endloop
+  endfacet
+  facet normal -0.368119 0.929779 0
+    outer loop
+      vertex 9.65545 -25.9627 60
+      vertex 10.7342 -25.5356 0
+      vertex 9.65545 -25.9627 0
+    endloop
+  endfacet
+  facet normal 0.653407 -0.757007 0
+    outer loop
+      vertex -18.5349 20.5851 0
+      vertex -17.6566 21.3432 60
+      vertex -18.5349 20.5851 60
+    endloop
+  endfacet
+  facet normal 0.653407 -0.757007 0
+    outer loop
+      vertex -17.6566 21.3432 60
+      vertex -18.5349 20.5851 0
+      vertex -17.6566 21.3432 0
+    endloop
+  endfacet
+  facet normal 0.207976 0.978134 -0
+    outer loop
+      vertex -5.19046 -27.2094 0
+      vertex -6.32532 -26.9681 60
+      vertex -5.19046 -27.2094 60
+    endloop
+  endfacet
+  facet normal 0.207976 0.978134 0
+    outer loop
+      vertex -6.32532 -26.9681 60
+      vertex -5.19046 -27.2094 0
+      vertex -6.32532 -26.9681 0
+    endloop
+  endfacet
+  facet normal 0.714481 0.699655 0
+    outer loop
+      vertex -19.3807 -19.7909 60
+      vertex -20.1924 -18.962 0
+      vertex -20.1924 -18.962 60
+    endloop
+  endfacet
+  facet normal 0.714481 0.699655 0
+    outer loop
+      vertex -20.1924 -18.962 0
+      vertex -19.3807 -19.7909 60
+      vertex -19.3807 -19.7909 0
+    endloop
+  endfacet
+  facet normal -0.963141 -0.268997 0
+    outer loop
+      vertex 26.8298 6.88871 0
+      vertex 26.5177 8.00618 60
+      vertex 26.5177 8.00618 0
+    endloop
+  endfacet
+  facet normal -0.963141 -0.268997 0
+    outer loop
+      vertex 26.5177 8.00618 60
+      vertex 26.8298 6.88871 0
+      vertex 26.8298 6.88871 60
+    endloop
+  endfacet
+  facet normal -0.553407 0.832911 0
+    outer loop
+      vertex 15.8088 -22.7458 0
+      vertex 14.8424 -23.3879 60
+      vertex 15.8088 -22.7458 60
+    endloop
+  endfacet
+  facet normal -0.553407 0.832911 0
+    outer loop
+      vertex 14.8424 -23.3879 60
+      vertex 15.8088 -22.7458 0
+      vertex 14.8424 -23.3879 0
+    endloop
+  endfacet
+  facet normal -0.904827 0.42578 0
+    outer loop
+      vertex 24.8112 -12.3164 0
+      vertex 25.3052 -11.2666 60
+      vertex 25.3052 -11.2666 0
+    endloop
+  endfacet
+  facet normal -0.904827 0.42578 0
+    outer loop
+      vertex 25.3052 -11.2666 60
+      vertex 24.8112 -12.3164 0
+      vertex 24.8112 -12.3164 60
+    endloop
+  endfacet
+  facet normal -0.166696 -0.986008 0
+    outer loop
+      vertex 4.0465 27.4028 0
+      vertex 5.19046 27.2094 60
+      vertex 4.0465 27.4028 60
+    endloop
+  endfacet
+  facet normal -0.166696 -0.986008 -0
+    outer loop
+      vertex 5.19046 27.2094 60
+      vertex 4.0465 27.4028 0
+      vertex 5.19046 27.2094 0
+    endloop
+  endfacet
+  facet normal 0.368119 0.929779 -0
+    outer loop
+      vertex -9.65545 -25.9627 0
+      vertex -10.7342 -25.5356 60
+      vertex -9.65545 -25.9627 60
+    endloop
+  endfacet
+  facet normal 0.368119 0.929779 0
+    outer loop
+      vertex -10.7342 -25.5356 60
+      vertex -9.65545 -25.9627 0
+      vertex -10.7342 -25.5356 0
+    endloop
+  endfacet
+  facet normal 0.998029 0.0627475 0
+    outer loop
+      vertex -27.6029 -2.31788 60
+      vertex -27.6757 -1.15996 0
+      vertex -27.6757 -1.15996 60
+    endloop
+  endfacet
+  facet normal 0.998029 0.0627475 0
+    outer loop
+      vertex -27.6757 -1.15996 0
+      vertex -27.6029 -2.31788 60
+      vertex -27.6029 -2.31788 0
+    endloop
+  endfacet
+  facet normal -0.821195 0.570648 0
+    outer loop
+      vertex 22.4098 -16.2817 0
+      vertex 23.0719 -15.3289 60
+      vertex 23.0719 -15.3289 0
+    endloop
+  endfacet
+  facet normal -0.821195 0.570648 0
+    outer loop
+      vertex 23.0719 -15.3289 60
+      vertex 22.4098 -16.2817 0
+      vertex 22.4098 -16.2817 60
+    endloop
+  endfacet
+  facet normal -0.48173 -0.87632 0
+    outer loop
+      vertex 12.8333 24.5478 0
+      vertex 13.85 23.9889 60
+      vertex 12.8333 24.5478 60
+    endloop
+  endfacet
+  facet normal -0.48173 -0.87632 -0
+    outer loop
+      vertex 13.85 23.9889 60
+      vertex 12.8333 24.5478 0
+      vertex 13.85 23.9889 0
+    endloop
+  endfacet
+  facet normal -0.951063 -0.308997 0
+    outer loop
+      vertex 26.5177 8.00618 0
+      vertex 26.1592 9.10961 60
+      vertex 26.1592 9.10961 0
+    endloop
+  endfacet
+  facet normal -0.951063 -0.308997 0
+    outer loop
+      vertex 26.1592 9.10961 60
+      vertex 26.5177 8.00618 0
+      vertex 26.5177 8.00618 60
+    endloop
+  endfacet
+  facet normal 0.125407 0.992105 -0
+    outer loop
+      vertex -2.89544 -27.5483 0
+      vertex -4.0465 -27.4028 60
+      vertex -2.89544 -27.5483 60
+    endloop
+  endfacet
+  facet normal 0.125407 0.992105 0
+    outer loop
+      vertex -4.0465 -27.4028 60
+      vertex -2.89544 -27.5483 0
+      vertex -4.0465 -27.4028 0
+    endloop
+  endfacet
+  facet normal -0.844317 -0.535843 0
+    outer loop
+      vertex 23.6936 14.3493 0
+      vertex 23.0719 15.3289 60
+      vertex 23.0719 15.3289 0
+    endloop
+  endfacet
+  facet normal -0.844317 -0.535843 0
+    outer loop
+      vertex 23.0719 15.3289 60
+      vertex 23.6936 14.3493 0
+      vertex 23.6936 14.3493 60
+    endloop
+  endfacet
+  facet normal 0.99452 0.10455 0
+    outer loop
+      vertex -27.4816 -3.47173 60
+      vertex -27.6029 -2.31788 0
+      vertex -27.6029 -2.31788 60
+    endloop
+  endfacet
+  facet normal 0.99452 0.10455 0
+    outer loop
+      vertex -27.6029 -2.31788 0
+      vertex -27.4816 -3.47173 60
+      vertex -27.4816 -3.47173 0
+    endloop
+  endfacet
+  facet normal 0.821195 0.570648 0
+    outer loop
+      vertex -22.4098 -16.2817 60
+      vertex -23.0719 -15.3289 0
+      vertex -23.0719 -15.3289 60
+    endloop
+  endfacet
+  facet normal 0.821195 0.570648 0
+    outer loop
+      vertex -23.0719 -15.3289 0
+      vertex -22.4098 -16.2817 60
+      vertex -22.4098 -16.2817 0
+    endloop
+  endfacet
+  facet normal -0.406738 -0.913545 0
+    outer loop
+      vertex 10.7342 25.5356 0
+      vertex 11.7941 25.0637 60
+      vertex 10.7342 25.5356 60
+    endloop
+  endfacet
+  facet normal -0.406738 -0.913545 -0
+    outer loop
+      vertex 11.7941 25.0637 60
+      vertex 10.7342 25.5356 0
+      vertex 11.7941 25.0637 0
+    endloop
+  endfacet
+  facet normal -0.998029 0.0627475 0
+    outer loop
+      vertex 27.6029 -2.31788 0
+      vertex 27.6757 -1.15996 60
+      vertex 27.6757 -1.15996 0
+    endloop
+  endfacet
+  facet normal -0.998029 0.0627475 0
+    outer loop
+      vertex 27.6757 -1.15996 60
+      vertex 27.6029 -2.31788 0
+      vertex 27.6029 -2.31788 60
+    endloop
+  endfacet
+  facet normal -0.68452 0.728994 0
+    outer loop
+      vertex 19.3807 -19.7909 0
+      vertex 18.5349 -20.5851 60
+      vertex 19.3807 -19.7909 60
+    endloop
+  endfacet
+  facet normal -0.68452 0.728994 0
+    outer loop
+      vertex 18.5349 -20.5851 60
+      vertex 19.3807 -19.7909 0
+      vertex 18.5349 -20.5851 0
+    endloop
+  endfacet
+  facet normal 0.770548 -0.637382 0
+    outer loop
+      vertex -21.7083 17.2058 60
+      vertex -20.9688 18.0998 0
+      vertex -20.9688 18.0998 60
+    endloop
+  endfacet
+  facet normal 0.770548 -0.637382 0
+    outer loop
+      vertex -20.9688 18.0998 0
+      vertex -21.7083 17.2058 60
+      vertex -21.7083 17.2058 0
+    endloop
+  endfacet
+  facet normal -0.125407 0.992105 0
+    outer loop
+      vertex 4.0465 -27.4028 0
+      vertex 2.89544 -27.5483 60
+      vertex 4.0465 -27.4028 60
+    endloop
+  endfacet
+  facet normal -0.125407 0.992105 0
+    outer loop
+      vertex 2.89544 -27.5483 60
+      vertex 4.0465 -27.4028 0
+      vertex 2.89544 -27.5483 0
+    endloop
+  endfacet
+  facet normal -0.3289 -0.944365 0
+    outer loop
+      vertex 8.55977 26.3443 0
+      vertex 9.65545 25.9627 60
+      vertex 8.55977 26.3443 60
+    endloop
+  endfacet
+  facet normal -0.3289 -0.944365 -0
+    outer loop
+      vertex 9.65545 25.9627 60
+      vertex 8.55977 26.3443 0
+      vertex 9.65545 25.9627 0
+    endloop
+  endfacet
+  facet normal 0.444661 -0.895699 0
+    outer loop
+      vertex -12.8333 24.5478 0
+      vertex -11.7941 25.0637 60
+      vertex -12.8333 24.5478 60
+    endloop
+  endfacet
+  facet normal 0.444661 -0.895699 0
+    outer loop
+      vertex -11.7941 25.0637 60
+      vertex -12.8333 24.5478 0
+      vertex -11.7941 25.0637 0
+    endloop
+  endfacet
+  facet normal -0.518015 -0.855371 0
+    outer loop
+      vertex 13.85 23.9889 0
+      vertex 14.8424 23.3879 60
+      vertex 13.85 23.9889 60
+    endloop
+  endfacet
+  facet normal -0.518015 -0.855371 -0
+    outer loop
+      vertex 14.8424 23.3879 60
+      vertex 13.85 23.9889 0
+      vertex 14.8424 23.3879 0
+    endloop
+  endfacet
+  facet normal 0.48173 -0.87632 0
+    outer loop
+      vertex -13.85 23.9889 0
+      vertex -12.8333 24.5478 60
+      vertex -13.85 23.9889 60
+    endloop
+  endfacet
+  facet normal 0.48173 -0.87632 0
+    outer loop
+      vertex -12.8333 24.5478 60
+      vertex -13.85 23.9889 0
+      vertex -12.8333 24.5478 0
+    endloop
+  endfacet
+  facet normal -0.963141 0.268997 0
+    outer loop
+      vertex 26.5177 -8.00618 0
+      vertex 26.8298 -6.88871 60
+      vertex 26.8298 -6.88871 0
+    endloop
+  endfacet
+  facet normal -0.963141 0.268997 0
+    outer loop
+      vertex 26.8298 -6.88871 60
+      vertex 26.5177 -8.00618 0
+      vertex 26.5177 -8.00618 60
+    endloop
+  endfacet
+  facet normal 0.518015 0.855371 -0
+    outer loop
+      vertex -13.85 -23.9889 0
+      vertex -14.8424 -23.3879 60
+      vertex -13.85 -23.9889 60
+    endloop
+  endfacet
+  facet normal 0.518015 0.855371 0
+    outer loop
+      vertex -14.8424 -23.3879 60
+      vertex -13.85 -23.9889 0
+      vertex -14.8424 -23.3879 0
+    endloop
+  endfacet
+  facet normal -0.866012 -0.500023 0
+    outer loop
+      vertex 24.2737 13.3446 0
+      vertex 23.6936 14.3493 60
+      vertex 23.6936 14.3493 0
+    endloop
+  endfacet
+  facet normal -0.866012 -0.500023 0
+    outer loop
+      vertex 23.6936 14.3493 60
+      vertex 24.2737 13.3446 0
+      vertex 24.2737 13.3446 60
+    endloop
+  endfacet
+  facet normal 0.866012 -0.500023 0
+    outer loop
+      vertex -24.2737 13.3446 60
+      vertex -23.6936 14.3493 0
+      vertex -23.6936 14.3493 60
+    endloop
+  endfacet
+  facet normal 0.866012 -0.500023 0
+    outer loop
+      vertex -23.6936 14.3493 0
+      vertex -24.2737 13.3446 60
+      vertex -24.2737 13.3446 0
+    endloop
+  endfacet
+  facet normal -0.714481 -0.699655 0
+    outer loop
+      vertex 20.1924 18.962 0
+      vertex 19.3807 19.7909 60
+      vertex 19.3807 19.7909 0
+    endloop
+  endfacet
+  facet normal -0.714481 -0.699655 0
+    outer loop
+      vertex 19.3807 19.7909 60
+      vertex 20.1924 18.962 0
+      vertex 20.1924 18.962 60
+    endloop
+  endfacet
+  facet normal -0.207976 -0.978134 0
+    outer loop
+      vertex 5.19046 27.2094 0
+      vertex 6.32532 26.9681 60
+      vertex 5.19046 27.2094 60
+    endloop
+  endfacet
+  facet normal -0.207976 -0.978134 -0
+    outer loop
+      vertex 6.32532 26.9681 60
+      vertex 5.19046 27.2094 0
+      vertex 6.32532 26.9681 0
+    endloop
+  endfacet
+  facet normal -0.0418888 -0.999122 0
+    outer loop
+      vertex 0.580105 27.6939 0
+      vertex 1.7393 27.6453 60
+      vertex 0.580105 27.6939 60
+    endloop
+  endfacet
+  facet normal -0.0418888 -0.999122 -0
+    outer loop
+      vertex 1.7393 27.6453 60
+      vertex 0.580105 27.6939 0
+      vertex 1.7393 27.6453 0
+    endloop
+  endfacet
+  facet normal -0.3289 0.944365 0
+    outer loop
+      vertex 9.65545 -25.9627 0
+      vertex 8.55977 -26.3443 60
+      vertex 9.65545 -25.9627 60
+    endloop
+  endfacet
+  facet normal -0.3289 0.944365 0
+    outer loop
+      vertex 8.55977 -26.3443 60
+      vertex 9.65545 -25.9627 0
+      vertex 8.55977 -26.3443 0
+    endloop
+  endfacet
+  facet normal 0.844317 -0.535843 0
+    outer loop
+      vertex -23.6936 14.3493 60
+      vertex -23.0719 15.3289 0
+      vertex -23.0719 15.3289 60
+    endloop
+  endfacet
+  facet normal 0.844317 -0.535843 0
+    outer loop
+      vertex -23.0719 15.3289 0
+      vertex -23.6936 14.3493 60
+      vertex -23.6936 14.3493 0
+    endloop
+  endfacet
+  facet normal -0.999781 0.0209444 0
+    outer loop
+      vertex 27.6757 -1.15996 0
+      vertex 27.7 0 60
+      vertex 27.7 0 0
+    endloop
+  endfacet
+  facet normal -0.999781 0.0209444 0
+    outer loop
+      vertex 27.7 0 60
+      vertex 27.6757 -1.15996 0
+      vertex 27.6757 -1.15996 60
+    endloop
+  endfacet
+  facet normal 0.518015 -0.855371 0
+    outer loop
+      vertex -14.8424 23.3879 0
+      vertex -13.85 23.9889 60
+      vertex -14.8424 23.3879 60
+    endloop
+  endfacet
+  facet normal 0.518015 -0.855371 0
+    outer loop
+      vertex -13.85 23.9889 60
+      vertex -14.8424 23.3879 0
+      vertex -13.85 23.9889 0
+    endloop
+  endfacet
+  facet normal 0.796501 0.604637 0
+    outer loop
+      vertex -21.7083 -17.2058 60
+      vertex -22.4098 -16.2817 0
+      vertex -22.4098 -16.2817 60
+    endloop
+  endfacet
+  facet normal 0.796501 0.604637 0
+    outer loop
+      vertex -22.4098 -16.2817 0
+      vertex -21.7083 -17.2058 60
+      vertex -21.7083 -17.2058 0
+    endloop
+  endfacet
+  facet normal -0.368119 -0.929779 0
+    outer loop
+      vertex 9.65545 25.9627 0
+      vertex 10.7342 25.5356 60
+      vertex 9.65545 25.9627 60
+    endloop
+  endfacet
+  facet normal -0.368119 -0.929779 -0
+    outer loop
+      vertex 10.7342 25.5356 60
+      vertex 9.65545 25.9627 0
+      vertex 10.7342 25.5356 0
+    endloop
+  endfacet
+  facet normal -0.48173 0.87632 0
+    outer loop
+      vertex 13.85 -23.9889 0
+      vertex 12.8333 -24.5478 60
+      vertex 13.85 -23.9889 60
+    endloop
+  endfacet
+  facet normal -0.48173 0.87632 0
+    outer loop
+      vertex 12.8333 -24.5478 60
+      vertex 13.85 -23.9889 0
+      vertex 12.8333 -24.5478 0
+    endloop
+  endfacet
+  facet normal -0.653407 0.757007 0
+    outer loop
+      vertex 18.5349 -20.5851 0
+      vertex 17.6566 -21.3432 60
+      vertex 18.5349 -20.5851 60
+    endloop
+  endfacet
+  facet normal -0.653407 0.757007 0
+    outer loop
+      vertex 17.6566 -21.3432 60
+      vertex 18.5349 -20.5851 0
+      vertex 17.6566 -21.3432 0
+    endloop
+  endfacet
+  facet normal 0.973586 0.228322 0
+    outer loop
+      vertex -26.8298 -6.88871 60
+      vertex -27.0947 -5.75915 0
+      vertex -27.0947 -5.75915 60
+    endloop
+  endfacet
+  facet normal 0.973586 0.228322 0
+    outer loop
+      vertex -27.0947 -5.75915 0
+      vertex -26.8298 -6.88871 60
+      vertex -26.8298 -6.88871 0
+    endloop
+  endfacet
+  facet normal 0.289003 0.957328 -0
+    outer loop
+      vertex -7.44908 -26.6796 0
+      vertex -8.55977 -26.3443 60
+      vertex -7.44908 -26.6796 60
+    endloop
+  endfacet
+  facet normal 0.289003 0.957328 0
+    outer loop
+      vertex -8.55977 -26.3443 60
+      vertex -7.44908 -26.6796 0
+      vertex -8.55977 -26.3443 0
+    endloop
+  endfacet
+  facet normal -0.444661 -0.895699 0
+    outer loop
+      vertex 11.7941 25.0637 0
+      vertex 12.8333 24.5478 60
+      vertex 11.7941 25.0637 60
+    endloop
+  endfacet
+  facet normal -0.444661 -0.895699 -0
+    outer loop
+      vertex 12.8333 24.5478 60
+      vertex 11.7941 25.0637 0
+      vertex 12.8333 24.5478 0
+    endloop
+  endfacet
+  facet normal -0.289003 0.957328 0
+    outer loop
+      vertex 8.55977 -26.3443 0
+      vertex 7.44908 -26.6796 60
+      vertex 8.55977 -26.3443 60
+    endloop
+  endfacet
+  facet normal -0.289003 0.957328 0
+    outer loop
+      vertex 7.44908 -26.6796 60
+      vertex 8.55977 -26.3443 0
+      vertex 7.44908 -26.6796 0
+    endloop
+  endfacet
+  facet normal -0.0418888 0.999122 0
+    outer loop
+      vertex 1.7393 -27.6453 0
+      vertex 0.580105 -27.6939 60
+      vertex 1.7393 -27.6453 60
+    endloop
+  endfacet
+  facet normal -0.0418888 0.999122 0
+    outer loop
+      vertex 0.580105 -27.6939 60
+      vertex 1.7393 -27.6453 0
+      vertex 0.580105 -27.6939 0
+    endloop
+  endfacet
+  facet normal -0.166696 0.986008 0
+    outer loop
+      vertex 5.19046 -27.2094 0
+      vertex 4.0465 -27.4028 60
+      vertex 5.19046 -27.2094 60
+    endloop
+  endfacet
+  facet normal -0.166696 0.986008 0
+    outer loop
+      vertex 4.0465 -27.4028 60
+      vertex 5.19046 -27.2094 0
+      vertex 4.0465 -27.4028 0
+    endloop
+  endfacet
+  facet normal -0.989271 -0.146094 0
+    outer loop
+      vertex 27.4816 3.47173 0
+      vertex 27.3121 4.61949 60
+      vertex 27.3121 4.61949 0
+    endloop
+  endfacet
+  facet normal -0.989271 -0.146094 0
+    outer loop
+      vertex 27.3121 4.61949 60
+      vertex 27.4816 3.47173 0
+      vertex 27.4816 3.47173 60
+    endloop
+  endfacet
+  facet normal 0.621189 0.783661 -0
+    outer loop
+      vertex -16.7474 -22.0639 0
+      vertex -17.6566 -21.3432 60
+      vertex -16.7474 -22.0639 60
+    endloop
+  endfacet
+  facet normal 0.621189 0.783661 0
+    outer loop
+      vertex -17.6566 -21.3432 60
+      vertex -16.7474 -22.0639 0
+      vertex -17.6566 -21.3432 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 0.580105 -27.6939 0
+      vertex -0.580105 -27.6939 60
+      vertex 0.580105 -27.6939 60
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.580105 -27.6939 60
+      vertex 0.580105 -27.6939 0
+      vertex -0.580105 -27.6939 0
+    endloop
+  endfacet
+  facet normal 0.621189 -0.783661 0
+    outer loop
+      vertex -17.6566 21.3432 0
+      vertex -16.7474 22.0639 60
+      vertex -17.6566 21.3432 60
+    endloop
+  endfacet
+  facet normal 0.621189 -0.783661 0
+    outer loop
+      vertex -16.7474 22.0639 60
+      vertex -17.6566 21.3432 0
+      vertex -16.7474 22.0639 0
+    endloop
+  endfacet
+  facet normal -0.886214 -0.463276 0
+    outer loop
+      vertex 24.8112 12.3164 0
+      vertex 24.2737 13.3446 60
+      vertex 24.2737 13.3446 0
+    endloop
+  endfacet
+  facet normal -0.886214 -0.463276 0
+    outer loop
+      vertex 24.2737 13.3446 60
+      vertex 24.8112 12.3164 0
+      vertex 24.8112 12.3164 60
+    endloop
+  endfacet
+  facet normal -0.770548 0.637382 0
+    outer loop
+      vertex 20.9688 -18.0998 0
+      vertex 21.7083 -17.2058 60
+      vertex 21.7083 -17.2058 0
+    endloop
+  endfacet
+  facet normal -0.770548 0.637382 0
+    outer loop
+      vertex 21.7083 -17.2058 60
+      vertex 20.9688 -18.0998 0
+      vertex 20.9688 -18.0998 60
+    endloop
+  endfacet
+  facet normal 0.0418888 0.999122 -0
+    outer loop
+      vertex -0.580105 -27.6939 0
+      vertex -1.7393 -27.6453 60
+      vertex -0.580105 -27.6939 60
+    endloop
+  endfacet
+  facet normal 0.0418888 0.999122 0
+    outer loop
+      vertex -1.7393 -27.6453 60
+      vertex -0.580105 -27.6939 0
+      vertex -1.7393 -27.6453 0
+    endloop
+  endfacet
+  facet normal -0.621189 -0.783661 0
+    outer loop
+      vertex 16.7474 22.0639 0
+      vertex 17.6566 21.3432 60
+      vertex 16.7474 22.0639 60
+    endloop
+  endfacet
+  facet normal -0.621189 -0.783661 -0
+    outer loop
+      vertex 17.6566 21.3432 60
+      vertex 16.7474 22.0639 0
+      vertex 17.6566 21.3432 0
+    endloop
+  endfacet
+  facet normal -0.904827 -0.42578 0
+    outer loop
+      vertex 25.3052 11.2666 0
+      vertex 24.8112 12.3164 60
+      vertex 24.8112 12.3164 0
+    endloop
+  endfacet
+  facet normal -0.904827 -0.42578 0
+    outer loop
+      vertex 24.8112 12.3164 60
+      vertex 25.3052 11.2666 0
+      vertex 25.3052 11.2666 60
+    endloop
+  endfacet
+  facet normal -0.770548 -0.637382 0
+    outer loop
+      vertex 21.7083 17.2058 0
+      vertex 20.9688 18.0998 60
+      vertex 20.9688 18.0998 0
+    endloop
+  endfacet
+  facet normal -0.770548 -0.637382 0
+    outer loop
+      vertex 20.9688 18.0998 60
+      vertex 21.7083 17.2058 0
+      vertex 21.7083 17.2058 60
+    endloop
+  endfacet
+  facet normal -0.982288 -0.18738 0
+    outer loop
+      vertex 27.3121 4.61949 0
+      vertex 27.0947 5.75915 60
+      vertex 27.0947 5.75915 0
+    endloop
+  endfacet
+  facet normal -0.982288 -0.18738 0
+    outer loop
+      vertex 27.0947 5.75915 60
+      vertex 27.3121 4.61949 0
+      vertex 27.3121 4.61949 60
+    endloop
+  endfacet
+  facet normal -0.973586 -0.228322 0
+    outer loop
+      vertex 27.0947 5.75915 0
+      vertex 26.8298 6.88871 60
+      vertex 26.8298 6.88871 0
+    endloop
+  endfacet
+  facet normal -0.973586 -0.228322 0
+    outer loop
+      vertex 26.8298 6.88871 60
+      vertex 27.0947 5.75915 0
+      vertex 27.0947 5.75915 60
+    endloop
+  endfacet
+  facet normal -0.587767 -0.80903 0
+    outer loop
+      vertex 15.8088 22.7458 0
+      vertex 16.7474 22.0639 60
+      vertex 15.8088 22.7458 60
+    endloop
+  endfacet
+  facet normal -0.587767 -0.80903 -0
+    outer loop
+      vertex 16.7474 22.0639 60
+      vertex 15.8088 22.7458 0
+      vertex 16.7474 22.0639 0
+    endloop
+  endfacet
+  facet normal -0.973586 0.228322 0
+    outer loop
+      vertex 26.8298 -6.88871 0
+      vertex 27.0947 -5.75915 60
+      vertex 27.0947 -5.75915 0
+    endloop
+  endfacet
+  facet normal -0.973586 0.228322 0
+    outer loop
+      vertex 27.0947 -5.75915 60
+      vertex 26.8298 -6.88871 0
+      vertex 26.8298 -6.88871 60
+    endloop
+  endfacet
+  facet normal -0.866012 0.500023 0
+    outer loop
+      vertex 23.6936 -14.3493 0
+      vertex 24.2737 -13.3446 60
+      vertex 24.2737 -13.3446 0
+    endloop
+  endfacet
+  facet normal -0.866012 0.500023 0
+    outer loop
+      vertex 24.2737 -13.3446 60
+      vertex 23.6936 -14.3493 0
+      vertex 23.6936 -14.3493 60
+    endloop
+  endfacet
+  facet normal -0.553407 -0.832911 0
+    outer loop
+      vertex 14.8424 23.3879 0
+      vertex 15.8088 22.7458 60
+      vertex 14.8424 23.3879 60
+    endloop
+  endfacet
+  facet normal -0.553407 -0.832911 -0
+    outer loop
+      vertex 15.8088 22.7458 60
+      vertex 14.8424 23.3879 0
+      vertex 15.8088 22.7458 0
+    endloop
+  endfacet
+  facet normal -0.99452 0.10455 0
+    outer loop
+      vertex 27.4816 -3.47173 0
+      vertex 27.6029 -2.31788 60
+      vertex 27.6029 -2.31788 0
+    endloop
+  endfacet
+  facet normal -0.99452 0.10455 0
+    outer loop
+      vertex 27.6029 -2.31788 60
+      vertex 27.4816 -3.47173 0
+      vertex 27.4816 -3.47173 60
+    endloop
+  endfacet
+  facet normal -0.406738 0.913545 0
+    outer loop
+      vertex 11.7941 -25.0637 0
+      vertex 10.7342 -25.5356 60
+      vertex 11.7941 -25.0637 60
+    endloop
+  endfacet
+  facet normal -0.406738 0.913545 0
+    outer loop
+      vertex 10.7342 -25.5356 60
+      vertex 11.7941 -25.0637 0
+      vertex 10.7342 -25.5356 0
+    endloop
+  endfacet
+  facet normal 0.998029 -0.0627475 0
+    outer loop
+      vertex -27.6757 1.15996 60
+      vertex -27.6029 2.31788 0
+      vertex -27.6029 2.31788 60
+    endloop
+  endfacet
+  facet normal 0.998029 -0.0627475 0
+    outer loop
+      vertex -27.6029 2.31788 0
+      vertex -27.6757 1.15996 60
+      vertex -27.6757 1.15996 0
+    endloop
+  endfacet
+  facet normal -0.989271 0.146094 0
+    outer loop
+      vertex 27.3121 -4.61949 0
+      vertex 27.4816 -3.47173 60
+      vertex 27.4816 -3.47173 0
+    endloop
+  endfacet
+  facet normal -0.989271 0.146094 0
+    outer loop
+      vertex 27.4816 -3.47173 60
+      vertex 27.3121 -4.61949 0
+      vertex 27.3121 -4.61949 60
+    endloop
+  endfacet
+  facet normal 0.0836061 -0.996499 0
+    outer loop
+      vertex -2.89544 27.5483 0
+      vertex -1.7393 27.6453 60
+      vertex -2.89544 27.5483 60
+    endloop
+  endfacet
+  facet normal 0.0836061 -0.996499 0
+    outer loop
+      vertex -1.7393 27.6453 60
+      vertex -2.89544 27.5483 0
+      vertex -1.7393 27.6453 0
+    endloop
+  endfacet
+  facet normal 0.963141 -0.268997 0
+    outer loop
+      vertex -26.8298 6.88871 60
+      vertex -26.5177 8.00618 0
+      vertex -26.5177 8.00618 60
+    endloop
+  endfacet
+  facet normal 0.963141 -0.268997 0
+    outer loop
+      vertex -26.5177 8.00618 0
+      vertex -26.8298 6.88871 60
+      vertex -26.8298 6.88871 0
+    endloop
+  endfacet
+  facet normal 0.444661 0.895699 -0
+    outer loop
+      vertex -11.7941 -25.0637 0
+      vertex -12.8333 -24.5478 60
+      vertex -11.7941 -25.0637 60
+    endloop
+  endfacet
+  facet normal 0.444661 0.895699 0
+    outer loop
+      vertex -12.8333 -24.5478 60
+      vertex -11.7941 -25.0637 0
+      vertex -12.8333 -24.5478 0
+    endloop
+  endfacet
+  facet normal -0.68452 -0.728994 0
+    outer loop
+      vertex 18.5349 20.5851 0
+      vertex 19.3807 19.7909 60
+      vertex 18.5349 20.5851 60
+    endloop
+  endfacet
+  facet normal -0.68452 -0.728994 -0
+    outer loop
+      vertex 19.3807 19.7909 60
+      vertex 18.5349 20.5851 0
+      vertex 19.3807 19.7909 0
+    endloop
+  endfacet
+  facet normal 0.289003 -0.957328 0
+    outer loop
+      vertex -8.55977 26.3443 0
+      vertex -7.44908 26.6796 60
+      vertex -8.55977 26.3443 60
+    endloop
+  endfacet
+  facet normal 0.289003 -0.957328 0
+    outer loop
+      vertex -7.44908 26.6796 60
+      vertex -8.55977 26.3443 0
+      vertex -7.44908 26.6796 0
+    endloop
+  endfacet
+  facet normal 0.166696 -0.986008 0
+    outer loop
+      vertex -5.19046 27.2094 0
+      vertex -4.0465 27.4028 60
+      vertex -5.19046 27.2094 60
+    endloop
+  endfacet
+  facet normal 0.166696 -0.986008 0
+    outer loop
+      vertex -4.0465 27.4028 60
+      vertex -5.19046 27.2094 0
+      vertex -4.0465 27.4028 0
+    endloop
+  endfacet
+  facet normal -0.248664 0.96859 0
+    outer loop
+      vertex 7.44908 -26.6796 0
+      vertex 6.32532 -26.9681 60
+      vertex 7.44908 -26.6796 60
+    endloop
+  endfacet
+  facet normal -0.248664 0.96859 0
+    outer loop
+      vertex 6.32532 -26.9681 60
+      vertex 7.44908 -26.6796 0
+      vertex 6.32532 -26.9681 0
+    endloop
+  endfacet
+  facet normal -0.743114 0.669165 0
+    outer loop
+      vertex 20.1924 -18.962 0
+      vertex 20.9688 -18.0998 60
+      vertex 20.9688 -18.0998 0
+    endloop
+  endfacet
+  facet normal -0.743114 0.669165 0
+    outer loop
+      vertex 20.9688 -18.0998 60
+      vertex 20.1924 -18.962 0
+      vertex 20.1924 -18.962 60
+    endloop
+  endfacet
+  facet normal 0.68452 -0.728994 0
+    outer loop
+      vertex -19.3807 19.7909 0
+      vertex -18.5349 20.5851 60
+      vertex -19.3807 19.7909 60
+    endloop
+  endfacet
+  facet normal 0.68452 -0.728994 0
+    outer loop
+      vertex -18.5349 20.5851 60
+      vertex -19.3807 19.7909 0
+      vertex -18.5349 20.5851 0
+    endloop
+  endfacet
+  facet normal 0.0418888 -0.999122 0
+    outer loop
+      vertex -1.7393 27.6453 0
+      vertex -0.580105 27.6939 60
+      vertex -1.7393 27.6453 60
+    endloop
+  endfacet
+  facet normal 0.0418888 -0.999122 0
+    outer loop
+      vertex -0.580105 27.6939 60
+      vertex -1.7393 27.6453 0
+      vertex -0.580105 27.6939 0
+    endloop
+  endfacet
+  facet normal 0.125407 -0.992105 0
+    outer loop
+      vertex -4.0465 27.4028 0
+      vertex -2.89544 27.5483 60
+      vertex -4.0465 27.4028 60
+    endloop
+  endfacet
+  facet normal 0.125407 -0.992105 0
+    outer loop
+      vertex -2.89544 27.5483 60
+      vertex -4.0465 27.4028 0
+      vertex -2.89544 27.5483 0
+    endloop
+  endfacet
+  facet normal -0.587767 0.80903 0
+    outer loop
+      vertex 16.7474 -22.0639 0
+      vertex 15.8088 -22.7458 60
+      vertex 16.7474 -22.0639 60
+    endloop
+  endfacet
+  facet normal -0.587767 0.80903 0
+    outer loop
+      vertex 15.8088 -22.7458 60
+      vertex 16.7474 -22.0639 0
+      vertex 15.8088 -22.7458 0
+    endloop
+  endfacet
+  facet normal 0.973586 -0.228322 0
+    outer loop
+      vertex -27.0947 5.75915 60
+      vertex -26.8298 6.88871 0
+      vertex -26.8298 6.88871 60
+    endloop
+  endfacet
+  facet normal 0.973586 -0.228322 0
+    outer loop
+      vertex -26.8298 6.88871 0
+      vertex -27.0947 5.75915 60
+      vertex -27.0947 5.75915 0
+    endloop
+  endfacet
+  facet normal 0.921856 0.387533 0
+    outer loop
+      vertex -25.3052 -11.2666 60
+      vertex -25.7548 -10.1971 0
+      vertex -25.7548 -10.1971 60
+    endloop
+  endfacet
+  facet normal 0.921856 0.387533 0
+    outer loop
+      vertex -25.7548 -10.1971 0
+      vertex -25.3052 -11.2666 60
+      vertex -25.3052 -11.2666 0
+    endloop
+  endfacet
+  facet normal 0.937292 0.348546 0
+    outer loop
+      vertex -25.7548 -10.1971 60
+      vertex -26.1592 -9.10961 0
+      vertex -26.1592 -9.10961 60
+    endloop
+  endfacet
+  facet normal 0.937292 0.348546 0
+    outer loop
+      vertex -26.1592 -9.10961 0
+      vertex -25.7548 -10.1971 60
+      vertex -25.7548 -10.1971 0
+    endloop
+  endfacet
+  facet normal 0.989271 0.146094 0
+    outer loop
+      vertex -27.3121 -4.61949 60
+      vertex -27.4816 -3.47173 0
+      vertex -27.4816 -3.47173 60
+    endloop
+  endfacet
+  facet normal 0.989271 0.146094 0
+    outer loop
+      vertex -27.4816 -3.47173 0
+      vertex -27.3121 -4.61949 60
+      vertex -27.3121 -4.61949 0
+    endloop
+  endfacet
+  facet normal 0.982288 0.18738 0
+    outer loop
+      vertex -27.0947 -5.75915 60
+      vertex -27.3121 -4.61949 0
+      vertex -27.3121 -4.61949 60
+    endloop
+  endfacet
+  facet normal 0.982288 0.18738 0
+    outer loop
+      vertex -27.3121 -4.61949 0
+      vertex -27.0947 -5.75915 60
+      vertex -27.0947 -5.75915 0
+    endloop
+  endfacet
+  facet normal 0.937292 -0.348546 0
+    outer loop
+      vertex -26.1592 9.10961 60
+      vertex -25.7548 10.1971 0
+      vertex -25.7548 10.1971 60
+    endloop
+  endfacet
+  facet normal 0.937292 -0.348546 0
+    outer loop
+      vertex -25.7548 10.1971 0
+      vertex -26.1592 9.10961 60
+      vertex -26.1592 9.10961 0
+    endloop
+  endfacet
+  facet normal 0.553407 -0.832911 0
+    outer loop
+      vertex -15.8088 22.7458 0
+      vertex -14.8424 23.3879 60
+      vertex -15.8088 22.7458 60
+    endloop
+  endfacet
+  facet normal 0.553407 -0.832911 0
+    outer loop
+      vertex -14.8424 23.3879 60
+      vertex -15.8088 22.7458 0
+      vertex -14.8424 23.3879 0
+    endloop
+  endfacet
+  facet normal -0.248664 -0.96859 0
+    outer loop
+      vertex 6.32532 26.9681 0
+      vertex 7.44908 26.6796 60
+      vertex 6.32532 26.9681 60
+    endloop
+  endfacet
+  facet normal -0.248664 -0.96859 -0
+    outer loop
+      vertex 7.44908 26.6796 60
+      vertex 6.32532 26.9681 0
+      vertex 7.44908 26.6796 0
+    endloop
+  endfacet
+  facet normal 0.886214 -0.463276 0
+    outer loop
+      vertex -24.8112 12.3164 60
+      vertex -24.2737 13.3446 0
+      vertex -24.2737 13.3446 60
+    endloop
+  endfacet
+  facet normal 0.886214 -0.463276 0
+    outer loop
+      vertex -24.2737 13.3446 0
+      vertex -24.8112 12.3164 60
+      vertex -24.8112 12.3164 0
+    endloop
+  endfacet
+  facet normal -0.921856 -0.387533 0
+    outer loop
+      vertex 25.7548 10.1971 0
+      vertex 25.3052 11.2666 60
+      vertex 25.3052 11.2666 0
+    endloop
+  endfacet
+  facet normal -0.921856 -0.387533 0
+    outer loop
+      vertex 25.3052 11.2666 60
+      vertex 25.7548 10.1971 0
+      vertex 25.7548 10.1971 60
+    endloop
+  endfacet
+  facet normal 0.99452 -0.10455 0
+    outer loop
+      vertex -27.6029 2.31788 60
+      vertex -27.4816 3.47173 0
+      vertex -27.4816 3.47173 60
+    endloop
+  endfacet
+  facet normal 0.99452 -0.10455 0
+    outer loop
+      vertex -27.4816 3.47173 0
+      vertex -27.6029 2.31788 60
+      vertex -27.6029 2.31788 0
+    endloop
+  endfacet
+  facet normal 0.770548 0.637382 0
+    outer loop
+      vertex -20.9688 -18.0998 60
+      vertex -21.7083 -17.2058 0
+      vertex -21.7083 -17.2058 60
+    endloop
+  endfacet
+  facet normal 0.770548 0.637382 0
+    outer loop
+      vertex -21.7083 -17.2058 0
+      vertex -20.9688 -18.0998 60
+      vertex -20.9688 -18.0998 0
+    endloop
+  endfacet
+  facet normal 0.951063 -0.308997 0
+    outer loop
+      vertex -26.5177 8.00618 60
+      vertex -26.1592 9.10961 0
+      vertex -26.1592 9.10961 60
+    endloop
+  endfacet
+  facet normal 0.951063 -0.308997 0
+    outer loop
+      vertex -26.1592 9.10961 0
+      vertex -26.5177 8.00618 60
+      vertex -26.5177 8.00618 0
+    endloop
+  endfacet
+  facet normal 0.999781 -0.0209444 0
+    outer loop
+      vertex -27.7 0 60
+      vertex -27.6757 1.15996 0
+      vertex -27.6757 1.15996 60
+    endloop
+  endfacet
+  facet normal 0.999781 -0.0209444 0
+    outer loop
+      vertex -27.6757 1.15996 0
+      vertex -27.7 0 60
+      vertex -27.7 0 0
+    endloop
+  endfacet
+  facet normal -0.289003 -0.957328 0
+    outer loop
+      vertex 7.44908 26.6796 0
+      vertex 8.55977 26.3443 60
+      vertex 7.44908 26.6796 60
+    endloop
+  endfacet
+  facet normal -0.289003 -0.957328 -0
+    outer loop
+      vertex 8.55977 26.3443 60
+      vertex 7.44908 26.6796 0
+      vertex 8.55977 26.3443 0
+    endloop
+  endfacet
+  facet normal -0.796501 0.604637 0
+    outer loop
+      vertex 21.7083 -17.2058 0
+      vertex 22.4098 -16.2817 60
+      vertex 22.4098 -16.2817 0
+    endloop
+  endfacet
+  facet normal -0.796501 0.604637 0
+    outer loop
+      vertex 22.4098 -16.2817 60
+      vertex 21.7083 -17.2058 0
+      vertex 21.7083 -17.2058 60
+    endloop
+  endfacet
+  facet normal 0.3289 -0.944365 0
+    outer loop
+      vertex -9.65545 25.9627 0
+      vertex -8.55977 26.3443 60
+      vertex -9.65545 25.9627 60
+    endloop
+  endfacet
+  facet normal 0.3289 -0.944365 0
+    outer loop
+      vertex -8.55977 26.3443 60
+      vertex -9.65545 25.9627 0
+      vertex -8.55977 26.3443 0
+    endloop
+  endfacet
+  facet normal 0.587767 -0.80903 0
+    outer loop
+      vertex -16.7474 22.0639 0
+      vertex -15.8088 22.7458 60
+      vertex -16.7474 22.0639 60
+    endloop
+  endfacet
+  facet normal 0.587767 -0.80903 0
+    outer loop
+      vertex -15.8088 22.7458 60
+      vertex -16.7474 22.0639 0
+      vertex -15.8088 22.7458 0
+    endloop
+  endfacet
+  facet normal -0.444661 0.895699 0
+    outer loop
+      vertex 12.8333 -24.5478 0
+      vertex 11.7941 -25.0637 60
+      vertex 12.8333 -24.5478 60
+    endloop
+  endfacet
+  facet normal -0.444661 0.895699 0
+    outer loop
+      vertex 11.7941 -25.0637 60
+      vertex 12.8333 -24.5478 0
+      vertex 11.7941 -25.0637 0
+    endloop
+  endfacet
+  facet normal -0.951063 0.308997 0
+    outer loop
+      vertex 26.1592 -9.10961 0
+      vertex 26.5177 -8.00618 60
+      vertex 26.5177 -8.00618 0
+    endloop
+  endfacet
+  facet normal -0.951063 0.308997 0
+    outer loop
+      vertex 26.5177 -8.00618 60
+      vertex 26.1592 -9.10961 0
+      vertex 26.1592 -9.10961 60
+    endloop
+  endfacet
+  facet normal -0.886214 0.463276 0
+    outer loop
+      vertex 24.2737 -13.3446 0
+      vertex 24.8112 -12.3164 60
+      vertex 24.8112 -12.3164 0
+    endloop
+  endfacet
+  facet normal -0.886214 0.463276 0
+    outer loop
+      vertex 24.8112 -12.3164 60
+      vertex 24.2737 -13.3446 0
+      vertex 24.2737 -13.3446 60
+    endloop
+  endfacet
+  facet normal -0.796501 -0.604637 0
+    outer loop
+      vertex 22.4098 16.2817 0
+      vertex 21.7083 17.2058 60
+      vertex 21.7083 17.2058 0
+    endloop
+  endfacet
+  facet normal -0.796501 -0.604637 0
+    outer loop
+      vertex 21.7083 17.2058 60
+      vertex 22.4098 16.2817 0
+      vertex 22.4098 16.2817 60
+    endloop
+  endfacet
+  facet normal -0.743114 -0.669165 0
+    outer loop
+      vertex 20.9688 18.0998 0
+      vertex 20.1924 18.962 60
+      vertex 20.1924 18.962 0
+    endloop
+  endfacet
+  facet normal -0.743114 -0.669165 0
+    outer loop
+      vertex 20.1924 18.962 60
+      vertex 20.9688 18.0998 0
+      vertex 20.9688 18.0998 60
+    endloop
+  endfacet
+  facet normal -0.621189 0.783661 0
+    outer loop
+      vertex 17.6566 -21.3432 0
+      vertex 16.7474 -22.0639 60
+      vertex 17.6566 -21.3432 60
+    endloop
+  endfacet
+  facet normal -0.621189 0.783661 0
+    outer loop
+      vertex 16.7474 -22.0639 60
+      vertex 17.6566 -21.3432 0
+      vertex 16.7474 -22.0639 0
+    endloop
+  endfacet
+  facet normal 0.904827 0.42578 0
+    outer loop
+      vertex -24.8112 -12.3164 60
+      vertex -25.3052 -11.2666 0
+      vertex -25.3052 -11.2666 60
+    endloop
+  endfacet
+  facet normal 0.904827 0.42578 0
+    outer loop
+      vertex -25.3052 -11.2666 0
+      vertex -24.8112 -12.3164 60
+      vertex -24.8112 -12.3164 0
+    endloop
+  endfacet
+  facet normal 0.368119 -0.929779 0
+    outer loop
+      vertex -10.7342 25.5356 0
+      vertex -9.65545 25.9627 60
+      vertex -10.7342 25.5356 60
+    endloop
+  endfacet
+  facet normal 0.368119 -0.929779 0
+    outer loop
+      vertex -9.65545 25.9627 60
+      vertex -10.7342 25.5356 0
+      vertex -9.65545 25.9627 0
+    endloop
+  endfacet
+  facet normal 0.248664 -0.96859 0
+    outer loop
+      vertex -7.44908 26.6796 0
+      vertex -6.32532 26.9681 60
+      vertex -7.44908 26.6796 60
+    endloop
+  endfacet
+  facet normal 0.248664 -0.96859 0
+    outer loop
+      vertex -6.32532 26.9681 60
+      vertex -7.44908 26.6796 0
+      vertex -6.32532 26.9681 0
+    endloop
+  endfacet
+  facet normal 0.207976 -0.978134 0
+    outer loop
+      vertex -6.32532 26.9681 0
+      vertex -5.19046 27.2094 60
+      vertex -6.32532 26.9681 60
+    endloop
+  endfacet
+  facet normal 0.207976 -0.978134 0
+    outer loop
+      vertex -5.19046 27.2094 60
+      vertex -6.32532 26.9681 0
+      vertex -5.19046 27.2094 0
+    endloop
+  endfacet
+  facet normal 0.982288 -0.18738 0
+    outer loop
+      vertex -27.3121 4.61949 60
+      vertex -27.0947 5.75915 0
+      vertex -27.0947 5.75915 60
+    endloop
+  endfacet
+  facet normal 0.982288 -0.18738 0
+    outer loop
+      vertex -27.0947 5.75915 0
+      vertex -27.3121 4.61949 60
+      vertex -27.3121 4.61949 0
+    endloop
+  endfacet
+  facet normal 0.989271 -0.146094 0
+    outer loop
+      vertex -27.4816 3.47173 60
+      vertex -27.3121 4.61949 0
+      vertex -27.3121 4.61949 60
+    endloop
+  endfacet
+  facet normal 0.989271 -0.146094 0
+    outer loop
+      vertex -27.3121 4.61949 0
+      vertex -27.4816 3.47173 60
+      vertex -27.4816 3.47173 0
+    endloop
+  endfacet
+  facet normal 0.714481 -0.699655 0
+    outer loop
+      vertex -20.1924 18.962 60
+      vertex -19.3807 19.7909 0
+      vertex -19.3807 19.7909 60
+    endloop
+  endfacet
+  facet normal 0.714481 -0.699655 0
+    outer loop
+      vertex -19.3807 19.7909 0
+      vertex -20.1924 18.962 60
+      vertex -20.1924 18.962 0
+    endloop
+  endfacet
+  facet normal 0.553407 0.832911 -0
+    outer loop
+      vertex -14.8424 -23.3879 0
+      vertex -15.8088 -22.7458 60
+      vertex -14.8424 -23.3879 60
+    endloop
+  endfacet
+  facet normal 0.553407 0.832911 0
+    outer loop
+      vertex -15.8088 -22.7458 60
+      vertex -14.8424 -23.3879 0
+      vertex -15.8088 -22.7458 0
+    endloop
+  endfacet
+  facet normal -0.937292 0.348546 0
+    outer loop
+      vertex 25.7548 -10.1971 0
+      vertex 26.1592 -9.10961 60
+      vertex 26.1592 -9.10961 0
+    endloop
+  endfacet
+  facet normal -0.937292 0.348546 0
+    outer loop
+      vertex 26.1592 -9.10961 60
+      vertex 25.7548 -10.1971 0
+      vertex 25.7548 -10.1971 60
+    endloop
+  endfacet
+  facet normal 0.3289 0.944365 -0
+    outer loop
+      vertex -8.55977 -26.3443 0
+      vertex -9.65545 -25.9627 60
+      vertex -8.55977 -26.3443 60
+    endloop
+  endfacet
+  facet normal 0.3289 0.944365 0
+    outer loop
+      vertex -9.65545 -25.9627 60
+      vertex -8.55977 -26.3443 0
+      vertex -9.65545 -25.9627 0
+    endloop
+  endfacet
+  facet normal 0.406738 0.913545 -0
+    outer loop
+      vertex -10.7342 -25.5356 0
+      vertex -11.7941 -25.0637 60
+      vertex -10.7342 -25.5356 60
+    endloop
+  endfacet
+  facet normal 0.406738 0.913545 0
+    outer loop
+      vertex -11.7941 -25.0637 60
+      vertex -10.7342 -25.5356 0
+      vertex -11.7941 -25.0637 0
+    endloop
+  endfacet
+  facet normal -0.518015 0.855371 0
+    outer loop
+      vertex 14.8424 -23.3879 0
+      vertex 13.85 -23.9889 60
+      vertex 14.8424 -23.3879 60
+    endloop
+  endfacet
+  facet normal -0.518015 0.855371 0
+    outer loop
+      vertex 13.85 -23.9889 60
+      vertex 14.8424 -23.3879 0
+      vertex 13.85 -23.9889 0
+    endloop
+  endfacet
+  facet normal -0.982288 0.18738 0
+    outer loop
+      vertex 27.0947 -5.75915 0
+      vertex 27.3121 -4.61949 60
+      vertex 27.3121 -4.61949 0
+    endloop
+  endfacet
+  facet normal -0.982288 0.18738 0
+    outer loop
+      vertex 27.3121 -4.61949 60
+      vertex 27.0947 -5.75915 0
+      vertex 27.0947 -5.75915 60
+    endloop
+  endfacet
+  facet normal -0.921856 0.387533 0
+    outer loop
+      vertex 25.3052 -11.2666 0
+      vertex 25.7548 -10.1971 60
+      vertex 25.7548 -10.1971 0
+    endloop
+  endfacet
+  facet normal -0.921856 0.387533 0
+    outer loop
+      vertex 25.7548 -10.1971 60
+      vertex 25.3052 -11.2666 0
+      vertex 25.3052 -11.2666 60
+    endloop
+  endfacet
+  facet normal 0.921856 -0.387533 0
+    outer loop
+      vertex -25.7548 10.1971 60
+      vertex -25.3052 11.2666 0
+      vertex -25.3052 11.2666 60
+    endloop
+  endfacet
+  facet normal 0.921856 -0.387533 0
+    outer loop
+      vertex -25.3052 11.2666 0
+      vertex -25.7548 10.1971 60
+      vertex -25.7548 10.1971 0
+    endloop
+  endfacet
+  facet normal 0.999781 0.0209444 0
+    outer loop
+      vertex -27.6757 -1.15996 60
+      vertex -27.7 0 0
+      vertex -27.7 0 60
+    endloop
+  endfacet
+  facet normal 0.999781 0.0209444 0
+    outer loop
+      vertex -27.7 0 0
+      vertex -27.6757 -1.15996 60
+      vertex -27.6757 -1.15996 0
+    endloop
+  endfacet
+  facet normal -0.937292 -0.348546 0
+    outer loop
+      vertex 26.1592 9.10961 0
+      vertex 25.7548 10.1971 60
+      vertex 25.7548 10.1971 0
+    endloop
+  endfacet
+  facet normal -0.937292 -0.348546 0
+    outer loop
+      vertex 25.7548 10.1971 60
+      vertex 26.1592 9.10961 0
+      vertex 26.1592 9.10961 60
+    endloop
+  endfacet
+  facet normal 0.587767 0.80903 -0
+    outer loop
+      vertex -15.8088 -22.7458 0
+      vertex -16.7474 -22.0639 60
+      vertex -15.8088 -22.7458 60
+    endloop
+  endfacet
+  facet normal 0.587767 0.80903 0
+    outer loop
+      vertex -16.7474 -22.0639 60
+      vertex -15.8088 -22.7458 0
+      vertex -16.7474 -22.0639 0
+    endloop
+  endfacet
+  facet normal 0.904827 -0.42578 0
+    outer loop
+      vertex -25.3052 11.2666 60
+      vertex -24.8112 12.3164 0
+      vertex -24.8112 12.3164 60
+    endloop
+  endfacet
+  facet normal 0.904827 -0.42578 0
+    outer loop
+      vertex -24.8112 12.3164 0
+      vertex -25.3052 11.2666 60
+      vertex -25.3052 11.2666 0
+    endloop
+  endfacet
+  facet normal -0.821195 -0.570648 0
+    outer loop
+      vertex 23.0719 15.3289 0
+      vertex 22.4098 16.2817 60
+      vertex 22.4098 16.2817 0
+    endloop
+  endfacet
+  facet normal -0.821195 -0.570648 0
+    outer loop
+      vertex 22.4098 16.2817 60
+      vertex 23.0719 15.3289 0
+      vertex 23.0719 15.3289 60
+    endloop
+  endfacet
+  facet normal 0.796501 -0.604637 0
+    outer loop
+      vertex -22.4098 16.2817 60
+      vertex -21.7083 17.2058 0
+      vertex -21.7083 17.2058 60
+    endloop
+  endfacet
+  facet normal 0.796501 -0.604637 0
+    outer loop
+      vertex -21.7083 17.2058 0
+      vertex -22.4098 16.2817 60
+      vertex -22.4098 16.2817 0
+    endloop
+  endfacet
+  facet normal 0.866012 0.500023 0
+    outer loop
+      vertex -23.6936 -14.3493 60
+      vertex -24.2737 -13.3446 0
+      vertex -24.2737 -13.3446 60
+    endloop
+  endfacet
+  facet normal 0.866012 0.500023 0
+    outer loop
+      vertex -24.2737 -13.3446 0
+      vertex -23.6936 -14.3493 60
+      vertex -23.6936 -14.3493 0
+    endloop
+  endfacet
+  facet normal 0.844317 0.535843 0
+    outer loop
+      vertex -23.0719 -15.3289 60
+      vertex -23.6936 -14.3493 0
+      vertex -23.6936 -14.3493 60
+    endloop
+  endfacet
+  facet normal 0.844317 0.535843 0
+    outer loop
+      vertex -23.6936 -14.3493 0
+      vertex -23.0719 -15.3289 60
+      vertex -23.0719 -15.3289 0
+    endloop
+  endfacet
+  facet normal 0.743114 0.669165 0
+    outer loop
+      vertex -20.1924 -18.962 60
+      vertex -20.9688 -18.0998 0
+      vertex -20.9688 -18.0998 60
+    endloop
+  endfacet
+  facet normal 0.743114 0.669165 0
+    outer loop
+      vertex -20.9688 -18.0998 0
+      vertex -20.1924 -18.962 60
+      vertex -20.1924 -18.962 0
+    endloop
+  endfacet
+  facet normal 0.821195 -0.570648 0
+    outer loop
+      vertex -23.0719 15.3289 60
+      vertex -22.4098 16.2817 0
+      vertex -22.4098 16.2817 60
+    endloop
+  endfacet
+  facet normal 0.821195 -0.570648 0
+    outer loop
+      vertex -22.4098 16.2817 0
+      vertex -23.0719 15.3289 60
+      vertex -23.0719 15.3289 0
+    endloop
+  endfacet
+  facet normal -0.207976 0.978134 0
+    outer loop
+      vertex 6.32532 -26.9681 0
+      vertex 5.19046 -27.2094 60
+      vertex 6.32532 -26.9681 60
+    endloop
+  endfacet
+  facet normal -0.207976 0.978134 0
+    outer loop
+      vertex 5.19046 -27.2094 60
+      vertex 6.32532 -26.9681 0
+      vertex 5.19046 -27.2094 0
+    endloop
+  endfacet
+  facet normal 0.248664 0.96859 -0
+    outer loop
+      vertex -6.32532 -26.9681 0
+      vertex -7.44908 -26.6796 60
+      vertex -6.32532 -26.9681 60
+    endloop
+  endfacet
+  facet normal 0.248664 0.96859 0
+    outer loop
+      vertex -7.44908 -26.6796 60
+      vertex -6.32532 -26.9681 0
+      vertex -7.44908 -26.6796 0
+    endloop
+  endfacet
+  facet normal 0.963141 0.268997 0
+    outer loop
+      vertex -26.5177 -8.00618 60
+      vertex -26.8298 -6.88871 0
+      vertex -26.8298 -6.88871 60
+    endloop
+  endfacet
+  facet normal 0.963141 0.268997 0
+    outer loop
+      vertex -26.8298 -6.88871 0
+      vertex -26.5177 -8.00618 60
+      vertex -26.5177 -8.00618 0
+    endloop
+  endfacet
+  facet normal 0.0836061 0.996499 -0
+    outer loop
+      vertex -1.7393 -27.6453 0
+      vertex -2.89544 -27.5483 60
+      vertex -1.7393 -27.6453 60
+    endloop
+  endfacet
+  facet normal 0.0836061 0.996499 0
+    outer loop
+      vertex -2.89544 -27.5483 60
+      vertex -1.7393 -27.6453 0
+      vertex -2.89544 -27.5483 0
+    endloop
+  endfacet
+  facet normal -0.125407 -0.992105 0
+    outer loop
+      vertex 2.89544 27.5483 0
+      vertex 4.0465 27.4028 60
+      vertex 2.89544 27.5483 60
+    endloop
+  endfacet
+  facet normal -0.125407 -0.992105 -0
+    outer loop
+      vertex 4.0465 27.4028 60
+      vertex 2.89544 27.5483 0
+      vertex 4.0465 27.4028 0
+    endloop
+  endfacet
+  facet normal 0.166696 0.986008 -0
+    outer loop
+      vertex -4.0465 -27.4028 0
+      vertex -5.19046 -27.2094 60
+      vertex -4.0465 -27.4028 60
+    endloop
+  endfacet
+  facet normal 0.166696 0.986008 0
+    outer loop
+      vertex -5.19046 -27.2094 60
+      vertex -4.0465 -27.4028 0
+      vertex -5.19046 -27.2094 0
+    endloop
+  endfacet
+  facet normal 0.406738 -0.913545 0
+    outer loop
+      vertex -11.7941 25.0637 0
+      vertex -10.7342 25.5356 60
+      vertex -11.7941 25.0637 60
+    endloop
+  endfacet
+  facet normal 0.406738 -0.913545 0
+    outer loop
+      vertex -10.7342 25.5356 60
+      vertex -11.7941 25.0637 0
+      vertex -10.7342 25.5356 0
+    endloop
+  endfacet
+  facet normal 0.743114 -0.669165 0
+    outer loop
+      vertex -20.9688 18.0998 60
+      vertex -20.1924 18.962 0
+      vertex -20.1924 18.962 60
+    endloop
+  endfacet
+  facet normal 0.743114 -0.669165 0
+    outer loop
+      vertex -20.1924 18.962 0
+      vertex -20.9688 18.0998 60
+      vertex -20.9688 18.0998 0
+    endloop
+  endfacet
+  facet normal -0.0836061 -0.996499 0
+    outer loop
+      vertex 1.7393 27.6453 0
+      vertex 2.89544 27.5483 60
+      vertex 1.7393 27.6453 60
+    endloop
+  endfacet
+  facet normal -0.0836061 -0.996499 -0
+    outer loop
+      vertex 2.89544 27.5483 60
+      vertex 1.7393 27.6453 0
+      vertex 2.89544 27.5483 0
+    endloop
+  endfacet
+  facet normal 0.653407 0.757007 -0
+    outer loop
+      vertex -17.6566 -21.3432 0
+      vertex -18.5349 -20.5851 60
+      vertex -17.6566 -21.3432 60
+    endloop
+  endfacet
+  facet normal 0.653407 0.757007 0
+    outer loop
+      vertex -18.5349 -20.5851 60
+      vertex -17.6566 -21.3432 0
+      vertex -18.5349 -20.5851 0
+    endloop
+  endfacet
+  facet normal 0.886214 0.463276 0
+    outer loop
+      vertex -24.2737 -13.3446 60
+      vertex -24.8112 -12.3164 0
+      vertex -24.8112 -12.3164 60
+    endloop
+  endfacet
+  facet normal 0.886214 0.463276 0
+    outer loop
+      vertex -24.8112 -12.3164 0
+      vertex -24.2737 -13.3446 60
+      vertex -24.2737 -13.3446 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/tests/cad/test_spool_core_sleeve.sh
+++ b/tests/cad/test_spool_core_sleeve.sh
@@ -4,18 +4,25 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
-# Render a known-good preset and check echo'd wall thickness
-PRESET="sunlu55_to63_len60"
-bash "${REPO_ROOT}/scripts/openscad_render_spool_core_sleeve.sh" || true
-PRESET="${PRESET}" bash "${REPO_ROOT}/scripts/openscad_render_spool_core_sleeve.sh"
+# Render known presets and check echo'd wall thicknesses
+for PRESET in sunlu55_to63_len60 sunlu55_to63cyl_len60; do
+    bash "${REPO_ROOT}/scripts/openscad_render_spool_core_sleeve.sh" || true
+    PRESET="${PRESET}" bash "${REPO_ROOT}/scripts/openscad_render_spool_core_sleeve.sh"
 
-LOG="${REPO_ROOT}/stl/spool_core_sleeve/${PRESET}.log"
-STL="${REPO_ROOT}/stl/spool_core_sleeve/${PRESET}.stl"
+    LOG="${REPO_ROOT}/stl/spool_core_sleeve/${PRESET}.log"
+    STL="${REPO_ROOT}/stl/spool_core_sleeve/${PRESET}.stl"
 
-[[ -s "${STL}" ]] || { echo "FAIL: STL missing"; exit 1; }
+    [[ -s "${STL}" ]] || { echo "FAIL: STL missing for ${PRESET}"; exit 1; }
 
-# Expect wall thickness start/end = 4 mm -> 4.5 mm
-grep -E 'Radial wall thickness: +4(\.0+)? +mm -> +4\.5(\.0+)? +mm' "${LOG}" >/dev/null \
-    || { echo "FAIL: unexpected wall thickness (see ${LOG})"; exit 1; }
+    if [[ "${PRESET}" == "sunlu55_to63_len60" ]]; then
+        # Expect wall thickness start/end = 4 mm -> 4.5 mm
+        grep -E 'Radial wall thickness: +4(\.0+)? +mm -> +4\.5(\.0+)? +mm' "${LOG}" >/dev/null \
+            || { echo "FAIL: unexpected wall thickness (see ${LOG})"; exit 1; }
+    else
+        # Expect wall thickness start/end = 4 mm -> 4 mm
+        grep -E 'Radial wall thickness: +4(\.0+)? +mm -> +4(\.0+)? +mm' "${LOG}" >/dev/null \
+            || { echo "FAIL: unexpected wall thickness (see ${LOG})"; exit 1; }
+    fi
+done
 
 echo "All checks passed."


### PR DESCRIPTION
## Summary
- add Sunlu 63 mm cylinder preset and SCAD/STL for wedge removal
- document and test both tapered adapter and removal cylinder

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`
- `tests/cad/test_spool_core_sleeve.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a7ce1ace78832f92a91ee5c37e8c03