### PR TITLE
Validate repo status attempts parameter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
           - Flask
           - responses
           - trimesh
+          - tabulate
           - bandit
           - safety
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ or skip end-to-end tests by prefixing commands with `SKIP_E2E=1`.
 - DEPENDABOT for automated dependency updates
 - CodeQL workflow for security scanning
 - Style guides for Python and JavaScript
-- README status script handles mixed-case GitHub workflow conclusions
+- README status script handles mixed-case GitHub workflow conclusions and validates attempt counts
 - Detailed best practice explanations in `docs/best_practices_catalog.md`
 - Dark pattern guidance in `docs/dark-patterns.md`
 - Bright pattern catalog in `docs/bright-patterns.md`

--- a/src/repo_status.py
+++ b/src/repo_status.py
@@ -46,8 +46,11 @@ def fetch_repo_status(
     The GitHub API occasionally returns inconsistent data if a workflow is
     updating while we query it. To catch this non-determinism we fetch the
     status multiple times and ensure all results match. If they differ we raise
-    ``RuntimeError`` so the calling workflow fails loudly.
+    ``RuntimeError`` so the calling workflow fails loudly. ``attempts`` must be
+    at least ``1`` to ensure we have a conclusion to report.
     """
+    if attempts < 1:
+        raise ValueError("attempts must be >= 1")
     headers = {"Accept": "application/vnd.github+json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"

--- a/tests/test_repo_status.py
+++ b/tests/test_repo_status.py
@@ -54,6 +54,11 @@ def test_fetch_repo_status_inconsistent(monkeypatch):
         rs.fetch_repo_status("owner/repo", attempts=2)
 
 
+def test_fetch_repo_status_attempts_zero():
+    with pytest.raises(ValueError):
+        rs.fetch_repo_status("owner/repo", attempts=0)
+
+
 def test_update_readme(tmp_path, monkeypatch):
     readme = tmp_path / "README.md"
     readme.write_text("## Related Projects\n- https://github.com/a/b\n")


### PR DESCRIPTION
## Summary
- ensure fetch_repo_status rejects attempts < 1
- cover ValueError case in tests
- document attempt validation and add tabulate to pre-commit deps

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `SKIP_E2E=1 npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aba883302c832fbb01e01daabca0c9