### PR TITLE
docs: add Codex prompt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,5 @@ repos:
           - trimesh
           - bandit
           - safety
+          - tabulate
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -293,3 +293,5 @@ We aim for a positive-sum, empathetic community. The flywheel embraces regenerat
   See `docs/sugarkube-integration.md`.
 
 A summary of flywheel features adopted across repos lives in [docs/repo-feature-summary.md](docs/repo-feature-summary.md).
+
+For automation guidelines see the [Codex prompt](docs/prompts/codex/automation.md).


### PR DESCRIPTION
## Summary
- link to Codex automation prompt in README
- install tabulate via pre-commit to keep checks green

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aba9289cd0832f9e374f030095f673