### PR TITLE
🐛 catch missing SCAD variable values

### DIFF
--- a/flywheel/fit.py
+++ b/flywheel/fit.py
@@ -25,7 +25,8 @@ def parse_scad_vars(path: str | Path) -> Dict[str, float]:
     supports negative values, decimals without a leading zero, trailing
     decimal points, scientific notation, underscore digit separators, and
     multiple assignments on the same line. Raises :class:`ValueError` when a
-    variable assignment lacks a numeric value.
+    variable assignment lacks a numeric value or has an empty right-hand
+    side.
     """
     path = Path(path)
     text = path.read_text()
@@ -47,6 +48,9 @@ def parse_scad_vars(path: str | Path) -> Dict[str, float]:
                 part,
             ):
                 raise ValueError(f"invalid assignment: {part}")
+            elif re.match(r"[a-zA-Z_][a-zA-Z0-9_]*\s*=\s*$", part):
+                name = part.split("=", 1)[0].strip()
+                raise ValueError(f"missing value for {name}")
     return vars
 
 

--- a/tests/test_parse_scad_vars_missing_value.py
+++ b/tests/test_parse_scad_vars_missing_value.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+import pytest
+
+from flywheel.fit import parse_scad_vars
+
+
+def test_parse_scad_vars_errors_on_missing_value(tmp_path: Path) -> None:
+    scad = tmp_path / "bad.scad"
+    scad.write_text("x = ;")
+    with pytest.raises(ValueError):
+        parse_scad_vars(scad)


### PR DESCRIPTION
## Summary
- error on SCAD assignments missing numeric values
- document behavior and add regression test

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a80948b978832fa2cb768562b77928