### PR TITLE
fix: reject overflow numbers in SCAD parser

### DIFF
--- a/docs/pms/2025-08-25-scad-overflow.md
+++ b/docs/pms/2025-08-25-scad-overflow.md
@@ -1,0 +1,16 @@
+# SCAD variable overflow
+
+## Summary
+`parse_scad_vars` accepted numbers exceeding float range and produced infinite values.
+
+## Impact
+Unbounded CAD parameters could propagate into fit checks or geometry calculations.
+
+## Root Cause
+The parser converted numeric strings without verifying finiteness, so `1e309` became `inf`.
+
+## Resolution
+Reject non-finite numbers during parsing and raise `ValueError`.
+
+## Prevention
+Add fuzz tests for extreme numeric values.

--- a/flywheel/fit.py
+++ b/flywheel/fit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import re
 from pathlib import Path
 from typing import Dict, Tuple
@@ -25,8 +26,8 @@ def parse_scad_vars(path: str | Path) -> Dict[str, float]:
     supports negative values, decimals without a leading zero, trailing
     decimal points, scientific notation, underscore digit separators, and
     multiple assignments on the same line. Raises :class:`ValueError` when a
-    variable assignment lacks a numeric value or has an empty right-hand
-    side.
+    variable assignment lacks a numeric value, has an empty right-hand side,
+    or exceeds floating-point range.
     """
     path = Path(path)
     text = path.read_text()
@@ -42,7 +43,10 @@ def parse_scad_vars(path: str | Path) -> Dict[str, float]:
             m = _DEF_RE.match(part + ";")
             if m:
                 num = m.group(2).replace("_", "")
-                vars[m.group(1)] = float(num)
+                value = float(num)
+                if not math.isfinite(value):
+                    raise ValueError(f"invalid number for {m.group(1)}: {num}")
+                vars[m.group(1)] = value
             elif re.match(
                 r"[a-zA-Z_][a-zA-Z0-9_]*\s*=\s*" r"[a-zA-Z_][a-zA-Z0-9_]*\s*$",
                 part,

--- a/outages/2025-08-25-scad-overflow.json
+++ b/outages/2025-08-25-scad-overflow.json
@@ -1,0 +1,8 @@
+{
+    "id": "2025-08-25-scad-overflow",
+    "date": "2025-08-25",
+    "component": "parse_scad_vars",
+    "rootCause": "Parser accepted numbers exceeding float range producing infinities",
+    "resolution": "Check for non-finite numbers and raise ValueError",
+    "references": ["docs/pms/2025-08-25-scad-overflow.md"]
+}

--- a/tests/test_parse_scad_vars_overflow.py
+++ b/tests/test_parse_scad_vars_overflow.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+import pytest
+
+from flywheel.fit import parse_scad_vars
+
+
+def test_parse_scad_vars_errors_on_overflow(tmp_path: Path) -> None:
+    scad = tmp_path / "overflow.scad"
+    scad.write_text("x = 1e309;")
+    with pytest.raises(ValueError):
+        parse_scad_vars(scad)


### PR DESCRIPTION
## Summary
- fuzz `parse_scad_vars` to reject numbers exceeding float range
- document SCAD overflow incident

## Testing
- `pre-commit run --all-files` *(fails: ModuleNotFoundError: No module named 'tabulate')*
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh` *(Playwright tests did not run)*

## Postmortem
- [SCAD overflow postmortem](docs/pms/2025-08-25-scad-overflow.md)
- [dspace mirror](https://github.com/democratizedspace/dspace/blob/v3/docs/pms/2025-08-25-scad-overflow.md)


------
https://chatgpt.com/codex/tasks/task_e_68aba901b890832f8c8f820dc558c14f