### PR TITLE
🐛: handle mixed-case GitHub workflow conclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ or skip end-to-end tests by prefixing commands with `SKIP_E2E=1`.
 - DEPENDABOT for automated dependency updates
 - CodeQL workflow for security scanning
 - Style guides for Python and JavaScript
+- README status script handles mixed-case GitHub workflow conclusions
 - Detailed best practice explanations in `docs/best_practices_catalog.md`
 - Dark pattern guidance in `docs/dark-patterns.md`
 - Bright pattern catalog in `docs/bright-patterns.md`

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -23,8 +23,11 @@ def status_to_emoji(conclusion: str | None) -> str:
     """Return an emoji representing the workflow conclusion.
 
     GitHub may mark runs as ``neutral`` or ``skipped`` when no jobs execute.
-    Treat those as successful for status reporting purposes.
+    Treat those as successful for status reporting purposes. The ``conclusion``
+    string is handled case-insensitively.
     """
+    if conclusion is not None:
+        conclusion = conclusion.lower()
     if conclusion in {"success", "neutral", "skipped"}:
         return "✅"
     if conclusion is None:

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -11,6 +11,8 @@ def test_status_to_emoji():
     assert rs.status_to_emoji("skipped") == "✅"
     assert rs.status_to_emoji("failure") == "❌"
     assert rs.status_to_emoji(None) == "❓"
+    assert rs.status_to_emoji("Success") == "✅"
+    assert rs.status_to_emoji("FAILURE") == "❌"
 
 
 def test_fetch_repo_status_success(monkeypatch):


### PR DESCRIPTION
what: ensure repo status handles mixed-case workflow conclusions
why: mixed-case API results were misclassified
how to test:
- pre-commit run --all-files
- pytest -q
- SKIP_E2E=1 npm run test:ci
- python -m flywheel.fit
- SKIP_E2E=1 bash scripts/checks.sh
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a80948b978832fa2cb768562b77928