### PR TITLE
📝 : – mirror status_to_emoji incident

### DIFF
--- a/docs/pms/2025-08-25-status-emoji-non-string.md
+++ b/docs/pms/2025-08-25-status-emoji-non-string.md
@@ -1,0 +1,16 @@
+# Non-string conclusion crashes status_to_emoji
+
+## Summary
+`status_to_emoji` crashed with `AttributeError` when GitHub's API returned a non-string `conclusion` value.
+
+## Root Cause
+The function unconditionally called `.lower()` on the `conclusion` parameter, assuming it was a string.
+
+## Resolution
+Cast the value to `str` before lowercasing so unexpected types fall back to the failure emoji.
+
+## Impact
+Any tooling using `status_to_emoji` could crash if the API returned numeric or boolean conclusions.
+
+## Mitigation
+Add type coercion and a regression test to ensure robust handling of malformed API responses.

--- a/outages/2025-08-25-status-emoji-non-string.json
+++ b/outages/2025-08-25-status-emoji-non-string.json
@@ -1,0 +1,8 @@
+{
+  "id": "status-emoji-non-string",
+  "date": "2025-08-25",
+  "component": "repo_status.status_to_emoji",
+  "rootCause": "function called .lower() on non-string conclusion, crashing on numeric API responses",
+  "resolution": "cast conclusion to string before lowercasing to handle non-string inputs",
+  "references": ["tests/test_repo_status.py::test_status_to_emoji_non_string"]
+}

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -27,7 +27,7 @@ def status_to_emoji(conclusion: str | None) -> str:
     string is handled case-insensitively.
     """
     if conclusion is not None:
-        conclusion = conclusion.lower()
+        conclusion = str(conclusion).lower()
     if conclusion in {"success", "neutral", "skipped"}:
         return "✅"
     if conclusion is None:

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -15,6 +15,10 @@ def test_status_to_emoji():
     assert rs.status_to_emoji("FAILURE") == "❌"
 
 
+def test_status_to_emoji_non_string():
+    assert rs.status_to_emoji(42) == "❌"
+
+
 def test_fetch_repo_status_success(monkeypatch):
     class Resp:
         def __init__(self, conclusion):


### PR DESCRIPTION
## Summary
Mirror postmortem for status_to_emoji non-string crash from flywheel.

## Testing
- `SKIP_E2E=1 npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: @typescript-eslint/eslint-plugin missing)*
- `npm run type-check` *(fails: missing vitest/globals types)*
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aba901b890832f8c8f820dc558c14f