### PR TITLE
Draft: fix blank prompt-docs-todos with tests

### DIFF
--- a/docs/prompt-docs-todos.md
+++ b/docs/prompt-docs-todos.md
@@ -1,0 +1,6 @@
+# Prompt Docs TODOs
+
+Track outstanding prompt documentation work across repositories. Add rows below as TODOs emerge.
+
+| Repo | Suggested Prompt | Type | Notes |
+|------|-----------------|------|-------|

--- a/outages/2025-08-20-prompt-docs-todos-blank.json
+++ b/outages/2025-08-20-prompt-docs-todos-blank.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-08-20-prompt-docs-todos-blank",
+  "date": "2025-08-20",
+  "component": "docs/prompt-docs-todos",
+  "rootCause": "Commit 35c0d684 cleared the file content without a placeholder",
+  "resolution": "Restored header with guidance and added test to ensure file isn't empty",
+  "references": [
+    "https://github.com/futuroptimist/flywheel/commit/35c0d6843b5d6dddfffc6a7c59e648c30eabec44"
+  ]
+}

--- a/tests/test_prompt_docs_todos_exists.py
+++ b/tests/test_prompt_docs_todos_exists.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+DOC = Path("docs/prompt-docs-todos.md")
+
+
+def test_prompt_docs_todos_has_table_header():
+    lines = DOC.read_text().splitlines()
+    assert lines, "docs/prompt-docs-todos.md should not be empty"
+    assert any(
+        line.startswith("| Repo |") for line in lines
+    ), "missing table header"  # noqa: E501


### PR DESCRIPTION
## Summary
- restore placeholder and table header in docs/prompt-docs-todos.md
- add regression test and outage entry

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci` *(fails: playwright tests interrupted)*
- `python -m flywheel.fit`
- `bash scripts/checks.sh` *(warned: npm unknown env config)*

------
https://chatgpt.com/codex/tasks/task_e_68a808fc3f1c832fab46ebf53db88fe6