### PR TITLE
🐛 fix: defer tabulate import in prompt doc script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [2025-08-27] - Scan root docs for prompt files
 - include `docs/prompts-*.md` in prompt docs crawler
 
+## [2025-08-25] - Defer tabulate import in prompt doc script
+- allow tests to run without installing tabulate
+
 ## [2025-08-23] - Fix newline in prompt docs summary
 - add missing newline to docs/prompt-docs-summary.md to satisfy pre-commit
 

--- a/docs/pms/2025-08-25-precommit-tabulate.md
+++ b/docs/pms/2025-08-25-precommit-tabulate.md
@@ -1,0 +1,18 @@
+# 2025-08-25: Pre-commit tabulate import
+
+- **Date:** 2025-08-25
+- **Author:** codex-bot
+- **Status:** fixed
+
+## What went wrong
+Pre-commit checks failed because `scripts/update_prompt_docs_summary.py` imported `tabulate` at module load and the hook environment lacked the dependency.
+
+## Root cause
+Module-level import of `tabulate` caused `ModuleNotFoundError` during test collection when `tabulate` wasn't installed.
+
+## Impact
+CI failed on `run project checks`, blocking merges.
+
+## Actions to take
+- move `tabulate` import inside `main` so only the CLI requires it
+- consider adding optional dependency check in script

--- a/outages/2025-08-25-precommit-tabulate.json
+++ b/outages/2025-08-25-precommit-tabulate.json
@@ -1,0 +1,8 @@
+{
+  "id": "precommit-tabulate",
+  "date": "2025-08-25",
+  "component": "pre-commit",
+  "rootCause": "update_prompt_docs_summary imported tabulate at module load, so environments without the package failed",
+  "resolution": "move tabulate import inside main so pre-commit tests no longer require the dependency",
+  "references": ["https://github.com/flywheel/flywheel/actions/runs/0000000000"]
+}

--- a/scripts/update_prompt_docs_summary.py
+++ b/scripts/update_prompt_docs_summary.py
@@ -11,9 +11,6 @@ from pathlib import Path
 from typing import DefaultDict, Iterable, List, Set
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-
-from tabulate import tabulate  # noqa: E402
-
 from flywheel.repocrawler import RepoCrawler  # noqa: E402
 
 
@@ -125,6 +122,8 @@ def iter_local_prompt_docs(docs_root: Path) -> Iterable[Path]:
 
 
 def main() -> None:
+    from tabulate import tabulate
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--repos-from", type=Path, required=True)
     parser.add_argument("--out", type=Path, required=True)

--- a/tests/test_iter_local_prompt_docs.py
+++ b/tests/test_iter_local_prompt_docs.py
@@ -1,7 +1,10 @@
-from scripts.update_prompt_docs_summary import iter_local_prompt_docs
+import importlib
+import sys
 
 
 def test_iter_local_prompt_docs_includes_top_level(tmp_path):
+    from scripts.update_prompt_docs_summary import iter_local_prompt_docs
+
     docs_root = tmp_path / "docs"
     codex_dir = docs_root / "prompts" / "codex"
     codex_dir.mkdir(parents=True)
@@ -11,3 +14,19 @@ def test_iter_local_prompt_docs_includes_top_level(tmp_path):
     files = list(iter_local_prompt_docs(docs_root))
     names = sorted(p.name for p in files)
     assert names == ["a.md", "prompts-extra.md"]
+
+
+def test_import_without_tabulate(monkeypatch, tmp_path):
+    monkeypatch.delitem(sys.modules, "tabulate", raising=False)
+    module = importlib.reload(
+        importlib.import_module("scripts.update_prompt_docs_summary")
+    )
+
+    docs_root = tmp_path / "docs"
+    codex_dir = docs_root / "prompts" / "codex"
+    codex_dir.mkdir(parents=True)
+    (codex_dir / "a.md").write_text("# A\n")
+
+    files = list(module.iter_local_prompt_docs(docs_root))
+    names = sorted(p.name for p in files)
+    assert names == ["a.md"]


### PR DESCRIPTION
## Summary
- lazy-load `tabulate` in `update_prompt_docs_summary.py` so importing helper functions doesn't require the package
- exercise script import without `tabulate` and document fix
- record outage and postmortem

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aba8f2ecf0832fa5b8fdfaa1447307