### PR TITLE
🐛 : ensure clone_repo creates parent directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ python -m flywheel.agents.scanner
 Reports are written to `reports/`. Each report lists only top-level non-hidden files and
 ignores directories. File names are sorted case-insensitively. Existing paths under the
 scanner's work area are removed before each clone so reports reflect a fresh snapshot.
+Missing parent directories are created automatically when cloning.
 
 ### Viewing the 3D flywheel
 

--- a/flywheel/agents/scanner.py
+++ b/flywheel/agents/scanner.py
@@ -17,8 +17,10 @@ def clone_repo(repo: str, dest: Path) -> None:
     """Clone ``repo`` into ``dest``, overwriting existing paths.
 
     Symlinks are removed without touching their targets.
+    Missing parent directories are created automatically.
     """
 
+    dest.parent.mkdir(parents=True, exist_ok=True)
     if dest.is_symlink():
         dest.unlink()
     elif dest.exists():

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -31,6 +31,17 @@ def test_clone_repo_overwrites_file(monkeypatch, tmp_path):
     assert not dest.exists()
 
 
+def test_clone_repo_creates_parent(monkeypatch, tmp_path):
+    dest = tmp_path / "nested" / "dest"
+
+    def fake_run(cmd, check):
+        assert Path(cmd[-1]).parent.exists()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    scanner.clone_repo("foo/bar", dest)
+    assert dest.parent.exists()
+
+
 def test_clone_repo_preserves_symlink_target(monkeypatch, tmp_path):
     target = tmp_path / "real"
     target.mkdir()


### PR DESCRIPTION
what: create parent dirs before cloning so scanner works with nested paths
why: previously cloning to nested dest failed
how to test: pre-commit run --all-files; pytest -q; npm run test:ci; python -m flywheel.fit; bash scripts/checks.sh
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68a80948b978832fa2cb768562b77928