### PR TITLE
fix: add timeout to RepoCrawler recent commit fetch

### DIFF
--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -434,6 +434,7 @@ class RepoCrawler:
             resp = self.session.get(
                 url,
                 headers={"Accept": "application/vnd.github+json"},
+                timeout=10,
             )
         except RequestException:
             return []

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -318,6 +318,22 @@ def test_recent_commits_request_exception():
     assert crawler._recent_commits("demo/repo", "main") == []
 
 
+def test_recent_commits_uses_timeout():
+    captured = {}
+
+    class Sess:
+        def __init__(self):
+            self.headers = {}
+
+        def get(self, url, **kwargs):
+            captured.update(kwargs)
+            return DummyResp(200, json_data=[{"sha": "aa"}])
+
+    crawler = RepoCrawler([], session=Sess())
+    assert crawler._recent_commits("demo/repo", "main") == ["aa"]
+    assert captured.get("timeout") == 10
+
+
 @pytest.mark.parametrize("conclusion", ["success", "neutral", "skipped"])
 def test_branch_green_actions_pass(conclusion):
     sess = make_session(


### PR DESCRIPTION
## Summary
- add 10s timeout to RepoCrawler._recent_commits
- test that timeout argument is passed through

## Testing
- `SKIP=run-checks .venv/bin/pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci` *(fails: apt dependency; ran `npm run jest -- --coverage --coverageReporters=lcov`)*
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh`

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68aba883302c832fbb01e01daabca0c9