### PR TITLE
🐛: include root prompt docs in crawler

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [2025-08-27] - Scan root docs for prompt files
+- include `docs/prompts-*.md` in prompt docs crawler
+
 ## [2025-08-23] - Fix newline in prompt docs summary
 - add missing newline to docs/prompt-docs-summary.md to satisfy pre-commit
 

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -12,7 +12,7 @@ Think of each listed repository as a small flywheel belted to this codebase. The
 
 All prompts are verified with OpenAI Codex. Other coding agents like Claude Code, Gemini CLI, and Cursor should work too.
 
-**125 one-click prompts verified across 11 repos (24 evergreen, 1 one-off, 3 unknown).**
+**127 one-click prompts verified across 11 repos (24 evergreen, 1 one-off, 3 unknown).**
 
 One-off prompts are temporary—copy them into issues or PRs, implement, and then remove them from source docs.
 
@@ -24,6 +24,7 @@ Repos with prompts still marked as unknown or one-off.
 
 | Repo                                                                          |   Unknown |   One-off |
 |-------------------------------------------------------------------------------|-----------|-----------|
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       |         0 |         1 |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) |         0 |         1 |
 | [democratizedspace/dspace](https://github.com/democratizedspace/dspace)       |         0 |        10 |
 | [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     |         0 |         2 |
@@ -46,6 +47,12 @@ python scripts/update_prompt_docs_summary.py --repos-from docs/repo_list.txt --o
 | evergreen | prompts that can be reused to hillclimb toward goals like feature completeness or test coverage  |
 | one-off   | prompts to implement features or make recommended changes (glorified TODO; remove after cleanup) |
 | unknown   | catch-all; refine into another category or create a new one                                      |
+
+## **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**
+
+| Path                                                                                                                 | Prompt                                                                                                                                    | Type        | One-click?   |
+|----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|--------------|
+| **[docs/prompts-major-filter.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-major-filter.md)** | **[Prompt Docs Major Filter](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-major-filter.md#prompt-docs-major-filter)** | **one-off** | **yes**      |
 
 ## [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist)
 
@@ -129,6 +136,8 @@ python scripts/update_prompt_docs_summary.py --repos-from docs/repo_list.txt --o
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [docs/prompts/codex/propagate.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/propagate.md)                                                   | [Upgrade Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/propagate.md#upgrade-prompt)                                                                                             | evergreen     | yes          |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [docs/prompts/codex/spellcheck.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/spellcheck.md)                                                 | [Codex Spellcheck Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/spellcheck.md#codex-spellcheck-prompt)                                                                          | evergreen     | yes          |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [docs/prompts/codex/spellcheck.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/spellcheck.md)                                                 | [Upgrade Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/spellcheck.md#upgrade-prompt)                                                                                            | evergreen     | yes          |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | **[docs/prompts-major-filter.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-major-filter.md)**                                                     | **[Prompt Docs Major Filter](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-major-filter.md#prompt-docs-major-filter)**                                                                        | **one-off**   | **yes**      |
+| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | **[docs/prompts-major-filter.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-major-filter.md)**                                                     | **[`scripts/update_prompt_docs_summary.py`](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-major-filter.md#scriptsupdatepromptdocssummarypy)**                                                 | **evergreen** | **yes**      |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | **[docs/prompts-codex-spellcheck.md](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-spellcheck.md)**                                        | **[Codex Spellcheck Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)**                                                                 | **evergreen** | **yes**      |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | **[docs/prompts-codex-video-script-ideas.md](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-video-script-ideas.md)**                        | **[Video Script Ideas Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-video-script-ideas.md#video-script-ideas-prompt)**                                                     | **evergreen** | **yes**      |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | **[docs/prompts-codex.md](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex.md)**                                                              | **[Codex Automation Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex.md#codex-automation-prompt)**                                                                            | **evergreen** | **yes**      |

--- a/tests/test_iter_local_prompt_docs.py
+++ b/tests/test_iter_local_prompt_docs.py
@@ -1,0 +1,13 @@
+from scripts.update_prompt_docs_summary import iter_local_prompt_docs
+
+
+def test_iter_local_prompt_docs_includes_top_level(tmp_path):
+    docs_root = tmp_path / "docs"
+    codex_dir = docs_root / "prompts" / "codex"
+    codex_dir.mkdir(parents=True)
+    (codex_dir / "a.md").write_text("# A\n")
+    (docs_root / "prompts-extra.md").write_text("# Extra\n")
+
+    files = list(iter_local_prompt_docs(docs_root))
+    names = sorted(p.name for p in files)
+    assert names == ["a.md", "prompts-extra.md"]


### PR DESCRIPTION
## what
- scan `docs/prompts-*.md` for local prompt docs
- document crawler update

## why
- prompt summary missed top-level docs

## how to test
- `npm run lint`
- `npm run test:ci`
- `pytest -q`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aa9239da24832fab03ed50c5e83d3b