### PR TITLE
🐛 fix: validate numeric scad assignments

### DIFF
--- a/docs/pms/2025-08-16-scad-parse.md
+++ b/docs/pms/2025-08-16-scad-parse.md
@@ -10,7 +10,8 @@ Invalid CAD parameters could propagate without notice.
 `parse_scad_vars` failed to validate assignments, skipping non-numeric values.
 
 ## Resolution
-Raise `ValueError` when an assignment lacks a numeric value.
+Raise `ValueError` when an assignment lacks a numeric value or contains
+non-numeric characters after the number.
 
 ## Prevention
 Add fuzz tests to ensure malformed content triggers errors.

--- a/flywheel/fit.py
+++ b/flywheel/fit.py
@@ -51,6 +51,11 @@ def parse_scad_vars(path: str | Path) -> Dict[str, float]:
             elif re.match(r"[a-zA-Z_][a-zA-Z0-9_]*\s*=\s*$", part):
                 name = part.split("=", 1)[0].strip()
                 raise ValueError(f"missing value for {name}")
+            elif re.match(
+                r"[a-zA-Z_][a-zA-Z0-9_]*\s*=\s*[-+]?(?:\d|\.)",
+                part,
+            ):
+                raise ValueError(f"invalid assignment: {part}")
     return vars
 
 

--- a/tests/test_parse_scad_vars_invalid_number.py
+++ b/tests/test_parse_scad_vars_invalid_number.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+import pytest
+
+from flywheel.fit import parse_scad_vars
+
+
+def test_parse_scad_vars_errors_on_invalid_number(tmp_path: Path) -> None:
+    scad = tmp_path / "bad.scad"
+    scad.write_text("x = 1abc;")
+    with pytest.raises(ValueError):
+        parse_scad_vars(scad)


### PR DESCRIPTION
what: raise ValueError for malformed numeric SCAD assignments and document.
why: prevent silent SCAD parsing failures.
how: run pre-commit, pytest, npm run test:ci, python -m flywheel.fit, bash scripts/checks.sh.
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a92583d7d8832f937649e3629c924c