### PR TITLE
Reject non-finite SCAD values in parser

### DIFF
--- a/docs/pms/2025-08-25-nonfinite-scad.md
+++ b/docs/pms/2025-08-25-nonfinite-scad.md
@@ -1,0 +1,23 @@
+# Non-finite SCAD value handling
+
+## Summary
+`parse_scad_vars` previously accepted extremely large numeric assignments like `1e5000`,
+returning `inf` and risking downstream geometry calculations.
+
+## Impact
+Malformed SCAD files could bypass size checks and produce invalid meshes.
+
+## Root Cause
+The parser converted numeric literals to floats without validating finiteness.
+
+## Resolution
+Added `math.isfinite` checks to raise `ValueError` on non-finite numbers and
+added regression tests.
+
+## Mitigation
+Rejecting `inf` and `NaN` protects dimension logic and prevents resource
+consumption from unbounded values.
+
+## Action Items
+- [x] Add non-finite number regression test
+- [x] Guard `parse_scad_vars` against `inf`/`NaN`

--- a/flywheel/fit.py
+++ b/flywheel/fit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import re
 from pathlib import Path
 from typing import Dict, Tuple
@@ -42,7 +43,10 @@ def parse_scad_vars(path: str | Path) -> Dict[str, float]:
             m = _DEF_RE.match(part + ";")
             if m:
                 num = m.group(2).replace("_", "")
-                vars[m.group(1)] = float(num)
+                value = float(num)
+                if not math.isfinite(value):
+                    raise ValueError(f"non-finite value for {m.group(1)}")
+                vars[m.group(1)] = value
             elif re.match(
                 r"[a-zA-Z_][a-zA-Z0-9_]*\s*=\s*" r"[a-zA-Z_][a-zA-Z0-9_]*\s*$",
                 part,

--- a/outages/2025-08-25-nonfinite-scad.json
+++ b/outages/2025-08-25-nonfinite-scad.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-08-25-nonfinite-scad",
+  "date": "2025-08-25",
+  "component": "parse_scad_vars",
+  "rootCause": "parser accepted non-finite numeric values producing infinities",
+  "resolution": "validate numbers and reject non-finite values",
+  "references": [
+    "docs/pms/2025-08-25-nonfinite-scad.md"
+  ]
+}

--- a/tests/test_parse_scad_vars_nonfinite.py
+++ b/tests/test_parse_scad_vars_nonfinite.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+import pytest
+
+from flywheel.fit import parse_scad_vars
+
+
+def test_parse_scad_vars_errors_on_non_finite(tmp_path: Path) -> None:
+    scad = tmp_path / "big.scad"
+    scad.write_text("radius = 1e5000;")
+    with pytest.raises(ValueError):
+        parse_scad_vars(scad)


### PR DESCRIPTION
## Summary
- validate `parse_scad_vars` to reject `inf`/`NaN`
- add regression test
- document incident and add outage record

## Testing
- `pytest -q`
- `python -m flywheel.fit`
- `npm run lint` *(skip: echo)*
- `pre-commit run --all-files` *(fails: KeyboardInterrupt during env install)*
- `npm run test:ci` *(fails: aborted after downloading dependencies)*
- `bash scripts/checks.sh` *(fails: aborted during execution)*

Postmortem: `docs/pms/2025-08-25-nonfinite-scad.md`
Dspace mirror: `democratizedspace/dspace@v3`

------
https://chatgpt.com/codex/tasks/task_e_68aba901b890832f8c8f820dc558c14f