### PR TITLE
fix: install tabulate for pre-commit run-checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,5 @@ repos:
           - trimesh
           - bandit
           - safety
+          - tabulate
         pass_filenames: false

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [2025-08-27] - Scan root docs for prompt files
 - include `docs/prompts-*.md` in prompt docs crawler
 
+## [2025-08-25] - Add tabulate to pre-commit
+- include tabulate in run-checks hook to install missing dependency
+
 ## [2025-08-23] - Fix newline in prompt docs summary
 - add missing newline to docs/prompt-docs-summary.md to satisfy pre-commit
 

--- a/docs/pms/2025-08-25-pre-commit-tabulate.md
+++ b/docs/pms/2025-08-25-pre-commit-tabulate.md
@@ -1,0 +1,18 @@
+# Pre-commit run-checks missing tabulate
+
+- Date: 2025-08-25
+- Author: OpenAI Assistant
+- Status: Resolved
+
+## What went wrong
+Pre-commit run-checks hook failed during test collection.
+
+## Root cause
+The hook environment didn't install the tabulate package required by tests.
+
+## Impact
+CI jobs using pre-commit could not run tests and failed.
+
+## Actions to take
+- Include tabulate in the pre-commit hook's additional dependencies.
+- Monitor future runs for similar missing packages.

--- a/outages/2025-08-25-pre-commit-tabulate.json
+++ b/outages/2025-08-25-pre-commit-tabulate.json
@@ -1,0 +1,8 @@
+{
+  "id": "2025-08-25-pre-commit-tabulate",
+  "date": "2025-08-25",
+  "component": "pre-commit",
+  "rootCause": "run-checks hook lacked tabulate so tests failed during collection",
+  "resolution": "added tabulate to additional_dependencies in pre-commit config",
+  "references": []
+}


### PR DESCRIPTION
## Summary
- include tabulate in run-checks hook so tests can import it
- record outage and postmortem entry

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `RUN_SECURITY_ONLY=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aba8f2ecf0832fa5b8fdfaa1447307