### PR TITLE
📝 docs: quantify flywheel mass and energy

### DIFF
--- a/docs/flywheel-construction.md
+++ b/docs/flywheel-construction.md
@@ -26,6 +26,27 @@ mounted to the shaft.
 - Ensure the wheel is firmly fixed to avoid wobble.
 - Consider adding washers or bearings for smooth rotation.
 
+## Mass, inertia, and energy
+
+Let `diameter`, `shaft_diameter`, and `height` be the parameters in
+[`cad/flywheel.scad`](../cad/flywheel.scad). The outer and inner radii are
+$r_o = \tfrac{\text{diameter}}{2}$ and $r_i = \tfrac{\text{shaft\_diameter}}{2}$.
+For material density $\rho$ the wheel's mass and moment of inertia are
+
+$$m = \rho \pi (r_o^2 - r_i^2) h$$
+$$I = \tfrac{1}{2} m (r_o^2 + r_i^2)$$
+
+Spinning at angular speed $\omega$ stores
+
+$$E = \tfrac{1}{2} I \omega^2$$
+
+Using the default dimensions (`diameter = 100`, `shaft_diameter = 10`,
+`height = 20`) and PLA ($\rho \approx 1.25\,\text{g/cm}^3$) yields
+$m \approx 0.19\,\text{kg}$ and $I \approx 2.5\times10^{-4}\,\text{kg·m}^2$.
+At 3000\,rpm ($\omega \approx 314\,\text{rad/s}$) the wheel holds about
+12\,J of kinetic energy. See [Flywheel Physics](flywheel-physics.md)
+for derivations.
+
 This general approach lets you experiment with different materials while
 keeping the overall design consistent.
 


### PR DESCRIPTION
## Summary
- tie CAD parameters to mass, inertia, and stored energy

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `SKIP_E2E=1 npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aba9071e80832f88a9737cb0252751