### PR TITLE
docs: refresh propagation prompt references

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
           - Flask
           - responses
           - trimesh
+          - tabulate
           - bandit
           - safety
         pass_filenames: false

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -12,7 +12,7 @@ Think of each listed repository as a small flywheel belted to this codebase. The
 
 All prompts are verified with OpenAI Codex. Other coding agents like Claude Code, Gemini CLI, and Cursor should work too.
 
-**127 one-click prompts verified across 11 repos (24 evergreen, 1 one-off, 3 unknown).**
+**130 one-click prompts verified across 11 repos (24 evergreen, 1 one-off, 6 unknown).**
 
 One-off prompts are temporary—copy them into issues or PRs, implement, and then remove them from source docs.
 
@@ -30,7 +30,7 @@ Repos with prompts still marked as unknown or one-off.
 | [futuroptimist/token.place](https://github.com/futuroptimist/token.place)     |         0 |         2 |
 | [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)             |         3 |         1 |
 | [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard)     |         0 |         1 |
-| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   |         2 |         1 |
+| [futuroptimist/axel](https://github.com/futuroptimist/axel)                   |         5 |         1 |
 | [futuroptimist/gitshelves](https://github.com/futuroptimist/gitshelves)       |         0 |         2 |
 | [futuroptimist/wove](https://github.com/futuroptimist/wove)                   |         0 |         3 |
 
@@ -101,6 +101,9 @@ python scripts/update_prompt_docs_summary.py --repos-from docs/repo_list.txt --o
 
 | Path                                                                                                                       | Prompt                                                                                                                                  | Type        | One-click?   |
 |----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|-------------|--------------|
+| [.axel/hillclimb/prompts/code.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/code.md)         | [code.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/code.md)                                              | unknown     | yes          |
+| [.axel/hillclimb/prompts/critique.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/critique.md) | [critique.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/critique.md)                                      | unknown     | yes          |
+| [.axel/hillclimb/prompts/plan.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/plan.md)         | [plan.md](https://github.com/futuroptimist/axel/blob/main/.axel/hillclimb/prompts/plan.md)                                              | unknown     | yes          |
 | **[docs/prompts-codex.md](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md)**                         | **[2. Update roadmap status](https://github.com/futuroptimist/axel/blob/main/docs/prompts-codex.md#2-update-roadmap-status)**           | **one-off** | **yes**      |
 | **[docs/prompts/prompts-hillclimb.md](https://github.com/futuroptimist/axel/blob/main/docs/prompts/prompts-hillclimb.md)** | **[add-pipx-install.yml](https://github.com/futuroptimist/axel/blob/main/docs/prompts/prompts-hillclimb.md#add-pipx-installyml)**       | **unknown** | **yes**      |
 | **[docs/prompts/prompts-hillclimb.md](https://github.com/futuroptimist/axel/blob/main/docs/prompts/prompts-hillclimb.md)** | **[docker-compose-mock.yml](https://github.com/futuroptimist/axel/blob/main/docs/prompts/prompts-hillclimb.md#docker-compose-mockyml)** | **unknown** | **yes**      |
@@ -136,7 +139,6 @@ python scripts/update_prompt_docs_summary.py --repos-from docs/repo_list.txt --o
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [docs/prompts/codex/propagate.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/propagate.md)                                                   | [Upgrade Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/propagate.md#upgrade-prompt)                                                                                             | evergreen     | yes          |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [docs/prompts/codex/spellcheck.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/spellcheck.md)                                                 | [Codex Spellcheck Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/spellcheck.md#codex-spellcheck-prompt)                                                                          | evergreen     | yes          |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | [docs/prompts/codex/spellcheck.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/spellcheck.md)                                                 | [Upgrade Prompt](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/spellcheck.md#upgrade-prompt)                                                                                            | evergreen     | yes          |
-| **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | **[docs/prompts-major-filter.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-major-filter.md)**                                                     | **[Prompt Docs Major Filter](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-major-filter.md#prompt-docs-major-filter)**                                                                        | **one-off**   | **yes**      |
 | **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**       | **[docs/prompts-major-filter.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-major-filter.md)**                                                     | **[`scripts/update_prompt_docs_summary.py`](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts-major-filter.md#scriptsupdatepromptdocssummarypy)**                                                 | **evergreen** | **yes**      |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | **[docs/prompts-codex-spellcheck.md](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-spellcheck.md)**                                        | **[Codex Spellcheck Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-spellcheck.md#codex-spellcheck-prompt)**                                                                 | **evergreen** | **yes**      |
 | [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist) | **[docs/prompts-codex-video-script-ideas.md](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-video-script-ideas.md)**                        | **[Video Script Ideas Prompt](https://github.com/futuroptimist/futuroptimist/blob/main/docs/prompts-codex-video-script-ideas.md#video-script-ideas-prompt)**                                                     | **evergreen** | **yes**      |
@@ -235,4 +237,4 @@ Track outstanding prompt documentation work across repositories. Add rows below 
 | Repo | Suggested Prompt | Type | Notes |
 |------|-----------------|------|-------|
 
-_Updated automatically: 2025-08-24_
+_Updated automatically: 2025-08-25_

--- a/docs/prompts/codex/propagate.md
+++ b/docs/prompts/codex/propagate.md
@@ -7,12 +7,13 @@ slug: 'codex-propagate'
 Type: evergreen
 
 Use this prompt to ask Codex to seed missing `prompts-*.md` files across repositories listed in
-[`docs/repo-feature-summary.md`](../../repo-feature-summary.md).
+[`dict/prompt-doc-repos.txt`](../../../dict/prompt-doc-repos.txt), which mirrors
+[`docs/repo_list.txt`](../../repo_list.txt).
 
 **Human set-up steps:**
 
-1. Review [`docs/prompts/summary.md`](../summary.md) and compile a list of repos that lack a
-   `docs/prompts/codex/automation.md` baseline.
+1. Review [`docs/prompt-docs-summary.md`](../../prompt-docs-summary.md) and compile a list of repos
+   that lack a `docs/prompts/codex/automation.md` baseline.
 2. Paste that list (one repo per line) at the top of your ChatGPT message.
 3. Add two blank lines, then copy the block below and send it.
 


### PR DESCRIPTION
## Summary
- point propagation prompt to dict/prompt-doc-repos.txt and prompt-docs summary
- regenerate prompt-docs summary
- include tabulate in pre-commit run-checks deps

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aba92dcd9c832fb01ad522fdfa7a93