### PR TITLE
Add 73 mm Sunlu spool core sleeve presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,12 @@ or skip end-to-end tests by prefixing commands with `SKIP_E2E=1`.
 - Web viewer instructions in `docs/web-viewer.md`
 - CI troubleshooting tips in `docs/ci-guide.md`
 - Nightly STL exports are committed back to `stl/` after each run
-- Sunlu spool core sleeve adapter (63→64 mm) [STL](./stl/spool_core_sleeve/sunlu55_to63_len60.stl)
-  and matching wedge-removal cylinder [STL](./stl/spool_core_sleeve/sunlu55_to63cyl_len60.stl)
+- Sunlu spool core sleeve adapters for Bambu Lab AMS:
+  [63→64 mm](./stl/spool_core_sleeve/sunlu55_to63_len60.stl) and
+  [73→74 mm](./stl/spool_core_sleeve/sunlu55_to73_len60.stl) sleeves with
+  matching wedge-removal cylinders
+  ([63 mm](./stl/spool_core_sleeve/sunlu55_to63cyl_len60.stl) and
+  [73 mm](./stl/spool_core_sleeve/sunlu55_to73cyl_len60.stl))
 - Flywheel construction guide in `docs/flywheel-construction.md` with CAD files in `cad/`
   including `stand.scad`, `shaft.scad`, and `adapter.scad`. Assembly details live in `docs/flywheel-stand.md`, clamp instructions in `docs/flywheel-adapter.md`, and physics in `docs/flywheel-physics.md`
 

--- a/cad/README.md
+++ b/cad/README.md
@@ -22,9 +22,11 @@ sudo apt-get install openscad
   (override `$fs` via the `resolution_fs` variable for finer meshes)
 - `utils/spool_core_sleeve.scad` – parametric spool core sleeve library.
   Ready-to-print presets live in `spool_core_sleeve/` with matching STLs in
-  `../stl/spool_core_sleeve/`, including a `sunlu55_to63_len60` 63→64 mm
-  tapered adapter and a `sunlu55_to63cyl_len60` straight 63 mm cylinder for
-  wedge removal.
+  `../stl/spool_core_sleeve/`, including:
+  - `sunlu55_to63_len60` 63→64 mm tapered adapter
+  - `sunlu55_to63cyl_len60` straight 63 mm removal cylinder
+  - `sunlu55_to73_len60` 73→74 mm tapered adapter
+  - `sunlu55_to73cyl_len60` straight 73 mm removal cylinder
 - `examples/spool_core_sleeve_example.scad` – demo spool core sleeve; the
   corresponding OBJ lives in `webapp/static/models/examples/` and the
   pre-generated 63→64 mm sleeve's OBJ is at

--- a/cad/spool_core_sleeve/README.md
+++ b/cad/spool_core_sleeve/README.md
@@ -1,0 +1,22 @@
+# Sunlu Spool Core Sleeves
+
+These OpenSCAD presets adapt Sunlu-branded filament spools to the Bambu Lab AMS.
+They wrap the 55 mm AMS hub and expand to the measured spool diameter.
+
+## Naming convention
+
+`sunlu55_to<OD>[cyl]_len<length>.scad`
+
+- `55` – inner bore diameter (AMS hub)
+- `<OD>` – starting outer diameter of the sleeve
+- `cyl` – optional straight cylinder used to push out a tapered sleeve
+- `len<length>` – axial length of the part in millimeters
+
+## Available presets
+
+| File | Description |
+|------|-------------|
+| `sunlu55_to63_len60.scad` | 63→64 mm tapered adapter |
+| `sunlu55_to63cyl_len60.scad` | straight 63 mm removal cylinder |
+| `sunlu55_to73_len60.scad` | 73→74 mm tapered adapter |
+| `sunlu55_to73cyl_len60.scad` | straight 73 mm removal cylinder |

--- a/cad/spool_core_sleeve/sunlu55_to73_len60.scad
+++ b/cad/spool_core_sleeve/sunlu55_to73_len60.scad
@@ -1,0 +1,3 @@
+use <../utils/spool_core_sleeve.scad>;
+
+spool_core_sleeve_preset("sunlu55_to73_len60");

--- a/cad/spool_core_sleeve/sunlu55_to73cyl_len60.scad
+++ b/cad/spool_core_sleeve/sunlu55_to73cyl_len60.scad
@@ -1,0 +1,3 @@
+use <../utils/spool_core_sleeve.scad>;
+
+spool_core_sleeve_preset("sunlu55_to73cyl_len60");

--- a/cad/utils/spool_core_sleeve.scad
+++ b/cad/utils/spool_core_sleeve.scad
@@ -61,6 +61,8 @@ module spool_core_sleeve(
 function _spool_core_sleeve_preset(preset) =
     (preset == "sunlu55_to63_len60") ? [55, 63, 64, 60, 0.20] :
     (preset == "sunlu55_to63cyl_len60") ? [55, 63, 63, 60, 0.20] :
+    (preset == "sunlu55_to73_len60") ? [55, 73, 74, 60, 0.20] :
+    (preset == "sunlu55_to73cyl_len60") ? [55, 73, 73, 60, 0.20] :
     undef;
 
 module spool_core_sleeve_preset(

--- a/docs/spool-core-sleeve.md
+++ b/docs/spool-core-sleeve.md
@@ -20,6 +20,10 @@ spool_core_sleeve_preset("sunlu55_to63_len60");
 
 // straight 63 mm cylinder (works as a wedge removal tool)
 spool_core_sleeve_preset("sunlu55_to63cyl_len60");
+
+// larger Sunlu spool variant (73→74 mm) and its remover
+spool_core_sleeve_preset("sunlu55_to73_len60");
+spool_core_sleeve_preset("sunlu55_to73cyl_len60");
 ```
 
 ### Parameters
@@ -58,10 +62,17 @@ openscad -o stl/spool_core_sleeve/sunlu55_to63_len60.stl \
 
 ## Ready-to-print files
 
-Two preset SCAD files live in `cad/spool_core_sleeve/` with matching STLs in
-`stl/spool_core_sleeve/`. The tapered adapter (`sunlu55_to63_len60`) expands from
-63 mm to 64 mm, while the straight cylinder (`sunlu55_to63cyl_len60`) serves as a
-wedge-removal tool so the adapter can be reused across many spools.
+Four preset SCAD files live in `cad/spool_core_sleeve/` with matching STLs in
+`stl/spool_core_sleeve/`:
+
+| Preset | Purpose |
+|--------|---------|
+| `sunlu55_to63_len60` | 63→64 mm tapered adapter |
+| `sunlu55_to63cyl_len60` | straight 63 mm removal cylinder |
+| `sunlu55_to73_len60` | 73→74 mm tapered adapter |
+| `sunlu55_to73cyl_len60` | straight 73 mm removal cylinder |
+
+The cylinders act as wedge-removal tools so adapters can be reused across spools.
 
 
 ## Printing notes

--- a/scripts/openscad_render_spool_core_sleeve.sh
+++ b/scripts/openscad_render_spool_core_sleeve.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 #   scripts/openscad_render_spool_core_sleeve.sh 55 63 64 60 0.20
 #   scripts/openscad_render_spool_core_sleeve.sh 55 63 60 0.20  # end defaults to 63
 #   PRESET=sunlu55_to63_len60 scripts/openscad_render_spool_core_sleeve.sh
+#   PRESET=sunlu55_to73_len60 scripts/openscad_render_spool_core_sleeve.sh
 # Outputs to stl/spool_core_sleeve/<name>.stl and logs echo to a .log file.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/stl/spool_core_sleeve/.gitignore
+++ b/stl/spool_core_sleeve/.gitignore
@@ -2,3 +2,5 @@
 *.log
 !sunlu55_to63_len60.stl
 !sunlu55_to63cyl_len60.stl
+!sunlu55_to73_len60.stl
+!sunlu55_to73cyl_len60.stl

--- a/stl/spool_core_sleeve/sunlu55_to73_len60.stl
+++ b/stl/spool_core_sleeve/sunlu55_to73_len60.stl
@@ -1,0 +1,9802 @@
+solid OpenSCAD_Model
+  facet normal 0.999842 0.0156976 -0.00833202
+    outer loop
+      vertex 36.5 0 0
+      vertex 36.482 1.14649 0
+      vertex 37 0 60
+    endloop
+  endfacet
+  facet normal -0.73961 0.672984 -0.00833071
+    outer loop
+      vertex -27.3791 24.1379 0
+      vertex -27.7541 24.4685 60
+      vertex -26.6074 24.986 0
+    endloop
+  endfacet
+  facet normal -0.999842 -0.0156976 -0.00833202
+    outer loop
+      vertex -36.482 -1.14649 0
+      vertex -37 0 60
+      vertex -36.5 0 0
+    endloop
+  endfacet
+  facet normal 0.672984 0.73961 -0.00833071
+    outer loop
+      vertex 24.986 26.6074 0
+      vertex 24.1379 27.3791 0
+      vertex 24.4685 27.7541 60
+    endloop
+  endfacet
+  facet normal -0.998857 0.0470587 -0.00833114
+    outer loop
+      vertex -36.482 1.14649 0
+      vertex -36.9817 1.1622 60
+      vertex -36.927 2.32325 60
+    endloop
+  endfacet
+  facet normal -0.171889 -0.985081 -0.00833292
+    outer loop
+      vertex -5.78807 -36.5445 60
+      vertex -6.83942 -35.8535 0
+      vertex -5.70986 -36.0506 0
+    endloop
+  endfacet
+  facet normal -0.760353 -0.649457 -0.00833243
+    outer loop
+      vertex -27.7541 -24.4685 60
+      vertex -28.509 -23.5847 60
+      vertex -28.1237 -23.266 0
+    endloop
+  endfacet
+  facet normal -0.353461 -0.935412 -0.00833242
+    outer loop
+      vertex -12.3639 -34.3421 0
+      vertex -13.6206 -34.4017 60
+      vertex -13.4365 -33.9368 0
+    endloop
+  endfacet
+  facet normal -0.140833 0.989998 -0.00833291
+    outer loop
+      vertex -5.70986 36.0506 0
+      vertex -5.78807 36.5445 60
+      vertex -4.63733 36.7082 60
+    endloop
+  endfacet
+  facet normal 0.993929 0.109709 -0.00833234
+    outer loop
+      vertex 36.338 3.43495 0
+      vertex 36.2122 4.57466 0
+      vertex 36.8358 3.48201 60
+    endloop
+  endfacet
+  facet normal -0.411474 -0.911383 -0.00833254
+    outer loop
+      vertex -14.6945 -33.9569 60
+      vertex -15.5409 -33.0262 0
+      vertex -14.4959 -33.498 0
+    endloop
+  endfacet
+  facet normal 0.0784595 -0.996882 -0.0083318
+    outer loop
+      vertex 2.32325 -36.927 60
+      vertex 2.29185 -36.428 0
+      vertex 3.48201 -36.8358 60
+    endloop
+  endfacet
+  facet normal 0.109774 -0.993922 -0.00833108
+    outer loop
+      vertex 4.63733 -36.7082 60
+      vertex 3.48201 -36.8358 60
+      vertex 4.57466 -36.2122 0
+    endloop
+  endfacet
+  facet normal 0.935412 -0.353461 -0.00833242
+    outer loop
+      vertex 34.4017 -13.6206 60
+      vertex 33.9368 -13.4365 0
+      vertex 34.3421 -12.3639 0
+    endloop
+  endfacet
+  facet normal 0.382653 -0.923855 -0.00833253
+    outer loop
+      vertex 14.6945 -33.9569 60
+      vertex 13.6206 -34.4017 60
+      vertex 14.4959 -33.498 0
+    endloop
+  endfacet
+  facet normal -0.835801 -0.54897 -0.00833101
+    outer loop
+      vertex -30.602 -20.7971 60
+      vertex -31.2401 -19.8256 60
+      vertex -30.818 -19.5577 0
+    endloop
+  endfacet
+  facet normal -0.996882 0.0784595 -0.0083318
+    outer loop
+      vertex -36.428 2.29185 0
+      vertex -36.927 2.32325 60
+      vertex -36.8358 3.48201 60
+    endloop
+  endfacet
+  facet normal 0.323976 -0.946028 -0.00833151
+    outer loop
+      vertex 11.4336 -35.1891 60
+      vertex 11.2791 -34.7136 0
+      vertex 12.3639 -34.3421 0
+    endloop
+  endfacet
+  facet normal -0.233457 0.972331 -0.00833106
+    outer loop
+      vertex -7.96223 35.621 0
+      vertex -9.07718 35.3533 0
+      vertex -8.0713 36.1089 60
+    endloop
+  endfacet
+  facet normal -0.989998 0.140833 -0.00833291
+    outer loop
+      vertex -36.0506 5.70986 0
+      vertex -36.7082 4.63733 60
+      vertex -36.5445 5.78807 60
+    endloop
+  endfacet
+  facet normal 0.964518 -0.263886 -0.00833217
+    outer loop
+      vertex 35.8376 -9.20153 60
+      vertex 35.0507 -10.1832 0
+      vertex 35.3533 -9.07718 0
+    endloop
+  endfacet
+  facet normal -0.818111 -0.575 -0.00833197
+    outer loop
+      vertex -29.9336 -21.7481 60
+      vertex -30.602 -20.7971 60
+      vertex -29.5291 -21.4542 0
+    endloop
+  endfacet
+  facet normal -0.171972 -0.985067 -0.0083313
+    outer loop
+      vertex -5.78807 -36.5445 60
+      vertex -6.93311 -36.3446 60
+      vertex -6.83942 -35.8535 0
+    endloop
+  endfacet
+  facet normal 0.972331 0.233457 -0.00833106
+    outer loop
+      vertex 35.621 7.96223 0
+      vertex 35.3533 9.07718 0
+      vertex 36.1089 8.0713 60
+    endloop
+  endfacet
+  facet normal 0.964528 -0.26385 -0.00833289
+    outer loop
+      vertex 35.5309 -10.3227 60
+      vertex 35.0507 -10.1832 0
+      vertex 35.8376 -9.20153 60
+    endloop
+  endfacet
+  facet normal -0.54897 0.835801 -0.00833101
+    outer loop
+      vertex -19.5577 30.818 0
+      vertex -20.7971 30.602 60
+      vertex -19.8256 31.2401 60
+    endloop
+  endfacet
+  facet normal -0.294064 0.95575 -0.00833288
+    outer loop
+      vertex -10.1832 35.0507 0
+      vertex -11.4336 35.1891 60
+      vertex -10.3227 35.5309 60
+    endloop
+  endfacet
+  facet normal 0.54897 -0.835801 -0.00833101
+    outer loop
+      vertex 19.8256 -31.2401 60
+      vertex 19.5577 -30.818 0
+      vertex 20.7971 -30.602 60
+    endloop
+  endfacet
+  facet normal 0.0156976 -0.999842 -0.00833202
+    outer loop
+      vertex 1.14649 -36.482 0
+      vertex 0 -37 60
+      vertex 0 -36.5 0
+    endloop
+  endfacet
+  facet normal -0.439928 -0.897994 -0.00833127
+    outer loop
+      vertex -15.5409 -33.0262 0
+      vertex -16.7976 -32.9672 60
+      vertex -16.5707 -32.5217 0
+    endloop
+  endfacet
+  facet normal 0.935399 0.353495 -0.00833312
+    outer loop
+      vertex 34.8126 12.5333 60
+      vertex 34.3421 12.3639 0
+      vertex 34.4017 13.6206 60
+    endloop
+  endfacet
+  facet normal -0.97919 -0.202774 -0.0083313
+    outer loop
+      vertex -36.1089 -8.0713 60
+      vertex -36.3446 -6.93311 60
+      vertex -35.8535 -6.83942 0
+    endloop
+  endfacet
+  facet normal 0.467895 0.883745 -0.00833123
+    outer loop
+      vertex 17.8249 32.4233 60
+      vertex 16.5707 32.5217 0
+      vertex 16.7976 32.9672 60
+    endloop
+  endfacet
+  facet normal 0.140833 0.989998 -0.00833291
+    outer loop
+      vertex 5.70986 36.0506 0
+      vertex 4.63733 36.7082 60
+      vertex 5.78807 36.5445 60
+    endloop
+  endfacet
+  facet normal -0.0157435 -0.999841 -0.00833113
+    outer loop
+      vertex 0 -37 60
+      vertex -1.1622 -36.9817 60
+      vertex -1.14649 -36.482 0
+    endloop
+  endfacet
+  facet normal -0.964528 -0.26385 -0.00833289
+    outer loop
+      vertex -35.5309 -10.3227 60
+      vertex -35.8376 -9.20153 60
+      vertex -35.0507 -10.1832 0
+    endloop
+  endfacet
+  facet normal 0.868626 -0.495399 -0.00833226
+    outer loop
+      vertex 31.8475 -18.8345 60
+      vertex 31.4171 -18.58 0
+      vertex 32.4233 -17.8249 60
+    endloop
+  endfacet
+  facet normal -0.852624 0.522458 -0.00833099
+    outer loop
+      vertex -30.818 19.5577 0
+      vertex -31.4171 18.58 0
+      vertex -31.2401 19.8256 60
+    endloop
+  endfacet
+  facet normal 0.323897 0.946056 -0.00833312
+    outer loop
+      vertex 12.3639 34.3421 0
+      vertex 11.4336 35.1891 60
+      vertex 12.5333 34.8126 60
+    endloop
+  endfacet
+  facet normal -0.0470587 0.998857 -0.00833114
+    outer loop
+      vertex -1.14649 36.482 0
+      vertex -2.32325 36.927 60
+      vertex -1.1622 36.9817 60
+    endloop
+  endfacet
+  facet normal -0.353461 0.935412 -0.00833242
+    outer loop
+      vertex -13.4365 33.9368 0
+      vertex -13.6206 34.4017 60
+      vertex -12.3639 34.3421 0
+    endloop
+  endfacet
+  facet normal 0.99688 -0.0784876 -0.00833234
+    outer loop
+      vertex 36.8358 -3.48201 60
+      vertex 36.338 -3.43495 0
+      vertex 36.428 -2.29185 0
+    endloop
+  endfacet
+  facet normal 0.411506 -0.911369 -0.00833188
+    outer loop
+      vertex 15.7538 -33.4786 60
+      vertex 14.6945 -33.9569 60
+      vertex 15.5409 -33.0262 0
+    endloop
+  endfacet
+  facet normal -0.439957 -0.89798 -0.00833188
+    outer loop
+      vertex -15.7538 -33.4786 60
+      vertex -16.7976 -32.9672 60
+      vertex -15.5409 -33.0262 0
+    endloop
+  endfacet
+  facet normal 0.140928 0.989985 -0.00833107
+    outer loop
+      vertex 5.70986 36.0506 0
+      vertex 4.57466 36.2122 0
+      vertex 4.63733 36.7082 60
+    endloop
+  endfacet
+  facet normal -0.911369 0.411506 -0.00833188
+    outer loop
+      vertex -33.0262 15.5409 0
+      vertex -33.9569 14.6945 60
+      vertex -33.4786 15.7538 60
+    endloop
+  endfacet
+  facet normal 0.171889 -0.985081 -0.00833292
+    outer loop
+      vertex 5.78807 -36.5445 60
+      vertex 5.70986 -36.0506 0
+      vertex 6.83942 -35.8535 0
+    endloop
+  endfacet
+  facet normal 0.549074 0.835732 -0.00833339
+    outer loop
+      vertex 20.516 30.1884 0
+      vertex 19.5577 30.818 0
+      vertex 20.7971 30.602 60
+    endloop
+  endfacet
+  facet normal 0.649389 -0.760411 -0.0083307
+    outer loop
+      vertex 24.4685 -27.7541 60
+      vertex 23.266 -28.1237 0
+      vertex 24.1379 -27.3791 0
+    endloop
+  endfacet
+  facet normal -0.989998 -0.140833 -0.00833291
+    outer loop
+      vertex -36.5445 -5.78807 60
+      vertex -36.7082 -4.63733 60
+      vertex -36.0506 -5.70986 0
+    endloop
+  endfacet
+  facet normal 0.868626 0.495399 -0.00833226
+    outer loop
+      vertex 32.4233 17.8249 60
+      vertex 31.4171 18.58 0
+      vertex 31.8475 18.8345 60
+    endloop
+  endfacet
+  facet normal -0.439957 0.89798 -0.00833188
+    outer loop
+      vertex -15.5409 33.0262 0
+      vertex -16.7976 32.9672 60
+      vertex -15.7538 33.4786 60
+    endloop
+  endfacet
+  facet normal 0.522458 0.852624 -0.00833099
+    outer loop
+      vertex 19.5577 30.818 0
+      vertex 18.58 31.4171 0
+      vertex 19.8256 31.2401 60
+    endloop
+  endfacet
+  facet normal -0.923853 0.382657 -0.00833244
+    outer loop
+      vertex -33.9368 13.4365 0
+      vertex -34.4017 13.6206 60
+      vertex -33.498 14.4959 0
+    endloop
+  endfacet
+  facet normal -0.85259 -0.522514 -0.00833224
+    outer loop
+      vertex -31.2401 -19.8256 60
+      vertex -31.8475 -18.8345 60
+      vertex -31.4171 -18.58 0
+    endloop
+  endfacet
+  facet normal 0.935412 0.353461 -0.00833242
+    outer loop
+      vertex 34.3421 12.3639 0
+      vertex 33.9368 13.4365 0
+      vertex 34.4017 13.6206 60
+    endloop
+  endfacet
+  facet normal 0.946056 0.323897 -0.00833312
+    outer loop
+      vertex 35.1891 11.4336 60
+      vertex 34.3421 12.3639 0
+      vertex 34.8126 12.5333 60
+    endloop
+  endfacet
+  facet normal -0.897994 -0.439928 -0.00833127
+    outer loop
+      vertex -32.9672 -16.7976 60
+      vertex -33.0262 -15.5409 0
+      vertex -32.5217 -16.5707 0
+    endloop
+  endfacet
+  facet normal -0.69581 0.718178 -0.00833017
+    outer loop
+      vertex -24.986 26.6074 0
+      vertex -26.163 26.163 60
+      vertex -25.3282 26.9718 60
+    endloop
+  endfacet
+  facet normal 0.382657 -0.923853 -0.00833244
+    outer loop
+      vertex 13.6206 -34.4017 60
+      vertex 13.4365 -33.9368 0
+      vertex 14.4959 -33.498 0
+    endloop
+  endfacet
+  facet normal 0.95575 0.294064 -0.00833288
+    outer loop
+      vertex 35.5309 10.3227 60
+      vertex 35.0507 10.1832 0
+      vertex 35.1891 11.4336 60
+    endloop
+  endfacet
+  facet normal 0.109774 0.993922 -0.00833108
+    outer loop
+      vertex 4.57466 36.2122 0
+      vertex 3.48201 36.8358 60
+      vertex 4.63733 36.7082 60
+    endloop
+  endfacet
+  facet normal -0.0784595 -0.996882 -0.0083318
+    outer loop
+      vertex -2.32325 -36.927 60
+      vertex -3.48201 -36.8358 60
+      vertex -2.29185 -36.428 0
+    endloop
+  endfacet
+  facet normal -0.818153 0.57494 -0.0083334
+    outer loop
+      vertex -30.1884 20.516 0
+      vertex -30.602 20.7971 60
+      vertex -29.5291 21.4542 0
+    endloop
+  endfacet
+  facet normal -0.780382 0.625247 -0.00833246
+    outer loop
+      vertex -28.1237 23.266 0
+      vertex -28.8407 22.3711 0
+      vertex -28.509 23.5847 60
+    endloop
+  endfacet
+  facet normal 0.964518 0.263886 -0.00833217
+    outer loop
+      vertex 35.3533 9.07718 0
+      vertex 35.0507 10.1832 0
+      vertex 35.8376 9.20153 60
+    endloop
+  endfacet
+  facet normal 0.985067 -0.171972 -0.0083313
+    outer loop
+      vertex 36.3446 -6.93311 60
+      vertex 35.8535 -6.83942 0
+      vertex 36.5445 -5.78807 60
+    endloop
+  endfacet
+  facet normal 0.57494 0.818153 -0.0083334
+    outer loop
+      vertex 21.4542 29.5291 0
+      vertex 20.516 30.1884 0
+      vertex 20.7971 30.602 60
+    endloop
+  endfacet
+  facet normal -0.293996 -0.95577 -0.00833152
+    outer loop
+      vertex -10.1832 -35.0507 0
+      vertex -11.4336 -35.1891 60
+      vertex -11.2791 -34.7136 0
+    endloop
+  endfacet
+  facet normal 0.946028 -0.323976 -0.00833151
+    outer loop
+      vertex 35.1891 -11.4336 60
+      vertex 34.3421 -12.3639 0
+      vertex 34.7136 -11.2791 0
+    endloop
+  endfacet
+  facet normal 0.998857 0.0470587 -0.00833114
+    outer loop
+      vertex 36.9817 1.1622 60
+      vertex 36.482 1.14649 0
+      vertex 36.927 2.32325 60
+    endloop
+  endfacet
+  facet normal 0.835801 -0.54897 -0.00833101
+    outer loop
+      vertex 31.2401 -19.8256 60
+      vertex 30.602 -20.7971 60
+      vertex 30.818 -19.5577 0
+    endloop
+  endfacet
+  facet normal 0.294064 -0.95575 -0.00833288
+    outer loop
+      vertex 10.3227 -35.5309 60
+      vertex 10.1832 -35.0507 0
+      vertex 11.4336 -35.1891 60
+    endloop
+  endfacet
+  facet normal -0.985067 0.171972 -0.0083313
+    outer loop
+      vertex -35.8535 6.83942 0
+      vertex -36.5445 5.78807 60
+      vertex -36.3446 6.93311 60
+    endloop
+  endfacet
+  facet normal 0.989998 -0.140833 -0.00833291
+    outer loop
+      vertex 36.5445 -5.78807 60
+      vertex 36.0506 -5.70986 0
+      vertex 36.7082 -4.63733 60
+    endloop
+  endfacet
+  facet normal -0.964518 0.263886 -0.00833217
+    outer loop
+      vertex -35.3533 9.07718 0
+      vertex -35.8376 9.20153 60
+      vertex -35.0507 10.1832 0
+    endloop
+  endfacet
+  facet normal -0.835732 0.549074 -0.00833339
+    outer loop
+      vertex -30.1884 20.516 0
+      vertex -30.818 19.5577 0
+      vertex -30.602 20.7971 60
+    endloop
+  endfacet
+  facet normal -0.26385 0.964528 -0.00833289
+    outer loop
+      vertex -10.1832 35.0507 0
+      vertex -10.3227 35.5309 60
+      vertex -9.20153 35.8376 60
+    endloop
+  endfacet
+  facet normal 0.780413 0.625208 -0.00833149
+    outer loop
+      vertex 28.8407 22.3711 0
+      vertex 28.509 23.5847 60
+      vertex 29.2357 22.6776 60
+    endloop
+  endfacet
+  facet normal 0.673005 0.739591 -0.00833015
+    outer loop
+      vertex 24.986 26.6074 0
+      vertex 24.4685 27.7541 60
+      vertex 25.3282 26.9718 60
+    endloop
+  endfacet
+  facet normal -0.799652 0.600406 -0.00833198
+    outer loop
+      vertex -29.5291 21.4542 0
+      vertex -29.9336 21.7481 60
+      vertex -29.2357 22.6776 60
+    endloop
+  endfacet
+  facet normal 0.467904 0.88374 -0.00833141
+    outer loop
+      vertex 17.584 31.9852 0
+      vertex 16.5707 32.5217 0
+      vertex 17.8249 32.4233 60
+    endloop
+  endfacet
+  facet normal -0.233401 0.972345 -0.00833217
+    outer loop
+      vertex -9.07718 35.3533 0
+      vertex -9.20153 35.8376 60
+      vertex -8.0713 36.1089 60
+    endloop
+  endfacet
+  facet normal -0.140928 0.989985 -0.00833107
+    outer loop
+      vertex -4.57466 36.2122 0
+      vertex -5.70986 36.0506 0
+      vertex -4.63733 36.7082 60
+    endloop
+  endfacet
+  facet normal -0.263886 -0.964518 -0.00833217
+    outer loop
+      vertex -9.20153 -35.8376 60
+      vertex -10.1832 -35.0507 0
+      vertex -9.07718 -35.3533 0
+    endloop
+  endfacet
+  facet normal 0.672984 -0.73961 -0.00833071
+    outer loop
+      vertex 24.4685 -27.7541 60
+      vertex 24.1379 -27.3791 0
+      vertex 24.986 -26.6074 0
+    endloop
+  endfacet
+  facet normal -0.923855 -0.382653 -0.00833253
+    outer loop
+      vertex -33.9569 -14.6945 60
+      vertex -34.4017 -13.6206 60
+      vertex -33.498 -14.4959 0
+    endloop
+  endfacet
+  facet normal -0.673005 0.739591 -0.00833015
+    outer loop
+      vertex -24.986 26.6074 0
+      vertex -25.3282 26.9718 60
+      vertex -24.4685 27.7541 60
+    endloop
+  endfacet
+  facet normal -0.495399 -0.868626 -0.00833226
+    outer loop
+      vertex -17.8249 -32.4233 60
+      vertex -18.8345 -31.8475 60
+      vertex -18.58 -31.4171 0
+    endloop
+  endfacet
+  facet normal 0.760353 0.649457 -0.00833243
+    outer loop
+      vertex 28.1237 23.266 0
+      vertex 27.7541 24.4685 60
+      vertex 28.509 23.5847 60
+    endloop
+  endfacet
+  facet normal 0.171972 0.985067 -0.0083313
+    outer loop
+      vertex 6.83942 35.8535 0
+      vertex 5.78807 36.5445 60
+      vertex 6.93311 36.3446 60
+    endloop
+  endfacet
+  facet normal 0.799652 -0.600406 -0.00833198
+    outer loop
+      vertex 29.9336 -21.7481 60
+      vertex 29.2357 -22.6776 60
+      vertex 29.5291 -21.4542 0
+    endloop
+  endfacet
+  facet normal 0.411474 0.911383 -0.00833254
+    outer loop
+      vertex 15.5409 33.0262 0
+      vertex 14.4959 33.498 0
+      vertex 14.6945 33.9569 60
+    endloop
+  endfacet
+  facet normal -0.382657 0.923853 -0.00833244
+    outer loop
+      vertex -13.4365 33.9368 0
+      vertex -14.4959 33.498 0
+      vertex -13.6206 34.4017 60
+    endloop
+  endfacet
+  facet normal -0.718178 -0.69581 -0.00833017
+    outer loop
+      vertex -26.163 -26.163 60
+      vertex -26.9718 -25.3282 60
+      vertex -26.6074 -24.986 0
+    endloop
+  endfacet
+  facet normal -0.97919 0.202774 -0.0083313
+    outer loop
+      vertex -35.8535 6.83942 0
+      vertex -36.3446 6.93311 60
+      vertex -36.1089 8.0713 60
+    endloop
+  endfacet
+  facet normal -0.897994 0.439928 -0.00833127
+    outer loop
+      vertex -32.5217 16.5707 0
+      vertex -33.0262 15.5409 0
+      vertex -32.9672 16.7976 60
+    endloop
+  endfacet
+  facet normal 0.673005 -0.739591 -0.00833015
+    outer loop
+      vertex 25.3282 -26.9718 60
+      vertex 24.4685 -27.7541 60
+      vertex 24.986 -26.6074 0
+    endloop
+  endfacet
+  facet normal -0.996882 -0.0784595 -0.0083318
+    outer loop
+      vertex -36.8358 -3.48201 60
+      vertex -36.927 -2.32325 60
+      vertex -36.428 -2.29185 0
+    endloop
+  endfacet
+  facet normal 0.202774 -0.97919 -0.0083313
+    outer loop
+      vertex 6.93311 -36.3446 60
+      vertex 6.83942 -35.8535 0
+      vertex 8.0713 -36.1089 60
+    endloop
+  endfacet
+  facet normal -0.95575 -0.294064 -0.00833288
+    outer loop
+      vertex -35.1891 -11.4336 60
+      vertex -35.5309 -10.3227 60
+      vertex -35.0507 -10.1832 0
+    endloop
+  endfacet
+  facet normal -0.818111 0.575 -0.00833197
+    outer loop
+      vertex -29.5291 21.4542 0
+      vertex -30.602 20.7971 60
+      vertex -29.9336 21.7481 60
+    endloop
+  endfacet
+  facet normal 0.54897 0.835801 -0.00833101
+    outer loop
+      vertex 20.7971 30.602 60
+      vertex 19.5577 30.818 0
+      vertex 19.8256 31.2401 60
+    endloop
+  endfacet
+  facet normal 0.964528 0.26385 -0.00833289
+    outer loop
+      vertex 35.8376 9.20153 60
+      vertex 35.0507 10.1832 0
+      vertex 35.5309 10.3227 60
+    endloop
+  endfacet
+  facet normal -0.649457 0.760353 -0.00833243
+    outer loop
+      vertex -23.266 28.1237 0
+      vertex -24.4685 27.7541 60
+      vertex -23.5847 28.509 60
+    endloop
+  endfacet
+  facet normal 0.993922 -0.109774 -0.00833108
+    outer loop
+      vertex 36.7082 -4.63733 60
+      vertex 36.2122 -4.57466 0
+      vertex 36.8358 -3.48201 60
+    endloop
+  endfacet
+  facet normal 0.293996 -0.95577 -0.00833152
+    outer loop
+      vertex 11.4336 -35.1891 60
+      vertex 10.1832 -35.0507 0
+      vertex 11.2791 -34.7136 0
+    endloop
+  endfacet
+  facet normal 0.0157435 0.999841 -0.00833113
+    outer loop
+      vertex 1.14649 36.482 0
+      vertex 0 37 60
+      vertex 1.1622 36.9817 60
+    endloop
+  endfacet
+  facet normal 0.439957 -0.89798 -0.00833188
+    outer loop
+      vertex 15.7538 -33.4786 60
+      vertex 15.5409 -33.0262 0
+      vertex 16.7976 -32.9672 60
+    endloop
+  endfacet
+  facet normal -0.411506 0.911369 -0.00833188
+    outer loop
+      vertex -15.5409 33.0262 0
+      vertex -15.7538 33.4786 60
+      vertex -14.6945 33.9569 60
+    endloop
+  endfacet
+  facet normal 0.522514 -0.85259 -0.00833224
+    outer loop
+      vertex 18.8345 -31.8475 60
+      vertex 18.58 -31.4171 0
+      vertex 19.8256 -31.2401 60
+    endloop
+  endfacet
+  facet normal -0.57494 0.818153 -0.0083334
+    outer loop
+      vertex -20.516 30.1884 0
+      vertex -21.4542 29.5291 0
+      vertex -20.7971 30.602 60
+    endloop
+  endfacet
+  facet normal 0.979193 -0.202761 -0.00833106
+    outer loop
+      vertex 36.1089 -8.0713 60
+      vertex 35.621 -7.96223 0
+      vertex 35.8535 -6.83942 0
+    endloop
+  endfacet
+  facet normal 0.26385 -0.964528 -0.00833289
+    outer loop
+      vertex 10.3227 -35.5309 60
+      vertex 9.20153 -35.8376 60
+      vertex 10.1832 -35.0507 0
+    endloop
+  endfacet
+  facet normal 0.88374 -0.467904 -0.00833141
+    outer loop
+      vertex 32.4233 -17.8249 60
+      vertex 31.9852 -17.584 0
+      vertex 32.5217 -16.5707 0
+    endloop
+  endfacet
+  facet normal 0.935399 -0.353495 -0.00833312
+    outer loop
+      vertex 34.4017 -13.6206 60
+      vertex 34.3421 -12.3639 0
+      vertex 34.8126 -12.5333 60
+    endloop
+  endfacet
+  facet normal 0.897994 0.439928 -0.00833127
+    outer loop
+      vertex 33.0262 15.5409 0
+      vertex 32.5217 16.5707 0
+      vertex 32.9672 16.7976 60
+    endloop
+  endfacet
+  facet normal -0.26385 -0.964528 -0.00833289
+    outer loop
+      vertex -9.20153 -35.8376 60
+      vertex -10.3227 -35.5309 60
+      vertex -10.1832 -35.0507 0
+    endloop
+  endfacet
+  facet normal 0.649457 0.760353 -0.00833243
+    outer loop
+      vertex 24.4685 27.7541 60
+      vertex 23.266 28.1237 0
+      vertex 23.5847 28.509 60
+    endloop
+  endfacet
+  facet normal -0.799669 -0.600384 -0.00833145
+    outer loop
+      vertex -29.2357 -22.6776 60
+      vertex -29.5291 -21.4542 0
+      vertex -28.8407 -22.3711 0
+    endloop
+  endfacet
+  facet normal -0.600384 -0.799669 -0.00833145
+    outer loop
+      vertex -21.4542 -29.5291 0
+      vertex -22.6776 -29.2357 60
+      vertex -22.3711 -28.8407 0
+    endloop
+  endfacet
+  facet normal -0.852624 -0.522458 -0.00833099
+    outer loop
+      vertex -31.2401 -19.8256 60
+      vertex -31.4171 -18.58 0
+      vertex -30.818 -19.5577 0
+    endloop
+  endfacet
+  facet normal -0.985081 0.171889 -0.00833292
+    outer loop
+      vertex -36.0506 5.70986 0
+      vertex -36.5445 5.78807 60
+      vertex -35.8535 6.83942 0
+    endloop
+  endfacet
+  facet normal 0.97919 -0.202774 -0.0083313
+    outer loop
+      vertex 36.1089 -8.0713 60
+      vertex 35.8535 -6.83942 0
+      vertex 36.3446 -6.93311 60
+    endloop
+  endfacet
+  facet normal -0.600406 -0.799652 -0.00833198
+    outer loop
+      vertex -21.7481 -29.9336 60
+      vertex -22.6776 -29.2357 60
+      vertex -21.4542 -29.5291 0
+    endloop
+  endfacet
+  facet normal 0.233457 0.972331 -0.00833106
+    outer loop
+      vertex 9.07718 35.3533 0
+      vertex 7.96223 35.621 0
+      vertex 8.0713 36.1089 60
+    endloop
+  endfacet
+  facet normal 0.835801 0.54897 -0.00833101
+    outer loop
+      vertex 30.818 19.5577 0
+      vertex 30.602 20.7971 60
+      vertex 31.2401 19.8256 60
+    endloop
+  endfacet
+  facet normal -0.600406 0.799652 -0.00833198
+    outer loop
+      vertex -21.4542 29.5291 0
+      vertex -22.6776 29.2357 60
+      vertex -21.7481 29.9336 60
+    endloop
+  endfacet
+  facet normal 0.799652 0.600406 -0.00833198
+    outer loop
+      vertex 29.5291 21.4542 0
+      vertex 29.2357 22.6776 60
+      vertex 29.9336 21.7481 60
+    endloop
+  endfacet
+  facet normal 0.99688 0.0784876 -0.00833234
+    outer loop
+      vertex 36.428 2.29185 0
+      vertex 36.338 3.43495 0
+      vertex 36.8358 3.48201 60
+    endloop
+  endfacet
+  facet normal 0.0470587 0.998857 -0.00833114
+    outer loop
+      vertex 2.32325 36.927 60
+      vertex 1.14649 36.482 0
+      vertex 1.1622 36.9817 60
+    endloop
+  endfacet
+  facet normal -0.293996 0.95577 -0.00833152
+    outer loop
+      vertex -11.2791 34.7136 0
+      vertex -11.4336 35.1891 60
+      vertex -10.1832 35.0507 0
+    endloop
+  endfacet
+  facet normal 0.897994 -0.439928 -0.00833127
+    outer loop
+      vertex 32.9672 -16.7976 60
+      vertex 32.5217 -16.5707 0
+      vertex 33.0262 -15.5409 0
+    endloop
+  endfacet
+  facet normal 0.985081 -0.171889 -0.00833292
+    outer loop
+      vertex 36.5445 -5.78807 60
+      vertex 35.8535 -6.83942 0
+      vertex 36.0506 -5.70986 0
+    endloop
+  endfacet
+  facet normal 0.989998 0.140833 -0.00833291
+    outer loop
+      vertex 36.7082 4.63733 60
+      vertex 36.0506 5.70986 0
+      vertex 36.5445 5.78807 60
+    endloop
+  endfacet
+  facet normal 0.999842 -0.0156976 -0.00833202
+    outer loop
+      vertex 37 0 60
+      vertex 36.482 -1.14649 0
+      vertex 36.5 0 0
+    endloop
+  endfacet
+  facet normal -0.999841 0.0157435 -0.00833113
+    outer loop
+      vertex -36.482 1.14649 0
+      vertex -37 0 60
+      vertex -36.9817 1.1622 60
+    endloop
+  endfacet
+  facet normal 0.999841 -0.0157435 -0.00833113
+    outer loop
+      vertex 36.9817 -1.1622 60
+      vertex 36.482 -1.14649 0
+      vertex 37 0 60
+    endloop
+  endfacet
+  facet normal 0.233401 -0.972345 -0.00833217
+    outer loop
+      vertex 9.20153 -35.8376 60
+      vertex 8.0713 -36.1089 60
+      vertex 9.07718 -35.3533 0
+    endloop
+  endfacet
+  facet normal 0.999841 0.0157435 -0.00833113
+    outer loop
+      vertex 37 0 60
+      vertex 36.482 1.14649 0
+      vertex 36.9817 1.1622 60
+    endloop
+  endfacet
+  facet normal 0.996882 -0.0784595 -0.0083318
+    outer loop
+      vertex 36.8358 -3.48201 60
+      vertex 36.428 -2.29185 0
+      vertex 36.927 -2.32325 60
+    endloop
+  endfacet
+  facet normal 0.998857 -0.0470587 -0.00833114
+    outer loop
+      vertex 36.927 -2.32325 60
+      vertex 36.482 -1.14649 0
+      vertex 36.9817 -1.1622 60
+    endloop
+  endfacet
+  facet normal 0.263886 0.964518 -0.00833217
+    outer loop
+      vertex 10.1832 35.0507 0
+      vertex 9.07718 35.3533 0
+      vertex 9.20153 35.8376 60
+    endloop
+  endfacet
+  facet normal 0.69581 -0.718178 -0.00833017
+    outer loop
+      vertex 25.3282 -26.9718 60
+      vertex 24.986 -26.6074 0
+      vertex 26.163 -26.163 60
+    endloop
+  endfacet
+  facet normal -0.718178 0.69581 -0.00833017
+    outer loop
+      vertex -26.6074 24.986 0
+      vertex -26.9718 25.3282 60
+      vertex -26.163 26.163 60
+    endloop
+  endfacet
+  facet normal 0.818153 -0.57494 -0.0083334
+    outer loop
+      vertex 30.602 -20.7971 60
+      vertex 29.5291 -21.4542 0
+      vertex 30.1884 -20.516 0
+    endloop
+  endfacet
+  facet normal 0.89798 -0.439957 -0.00833188
+    outer loop
+      vertex 33.4786 -15.7538 60
+      vertex 32.9672 -16.7976 60
+      vertex 33.0262 -15.5409 0
+    endloop
+  endfacet
+  facet normal 0.923853 0.382657 -0.00833244
+    outer loop
+      vertex 33.9368 13.4365 0
+      vertex 33.498 14.4959 0
+      vertex 34.4017 13.6206 60
+    endloop
+  endfacet
+  facet normal -0.972331 -0.233457 -0.00833106
+    outer loop
+      vertex -35.3533 -9.07718 0
+      vertex -36.1089 -8.0713 60
+      vertex -35.621 -7.96223 0
+    endloop
+  endfacet
+  facet normal 0.202774 0.97919 -0.0083313
+    outer loop
+      vertex 8.0713 36.1089 60
+      vertex 6.83942 35.8535 0
+      vertex 6.93311 36.3446 60
+    endloop
+  endfacet
+  facet normal -0.883745 -0.467895 -0.00833123
+    outer loop
+      vertex -32.4233 -17.8249 60
+      vertex -32.9672 -16.7976 60
+      vertex -32.5217 -16.5707 0
+    endloop
+  endfacet
+  facet normal 0.353461 -0.935412 -0.00833242
+    outer loop
+      vertex 13.6206 -34.4017 60
+      vertex 12.3639 -34.3421 0
+      vertex 13.4365 -33.9368 0
+    endloop
+  endfacet
+  facet normal -0.672984 -0.73961 -0.00833071
+    outer loop
+      vertex -24.4685 -27.7541 60
+      vertex -24.986 -26.6074 0
+      vertex -24.1379 -27.3791 0
+    endloop
+  endfacet
+  facet normal 0.923855 -0.382653 -0.00833253
+    outer loop
+      vertex 33.9569 -14.6945 60
+      vertex 33.498 -14.4959 0
+      vertex 34.4017 -13.6206 60
+    endloop
+  endfacet
+  facet normal -0.495436 0.868605 -0.00833144
+    outer loop
+      vertex -17.584 31.9852 0
+      vertex -18.58 31.4171 0
+      vertex -17.8249 32.4233 60
+    endloop
+  endfacet
+  facet normal -0.993922 -0.109774 -0.00833108
+    outer loop
+      vertex -36.7082 -4.63733 60
+      vertex -36.8358 -3.48201 60
+      vertex -36.2122 -4.57466 0
+    endloop
+  endfacet
+  facet normal 0.202761 -0.979193 -0.00833106
+    outer loop
+      vertex 8.0713 -36.1089 60
+      vertex 6.83942 -35.8535 0
+      vertex 7.96223 -35.621 0
+    endloop
+  endfacet
+  facet normal 0.911383 0.411474 -0.00833254
+    outer loop
+      vertex 33.498 14.4959 0
+      vertex 33.0262 15.5409 0
+      vertex 33.9569 14.6945 60
+    endloop
+  endfacet
+  facet normal -0.993929 0.109709 -0.00833234
+    outer loop
+      vertex -36.338 3.43495 0
+      vertex -36.8358 3.48201 60
+      vertex -36.2122 4.57466 0
+    endloop
+  endfacet
+  facet normal 0.600384 -0.799669 -0.00833145
+    outer loop
+      vertex 22.6776 -29.2357 60
+      vertex 21.4542 -29.5291 0
+      vertex 22.3711 -28.8407 0
+    endloop
+  endfacet
+  facet normal -0.323897 0.946056 -0.00833312
+    outer loop
+      vertex -12.3639 34.3421 0
+      vertex -12.5333 34.8126 60
+      vertex -11.4336 35.1891 60
+    endloop
+  endfacet
+  facet normal 0.993922 0.109774 -0.00833108
+    outer loop
+      vertex 36.8358 3.48201 60
+      vertex 36.2122 4.57466 0
+      vertex 36.7082 4.63733 60
+    endloop
+  endfacet
+  facet normal -0.946056 0.323897 -0.00833312
+    outer loop
+      vertex -34.3421 12.3639 0
+      vertex -35.1891 11.4336 60
+      vertex -34.8126 12.5333 60
+    endloop
+  endfacet
+  facet normal -0.382657 -0.923853 -0.00833244
+    outer loop
+      vertex -13.6206 -34.4017 60
+      vertex -14.4959 -33.498 0
+      vertex -13.4365 -33.9368 0
+    endloop
+  endfacet
+  facet normal 0.923855 0.382653 -0.00833253
+    outer loop
+      vertex 34.4017 13.6206 60
+      vertex 33.498 14.4959 0
+      vertex 33.9569 14.6945 60
+    endloop
+  endfacet
+  facet normal 0.972345 -0.233401 -0.00833217
+    outer loop
+      vertex 35.8376 -9.20153 60
+      vertex 35.3533 -9.07718 0
+      vertex 36.1089 -8.0713 60
+    endloop
+  endfacet
+  facet normal -0.575 0.818111 -0.00833197
+    outer loop
+      vertex -21.4542 29.5291 0
+      vertex -21.7481 29.9336 60
+      vertex -20.7971 30.602 60
+    endloop
+  endfacet
+  facet normal -0.294064 -0.95575 -0.00833288
+    outer loop
+      vertex -10.3227 -35.5309 60
+      vertex -11.4336 -35.1891 60
+      vertex -10.1832 -35.0507 0
+    endloop
+  endfacet
+  facet normal 0.353495 0.935399 -0.00833312
+    outer loop
+      vertex 13.6206 34.4017 60
+      vertex 12.3639 34.3421 0
+      vertex 12.5333 34.8126 60
+    endloop
+  endfacet
+  facet normal 0.439928 -0.897994 -0.00833127
+    outer loop
+      vertex 16.7976 -32.9672 60
+      vertex 15.5409 -33.0262 0
+      vertex 16.5707 -32.5217 0
+    endloop
+  endfacet
+  facet normal 0.97919 0.202774 -0.0083313
+    outer loop
+      vertex 36.3446 6.93311 60
+      vertex 35.8535 6.83942 0
+      vertex 36.1089 8.0713 60
+    endloop
+  endfacet
+  facet normal -0.522458 -0.852624 -0.00833099
+    outer loop
+      vertex -18.58 -31.4171 0
+      vertex -19.8256 -31.2401 60
+      vertex -19.5577 -30.818 0
+    endloop
+  endfacet
+  facet normal -0.946056 -0.323897 -0.00833312
+    outer loop
+      vertex -34.8126 -12.5333 60
+      vertex -35.1891 -11.4336 60
+      vertex -34.3421 -12.3639 0
+    endloop
+  endfacet
+  facet normal -0.411474 0.911383 -0.00833254
+    outer loop
+      vertex -14.4959 33.498 0
+      vertex -15.5409 33.0262 0
+      vertex -14.6945 33.9569 60
+    endloop
+  endfacet
+  facet normal -0.799652 -0.600406 -0.00833198
+    outer loop
+      vertex -29.2357 -22.6776 60
+      vertex -29.9336 -21.7481 60
+      vertex -29.5291 -21.4542 0
+    endloop
+  endfacet
+  facet normal -0.323976 0.946028 -0.00833151
+    outer loop
+      vertex -11.2791 34.7136 0
+      vertex -12.3639 34.3421 0
+      vertex -11.4336 35.1891 60
+    endloop
+  endfacet
+  facet normal -0.911383 0.411474 -0.00833254
+    outer loop
+      vertex -33.498 14.4959 0
+      vertex -33.9569 14.6945 60
+      vertex -33.0262 15.5409 0
+    endloop
+  endfacet
+  facet normal -0.99688 0.0784876 -0.00833234
+    outer loop
+      vertex -36.428 2.29185 0
+      vertex -36.8358 3.48201 60
+      vertex -36.338 3.43495 0
+    endloop
+  endfacet
+  facet normal -0.780413 -0.625208 -0.00833149
+    outer loop
+      vertex -28.509 -23.5847 60
+      vertex -29.2357 -22.6776 60
+      vertex -28.8407 -22.3711 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.7 0 60
+      vertex 37 0 60
+      vertex 36.9817 1.1622 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.6757 1.15996 60
+      vertex 36.9817 1.1622 60
+      vertex 36.927 2.32325 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 37 0 60
+      vertex 27.7 0 60
+      vertex 36.9817 -1.1622 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.6029 2.31788 60
+      vertex 36.927 2.32325 60
+      vertex 36.8358 3.48201 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.6757 -1.15996 60
+      vertex 36.9817 -1.1622 60
+      vertex 27.7 0 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.4816 3.47173 60
+      vertex 36.8358 3.48201 60
+      vertex 36.7082 4.63733 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.9817 -1.1622 60
+      vertex 27.6757 -1.15996 60
+      vertex 36.927 -2.32325 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.4816 3.47173 60
+      vertex 36.7082 4.63733 60
+      vertex 36.5445 5.78807 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.6029 -2.31788 60
+      vertex 36.927 -2.32325 60
+      vertex 27.6757 -1.15996 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.3121 4.61949 60
+      vertex 36.5445 5.78807 60
+      vertex 36.3446 6.93311 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.927 -2.32325 60
+      vertex 27.6029 -2.31788 60
+      vertex 36.8358 -3.48201 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.0947 5.75915 60
+      vertex 36.3446 6.93311 60
+      vertex 36.1089 8.0713 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.4816 -3.47173 60
+      vertex 36.8358 -3.48201 60
+      vertex 27.6029 -2.31788 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.8298 6.88871 60
+      vertex 36.1089 8.0713 60
+      vertex 35.8376 9.20153 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.8358 -3.48201 60
+      vertex 27.4816 -3.47173 60
+      vertex 36.7082 -4.63733 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.8298 6.88871 60
+      vertex 35.8376 9.20153 60
+      vertex 35.5309 10.3227 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.7082 -4.63733 60
+      vertex 27.4816 -3.47173 60
+      vertex 36.5445 -5.78807 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.5177 8.00618 60
+      vertex 35.5309 10.3227 60
+      vertex 35.1891 11.4336 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.3121 -4.61949 60
+      vertex 36.5445 -5.78807 60
+      vertex 27.4816 -3.47173 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.1592 9.10961 60
+      vertex 35.1891 11.4336 60
+      vertex 34.8126 12.5333 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.5445 -5.78807 60
+      vertex 27.3121 -4.61949 60
+      vertex 36.3446 -6.93311 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.7548 10.1971 60
+      vertex 34.8126 12.5333 60
+      vertex 34.4017 13.6206 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.0947 -5.75915 60
+      vertex 36.3446 -6.93311 60
+      vertex 27.3121 -4.61949 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.7548 10.1971 60
+      vertex 34.4017 13.6206 60
+      vertex 33.9569 14.6945 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.3446 -6.93311 60
+      vertex 27.0947 -5.75915 60
+      vertex 36.1089 -8.0713 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.3052 11.2666 60
+      vertex 33.9569 14.6945 60
+      vertex 33.4786 15.7538 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.8298 -6.88871 60
+      vertex 36.1089 -8.0713 60
+      vertex 27.0947 -5.75915 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8112 12.3164 60
+      vertex 33.4786 15.7538 60
+      vertex 32.9672 16.7976 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.1089 -8.0713 60
+      vertex 26.8298 -6.88871 60
+      vertex 35.8376 -9.20153 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.2737 13.3446 60
+      vertex 32.9672 16.7976 60
+      vertex 32.4233 17.8249 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.8376 -9.20153 60
+      vertex 26.8298 -6.88871 60
+      vertex 35.5309 -10.3227 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.2737 13.3446 60
+      vertex 32.4233 17.8249 60
+      vertex 31.8475 18.8345 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.5177 -8.00618 60
+      vertex 35.5309 -10.3227 60
+      vertex 26.8298 -6.88871 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.6936 14.3493 60
+      vertex 31.8475 18.8345 60
+      vertex 31.2401 19.8256 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.5309 -10.3227 60
+      vertex 26.5177 -8.00618 60
+      vertex 35.1891 -11.4336 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.0719 15.3289 60
+      vertex 31.2401 19.8256 60
+      vertex 30.602 20.7971 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.1592 -9.10961 60
+      vertex 35.1891 -11.4336 60
+      vertex 26.5177 -8.00618 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.4098 16.2817 60
+      vertex 30.602 20.7971 60
+      vertex 29.9336 21.7481 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.1891 -11.4336 60
+      vertex 26.1592 -9.10961 60
+      vertex 34.8126 -12.5333 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.4098 16.2817 60
+      vertex 29.9336 21.7481 60
+      vertex 29.2357 22.6776 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.7548 -10.1971 60
+      vertex 34.8126 -12.5333 60
+      vertex 26.1592 -9.10961 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.7083 17.2058 60
+      vertex 29.2357 22.6776 60
+      vertex 28.509 23.5847 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.8126 -12.5333 60
+      vertex 25.7548 -10.1971 60
+      vertex 34.4017 -13.6206 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.9688 18.0998 60
+      vertex 28.509 23.5847 60
+      vertex 27.7541 24.4685 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.4017 -13.6206 60
+      vertex 25.7548 -10.1971 60
+      vertex 33.9569 -14.6945 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.3052 -11.2666 60
+      vertex 33.9569 -14.6945 60
+      vertex 25.7548 -10.1971 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.9817 1.1622 60
+      vertex 27.6757 1.15996 60
+      vertex 27.7 0 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.927 2.32325 60
+      vertex 27.6029 2.31788 60
+      vertex 27.6757 1.15996 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.8358 3.48201 60
+      vertex 27.4816 3.47173 60
+      vertex 27.6029 2.31788 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.5445 5.78807 60
+      vertex 27.3121 4.61949 60
+      vertex 27.4816 3.47173 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.3446 6.93311 60
+      vertex 27.0947 5.75915 60
+      vertex 27.3121 4.61949 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1924 18.962 60
+      vertex 27.7541 24.4685 60
+      vertex 26.9718 25.3282 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.1089 8.0713 60
+      vertex 26.8298 6.88871 60
+      vertex 27.0947 5.75915 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.5309 10.3227 60
+      vertex 26.5177 8.00618 60
+      vertex 26.8298 6.88871 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1924 18.962 60
+      vertex 26.9718 25.3282 60
+      vertex 26.163 26.163 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.1891 11.4336 60
+      vertex 26.1592 9.10961 60
+      vertex 26.5177 8.00618 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.8126 12.5333 60
+      vertex 25.7548 10.1971 60
+      vertex 26.1592 9.10961 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3807 19.7909 60
+      vertex 26.163 26.163 60
+      vertex 25.3282 26.9718 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.9569 14.6945 60
+      vertex 25.3052 11.2666 60
+      vertex 25.7548 10.1971 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.4786 15.7538 60
+      vertex 24.8112 12.3164 60
+      vertex 25.3052 11.2666 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5349 20.5851 60
+      vertex 25.3282 26.9718 60
+      vertex 24.4685 27.7541 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 32.9672 16.7976 60
+      vertex 24.2737 13.3446 60
+      vertex 24.8112 12.3164 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.8475 18.8345 60
+      vertex 23.6936 14.3493 60
+      vertex 24.2737 13.3446 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6566 21.3432 60
+      vertex 24.4685 27.7541 60
+      vertex 23.5847 28.509 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.2401 19.8256 60
+      vertex 23.0719 15.3289 60
+      vertex 23.6936 14.3493 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6566 21.3432 60
+      vertex 23.5847 28.509 60
+      vertex 22.6776 29.2357 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.602 20.7971 60
+      vertex 22.4098 16.2817 60
+      vertex 23.0719 15.3289 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.7474 22.0639 60
+      vertex 22.6776 29.2357 60
+      vertex 21.7481 29.9336 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.2357 22.6776 60
+      vertex 21.7083 17.2058 60
+      vertex 22.4098 16.2817 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.509 23.5847 60
+      vertex 20.9688 18.0998 60
+      vertex 21.7083 17.2058 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.8088 22.7458 60
+      vertex 21.7481 29.9336 60
+      vertex 20.7971 30.602 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.7541 24.4685 60
+      vertex 20.1924 18.962 60
+      vertex 20.9688 18.0998 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8424 23.3879 60
+      vertex 20.7971 30.602 60
+      vertex 19.8256 31.2401 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.163 26.163 60
+      vertex 19.3807 19.7909 60
+      vertex 20.1924 18.962 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8424 23.3879 60
+      vertex 19.8256 31.2401 60
+      vertex 18.8345 31.8475 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.3282 26.9718 60
+      vertex 18.5349 20.5851 60
+      vertex 19.3807 19.7909 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.85 23.9889 60
+      vertex 18.8345 31.8475 60
+      vertex 17.8249 32.4233 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.4685 27.7541 60
+      vertex 17.6566 21.3432 60
+      vertex 18.5349 20.5851 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.8333 24.5478 60
+      vertex 17.8249 32.4233 60
+      vertex 16.7976 32.9672 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.6776 29.2357 60
+      vertex 16.7474 22.0639 60
+      vertex 17.6566 21.3432 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.7481 29.9336 60
+      vertex 15.8088 22.7458 60
+      vertex 16.7474 22.0639 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7941 25.0637 60
+      vertex 16.7976 32.9672 60
+      vertex 15.7538 33.4786 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.7971 30.602 60
+      vertex 14.8424 23.3879 60
+      vertex 15.8088 22.7458 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7941 25.0637 60
+      vertex 15.7538 33.4786 60
+      vertex 14.6945 33.9569 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.8345 31.8475 60
+      vertex 13.85 23.9889 60
+      vertex 14.8424 23.3879 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.7342 25.5356 60
+      vertex 14.6945 33.9569 60
+      vertex 13.6206 34.4017 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.8249 32.4233 60
+      vertex 12.8333 24.5478 60
+      vertex 13.85 23.9889 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.65545 25.9627 60
+      vertex 13.6206 34.4017 60
+      vertex 12.5333 34.8126 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.7976 32.9672 60
+      vertex 11.7941 25.0637 60
+      vertex 12.8333 24.5478 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.55977 26.3443 60
+      vertex 12.5333 34.8126 60
+      vertex 11.4336 35.1891 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.6945 33.9569 60
+      vertex 10.7342 25.5356 60
+      vertex 11.7941 25.0637 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.55977 26.3443 60
+      vertex 11.4336 35.1891 60
+      vertex 10.3227 35.5309 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6206 34.4017 60
+      vertex 9.65545 25.9627 60
+      vertex 10.7342 25.5356 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.44908 26.6796 60
+      vertex 10.3227 35.5309 60
+      vertex 9.20153 35.8376 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.5333 34.8126 60
+      vertex 8.55977 26.3443 60
+      vertex 9.65545 25.9627 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.32532 26.9681 60
+      vertex 9.20153 35.8376 60
+      vertex 8.0713 36.1089 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.3227 35.5309 60
+      vertex 7.44908 26.6796 60
+      vertex 8.55977 26.3443 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.19046 27.2094 60
+      vertex 8.0713 36.1089 60
+      vertex 6.93311 36.3446 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.20153 35.8376 60
+      vertex 6.32532 26.9681 60
+      vertex 7.44908 26.6796 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.19046 27.2094 60
+      vertex 6.93311 36.3446 60
+      vertex 5.78807 36.5445 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.0713 36.1089 60
+      vertex 5.19046 27.2094 60
+      vertex 6.32532 26.9681 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.0465 27.4028 60
+      vertex 5.78807 36.5445 60
+      vertex 4.63733 36.7082 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.78807 36.5445 60
+      vertex 4.0465 27.4028 60
+      vertex 5.19046 27.2094 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.89544 27.5483 60
+      vertex 4.63733 36.7082 60
+      vertex 3.48201 36.8358 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.63733 36.7082 60
+      vertex 2.89544 27.5483 60
+      vertex 4.0465 27.4028 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.7393 27.6453 60
+      vertex 3.48201 36.8358 60
+      vertex 2.32325 36.927 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.48201 36.8358 60
+      vertex 1.7393 27.6453 60
+      vertex 2.89544 27.5483 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.1622 36.9817 60
+      vertex 1.7393 27.6453 60
+      vertex 2.32325 36.927 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.1622 36.9817 60
+      vertex 0.580105 27.6939 60
+      vertex 1.7393 27.6453 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 37 60
+      vertex 0.580105 27.6939 60
+      vertex 1.1622 36.9817 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 37 60
+      vertex -0.580105 27.6939 60
+      vertex 0.580105 27.6939 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.1622 36.9817 60
+      vertex -0.580105 27.6939 60
+      vertex 0 37 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.1622 36.9817 60
+      vertex -1.7393 27.6453 60
+      vertex -0.580105 27.6939 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.32325 36.927 60
+      vertex -1.7393 27.6453 60
+      vertex -1.1622 36.9817 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3.48201 36.8358 60
+      vertex -1.7393 27.6453 60
+      vertex -2.32325 36.927 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.7393 27.6453 60
+      vertex -3.48201 36.8358 60
+      vertex -2.89544 27.5483 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -4.63733 36.7082 60
+      vertex -2.89544 27.5483 60
+      vertex -3.48201 36.8358 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.89544 27.5483 60
+      vertex -4.63733 36.7082 60
+      vertex -4.0465 27.4028 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.78807 36.5445 60
+      vertex -4.0465 27.4028 60
+      vertex -4.63733 36.7082 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.0465 27.4028 60
+      vertex -5.78807 36.5445 60
+      vertex -5.19046 27.2094 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -6.93311 36.3446 60
+      vertex -5.19046 27.2094 60
+      vertex -5.78807 36.5445 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -8.0713 36.1089 60
+      vertex -5.19046 27.2094 60
+      vertex -6.93311 36.3446 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.19046 27.2094 60
+      vertex -8.0713 36.1089 60
+      vertex -6.32532 26.9681 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.20153 35.8376 60
+      vertex -6.32532 26.9681 60
+      vertex -8.0713 36.1089 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.32532 26.9681 60
+      vertex -9.20153 35.8376 60
+      vertex -7.44908 26.6796 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.3227 35.5309 60
+      vertex -7.44908 26.6796 60
+      vertex -9.20153 35.8376 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.44908 26.6796 60
+      vertex -10.3227 35.5309 60
+      vertex -8.55977 26.3443 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.4336 35.1891 60
+      vertex -8.55977 26.3443 60
+      vertex -10.3227 35.5309 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.5333 34.8126 60
+      vertex -8.55977 26.3443 60
+      vertex -11.4336 35.1891 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.55977 26.3443 60
+      vertex -12.5333 34.8126 60
+      vertex -9.65545 25.9627 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.6206 34.4017 60
+      vertex -9.65545 25.9627 60
+      vertex -12.5333 34.8126 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.65545 25.9627 60
+      vertex -13.6206 34.4017 60
+      vertex -10.7342 25.5356 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.6945 33.9569 60
+      vertex -10.7342 25.5356 60
+      vertex -13.6206 34.4017 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.7342 25.5356 60
+      vertex -14.6945 33.9569 60
+      vertex -11.7941 25.0637 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.7538 33.4786 60
+      vertex -11.7941 25.0637 60
+      vertex -14.6945 33.9569 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.7976 32.9672 60
+      vertex -11.7941 25.0637 60
+      vertex -15.7538 33.4786 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7941 25.0637 60
+      vertex -16.7976 32.9672 60
+      vertex -12.8333 24.5478 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.8249 32.4233 60
+      vertex -12.8333 24.5478 60
+      vertex -16.7976 32.9672 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.8333 24.5478 60
+      vertex -17.8249 32.4233 60
+      vertex -13.85 23.9889 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.8345 31.8475 60
+      vertex -13.85 23.9889 60
+      vertex -17.8249 32.4233 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.85 23.9889 60
+      vertex -18.8345 31.8475 60
+      vertex -14.8424 23.3879 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.8256 31.2401 60
+      vertex -14.8424 23.3879 60
+      vertex -18.8345 31.8475 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.7971 30.602 60
+      vertex -14.8424 23.3879 60
+      vertex -19.8256 31.2401 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8424 23.3879 60
+      vertex -20.7971 30.602 60
+      vertex -15.8088 22.7458 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.7481 29.9336 60
+      vertex -15.8088 22.7458 60
+      vertex -20.7971 30.602 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.8088 22.7458 60
+      vertex -21.7481 29.9336 60
+      vertex -16.7474 22.0639 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.6776 29.2357 60
+      vertex -16.7474 22.0639 60
+      vertex -21.7481 29.9336 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.7474 22.0639 60
+      vertex -22.6776 29.2357 60
+      vertex -17.6566 21.3432 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.5847 28.509 60
+      vertex -17.6566 21.3432 60
+      vertex -22.6776 29.2357 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.4685 27.7541 60
+      vertex -17.6566 21.3432 60
+      vertex -23.5847 28.509 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6566 21.3432 60
+      vertex -24.4685 27.7541 60
+      vertex -18.5349 20.5851 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -25.3282 26.9718 60
+      vertex -18.5349 20.5851 60
+      vertex -24.4685 27.7541 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5349 20.5851 60
+      vertex -25.3282 26.9718 60
+      vertex -19.3807 19.7909 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -26.163 26.163 60
+      vertex -19.3807 19.7909 60
+      vertex -25.3282 26.9718 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3807 19.7909 60
+      vertex -26.163 26.163 60
+      vertex -20.1924 18.962 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -26.9718 25.3282 60
+      vertex -20.1924 18.962 60
+      vertex -26.163 26.163 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.7541 24.4685 60
+      vertex -20.1924 18.962 60
+      vertex -26.9718 25.3282 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1924 18.962 60
+      vertex -27.7541 24.4685 60
+      vertex -20.9688 18.0998 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.509 23.5847 60
+      vertex -20.9688 18.0998 60
+      vertex -27.7541 24.4685 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.9688 18.0998 60
+      vertex -28.509 23.5847 60
+      vertex -21.7083 17.2058 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -29.2357 22.6776 60
+      vertex -21.7083 17.2058 60
+      vertex -28.509 23.5847 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.7083 17.2058 60
+      vertex -29.2357 22.6776 60
+      vertex -22.4098 16.2817 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -29.9336 21.7481 60
+      vertex -22.4098 16.2817 60
+      vertex -29.2357 22.6776 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.602 20.7971 60
+      vertex -22.4098 16.2817 60
+      vertex -29.9336 21.7481 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.4098 16.2817 60
+      vertex -30.602 20.7971 60
+      vertex -23.0719 15.3289 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.2401 19.8256 60
+      vertex -23.0719 15.3289 60
+      vertex -30.602 20.7971 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0719 15.3289 60
+      vertex -31.2401 19.8256 60
+      vertex -23.6936 14.3493 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.8475 18.8345 60
+      vertex -23.6936 14.3493 60
+      vertex -31.2401 19.8256 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.6936 14.3493 60
+      vertex -31.8475 18.8345 60
+      vertex -24.2737 13.3446 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -32.4233 17.8249 60
+      vertex -24.2737 13.3446 60
+      vertex -31.8475 18.8345 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -32.9672 16.7976 60
+      vertex -24.2737 13.3446 60
+      vertex -32.4233 17.8249 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.2737 13.3446 60
+      vertex -32.9672 16.7976 60
+      vertex -24.8112 12.3164 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -33.4786 15.7538 60
+      vertex -24.8112 12.3164 60
+      vertex -32.9672 16.7976 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -33.9569 14.6945 60
+      vertex -25.3052 11.2666 60
+      vertex -33.4786 15.7538 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8112 12.3164 60
+      vertex -33.4786 15.7538 60
+      vertex -25.3052 11.2666 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.9569 -14.6945 60
+      vertex 25.3052 -11.2666 60
+      vertex 33.4786 -15.7538 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.8112 -12.3164 60
+      vertex 33.4786 -15.7538 60
+      vertex 25.3052 -11.2666 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.4786 -15.7538 60
+      vertex 24.8112 -12.3164 60
+      vertex 32.9672 -16.7976 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.2737 -13.3446 60
+      vertex 32.9672 -16.7976 60
+      vertex 24.8112 -12.3164 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 32.9672 -16.7976 60
+      vertex 24.2737 -13.3446 60
+      vertex 32.4233 -17.8249 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 32.4233 -17.8249 60
+      vertex 24.2737 -13.3446 60
+      vertex 31.8475 -18.8345 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.6936 -14.3493 60
+      vertex 31.8475 -18.8345 60
+      vertex 24.2737 -13.3446 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.8475 -18.8345 60
+      vertex 23.6936 -14.3493 60
+      vertex 31.2401 -19.8256 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.0719 -15.3289 60
+      vertex 31.2401 -19.8256 60
+      vertex 23.6936 -14.3493 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.2401 -19.8256 60
+      vertex 23.0719 -15.3289 60
+      vertex 30.602 -20.7971 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.4098 -16.2817 60
+      vertex 30.602 -20.7971 60
+      vertex 23.0719 -15.3289 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.602 -20.7971 60
+      vertex 22.4098 -16.2817 60
+      vertex 29.9336 -21.7481 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.9336 -21.7481 60
+      vertex 22.4098 -16.2817 60
+      vertex 29.2357 -22.6776 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.7083 -17.2058 60
+      vertex 29.2357 -22.6776 60
+      vertex 22.4098 -16.2817 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.2357 -22.6776 60
+      vertex 21.7083 -17.2058 60
+      vertex 28.509 -23.5847 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.9688 -18.0998 60
+      vertex 28.509 -23.5847 60
+      vertex 21.7083 -17.2058 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.509 -23.5847 60
+      vertex 20.9688 -18.0998 60
+      vertex 27.7541 -24.4685 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.1924 -18.962 60
+      vertex 27.7541 -24.4685 60
+      vertex 20.9688 -18.0998 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.7541 -24.4685 60
+      vertex 20.1924 -18.962 60
+      vertex 26.9718 -25.3282 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.9718 -25.3282 60
+      vertex 20.1924 -18.962 60
+      vertex 26.163 -26.163 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.3807 -19.7909 60
+      vertex 26.163 -26.163 60
+      vertex 20.1924 -18.962 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.163 -26.163 60
+      vertex 19.3807 -19.7909 60
+      vertex 25.3282 -26.9718 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.5349 -20.5851 60
+      vertex 25.3282 -26.9718 60
+      vertex 19.3807 -19.7909 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.3282 -26.9718 60
+      vertex 18.5349 -20.5851 60
+      vertex 24.4685 -27.7541 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.6566 -21.3432 60
+      vertex 24.4685 -27.7541 60
+      vertex 18.5349 -20.5851 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.4685 -27.7541 60
+      vertex 17.6566 -21.3432 60
+      vertex 23.5847 -28.509 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.5847 -28.509 60
+      vertex 17.6566 -21.3432 60
+      vertex 22.6776 -29.2357 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.7474 -22.0639 60
+      vertex 22.6776 -29.2357 60
+      vertex 17.6566 -21.3432 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.6776 -29.2357 60
+      vertex 16.7474 -22.0639 60
+      vertex 21.7481 -29.9336 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.8088 -22.7458 60
+      vertex 21.7481 -29.9336 60
+      vertex 16.7474 -22.0639 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.7481 -29.9336 60
+      vertex 15.8088 -22.7458 60
+      vertex 20.7971 -30.602 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.8424 -23.3879 60
+      vertex 20.7971 -30.602 60
+      vertex 15.8088 -22.7458 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.7971 -30.602 60
+      vertex 14.8424 -23.3879 60
+      vertex 19.8256 -31.2401 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.8256 -31.2401 60
+      vertex 14.8424 -23.3879 60
+      vertex 18.8345 -31.8475 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.85 -23.9889 60
+      vertex 18.8345 -31.8475 60
+      vertex 14.8424 -23.3879 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.8345 -31.8475 60
+      vertex 13.85 -23.9889 60
+      vertex 17.8249 -32.4233 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.8333 -24.5478 60
+      vertex 17.8249 -32.4233 60
+      vertex 13.85 -23.9889 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.8249 -32.4233 60
+      vertex 12.8333 -24.5478 60
+      vertex 16.7976 -32.9672 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.7941 -25.0637 60
+      vertex 16.7976 -32.9672 60
+      vertex 12.8333 -24.5478 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.7976 -32.9672 60
+      vertex 11.7941 -25.0637 60
+      vertex 15.7538 -33.4786 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.7538 -33.4786 60
+      vertex 11.7941 -25.0637 60
+      vertex 14.6945 -33.9569 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.7342 -25.5356 60
+      vertex 14.6945 -33.9569 60
+      vertex 11.7941 -25.0637 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.6945 -33.9569 60
+      vertex 10.7342 -25.5356 60
+      vertex 13.6206 -34.4017 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.65545 -25.9627 60
+      vertex 13.6206 -34.4017 60
+      vertex 10.7342 -25.5356 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6206 -34.4017 60
+      vertex 9.65545 -25.9627 60
+      vertex 12.5333 -34.8126 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 8.55977 -26.3443 60
+      vertex 12.5333 -34.8126 60
+      vertex 9.65545 -25.9627 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.5333 -34.8126 60
+      vertex 8.55977 -26.3443 60
+      vertex 11.4336 -35.1891 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.4336 -35.1891 60
+      vertex 8.55977 -26.3443 60
+      vertex 10.3227 -35.5309 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 7.44908 -26.6796 60
+      vertex 10.3227 -35.5309 60
+      vertex 8.55977 -26.3443 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.3227 -35.5309 60
+      vertex 7.44908 -26.6796 60
+      vertex 9.20153 -35.8376 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 6.32532 -26.9681 60
+      vertex 9.20153 -35.8376 60
+      vertex 7.44908 -26.6796 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.20153 -35.8376 60
+      vertex 6.32532 -26.9681 60
+      vertex 8.0713 -36.1089 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.19046 -27.2094 60
+      vertex 8.0713 -36.1089 60
+      vertex 6.32532 -26.9681 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.0713 -36.1089 60
+      vertex 5.19046 -27.2094 60
+      vertex 6.93311 -36.3446 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.93311 -36.3446 60
+      vertex 5.19046 -27.2094 60
+      vertex 5.78807 -36.5445 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.0465 -27.4028 60
+      vertex 5.78807 -36.5445 60
+      vertex 5.19046 -27.2094 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.78807 -36.5445 60
+      vertex 4.0465 -27.4028 60
+      vertex 4.63733 -36.7082 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.89544 -27.5483 60
+      vertex 4.63733 -36.7082 60
+      vertex 4.0465 -27.4028 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.63733 -36.7082 60
+      vertex 2.89544 -27.5483 60
+      vertex 3.48201 -36.8358 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.7393 -27.6453 60
+      vertex 3.48201 -36.8358 60
+      vertex 2.89544 -27.5483 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.48201 -36.8358 60
+      vertex 1.7393 -27.6453 60
+      vertex 2.32325 -36.927 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.7393 -27.6453 60
+      vertex 1.1622 -36.9817 60
+      vertex 2.32325 -36.927 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.580105 -27.6939 60
+      vertex 1.1622 -36.9817 60
+      vertex 1.7393 -27.6453 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.580105 -27.6939 60
+      vertex 0 -37 60
+      vertex 1.1622 -36.9817 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.580105 -27.6939 60
+      vertex 0 -37 60
+      vertex 0.580105 -27.6939 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.580105 -27.6939 60
+      vertex -1.1622 -36.9817 60
+      vertex 0 -37 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.7393 -27.6453 60
+      vertex -1.1622 -36.9817 60
+      vertex -0.580105 -27.6939 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.7393 -27.6453 60
+      vertex -2.32325 -36.927 60
+      vertex -1.1622 -36.9817 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.48201 -36.8358 60
+      vertex -1.7393 -27.6453 60
+      vertex -2.89544 -27.5483 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.7393 -27.6453 60
+      vertex -3.48201 -36.8358 60
+      vertex -2.32325 -36.927 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.63733 -36.7082 60
+      vertex -2.89544 -27.5483 60
+      vertex -4.0465 -27.4028 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.89544 -27.5483 60
+      vertex -4.63733 -36.7082 60
+      vertex -3.48201 -36.8358 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.78807 -36.5445 60
+      vertex -4.0465 -27.4028 60
+      vertex -5.19046 -27.2094 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.0465 -27.4028 60
+      vertex -5.78807 -36.5445 60
+      vertex -4.63733 -36.7082 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.0713 -36.1089 60
+      vertex -5.19046 -27.2094 60
+      vertex -6.32532 -26.9681 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.19046 -27.2094 60
+      vertex -6.93311 -36.3446 60
+      vertex -5.78807 -36.5445 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.20153 -35.8376 60
+      vertex -6.32532 -26.9681 60
+      vertex -7.44908 -26.6796 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.19046 -27.2094 60
+      vertex -8.0713 -36.1089 60
+      vertex -6.93311 -36.3446 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.3227 -35.5309 60
+      vertex -7.44908 -26.6796 60
+      vertex -8.55977 -26.3443 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.32532 -26.9681 60
+      vertex -9.20153 -35.8376 60
+      vertex -8.0713 -36.1089 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.5333 -34.8126 60
+      vertex -8.55977 -26.3443 60
+      vertex -9.65545 -25.9627 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.44908 -26.6796 60
+      vertex -10.3227 -35.5309 60
+      vertex -9.20153 -35.8376 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.6206 -34.4017 60
+      vertex -9.65545 -25.9627 60
+      vertex -10.7342 -25.5356 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.55977 -26.3443 60
+      vertex -11.4336 -35.1891 60
+      vertex -10.3227 -35.5309 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.6945 -33.9569 60
+      vertex -10.7342 -25.5356 60
+      vertex -11.7941 -25.0637 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.55977 -26.3443 60
+      vertex -12.5333 -34.8126 60
+      vertex -11.4336 -35.1891 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.7976 -32.9672 60
+      vertex -11.7941 -25.0637 60
+      vertex -12.8333 -24.5478 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.65545 -25.9627 60
+      vertex -13.6206 -34.4017 60
+      vertex -12.5333 -34.8126 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.8249 -32.4233 60
+      vertex -12.8333 -24.5478 60
+      vertex -13.85 -23.9889 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.7342 -25.5356 60
+      vertex -14.6945 -33.9569 60
+      vertex -13.6206 -34.4017 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.8345 -31.8475 60
+      vertex -13.85 -23.9889 60
+      vertex -14.8424 -23.3879 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7941 -25.0637 60
+      vertex -15.7538 -33.4786 60
+      vertex -14.6945 -33.9569 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.7971 -30.602 60
+      vertex -14.8424 -23.3879 60
+      vertex -15.8088 -22.7458 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.7481 -29.9336 60
+      vertex -15.8088 -22.7458 60
+      vertex -16.7474 -22.0639 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7941 -25.0637 60
+      vertex -16.7976 -32.9672 60
+      vertex -15.7538 -33.4786 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.6776 -29.2357 60
+      vertex -16.7474 -22.0639 60
+      vertex -17.6566 -21.3432 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.8333 -24.5478 60
+      vertex -17.8249 -32.4233 60
+      vertex -16.7976 -32.9672 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.4685 -27.7541 60
+      vertex -17.6566 -21.3432 60
+      vertex -18.5349 -20.5851 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.85 -23.9889 60
+      vertex -18.8345 -31.8475 60
+      vertex -17.8249 -32.4233 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3282 -26.9718 60
+      vertex -18.5349 -20.5851 60
+      vertex -19.3807 -19.7909 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8424 -23.3879 60
+      vertex -19.8256 -31.2401 60
+      vertex -18.8345 -31.8475 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.163 -26.163 60
+      vertex -19.3807 -19.7909 60
+      vertex -20.1924 -18.962 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8424 -23.3879 60
+      vertex -20.7971 -30.602 60
+      vertex -19.8256 -31.2401 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.7541 -24.4685 60
+      vertex -20.1924 -18.962 60
+      vertex -20.9688 -18.0998 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.509 -23.5847 60
+      vertex -20.9688 -18.0998 60
+      vertex -21.7083 -17.2058 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.8088 -22.7458 60
+      vertex -21.7481 -29.9336 60
+      vertex -20.7971 -30.602 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -29.2357 -22.6776 60
+      vertex -21.7083 -17.2058 60
+      vertex -22.4098 -16.2817 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.7474 -22.0639 60
+      vertex -22.6776 -29.2357 60
+      vertex -21.7481 -29.9336 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.602 -20.7971 60
+      vertex -22.4098 -16.2817 60
+      vertex -23.0719 -15.3289 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6566 -21.3432 60
+      vertex -23.5847 -28.509 60
+      vertex -22.6776 -29.2357 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.2401 -19.8256 60
+      vertex -23.0719 -15.3289 60
+      vertex -23.6936 -14.3493 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.8475 -18.8345 60
+      vertex -23.6936 -14.3493 60
+      vertex -24.2737 -13.3446 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6566 -21.3432 60
+      vertex -24.4685 -27.7541 60
+      vertex -23.5847 -28.509 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -32.9672 -16.7976 60
+      vertex -24.2737 -13.3446 60
+      vertex -24.8112 -12.3164 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.4786 -15.7538 60
+      vertex -24.8112 -12.3164 60
+      vertex -25.3052 -11.2666 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5349 -20.5851 60
+      vertex -25.3282 -26.9718 60
+      vertex -24.4685 -27.7541 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.9569 -14.6945 60
+      vertex -25.3052 -11.2666 60
+      vertex -25.7548 -10.1971 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.8126 -12.5333 60
+      vertex -25.7548 -10.1971 60
+      vertex -26.1592 -9.10961 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3807 -19.7909 60
+      vertex -26.163 -26.163 60
+      vertex -25.3282 -26.9718 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.1891 -11.4336 60
+      vertex -26.1592 -9.10961 60
+      vertex -26.5177 -8.00618 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.5309 -10.3227 60
+      vertex -26.5177 -8.00618 60
+      vertex -26.8298 -6.88871 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1924 -18.962 60
+      vertex -26.9718 -25.3282 60
+      vertex -26.163 -26.163 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -36.1089 -8.0713 60
+      vertex -26.8298 -6.88871 60
+      vertex -27.0947 -5.75915 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -36.3446 -6.93311 60
+      vertex -27.0947 -5.75915 60
+      vertex -27.3121 -4.61949 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -36.5445 -5.78807 60
+      vertex -27.3121 -4.61949 60
+      vertex -27.4816 -3.47173 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -36.8358 -3.48201 60
+      vertex -27.4816 -3.47173 60
+      vertex -27.6029 -2.31788 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -36.927 -2.32325 60
+      vertex -27.6029 -2.31788 60
+      vertex -27.6757 -1.15996 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1924 -18.962 60
+      vertex -27.7541 -24.4685 60
+      vertex -26.9718 -25.3282 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -36.9817 -1.1622 60
+      vertex -27.6757 -1.15996 60
+      vertex -27.7 0 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3052 11.2666 60
+      vertex -33.9569 14.6945 60
+      vertex -25.7548 10.1971 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -34.4017 13.6206 60
+      vertex -25.7548 10.1971 60
+      vertex -33.9569 14.6945 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.9688 -18.0998 60
+      vertex -28.509 -23.5847 60
+      vertex -27.7541 -24.4685 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -34.8126 12.5333 60
+      vertex -25.7548 10.1971 60
+      vertex -34.4017 13.6206 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.7083 -17.2058 60
+      vertex -29.2357 -22.6776 60
+      vertex -28.509 -23.5847 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.7548 10.1971 60
+      vertex -34.8126 12.5333 60
+      vertex -26.1592 9.10961 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.4098 -16.2817 60
+      vertex -29.9336 -21.7481 60
+      vertex -29.2357 -22.6776 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -35.1891 11.4336 60
+      vertex -26.1592 9.10961 60
+      vertex -34.8126 12.5333 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.4098 -16.2817 60
+      vertex -30.602 -20.7971 60
+      vertex -29.9336 -21.7481 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1592 9.10961 60
+      vertex -35.1891 11.4336 60
+      vertex -26.5177 8.00618 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0719 -15.3289 60
+      vertex -31.2401 -19.8256 60
+      vertex -30.602 -20.7971 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -35.5309 10.3227 60
+      vertex -26.5177 8.00618 60
+      vertex -35.1891 11.4336 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.6936 -14.3493 60
+      vertex -31.8475 -18.8345 60
+      vertex -31.2401 -19.8256 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.5177 8.00618 60
+      vertex -35.5309 10.3227 60
+      vertex -26.8298 6.88871 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.2737 -13.3446 60
+      vertex -32.4233 -17.8249 60
+      vertex -31.8475 -18.8345 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -35.8376 9.20153 60
+      vertex -26.8298 6.88871 60
+      vertex -35.5309 10.3227 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.2737 -13.3446 60
+      vertex -32.9672 -16.7976 60
+      vertex -32.4233 -17.8249 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -36.1089 8.0713 60
+      vertex -26.8298 6.88871 60
+      vertex -35.8376 9.20153 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8112 -12.3164 60
+      vertex -33.4786 -15.7538 60
+      vertex -32.9672 -16.7976 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8298 6.88871 60
+      vertex -36.1089 8.0713 60
+      vertex -27.0947 5.75915 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3052 -11.2666 60
+      vertex -33.9569 -14.6945 60
+      vertex -33.4786 -15.7538 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -36.3446 6.93311 60
+      vertex -27.0947 5.75915 60
+      vertex -36.1089 8.0713 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.7548 -10.1971 60
+      vertex -34.4017 -13.6206 60
+      vertex -33.9569 -14.6945 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0947 5.75915 60
+      vertex -36.3446 6.93311 60
+      vertex -27.3121 4.61949 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.7548 -10.1971 60
+      vertex -34.8126 -12.5333 60
+      vertex -34.4017 -13.6206 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -36.5445 5.78807 60
+      vertex -27.3121 4.61949 60
+      vertex -36.3446 6.93311 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1592 -9.10961 60
+      vertex -35.1891 -11.4336 60
+      vertex -34.8126 -12.5333 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3121 4.61949 60
+      vertex -36.5445 5.78807 60
+      vertex -27.4816 3.47173 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.5177 -8.00618 60
+      vertex -35.5309 -10.3227 60
+      vertex -35.1891 -11.4336 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -36.7082 4.63733 60
+      vertex -27.4816 3.47173 60
+      vertex -36.5445 5.78807 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8298 -6.88871 60
+      vertex -35.8376 -9.20153 60
+      vertex -35.5309 -10.3227 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -36.8358 3.48201 60
+      vertex -27.4816 3.47173 60
+      vertex -36.7082 4.63733 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8298 -6.88871 60
+      vertex -36.1089 -8.0713 60
+      vertex -35.8376 -9.20153 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.4816 3.47173 60
+      vertex -36.8358 3.48201 60
+      vertex -27.6029 2.31788 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0947 -5.75915 60
+      vertex -36.3446 -6.93311 60
+      vertex -36.1089 -8.0713 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -36.927 2.32325 60
+      vertex -27.6029 2.31788 60
+      vertex -36.8358 3.48201 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3121 -4.61949 60
+      vertex -36.5445 -5.78807 60
+      vertex -36.3446 -6.93311 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6029 2.31788 60
+      vertex -36.927 2.32325 60
+      vertex -27.6757 1.15996 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.4816 -3.47173 60
+      vertex -36.7082 -4.63733 60
+      vertex -36.5445 -5.78807 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -36.9817 1.1622 60
+      vertex -27.6757 1.15996 60
+      vertex -36.927 2.32325 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.4816 -3.47173 60
+      vertex -36.8358 -3.48201 60
+      vertex -36.7082 -4.63733 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6757 1.15996 60
+      vertex -36.9817 1.1622 60
+      vertex -27.7 0 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6029 -2.31788 60
+      vertex -36.927 -2.32325 60
+      vertex -36.8358 -3.48201 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37 0 60
+      vertex -27.7 0 60
+      vertex -36.9817 1.1622 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6757 -1.15996 60
+      vertex -36.9817 -1.1622 60
+      vertex -36.927 -2.32325 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.7 0 60
+      vertex -37 0 60
+      vertex -36.9817 -1.1622 60
+    endloop
+  endfacet
+  facet normal 0.0784876 0.99688 -0.00833234
+    outer loop
+      vertex 3.43495 36.338 0
+      vertex 2.29185 36.428 0
+      vertex 3.48201 36.8358 60
+    endloop
+  endfacet
+  facet normal 0.0784595 0.996882 -0.0083318
+    outer loop
+      vertex 3.48201 36.8358 60
+      vertex 2.29185 36.428 0
+      vertex 2.32325 36.927 60
+    endloop
+  endfacet
+  facet normal 0.718071 0.69592 -0.00833312
+    outer loop
+      vertex 26.6074 24.986 0
+      vertex 25.8094 25.8094 0
+      vertex 26.163 26.163 60
+    endloop
+  endfacet
+  facet normal 0.946028 0.323976 -0.00833151
+    outer loop
+      vertex 34.7136 11.2791 0
+      vertex 34.3421 12.3639 0
+      vertex 35.1891 11.4336 60
+    endloop
+  endfacet
+  facet normal -0.0784595 0.996882 -0.0083318
+    outer loop
+      vertex -2.29185 36.428 0
+      vertex -3.48201 36.8358 60
+      vertex -2.32325 36.927 60
+    endloop
+  endfacet
+  facet normal -0.600384 0.799669 -0.00833145
+    outer loop
+      vertex -22.3711 28.8407 0
+      vertex -22.6776 29.2357 60
+      vertex -21.4542 29.5291 0
+    endloop
+  endfacet
+  facet normal 0.439928 0.897994 -0.00833127
+    outer loop
+      vertex 16.5707 32.5217 0
+      vertex 15.5409 33.0262 0
+      vertex 16.7976 32.9672 60
+    endloop
+  endfacet
+  facet normal -0.109774 0.993922 -0.00833108
+    outer loop
+      vertex -4.57466 36.2122 0
+      vertex -4.63733 36.7082 60
+      vertex -3.48201 36.8358 60
+    endloop
+  endfacet
+  facet normal 0.95575 -0.294064 -0.00833288
+    outer loop
+      vertex 35.1891 -11.4336 60
+      vertex 35.0507 -10.1832 0
+      vertex 35.5309 -10.3227 60
+    endloop
+  endfacet
+  facet normal 0.85259 0.522514 -0.00833224
+    outer loop
+      vertex 31.4171 18.58 0
+      vertex 31.2401 19.8256 60
+      vertex 31.8475 18.8345 60
+    endloop
+  endfacet
+  facet normal 0.760411 -0.649389 -0.0083307
+    outer loop
+      vertex 27.7541 -24.4685 60
+      vertex 27.3791 -24.1379 0
+      vertex 28.1237 -23.266 0
+    endloop
+  endfacet
+  facet normal 0.57494 -0.818153 -0.0083334
+    outer loop
+      vertex 20.7971 -30.602 60
+      vertex 20.516 -30.1884 0
+      vertex 21.4542 -29.5291 0
+    endloop
+  endfacet
+  facet normal 0.989985 0.140928 -0.00833107
+    outer loop
+      vertex 36.2122 4.57466 0
+      vertex 36.0506 5.70986 0
+      vertex 36.7082 4.63733 60
+    endloop
+  endfacet
+  facet normal 0.171889 0.985081 -0.00833292
+    outer loop
+      vertex 6.83942 35.8535 0
+      vertex 5.70986 36.0506 0
+      vertex 5.78807 36.5445 60
+    endloop
+  endfacet
+  facet normal 0.985081 0.171889 -0.00833292
+    outer loop
+      vertex 36.0506 5.70986 0
+      vertex 35.8535 6.83942 0
+      vertex 36.5445 5.78807 60
+    endloop
+  endfacet
+  facet normal 0.0157435 -0.999841 -0.00833113
+    outer loop
+      vertex 1.1622 -36.9817 60
+      vertex 0 -37 60
+      vertex 1.14649 -36.482 0
+    endloop
+  endfacet
+  facet normal 0.911383 -0.411474 -0.00833254
+    outer loop
+      vertex 33.9569 -14.6945 60
+      vertex 33.0262 -15.5409 0
+      vertex 33.498 -14.4959 0
+    endloop
+  endfacet
+  facet normal 0.883745 -0.467895 -0.00833123
+    outer loop
+      vertex 32.9672 -16.7976 60
+      vertex 32.4233 -17.8249 60
+      vertex 32.5217 -16.5707 0
+    endloop
+  endfacet
+  facet normal 0.852624 0.522458 -0.00833099
+    outer loop
+      vertex 31.4171 18.58 0
+      vertex 30.818 19.5577 0
+      vertex 31.2401 19.8256 60
+    endloop
+  endfacet
+  facet normal 0.760353 -0.649457 -0.00833243
+    outer loop
+      vertex 28.509 -23.5847 60
+      vertex 27.7541 -24.4685 60
+      vertex 28.1237 -23.266 0
+    endloop
+  endfacet
+  facet normal 0.852624 -0.522458 -0.00833099
+    outer loop
+      vertex 31.2401 -19.8256 60
+      vertex 30.818 -19.5577 0
+      vertex 31.4171 -18.58 0
+    endloop
+  endfacet
+  facet normal 0.85259 -0.522514 -0.00833224
+    outer loop
+      vertex 31.8475 -18.8345 60
+      vertex 31.2401 -19.8256 60
+      vertex 31.4171 -18.58 0
+    endloop
+  endfacet
+  facet normal 0.109709 0.993929 -0.00833234
+    outer loop
+      vertex 4.57466 36.2122 0
+      vertex 3.43495 36.338 0
+      vertex 3.48201 36.8358 60
+    endloop
+  endfacet
+  facet normal 0.171972 -0.985067 -0.0083313
+    outer loop
+      vertex 6.93311 -36.3446 60
+      vertex 5.78807 -36.5445 60
+      vertex 6.83942 -35.8535 0
+    endloop
+  endfacet
+  facet normal 0.353495 -0.935399 -0.00833312
+    outer loop
+      vertex 12.5333 -34.8126 60
+      vertex 12.3639 -34.3421 0
+      vertex 13.6206 -34.4017 60
+    endloop
+  endfacet
+  facet normal 0.323897 -0.946056 -0.00833312
+    outer loop
+      vertex 12.5333 -34.8126 60
+      vertex 11.4336 -35.1891 60
+      vertex 12.3639 -34.3421 0
+    endloop
+  endfacet
+  facet normal -0.835801 0.54897 -0.00833101
+    outer loop
+      vertex -30.818 19.5577 0
+      vertex -31.2401 19.8256 60
+      vertex -30.602 20.7971 60
+    endloop
+  endfacet
+  facet normal 0.411474 -0.911383 -0.00833254
+    outer loop
+      vertex 14.6945 -33.9569 60
+      vertex 14.4959 -33.498 0
+      vertex 15.5409 -33.0262 0
+    endloop
+  endfacet
+  facet normal 0.0470587 -0.998857 -0.00833114
+    outer loop
+      vertex 1.1622 -36.9817 60
+      vertex 1.14649 -36.482 0
+      vertex 2.32325 -36.927 60
+    endloop
+  endfacet
+  facet normal -0.467904 -0.88374 -0.00833141
+    outer loop
+      vertex -16.5707 -32.5217 0
+      vertex -17.8249 -32.4233 60
+      vertex -17.584 -31.9852 0
+    endloop
+  endfacet
+  facet normal 0.140833 -0.989998 -0.00833291
+    outer loop
+      vertex 5.78807 -36.5445 60
+      vertex 4.63733 -36.7082 60
+      vertex 5.70986 -36.0506 0
+    endloop
+  endfacet
+  facet normal 0.69592 0.718071 -0.00833312
+    outer loop
+      vertex 25.8094 25.8094 0
+      vertex 24.986 26.6074 0
+      vertex 26.163 26.163 60
+    endloop
+  endfacet
+  facet normal -0.649457 -0.760353 -0.00833243
+    outer loop
+      vertex -23.5847 -28.509 60
+      vertex -24.4685 -27.7541 60
+      vertex -23.266 -28.1237 0
+    endloop
+  endfacet
+  facet normal -0.673005 -0.739591 -0.00833015
+    outer loop
+      vertex -24.4685 -27.7541 60
+      vertex -25.3282 -26.9718 60
+      vertex -24.986 -26.6074 0
+    endloop
+  endfacet
+  facet normal 0.923853 -0.382657 -0.00833244
+    outer loop
+      vertex 34.4017 -13.6206 60
+      vertex 33.498 -14.4959 0
+      vertex 33.9368 -13.4365 0
+    endloop
+  endfacet
+  facet normal 0.382657 0.923853 -0.00833244
+    outer loop
+      vertex 14.4959 33.498 0
+      vertex 13.4365 33.9368 0
+      vertex 13.6206 34.4017 60
+    endloop
+  endfacet
+  facet normal -0.649389 0.760411 -0.0083307
+    outer loop
+      vertex -24.1379 27.3791 0
+      vertex -24.4685 27.7541 60
+      vertex -23.266 28.1237 0
+    endloop
+  endfacet
+  facet normal 0.575 -0.818111 -0.00833197
+    outer loop
+      vertex 21.7481 -29.9336 60
+      vertex 20.7971 -30.602 60
+      vertex 21.4542 -29.5291 0
+    endloop
+  endfacet
+  facet normal 0.998856 -0.0470928 -0.0083318
+    outer loop
+      vertex 36.927 -2.32325 60
+      vertex 36.428 -2.29185 0
+      vertex 36.482 -1.14649 0
+    endloop
+  endfacet
+  facet normal 0.911369 0.411506 -0.00833188
+    outer loop
+      vertex 33.9569 14.6945 60
+      vertex 33.0262 15.5409 0
+      vertex 33.4786 15.7538 60
+    endloop
+  endfacet
+  facet normal -0.868605 -0.495436 -0.00833144
+    outer loop
+      vertex -31.4171 -18.58 0
+      vertex -32.4233 -17.8249 60
+      vertex -31.9852 -17.584 0
+    endloop
+  endfacet
+  facet normal -0.171889 0.985081 -0.00833292
+    outer loop
+      vertex -5.70986 36.0506 0
+      vertex -6.83942 35.8535 0
+      vertex -5.78807 36.5445 60
+    endloop
+  endfacet
+  facet normal 0.996882 0.0784595 -0.0083318
+    outer loop
+      vertex 36.927 2.32325 60
+      vertex 36.428 2.29185 0
+      vertex 36.8358 3.48201 60
+    endloop
+  endfacet
+  facet normal 0.998856 0.0470928 -0.0083318
+    outer loop
+      vertex 36.482 1.14649 0
+      vertex 36.428 2.29185 0
+      vertex 36.927 2.32325 60
+    endloop
+  endfacet
+  facet normal -0.625247 -0.780382 -0.00833246
+    outer loop
+      vertex -22.3711 -28.8407 0
+      vertex -23.5847 -28.509 60
+      vertex -23.266 -28.1237 0
+    endloop
+  endfacet
+  facet normal 0.0156976 0.999842 -0.00833202
+    outer loop
+      vertex 1.14649 36.482 0
+      vertex 0 36.5 0
+      vertex 0 37 60
+    endloop
+  endfacet
+  facet normal 0.140928 -0.989985 -0.00833107
+    outer loop
+      vertex 4.63733 -36.7082 60
+      vertex 4.57466 -36.2122 0
+      vertex 5.70986 -36.0506 0
+    endloop
+  endfacet
+  facet normal -0.935399 -0.353495 -0.00833312
+    outer loop
+      vertex -34.4017 -13.6206 60
+      vertex -34.8126 -12.5333 60
+      vertex -34.3421 -12.3639 0
+    endloop
+  endfacet
+  facet normal 0.26385 0.964528 -0.00833289
+    outer loop
+      vertex 10.1832 35.0507 0
+      vertex 9.20153 35.8376 60
+      vertex 10.3227 35.5309 60
+    endloop
+  endfacet
+  facet normal 0.835732 -0.549074 -0.00833339
+    outer loop
+      vertex 30.602 -20.7971 60
+      vertex 30.1884 -20.516 0
+      vertex 30.818 -19.5577 0
+    endloop
+  endfacet
+  facet normal 0.835732 0.549074 -0.00833339
+    outer loop
+      vertex 30.818 19.5577 0
+      vertex 30.1884 20.516 0
+      vertex 30.602 20.7971 60
+    endloop
+  endfacet
+  facet normal -0.760353 0.649457 -0.00833243
+    outer loop
+      vertex -28.1237 23.266 0
+      vertex -28.509 23.5847 60
+      vertex -27.7541 24.4685 60
+    endloop
+  endfacet
+  facet normal -0.911383 -0.411474 -0.00833254
+    outer loop
+      vertex -33.0262 -15.5409 0
+      vertex -33.9569 -14.6945 60
+      vertex -33.498 -14.4959 0
+    endloop
+  endfacet
+  facet normal -0.54897 -0.835801 -0.00833101
+    outer loop
+      vertex -19.8256 -31.2401 60
+      vertex -20.7971 -30.602 60
+      vertex -19.5577 -30.818 0
+    endloop
+  endfacet
+  facet normal 0.0470928 -0.998856 -0.0083318
+    outer loop
+      vertex 2.32325 -36.927 60
+      vertex 1.14649 -36.482 0
+      vertex 2.29185 -36.428 0
+    endloop
+  endfacet
+  facet normal -0.382653 0.923855 -0.00833253
+    outer loop
+      vertex -14.4959 33.498 0
+      vertex -14.6945 33.9569 60
+      vertex -13.6206 34.4017 60
+    endloop
+  endfacet
+  facet normal -0.999842 0.0156976 -0.00833202
+    outer loop
+      vertex -36.5 0 0
+      vertex -37 0 60
+      vertex -36.482 1.14649 0
+    endloop
+  endfacet
+  facet normal -0.625208 -0.780413 -0.00833149
+    outer loop
+      vertex -22.6776 -29.2357 60
+      vertex -23.5847 -28.509 60
+      vertex -22.3711 -28.8407 0
+    endloop
+  endfacet
+  facet normal 0.0470928 0.998856 -0.0083318
+    outer loop
+      vertex 2.29185 36.428 0
+      vertex 1.14649 36.482 0
+      vertex 2.32325 36.927 60
+    endloop
+  endfacet
+  facet normal 0.109709 -0.993929 -0.00833234
+    outer loop
+      vertex 3.48201 -36.8358 60
+      vertex 3.43495 -36.338 0
+      vertex 4.57466 -36.2122 0
+    endloop
+  endfacet
+  facet normal 0.818153 0.57494 -0.0083334
+    outer loop
+      vertex 30.1884 20.516 0
+      vertex 29.5291 21.4542 0
+      vertex 30.602 20.7971 60
+    endloop
+  endfacet
+  facet normal -0.972345 -0.233401 -0.00833217
+    outer loop
+      vertex -35.8376 -9.20153 60
+      vertex -36.1089 -8.0713 60
+      vertex -35.3533 -9.07718 0
+    endloop
+  endfacet
+  facet normal 0.739591 -0.673005 -0.00833015
+    outer loop
+      vertex 26.9718 -25.3282 60
+      vertex 26.6074 -24.986 0
+      vertex 27.7541 -24.4685 60
+    endloop
+  endfacet
+  facet normal -0.109709 -0.993929 -0.00833234
+    outer loop
+      vertex -3.48201 -36.8358 60
+      vertex -4.57466 -36.2122 0
+      vertex -3.43495 -36.338 0
+    endloop
+  endfacet
+  facet normal -0.495399 0.868626 -0.00833226
+    outer loop
+      vertex -18.58 31.4171 0
+      vertex -18.8345 31.8475 60
+      vertex -17.8249 32.4233 60
+    endloop
+  endfacet
+  facet normal 0.911369 -0.411506 -0.00833188
+    outer loop
+      vertex 33.4786 -15.7538 60
+      vertex 33.0262 -15.5409 0
+      vertex 33.9569 -14.6945 60
+    endloop
+  endfacet
+  facet normal 0.233457 -0.972331 -0.00833106
+    outer loop
+      vertex 8.0713 -36.1089 60
+      vertex 7.96223 -35.621 0
+      vertex 9.07718 -35.3533 0
+    endloop
+  endfacet
+  facet normal -0.57494 -0.818153 -0.0083334
+    outer loop
+      vertex -20.7971 -30.602 60
+      vertex -21.4542 -29.5291 0
+      vertex -20.516 -30.1884 0
+    endloop
+  endfacet
+  facet normal 0.625247 -0.780382 -0.00833246
+    outer loop
+      vertex 23.5847 -28.509 60
+      vertex 22.3711 -28.8407 0
+      vertex 23.266 -28.1237 0
+    endloop
+  endfacet
+  facet normal -0.411506 -0.911369 -0.00833188
+    outer loop
+      vertex -14.6945 -33.9569 60
+      vertex -15.7538 -33.4786 60
+      vertex -15.5409 -33.0262 0
+    endloop
+  endfacet
+  facet normal -0.964528 0.26385 -0.00833289
+    outer loop
+      vertex -35.0507 10.1832 0
+      vertex -35.8376 9.20153 60
+      vertex -35.5309 10.3227 60
+    endloop
+  endfacet
+  facet normal -0.95575 0.294064 -0.00833288
+    outer loop
+      vertex -35.0507 10.1832 0
+      vertex -35.5309 10.3227 60
+      vertex -35.1891 11.4336 60
+    endloop
+  endfacet
+  facet normal -0.923855 0.382653 -0.00833253
+    outer loop
+      vertex -33.498 14.4959 0
+      vertex -34.4017 13.6206 60
+      vertex -33.9569 14.6945 60
+    endloop
+  endfacet
+  facet normal -0.883745 0.467895 -0.00833123
+    outer loop
+      vertex -32.5217 16.5707 0
+      vertex -32.9672 16.7976 60
+      vertex -32.4233 17.8249 60
+    endloop
+  endfacet
+  facet normal -0.0470928 -0.998856 -0.0083318
+    outer loop
+      vertex -1.14649 -36.482 0
+      vertex -2.32325 -36.927 60
+      vertex -2.29185 -36.428 0
+    endloop
+  endfacet
+  facet normal 0.411506 0.911369 -0.00833188
+    outer loop
+      vertex 15.5409 33.0262 0
+      vertex 14.6945 33.9569 60
+      vertex 15.7538 33.4786 60
+    endloop
+  endfacet
+  facet normal -0.0156976 0.999842 -0.00833202
+    outer loop
+      vertex 0 36.5 0
+      vertex -1.14649 36.482 0
+      vertex 0 37 60
+    endloop
+  endfacet
+  facet normal -0.0157435 0.999841 -0.00833113
+    outer loop
+      vertex -1.14649 36.482 0
+      vertex -1.1622 36.9817 60
+      vertex 0 37 60
+    endloop
+  endfacet
+  facet normal 0.625247 0.780382 -0.00833246
+    outer loop
+      vertex 23.266 28.1237 0
+      vertex 22.3711 28.8407 0
+      vertex 23.5847 28.509 60
+    endloop
+  endfacet
+  facet normal -0.140928 -0.989985 -0.00833107
+    outer loop
+      vertex -4.63733 -36.7082 60
+      vertex -5.70986 -36.0506 0
+      vertex -4.57466 -36.2122 0
+    endloop
+  endfacet
+  facet normal -0.739591 -0.673005 -0.00833015
+    outer loop
+      vertex -26.9718 -25.3282 60
+      vertex -27.7541 -24.4685 60
+      vertex -26.6074 -24.986 0
+    endloop
+  endfacet
+  facet normal -0.0470928 0.998856 -0.0083318
+    outer loop
+      vertex -2.29185 36.428 0
+      vertex -2.32325 36.927 60
+      vertex -1.14649 36.482 0
+    endloop
+  endfacet
+  facet normal 0.989985 -0.140928 -0.00833107
+    outer loop
+      vertex 36.7082 -4.63733 60
+      vertex 36.0506 -5.70986 0
+      vertex 36.2122 -4.57466 0
+    endloop
+  endfacet
+  facet normal 0.780413 -0.625208 -0.00833149
+    outer loop
+      vertex 29.2357 -22.6776 60
+      vertex 28.509 -23.5847 60
+      vertex 28.8407 -22.3711 0
+    endloop
+  endfacet
+  facet normal -0.672984 0.73961 -0.00833071
+    outer loop
+      vertex -24.1379 27.3791 0
+      vertex -24.986 26.6074 0
+      vertex -24.4685 27.7541 60
+    endloop
+  endfacet
+  facet normal -0.202761 0.979193 -0.00833106
+    outer loop
+      vertex -7.96223 35.621 0
+      vertex -8.0713 36.1089 60
+      vertex -6.83942 35.8535 0
+    endloop
+  endfacet
+  facet normal -0.868605 0.495436 -0.00833144
+    outer loop
+      vertex -31.9852 17.584 0
+      vertex -32.4233 17.8249 60
+      vertex -31.4171 18.58 0
+    endloop
+  endfacet
+  facet normal 0.495436 0.868605 -0.00833144
+    outer loop
+      vertex 18.58 31.4171 0
+      vertex 17.584 31.9852 0
+      vertex 17.8249 32.4233 60
+    endloop
+  endfacet
+  facet normal 0.353461 0.935412 -0.00833242
+    outer loop
+      vertex 13.4365 33.9368 0
+      vertex 12.3639 34.3421 0
+      vertex 13.6206 34.4017 60
+    endloop
+  endfacet
+  facet normal -0.935412 0.353461 -0.00833242
+    outer loop
+      vertex -34.3421 12.3639 0
+      vertex -34.4017 13.6206 60
+      vertex -33.9368 13.4365 0
+    endloop
+  endfacet
+  facet normal -0.935399 0.353495 -0.00833312
+    outer loop
+      vertex -34.3421 12.3639 0
+      vertex -34.8126 12.5333 60
+      vertex -34.4017 13.6206 60
+    endloop
+  endfacet
+  facet normal 0.946056 -0.323897 -0.00833312
+    outer loop
+      vertex 34.8126 -12.5333 60
+      vertex 34.3421 -12.3639 0
+      vertex 35.1891 -11.4336 60
+    endloop
+  endfacet
+  facet normal 0.649457 -0.760353 -0.00833243
+    outer loop
+      vertex 23.5847 -28.509 60
+      vertex 23.266 -28.1237 0
+      vertex 24.4685 -27.7541 60
+    endloop
+  endfacet
+  facet normal 0.73961 -0.672984 -0.00833071
+    outer loop
+      vertex 27.7541 -24.4685 60
+      vertex 26.6074 -24.986 0
+      vertex 27.3791 -24.1379 0
+    endloop
+  endfacet
+  facet normal -0.818153 -0.57494 -0.0083334
+    outer loop
+      vertex -29.5291 -21.4542 0
+      vertex -30.602 -20.7971 60
+      vertex -30.1884 -20.516 0
+    endloop
+  endfacet
+  facet normal -0.439928 0.897994 -0.00833127
+    outer loop
+      vertex -16.5707 32.5217 0
+      vertex -16.7976 32.9672 60
+      vertex -15.5409 33.0262 0
+    endloop
+  endfacet
+  facet normal 0.382653 0.923855 -0.00833253
+    outer loop
+      vertex 14.4959 33.498 0
+      vertex 13.6206 34.4017 60
+      vertex 14.6945 33.9569 60
+    endloop
+  endfacet
+  facet normal -0.998856 0.0470928 -0.0083318
+    outer loop
+      vertex -36.482 1.14649 0
+      vertex -36.927 2.32325 60
+      vertex -36.428 2.29185 0
+    endloop
+  endfacet
+  facet normal -0.0784876 -0.99688 -0.00833234
+    outer loop
+      vertex -2.29185 -36.428 0
+      vertex -3.48201 -36.8358 60
+      vertex -3.43495 -36.338 0
+    endloop
+  endfacet
+  facet normal 0.868605 0.495436 -0.00833144
+    outer loop
+      vertex 31.9852 17.584 0
+      vertex 31.4171 18.58 0
+      vertex 32.4233 17.8249 60
+    endloop
+  endfacet
+  facet normal -0.522514 0.85259 -0.00833224
+    outer loop
+      vertex -18.58 31.4171 0
+      vertex -19.8256 31.2401 60
+      vertex -18.8345 31.8475 60
+    endloop
+  endfacet
+  facet normal 0.294064 0.95575 -0.00833288
+    outer loop
+      vertex 11.4336 35.1891 60
+      vertex 10.1832 35.0507 0
+      vertex 10.3227 35.5309 60
+    endloop
+  endfacet
+  facet normal -0.739591 0.673005 -0.00833015
+    outer loop
+      vertex -26.6074 24.986 0
+      vertex -27.7541 24.4685 60
+      vertex -26.9718 25.3282 60
+    endloop
+  endfacet
+  facet normal -0.95577 0.293996 -0.00833152
+    outer loop
+      vertex -35.0507 10.1832 0
+      vertex -35.1891 11.4336 60
+      vertex -34.7136 11.2791 0
+    endloop
+  endfacet
+  facet normal -0.549074 -0.835732 -0.00833339
+    outer loop
+      vertex -19.5577 -30.818 0
+      vertex -20.7971 -30.602 60
+      vertex -20.516 -30.1884 0
+    endloop
+  endfacet
+  facet normal -0.140833 -0.989998 -0.00833291
+    outer loop
+      vertex -4.63733 -36.7082 60
+      vertex -5.78807 -36.5445 60
+      vertex -5.70986 -36.0506 0
+    endloop
+  endfacet
+  facet normal -0.89798 0.439957 -0.00833188
+    outer loop
+      vertex -33.0262 15.5409 0
+      vertex -33.4786 15.7538 60
+      vertex -32.9672 16.7976 60
+    endloop
+  endfacet
+  facet normal -0.73961 -0.672984 -0.00833071
+    outer loop
+      vertex -26.6074 -24.986 0
+      vertex -27.7541 -24.4685 60
+      vertex -27.3791 -24.1379 0
+    endloop
+  endfacet
+  facet normal 0.467904 -0.88374 -0.00833141
+    outer loop
+      vertex 17.8249 -32.4233 60
+      vertex 16.5707 -32.5217 0
+      vertex 17.584 -31.9852 0
+    endloop
+  endfacet
+  facet normal 0.600406 0.799652 -0.00833198
+    outer loop
+      vertex 22.6776 29.2357 60
+      vertex 21.4542 29.5291 0
+      vertex 21.7481 29.9336 60
+    endloop
+  endfacet
+  facet normal 0.718071 -0.69592 -0.00833312
+    outer loop
+      vertex 26.163 -26.163 60
+      vertex 25.8094 -25.8094 0
+      vertex 26.6074 -24.986 0
+    endloop
+  endfacet
+  facet normal 0.600406 -0.799652 -0.00833198
+    outer loop
+      vertex 21.7481 -29.9336 60
+      vertex 21.4542 -29.5291 0
+      vertex 22.6776 -29.2357 60
+    endloop
+  endfacet
+  facet normal -0.353495 0.935399 -0.00833312
+    outer loop
+      vertex -12.3639 34.3421 0
+      vertex -13.6206 34.4017 60
+      vertex -12.5333 34.8126 60
+    endloop
+  endfacet
+  facet normal -0.69592 -0.718071 -0.00833312
+    outer loop
+      vertex -24.986 -26.6074 0
+      vertex -26.163 -26.163 60
+      vertex -25.8094 -25.8094 0
+    endloop
+  endfacet
+  facet normal 0.818111 -0.575 -0.00833197
+    outer loop
+      vertex 29.9336 -21.7481 60
+      vertex 29.5291 -21.4542 0
+      vertex 30.602 -20.7971 60
+    endloop
+  endfacet
+  facet normal -0.99688 -0.0784876 -0.00833234
+    outer loop
+      vertex -36.338 -3.43495 0
+      vertex -36.8358 -3.48201 60
+      vertex -36.428 -2.29185 0
+    endloop
+  endfacet
+  facet normal 0.739591 0.673005 -0.00833015
+    outer loop
+      vertex 27.7541 24.4685 60
+      vertex 26.6074 24.986 0
+      vertex 26.9718 25.3282 60
+    endloop
+  endfacet
+  facet normal 0.718178 0.69581 -0.00833017
+    outer loop
+      vertex 26.6074 24.986 0
+      vertex 26.163 26.163 60
+      vertex 26.9718 25.3282 60
+    endloop
+  endfacet
+  facet normal -0.109709 0.993929 -0.00833234
+    outer loop
+      vertex -3.43495 36.338 0
+      vertex -4.57466 36.2122 0
+      vertex -3.48201 36.8358 60
+    endloop
+  endfacet
+  facet normal 0.649389 0.760411 -0.0083307
+    outer loop
+      vertex 24.1379 27.3791 0
+      vertex 23.266 28.1237 0
+      vertex 24.4685 27.7541 60
+    endloop
+  endfacet
+  facet normal 0.293996 0.95577 -0.00833152
+    outer loop
+      vertex 11.2791 34.7136 0
+      vertex 10.1832 35.0507 0
+      vertex 11.4336 35.1891 60
+    endloop
+  endfacet
+  facet normal 0.972345 0.233401 -0.00833217
+    outer loop
+      vertex 36.1089 8.0713 60
+      vertex 35.3533 9.07718 0
+      vertex 35.8376 9.20153 60
+    endloop
+  endfacet
+  facet normal 0.95577 0.293996 -0.00833152
+    outer loop
+      vertex 35.0507 10.1832 0
+      vertex 34.7136 11.2791 0
+      vertex 35.1891 11.4336 60
+    endloop
+  endfacet
+  facet normal -0.323976 -0.946028 -0.00833151
+    outer loop
+      vertex -11.4336 -35.1891 60
+      vertex -12.3639 -34.3421 0
+      vertex -11.2791 -34.7136 0
+    endloop
+  endfacet
+  facet normal -0.998857 -0.0470587 -0.00833114
+    outer loop
+      vertex -36.927 -2.32325 60
+      vertex -36.9817 -1.1622 60
+      vertex -36.482 -1.14649 0
+    endloop
+  endfacet
+  facet normal -0.88374 0.467904 -0.00833141
+    outer loop
+      vertex -31.9852 17.584 0
+      vertex -32.5217 16.5707 0
+      vertex -32.4233 17.8249 60
+    endloop
+  endfacet
+  facet normal -0.999841 -0.0157435 -0.00833113
+    outer loop
+      vertex -36.9817 -1.1622 60
+      vertex -37 0 60
+      vertex -36.482 -1.14649 0
+    endloop
+  endfacet
+  facet normal -0.923853 -0.382657 -0.00833244
+    outer loop
+      vertex -33.498 -14.4959 0
+      vertex -34.4017 -13.6206 60
+      vertex -33.9368 -13.4365 0
+    endloop
+  endfacet
+  facet normal 0.263886 -0.964518 -0.00833217
+    outer loop
+      vertex 9.20153 -35.8376 60
+      vertex 9.07718 -35.3533 0
+      vertex 10.1832 -35.0507 0
+    endloop
+  endfacet
+  facet normal -0.935412 -0.353461 -0.00833242
+    outer loop
+      vertex -33.9368 -13.4365 0
+      vertex -34.4017 -13.6206 60
+      vertex -34.3421 -12.3639 0
+    endloop
+  endfacet
+  facet normal 0.625208 -0.780413 -0.00833149
+    outer loop
+      vertex 22.6776 -29.2357 60
+      vertex 22.3711 -28.8407 0
+      vertex 23.5847 -28.509 60
+    endloop
+  endfacet
+  facet normal -0.780382 -0.625247 -0.00833246
+    outer loop
+      vertex -28.509 -23.5847 60
+      vertex -28.8407 -22.3711 0
+      vertex -28.1237 -23.266 0
+    endloop
+  endfacet
+  facet normal -0.0784876 0.99688 -0.00833234
+    outer loop
+      vertex -3.43495 36.338 0
+      vertex -3.48201 36.8358 60
+      vertex -2.29185 36.428 0
+    endloop
+  endfacet
+  facet normal 0.993929 -0.109709 -0.00833234
+    outer loop
+      vertex 36.8358 -3.48201 60
+      vertex 36.2122 -4.57466 0
+      vertex 36.338 -3.43495 0
+    endloop
+  endfacet
+  facet normal -0.69581 -0.718178 -0.00833017
+    outer loop
+      vertex -25.3282 -26.9718 60
+      vertex -26.163 -26.163 60
+      vertex -24.986 -26.6074 0
+    endloop
+  endfacet
+  facet normal 0.95577 -0.293996 -0.00833152
+    outer loop
+      vertex 35.1891 -11.4336 60
+      vertex 34.7136 -11.2791 0
+      vertex 35.0507 -10.1832 0
+    endloop
+  endfacet
+  facet normal 0.69581 0.718178 -0.00833017
+    outer loop
+      vertex 26.163 26.163 60
+      vertex 24.986 26.6074 0
+      vertex 25.3282 26.9718 60
+    endloop
+  endfacet
+  facet normal -0.998856 -0.0470928 -0.0083318
+    outer loop
+      vertex -36.428 -2.29185 0
+      vertex -36.927 -2.32325 60
+      vertex -36.482 -1.14649 0
+    endloop
+  endfacet
+  facet normal 0.780382 -0.625247 -0.00833246
+    outer loop
+      vertex 28.509 -23.5847 60
+      vertex 28.1237 -23.266 0
+      vertex 28.8407 -22.3711 0
+    endloop
+  endfacet
+  facet normal 0.718178 -0.69581 -0.00833017
+    outer loop
+      vertex 26.9718 -25.3282 60
+      vertex 26.163 -26.163 60
+      vertex 26.6074 -24.986 0
+    endloop
+  endfacet
+  facet normal 0.69592 -0.718071 -0.00833312
+    outer loop
+      vertex 26.163 -26.163 60
+      vertex 24.986 -26.6074 0
+      vertex 25.8094 -25.8094 0
+    endloop
+  endfacet
+  facet normal -0.718071 0.69592 -0.00833312
+    outer loop
+      vertex -25.8094 25.8094 0
+      vertex -26.6074 24.986 0
+      vertex -26.163 26.163 60
+    endloop
+  endfacet
+  facet normal -0.972345 0.233401 -0.00833217
+    outer loop
+      vertex -35.3533 9.07718 0
+      vertex -36.1089 8.0713 60
+      vertex -35.8376 9.20153 60
+    endloop
+  endfacet
+  facet normal 0.600384 0.799669 -0.00833145
+    outer loop
+      vertex 22.3711 28.8407 0
+      vertex 21.4542 29.5291 0
+      vertex 22.6776 29.2357 60
+    endloop
+  endfacet
+  facet normal 0.0784876 -0.99688 -0.00833234
+    outer loop
+      vertex 3.48201 -36.8358 60
+      vertex 2.29185 -36.428 0
+      vertex 3.43495 -36.338 0
+    endloop
+  endfacet
+  facet normal -0.946028 0.323976 -0.00833151
+    outer loop
+      vertex -34.7136 11.2791 0
+      vertex -35.1891 11.4336 60
+      vertex -34.3421 12.3639 0
+    endloop
+  endfacet
+  facet normal -0.202774 -0.97919 -0.0083313
+    outer loop
+      vertex -6.93311 -36.3446 60
+      vertex -8.0713 -36.1089 60
+      vertex -6.83942 -35.8535 0
+    endloop
+  endfacet
+  facet normal -0.382653 -0.923855 -0.00833253
+    outer loop
+      vertex -13.6206 -34.4017 60
+      vertex -14.6945 -33.9569 60
+      vertex -14.4959 -33.498 0
+    endloop
+  endfacet
+  facet normal -0.323897 -0.946056 -0.00833312
+    outer loop
+      vertex -11.4336 -35.1891 60
+      vertex -12.5333 -34.8126 60
+      vertex -12.3639 -34.3421 0
+    endloop
+  endfacet
+  facet normal 0.495399 -0.868626 -0.00833226
+    outer loop
+      vertex 18.8345 -31.8475 60
+      vertex 17.8249 -32.4233 60
+      vertex 18.58 -31.4171 0
+    endloop
+  endfacet
+  facet normal 0.439957 0.89798 -0.00833188
+    outer loop
+      vertex 16.7976 32.9672 60
+      vertex 15.5409 33.0262 0
+      vertex 15.7538 33.4786 60
+    endloop
+  endfacet
+  facet normal -0.233401 -0.972345 -0.00833217
+    outer loop
+      vertex -8.0713 -36.1089 60
+      vertex -9.20153 -35.8376 60
+      vertex -9.07718 -35.3533 0
+    endloop
+  endfacet
+  facet normal -0.109774 -0.993922 -0.00833108
+    outer loop
+      vertex -3.48201 -36.8358 60
+      vertex -4.63733 -36.7082 60
+      vertex -4.57466 -36.2122 0
+    endloop
+  endfacet
+  facet normal -0.718071 -0.69592 -0.00833312
+    outer loop
+      vertex -26.163 -26.163 60
+      vertex -26.6074 -24.986 0
+      vertex -25.8094 -25.8094 0
+    endloop
+  endfacet
+  facet normal -0.202761 -0.979193 -0.00833106
+    outer loop
+      vertex -6.83942 -35.8535 0
+      vertex -8.0713 -36.1089 60
+      vertex -7.96223 -35.621 0
+    endloop
+  endfacet
+  facet normal -0.979193 0.202761 -0.00833106
+    outer loop
+      vertex -35.8535 6.83942 0
+      vertex -36.1089 8.0713 60
+      vertex -35.621 7.96223 0
+    endloop
+  endfacet
+  facet normal -0.760411 -0.649389 -0.0083307
+    outer loop
+      vertex -27.7541 -24.4685 60
+      vertex -28.1237 -23.266 0
+      vertex -27.3791 -24.1379 0
+    endloop
+  endfacet
+  facet normal 0.495399 0.868626 -0.00833226
+    outer loop
+      vertex 18.58 31.4171 0
+      vertex 17.8249 32.4233 60
+      vertex 18.8345 31.8475 60
+    endloop
+  endfacet
+  facet normal -0.989985 0.140928 -0.00833107
+    outer loop
+      vertex -36.2122 4.57466 0
+      vertex -36.7082 4.63733 60
+      vertex -36.0506 5.70986 0
+    endloop
+  endfacet
+  facet normal -0.993922 0.109774 -0.00833108
+    outer loop
+      vertex -36.2122 4.57466 0
+      vertex -36.8358 3.48201 60
+      vertex -36.7082 4.63733 60
+    endloop
+  endfacet
+  facet normal -0.85259 0.522514 -0.00833224
+    outer loop
+      vertex -31.4171 18.58 0
+      vertex -31.8475 18.8345 60
+      vertex -31.2401 19.8256 60
+    endloop
+  endfacet
+  facet normal -0.575 -0.818111 -0.00833197
+    outer loop
+      vertex -20.7971 -30.602 60
+      vertex -21.7481 -29.9336 60
+      vertex -21.4542 -29.5291 0
+    endloop
+  endfacet
+  facet normal -0.625247 0.780382 -0.00833246
+    outer loop
+      vertex -23.266 28.1237 0
+      vertex -23.5847 28.509 60
+      vertex -22.3711 28.8407 0
+    endloop
+  endfacet
+  facet normal -0.835732 -0.549074 -0.00833339
+    outer loop
+      vertex -30.602 -20.7971 60
+      vertex -30.818 -19.5577 0
+      vertex -30.1884 -20.516 0
+    endloop
+  endfacet
+  facet normal -0.549074 0.835732 -0.00833339
+    outer loop
+      vertex -20.516 30.1884 0
+      vertex -20.7971 30.602 60
+      vertex -19.5577 30.818 0
+    endloop
+  endfacet
+  facet normal -0.989985 -0.140928 -0.00833107
+    outer loop
+      vertex -36.0506 -5.70986 0
+      vertex -36.7082 -4.63733 60
+      vertex -36.2122 -4.57466 0
+    endloop
+  endfacet
+  facet normal -0.649389 -0.760411 -0.0083307
+    outer loop
+      vertex -23.266 -28.1237 0
+      vertex -24.4685 -27.7541 60
+      vertex -24.1379 -27.3791 0
+    endloop
+  endfacet
+  facet normal 0.972331 -0.233457 -0.00833106
+    outer loop
+      vertex 36.1089 -8.0713 60
+      vertex 35.3533 -9.07718 0
+      vertex 35.621 -7.96223 0
+    endloop
+  endfacet
+  facet normal 0.467895 -0.883745 -0.00833123
+    outer loop
+      vertex 16.7976 -32.9672 60
+      vertex 16.5707 -32.5217 0
+      vertex 17.8249 -32.4233 60
+    endloop
+  endfacet
+  facet normal -0.353495 -0.935399 -0.00833312
+    outer loop
+      vertex -12.5333 -34.8126 60
+      vertex -13.6206 -34.4017 60
+      vertex -12.3639 -34.3421 0
+    endloop
+  endfacet
+  facet normal 0.495436 -0.868605 -0.00833144
+    outer loop
+      vertex 17.8249 -32.4233 60
+      vertex 17.584 -31.9852 0
+      vertex 18.58 -31.4171 0
+    endloop
+  endfacet
+  facet normal -0.0470587 -0.998857 -0.00833114
+    outer loop
+      vertex -1.1622 -36.9817 60
+      vertex -2.32325 -36.927 60
+      vertex -1.14649 -36.482 0
+    endloop
+  endfacet
+  facet normal 0.575 0.818111 -0.00833197
+    outer loop
+      vertex 21.4542 29.5291 0
+      vertex 20.7971 30.602 60
+      vertex 21.7481 29.9336 60
+    endloop
+  endfacet
+  facet normal -0.522458 0.852624 -0.00833099
+    outer loop
+      vertex -19.5577 30.818 0
+      vertex -19.8256 31.2401 60
+      vertex -18.58 31.4171 0
+    endloop
+  endfacet
+  facet normal -0.69592 0.718071 -0.00833312
+    outer loop
+      vertex -25.8094 25.8094 0
+      vertex -26.163 26.163 60
+      vertex -24.986 26.6074 0
+    endloop
+  endfacet
+  facet normal 0.883745 0.467895 -0.00833123
+    outer loop
+      vertex 32.5217 16.5707 0
+      vertex 32.4233 17.8249 60
+      vertex 32.9672 16.7976 60
+    endloop
+  endfacet
+  facet normal 0.625208 0.780413 -0.00833149
+    outer loop
+      vertex 23.5847 28.509 60
+      vertex 22.3711 28.8407 0
+      vertex 22.6776 29.2357 60
+    endloop
+  endfacet
+  facet normal 0.760411 0.649389 -0.0083307
+    outer loop
+      vertex 28.1237 23.266 0
+      vertex 27.3791 24.1379 0
+      vertex 27.7541 24.4685 60
+    endloop
+  endfacet
+  facet normal -0.202774 0.97919 -0.0083313
+    outer loop
+      vertex -6.83942 35.8535 0
+      vertex -8.0713 36.1089 60
+      vertex -6.93311 36.3446 60
+    endloop
+  endfacet
+  facet normal -0.171972 0.985067 -0.0083313
+    outer loop
+      vertex -6.83942 35.8535 0
+      vertex -6.93311 36.3446 60
+      vertex -5.78807 36.5445 60
+    endloop
+  endfacet
+  facet normal -0.263886 0.964518 -0.00833217
+    outer loop
+      vertex -9.07718 35.3533 0
+      vertex -10.1832 35.0507 0
+      vertex -9.20153 35.8376 60
+    endloop
+  endfacet
+  facet normal 0.549074 -0.835732 -0.00833339
+    outer loop
+      vertex 20.7971 -30.602 60
+      vertex 19.5577 -30.818 0
+      vertex 20.516 -30.1884 0
+    endloop
+  endfacet
+  facet normal 0.522458 -0.852624 -0.00833099
+    outer loop
+      vertex 19.8256 -31.2401 60
+      vertex 18.58 -31.4171 0
+      vertex 19.5577 -30.818 0
+    endloop
+  endfacet
+  facet normal 0.202761 0.979193 -0.00833106
+    outer loop
+      vertex 7.96223 35.621 0
+      vertex 6.83942 35.8535 0
+      vertex 8.0713 36.1089 60
+    endloop
+  endfacet
+  facet normal 0.88374 0.467904 -0.00833141
+    outer loop
+      vertex 32.5217 16.5707 0
+      vertex 31.9852 17.584 0
+      vertex 32.4233 17.8249 60
+    endloop
+  endfacet
+  facet normal -0.88374 -0.467904 -0.00833141
+    outer loop
+      vertex -32.4233 -17.8249 60
+      vertex -32.5217 -16.5707 0
+      vertex -31.9852 -17.584 0
+    endloop
+  endfacet
+  facet normal 0.89798 0.439957 -0.00833188
+    outer loop
+      vertex 33.0262 15.5409 0
+      vertex 32.9672 16.7976 60
+      vertex 33.4786 15.7538 60
+    endloop
+  endfacet
+  facet normal -0.993929 -0.109709 -0.00833234
+    outer loop
+      vertex -36.2122 -4.57466 0
+      vertex -36.8358 -3.48201 60
+      vertex -36.338 -3.43495 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.7 0 0
+      vertex 36.5 0 0
+      vertex 36.482 -1.14649 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.6757 -1.15996 0
+      vertex 36.482 -1.14649 0
+      vertex 36.428 -2.29185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 36.5 0 0
+      vertex 27.7 0 0
+      vertex 36.482 1.14649 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.6029 -2.31788 0
+      vertex 36.428 -2.29185 0
+      vertex 36.338 -3.43495 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.6757 1.15996 0
+      vertex 36.482 1.14649 0
+      vertex 27.7 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.4816 -3.47173 0
+      vertex 36.338 -3.43495 0
+      vertex 36.2122 -4.57466 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 36.482 1.14649 0
+      vertex 27.6757 1.15996 0
+      vertex 36.428 2.29185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.4816 -3.47173 0
+      vertex 36.2122 -4.57466 0
+      vertex 36.0506 -5.70986 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.6029 2.31788 0
+      vertex 36.428 2.29185 0
+      vertex 27.6757 1.15996 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3121 -4.61949 0
+      vertex 36.0506 -5.70986 0
+      vertex 35.8535 -6.83942 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 36.428 2.29185 0
+      vertex 27.6029 2.31788 0
+      vertex 36.338 3.43495 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0947 -5.75915 0
+      vertex 35.8535 -6.83942 0
+      vertex 35.621 -7.96223 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.4816 3.47173 0
+      vertex 36.338 3.43495 0
+      vertex 27.6029 2.31788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8298 -6.88871 0
+      vertex 35.621 -7.96223 0
+      vertex 35.3533 -9.07718 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 36.338 3.43495 0
+      vertex 27.4816 3.47173 0
+      vertex 36.2122 4.57466 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8298 -6.88871 0
+      vertex 35.3533 -9.07718 0
+      vertex 35.0507 -10.1832 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 36.2122 4.57466 0
+      vertex 27.4816 3.47173 0
+      vertex 36.0506 5.70986 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.5177 -8.00618 0
+      vertex 35.0507 -10.1832 0
+      vertex 34.7136 -11.2791 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3121 4.61949 0
+      vertex 36.0506 5.70986 0
+      vertex 27.4816 3.47173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1592 -9.10961 0
+      vertex 34.7136 -11.2791 0
+      vertex 34.3421 -12.3639 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 36.0506 5.70986 0
+      vertex 27.3121 4.61949 0
+      vertex 35.8535 6.83942 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.7548 -10.1971 0
+      vertex 34.3421 -12.3639 0
+      vertex 33.9368 -13.4365 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0947 5.75915 0
+      vertex 35.8535 6.83942 0
+      vertex 27.3121 4.61949 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.7548 -10.1971 0
+      vertex 33.9368 -13.4365 0
+      vertex 33.498 -14.4959 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 35.8535 6.83942 0
+      vertex 27.0947 5.75915 0
+      vertex 35.621 7.96223 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.3052 -11.2666 0
+      vertex 33.498 -14.4959 0
+      vertex 33.0262 -15.5409 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8298 6.88871 0
+      vertex 35.621 7.96223 0
+      vertex 27.0947 5.75915 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8112 -12.3164 0
+      vertex 33.0262 -15.5409 0
+      vertex 32.5217 -16.5707 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 35.621 7.96223 0
+      vertex 26.8298 6.88871 0
+      vertex 35.3533 9.07718 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.2737 -13.3446 0
+      vertex 32.5217 -16.5707 0
+      vertex 31.9852 -17.584 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 35.3533 9.07718 0
+      vertex 26.8298 6.88871 0
+      vertex 35.0507 10.1832 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.2737 -13.3446 0
+      vertex 31.9852 -17.584 0
+      vertex 31.4171 -18.58 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.5177 8.00618 0
+      vertex 35.0507 10.1832 0
+      vertex 26.8298 6.88871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.6936 -14.3493 0
+      vertex 31.4171 -18.58 0
+      vertex 30.818 -19.5577 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 35.0507 10.1832 0
+      vertex 26.5177 8.00618 0
+      vertex 34.7136 11.2791 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.0719 -15.3289 0
+      vertex 30.818 -19.5577 0
+      vertex 30.1884 -20.516 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1592 9.10961 0
+      vertex 34.7136 11.2791 0
+      vertex 26.5177 8.00618 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.4098 -16.2817 0
+      vertex 30.1884 -20.516 0
+      vertex 29.5291 -21.4542 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 34.7136 11.2791 0
+      vertex 26.1592 9.10961 0
+      vertex 34.3421 12.3639 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.4098 -16.2817 0
+      vertex 29.5291 -21.4542 0
+      vertex 28.8407 -22.3711 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.7548 10.1971 0
+      vertex 34.3421 12.3639 0
+      vertex 26.1592 9.10961 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.7083 -17.2058 0
+      vertex 28.8407 -22.3711 0
+      vertex 28.1237 -23.266 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 34.3421 12.3639 0
+      vertex 25.7548 10.1971 0
+      vertex 33.9368 13.4365 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 33.9368 13.4365 0
+      vertex 25.7548 10.1971 0
+      vertex 33.498 14.4959 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 36.482 -1.14649 0
+      vertex 27.6757 -1.15996 0
+      vertex 27.7 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 36.428 -2.29185 0
+      vertex 27.6029 -2.31788 0
+      vertex 27.6757 -1.15996 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 36.338 -3.43495 0
+      vertex 27.4816 -3.47173 0
+      vertex 27.6029 -2.31788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.9688 -18.0998 0
+      vertex 28.1237 -23.266 0
+      vertex 27.3791 -24.1379 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 36.0506 -5.70986 0
+      vertex 27.3121 -4.61949 0
+      vertex 27.4816 -3.47173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.8535 -6.83942 0
+      vertex 27.0947 -5.75915 0
+      vertex 27.3121 -4.61949 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.621 -7.96223 0
+      vertex 26.8298 -6.88871 0
+      vertex 27.0947 -5.75915 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1924 -18.962 0
+      vertex 27.3791 -24.1379 0
+      vertex 26.6074 -24.986 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.0507 -10.1832 0
+      vertex 26.5177 -8.00618 0
+      vertex 26.8298 -6.88871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 34.7136 -11.2791 0
+      vertex 26.1592 -9.10961 0
+      vertex 26.5177 -8.00618 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1924 -18.962 0
+      vertex 26.6074 -24.986 0
+      vertex 25.8094 -25.8094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 34.3421 -12.3639 0
+      vertex 25.7548 -10.1971 0
+      vertex 26.1592 -9.10961 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 33.498 -14.4959 0
+      vertex 25.3052 -11.2666 0
+      vertex 25.7548 -10.1971 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3807 -19.7909 0
+      vertex 25.8094 -25.8094 0
+      vertex 24.986 -26.6074 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 33.0262 -15.5409 0
+      vertex 24.8112 -12.3164 0
+      vertex 25.3052 -11.2666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.5217 -16.5707 0
+      vertex 24.2737 -13.3446 0
+      vertex 24.8112 -12.3164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5349 -20.5851 0
+      vertex 24.986 -26.6074 0
+      vertex 24.1379 -27.3791 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31.4171 -18.58 0
+      vertex 23.6936 -14.3493 0
+      vertex 24.2737 -13.3446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.6566 -21.3432 0
+      vertex 24.1379 -27.3791 0
+      vertex 23.266 -28.1237 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.818 -19.5577 0
+      vertex 23.0719 -15.3289 0
+      vertex 23.6936 -14.3493 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.1884 -20.516 0
+      vertex 22.4098 -16.2817 0
+      vertex 23.0719 -15.3289 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.6566 -21.3432 0
+      vertex 23.266 -28.1237 0
+      vertex 22.3711 -28.8407 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.8407 -22.3711 0
+      vertex 21.7083 -17.2058 0
+      vertex 22.4098 -16.2817 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.7474 -22.0639 0
+      vertex 22.3711 -28.8407 0
+      vertex 21.4542 -29.5291 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.1237 -23.266 0
+      vertex 20.9688 -18.0998 0
+      vertex 21.7083 -17.2058 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8088 -22.7458 0
+      vertex 21.4542 -29.5291 0
+      vertex 20.516 -30.1884 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3791 -24.1379 0
+      vertex 20.1924 -18.962 0
+      vertex 20.9688 -18.0998 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8424 -23.3879 0
+      vertex 20.516 -30.1884 0
+      vertex 19.5577 -30.818 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.8094 -25.8094 0
+      vertex 19.3807 -19.7909 0
+      vertex 20.1924 -18.962 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8424 -23.3879 0
+      vertex 19.5577 -30.818 0
+      vertex 18.58 -31.4171 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.986 -26.6074 0
+      vertex 18.5349 -20.5851 0
+      vertex 19.3807 -19.7909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.1379 -27.3791 0
+      vertex 17.6566 -21.3432 0
+      vertex 18.5349 -20.5851 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.85 -23.9889 0
+      vertex 18.58 -31.4171 0
+      vertex 17.584 -31.9852 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.3711 -28.8407 0
+      vertex 16.7474 -22.0639 0
+      vertex 17.6566 -21.3432 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.8333 -24.5478 0
+      vertex 17.584 -31.9852 0
+      vertex 16.5707 -32.5217 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.4542 -29.5291 0
+      vertex 15.8088 -22.7458 0
+      vertex 16.7474 -22.0639 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.7941 -25.0637 0
+      vertex 16.5707 -32.5217 0
+      vertex 15.5409 -33.0262 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.516 -30.1884 0
+      vertex 14.8424 -23.3879 0
+      vertex 15.8088 -22.7458 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.7941 -25.0637 0
+      vertex 15.5409 -33.0262 0
+      vertex 14.4959 -33.498 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.58 -31.4171 0
+      vertex 13.85 -23.9889 0
+      vertex 14.8424 -23.3879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.7342 -25.5356 0
+      vertex 14.4959 -33.498 0
+      vertex 13.4365 -33.9368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.584 -31.9852 0
+      vertex 12.8333 -24.5478 0
+      vertex 13.85 -23.9889 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.65545 -25.9627 0
+      vertex 13.4365 -33.9368 0
+      vertex 12.3639 -34.3421 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.5707 -32.5217 0
+      vertex 11.7941 -25.0637 0
+      vertex 12.8333 -24.5478 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.55977 -26.3443 0
+      vertex 12.3639 -34.3421 0
+      vertex 11.2791 -34.7136 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.4959 -33.498 0
+      vertex 10.7342 -25.5356 0
+      vertex 11.7941 -25.0637 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.55977 -26.3443 0
+      vertex 11.2791 -34.7136 0
+      vertex 10.1832 -35.0507 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.4365 -33.9368 0
+      vertex 9.65545 -25.9627 0
+      vertex 10.7342 -25.5356 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.44908 -26.6796 0
+      vertex 10.1832 -35.0507 0
+      vertex 9.07718 -35.3533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.3639 -34.3421 0
+      vertex 8.55977 -26.3443 0
+      vertex 9.65545 -25.9627 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.32532 -26.9681 0
+      vertex 9.07718 -35.3533 0
+      vertex 7.96223 -35.621 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.1832 -35.0507 0
+      vertex 7.44908 -26.6796 0
+      vertex 8.55977 -26.3443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.19046 -27.2094 0
+      vertex 7.96223 -35.621 0
+      vertex 6.83942 -35.8535 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.07718 -35.3533 0
+      vertex 6.32532 -26.9681 0
+      vertex 7.44908 -26.6796 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.19046 -27.2094 0
+      vertex 6.83942 -35.8535 0
+      vertex 5.70986 -36.0506 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.96223 -35.621 0
+      vertex 5.19046 -27.2094 0
+      vertex 6.32532 -26.9681 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.0465 -27.4028 0
+      vertex 5.70986 -36.0506 0
+      vertex 4.57466 -36.2122 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.70986 -36.0506 0
+      vertex 4.0465 -27.4028 0
+      vertex 5.19046 -27.2094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.89544 -27.5483 0
+      vertex 4.57466 -36.2122 0
+      vertex 3.43495 -36.338 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.57466 -36.2122 0
+      vertex 2.89544 -27.5483 0
+      vertex 4.0465 -27.4028 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.7393 -27.6453 0
+      vertex 3.43495 -36.338 0
+      vertex 2.29185 -36.428 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.43495 -36.338 0
+      vertex 1.7393 -27.6453 0
+      vertex 2.89544 -27.5483 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.14649 -36.482 0
+      vertex 1.7393 -27.6453 0
+      vertex 2.29185 -36.428 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.14649 -36.482 0
+      vertex 0.580105 -27.6939 0
+      vertex 1.7393 -27.6453 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -36.5 0
+      vertex 0.580105 -27.6939 0
+      vertex 1.14649 -36.482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -36.5 0
+      vertex -0.580105 -27.6939 0
+      vertex 0.580105 -27.6939 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.14649 -36.482 0
+      vertex -0.580105 -27.6939 0
+      vertex 0 -36.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.14649 -36.482 0
+      vertex -1.7393 -27.6453 0
+      vertex -0.580105 -27.6939 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.29185 -36.428 0
+      vertex -1.7393 -27.6453 0
+      vertex -1.14649 -36.482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.43495 -36.338 0
+      vertex -1.7393 -27.6453 0
+      vertex -2.29185 -36.428 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.7393 -27.6453 0
+      vertex -3.43495 -36.338 0
+      vertex -2.89544 -27.5483 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.57466 -36.2122 0
+      vertex -2.89544 -27.5483 0
+      vertex -3.43495 -36.338 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -2.89544 -27.5483 0
+      vertex -4.57466 -36.2122 0
+      vertex -4.0465 -27.4028 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.70986 -36.0506 0
+      vertex -4.0465 -27.4028 0
+      vertex -4.57466 -36.2122 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -4.0465 -27.4028 0
+      vertex -5.70986 -36.0506 0
+      vertex -5.19046 -27.2094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.83942 -35.8535 0
+      vertex -5.19046 -27.2094 0
+      vertex -5.70986 -36.0506 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.96223 -35.621 0
+      vertex -5.19046 -27.2094 0
+      vertex -6.83942 -35.8535 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.19046 -27.2094 0
+      vertex -7.96223 -35.621 0
+      vertex -6.32532 -26.9681 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.07718 -35.3533 0
+      vertex -6.32532 -26.9681 0
+      vertex -7.96223 -35.621 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -6.32532 -26.9681 0
+      vertex -9.07718 -35.3533 0
+      vertex -7.44908 -26.6796 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.1832 -35.0507 0
+      vertex -7.44908 -26.6796 0
+      vertex -9.07718 -35.3533 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -7.44908 -26.6796 0
+      vertex -10.1832 -35.0507 0
+      vertex -8.55977 -26.3443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.2791 -34.7136 0
+      vertex -8.55977 -26.3443 0
+      vertex -10.1832 -35.0507 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.3639 -34.3421 0
+      vertex -8.55977 -26.3443 0
+      vertex -11.2791 -34.7136 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.55977 -26.3443 0
+      vertex -12.3639 -34.3421 0
+      vertex -9.65545 -25.9627 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.4365 -33.9368 0
+      vertex -9.65545 -25.9627 0
+      vertex -12.3639 -34.3421 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.65545 -25.9627 0
+      vertex -13.4365 -33.9368 0
+      vertex -10.7342 -25.5356 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.4959 -33.498 0
+      vertex -10.7342 -25.5356 0
+      vertex -13.4365 -33.9368 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -10.7342 -25.5356 0
+      vertex -14.4959 -33.498 0
+      vertex -11.7941 -25.0637 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.5409 -33.0262 0
+      vertex -11.7941 -25.0637 0
+      vertex -14.4959 -33.498 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.5707 -32.5217 0
+      vertex -11.7941 -25.0637 0
+      vertex -15.5409 -33.0262 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -11.7941 -25.0637 0
+      vertex -16.5707 -32.5217 0
+      vertex -12.8333 -24.5478 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.584 -31.9852 0
+      vertex -12.8333 -24.5478 0
+      vertex -16.5707 -32.5217 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -12.8333 -24.5478 0
+      vertex -17.584 -31.9852 0
+      vertex -13.85 -23.9889 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.58 -31.4171 0
+      vertex -13.85 -23.9889 0
+      vertex -17.584 -31.9852 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.85 -23.9889 0
+      vertex -18.58 -31.4171 0
+      vertex -14.8424 -23.3879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.5577 -30.818 0
+      vertex -14.8424 -23.3879 0
+      vertex -18.58 -31.4171 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.516 -30.1884 0
+      vertex -14.8424 -23.3879 0
+      vertex -19.5577 -30.818 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.8424 -23.3879 0
+      vertex -20.516 -30.1884 0
+      vertex -15.8088 -22.7458 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.4542 -29.5291 0
+      vertex -15.8088 -22.7458 0
+      vertex -20.516 -30.1884 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.8088 -22.7458 0
+      vertex -21.4542 -29.5291 0
+      vertex -16.7474 -22.0639 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.3711 -28.8407 0
+      vertex -16.7474 -22.0639 0
+      vertex -21.4542 -29.5291 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.7474 -22.0639 0
+      vertex -22.3711 -28.8407 0
+      vertex -17.6566 -21.3432 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.266 -28.1237 0
+      vertex -17.6566 -21.3432 0
+      vertex -22.3711 -28.8407 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.1379 -27.3791 0
+      vertex -17.6566 -21.3432 0
+      vertex -23.266 -28.1237 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -17.6566 -21.3432 0
+      vertex -24.1379 -27.3791 0
+      vertex -18.5349 -20.5851 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.986 -26.6074 0
+      vertex -18.5349 -20.5851 0
+      vertex -24.1379 -27.3791 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.5349 -20.5851 0
+      vertex -24.986 -26.6074 0
+      vertex -19.3807 -19.7909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.8094 -25.8094 0
+      vertex -19.3807 -19.7909 0
+      vertex -24.986 -26.6074 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.3807 -19.7909 0
+      vertex -25.8094 -25.8094 0
+      vertex -20.1924 -18.962 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.6074 -24.986 0
+      vertex -20.1924 -18.962 0
+      vertex -25.8094 -25.8094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.3791 -24.1379 0
+      vertex -20.1924 -18.962 0
+      vertex -26.6074 -24.986 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -20.1924 -18.962 0
+      vertex -27.3791 -24.1379 0
+      vertex -20.9688 -18.0998 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.1237 -23.266 0
+      vertex -20.9688 -18.0998 0
+      vertex -27.3791 -24.1379 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -20.9688 -18.0998 0
+      vertex -28.1237 -23.266 0
+      vertex -21.7083 -17.2058 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.8407 -22.3711 0
+      vertex -21.7083 -17.2058 0
+      vertex -28.1237 -23.266 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -21.7083 -17.2058 0
+      vertex -28.8407 -22.3711 0
+      vertex -22.4098 -16.2817 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.5291 -21.4542 0
+      vertex -22.4098 -16.2817 0
+      vertex -28.8407 -22.3711 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.1884 -20.516 0
+      vertex -22.4098 -16.2817 0
+      vertex -29.5291 -21.4542 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -22.4098 -16.2817 0
+      vertex -30.1884 -20.516 0
+      vertex -23.0719 -15.3289 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.818 -19.5577 0
+      vertex -23.0719 -15.3289 0
+      vertex -30.1884 -20.516 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.0719 -15.3289 0
+      vertex -30.818 -19.5577 0
+      vertex -23.6936 -14.3493 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.4171 -18.58 0
+      vertex -23.6936 -14.3493 0
+      vertex -30.818 -19.5577 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.6936 -14.3493 0
+      vertex -31.4171 -18.58 0
+      vertex -24.2737 -13.3446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.9852 -17.584 0
+      vertex -24.2737 -13.3446 0
+      vertex -31.4171 -18.58 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.5217 -16.5707 0
+      vertex -24.2737 -13.3446 0
+      vertex -31.9852 -17.584 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.2737 -13.3446 0
+      vertex -32.5217 -16.5707 0
+      vertex -24.8112 -12.3164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.0262 -15.5409 0
+      vertex -24.8112 -12.3164 0
+      vertex -32.5217 -16.5707 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.8112 -12.3164 0
+      vertex -33.0262 -15.5409 0
+      vertex -25.3052 -11.2666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.498 -14.4959 0
+      vertex -25.3052 -11.2666 0
+      vertex -33.0262 -15.5409 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.3052 -11.2666 0
+      vertex -33.498 -14.4959 0
+      vertex -25.7548 -10.1971 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.3052 11.2666 0
+      vertex 33.498 14.4959 0
+      vertex 25.7548 10.1971 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 33.498 14.4959 0
+      vertex 25.3052 11.2666 0
+      vertex 33.0262 15.5409 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8112 12.3164 0
+      vertex 33.0262 15.5409 0
+      vertex 25.3052 11.2666 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 33.0262 15.5409 0
+      vertex 24.8112 12.3164 0
+      vertex 32.5217 16.5707 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.2737 13.3446 0
+      vertex 32.5217 16.5707 0
+      vertex 24.8112 12.3164 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 32.5217 16.5707 0
+      vertex 24.2737 13.3446 0
+      vertex 31.9852 17.584 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 31.9852 17.584 0
+      vertex 24.2737 13.3446 0
+      vertex 31.4171 18.58 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.6936 14.3493 0
+      vertex 31.4171 18.58 0
+      vertex 24.2737 13.3446 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 31.4171 18.58 0
+      vertex 23.6936 14.3493 0
+      vertex 30.818 19.5577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.0719 15.3289 0
+      vertex 30.818 19.5577 0
+      vertex 23.6936 14.3493 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 30.818 19.5577 0
+      vertex 23.0719 15.3289 0
+      vertex 30.1884 20.516 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.4098 16.2817 0
+      vertex 30.1884 20.516 0
+      vertex 23.0719 15.3289 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 30.1884 20.516 0
+      vertex 22.4098 16.2817 0
+      vertex 29.5291 21.4542 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 29.5291 21.4542 0
+      vertex 22.4098 16.2817 0
+      vertex 28.8407 22.3711 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.7083 17.2058 0
+      vertex 28.8407 22.3711 0
+      vertex 22.4098 16.2817 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.8407 22.3711 0
+      vertex 21.7083 17.2058 0
+      vertex 28.1237 23.266 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.9688 18.0998 0
+      vertex 28.1237 23.266 0
+      vertex 21.7083 17.2058 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.1237 23.266 0
+      vertex 20.9688 18.0998 0
+      vertex 27.3791 24.1379 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1924 18.962 0
+      vertex 27.3791 24.1379 0
+      vertex 20.9688 18.0998 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 27.3791 24.1379 0
+      vertex 20.1924 18.962 0
+      vertex 26.6074 24.986 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 26.6074 24.986 0
+      vertex 20.1924 18.962 0
+      vertex 25.8094 25.8094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3807 19.7909 0
+      vertex 25.8094 25.8094 0
+      vertex 20.1924 18.962 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 25.8094 25.8094 0
+      vertex 19.3807 19.7909 0
+      vertex 24.986 26.6074 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5349 20.5851 0
+      vertex 24.986 26.6074 0
+      vertex 19.3807 19.7909 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 24.986 26.6074 0
+      vertex 18.5349 20.5851 0
+      vertex 24.1379 27.3791 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.6566 21.3432 0
+      vertex 24.1379 27.3791 0
+      vertex 18.5349 20.5851 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 24.1379 27.3791 0
+      vertex 17.6566 21.3432 0
+      vertex 23.266 28.1237 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 23.266 28.1237 0
+      vertex 17.6566 21.3432 0
+      vertex 22.3711 28.8407 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.7474 22.0639 0
+      vertex 22.3711 28.8407 0
+      vertex 17.6566 21.3432 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 22.3711 28.8407 0
+      vertex 16.7474 22.0639 0
+      vertex 21.4542 29.5291 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8088 22.7458 0
+      vertex 21.4542 29.5291 0
+      vertex 16.7474 22.0639 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 21.4542 29.5291 0
+      vertex 15.8088 22.7458 0
+      vertex 20.516 30.1884 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8424 23.3879 0
+      vertex 20.516 30.1884 0
+      vertex 15.8088 22.7458 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.516 30.1884 0
+      vertex 14.8424 23.3879 0
+      vertex 19.5577 30.818 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.5577 30.818 0
+      vertex 14.8424 23.3879 0
+      vertex 18.58 31.4171 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.85 23.9889 0
+      vertex 18.58 31.4171 0
+      vertex 14.8424 23.3879 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 18.58 31.4171 0
+      vertex 13.85 23.9889 0
+      vertex 17.584 31.9852 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.8333 24.5478 0
+      vertex 17.584 31.9852 0
+      vertex 13.85 23.9889 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.584 31.9852 0
+      vertex 12.8333 24.5478 0
+      vertex 16.5707 32.5217 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.7941 25.0637 0
+      vertex 16.5707 32.5217 0
+      vertex 12.8333 24.5478 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 16.5707 32.5217 0
+      vertex 11.7941 25.0637 0
+      vertex 15.5409 33.0262 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.5409 33.0262 0
+      vertex 11.7941 25.0637 0
+      vertex 14.4959 33.498 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.7342 25.5356 0
+      vertex 14.4959 33.498 0
+      vertex 11.7941 25.0637 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14.4959 33.498 0
+      vertex 10.7342 25.5356 0
+      vertex 13.4365 33.9368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.65545 25.9627 0
+      vertex 13.4365 33.9368 0
+      vertex 10.7342 25.5356 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 13.4365 33.9368 0
+      vertex 9.65545 25.9627 0
+      vertex 12.3639 34.3421 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.55977 26.3443 0
+      vertex 12.3639 34.3421 0
+      vertex 9.65545 25.9627 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 12.3639 34.3421 0
+      vertex 8.55977 26.3443 0
+      vertex 11.2791 34.7136 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.2791 34.7136 0
+      vertex 8.55977 26.3443 0
+      vertex 10.1832 35.0507 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.44908 26.6796 0
+      vertex 10.1832 35.0507 0
+      vertex 8.55977 26.3443 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.1832 35.0507 0
+      vertex 7.44908 26.6796 0
+      vertex 9.07718 35.3533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.32532 26.9681 0
+      vertex 9.07718 35.3533 0
+      vertex 7.44908 26.6796 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 9.07718 35.3533 0
+      vertex 6.32532 26.9681 0
+      vertex 7.96223 35.621 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.19046 27.2094 0
+      vertex 7.96223 35.621 0
+      vertex 6.32532 26.9681 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 7.96223 35.621 0
+      vertex 5.19046 27.2094 0
+      vertex 6.83942 35.8535 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 6.83942 35.8535 0
+      vertex 5.19046 27.2094 0
+      vertex 5.70986 36.0506 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.0465 27.4028 0
+      vertex 5.70986 36.0506 0
+      vertex 5.19046 27.2094 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 5.70986 36.0506 0
+      vertex 4.0465 27.4028 0
+      vertex 4.57466 36.2122 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.89544 27.5483 0
+      vertex 4.57466 36.2122 0
+      vertex 4.0465 27.4028 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 4.57466 36.2122 0
+      vertex 2.89544 27.5483 0
+      vertex 3.43495 36.338 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.7393 27.6453 0
+      vertex 3.43495 36.338 0
+      vertex 2.89544 27.5483 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 3.43495 36.338 0
+      vertex 1.7393 27.6453 0
+      vertex 2.29185 36.428 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.7393 27.6453 0
+      vertex 1.14649 36.482 0
+      vertex 2.29185 36.428 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.580105 27.6939 0
+      vertex 1.14649 36.482 0
+      vertex 1.7393 27.6453 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.580105 27.6939 0
+      vertex 0 36.5 0
+      vertex 1.14649 36.482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.580105 27.6939 0
+      vertex 0 36.5 0
+      vertex 0.580105 27.6939 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.580105 27.6939 0
+      vertex -1.14649 36.482 0
+      vertex 0 36.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.7393 27.6453 0
+      vertex -1.14649 36.482 0
+      vertex -0.580105 27.6939 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.7393 27.6453 0
+      vertex -2.29185 36.428 0
+      vertex -1.14649 36.482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.43495 36.338 0
+      vertex -1.7393 27.6453 0
+      vertex -2.89544 27.5483 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.7393 27.6453 0
+      vertex -3.43495 36.338 0
+      vertex -2.29185 36.428 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.57466 36.2122 0
+      vertex -2.89544 27.5483 0
+      vertex -4.0465 27.4028 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.89544 27.5483 0
+      vertex -4.57466 36.2122 0
+      vertex -3.43495 36.338 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.70986 36.0506 0
+      vertex -4.0465 27.4028 0
+      vertex -5.19046 27.2094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.0465 27.4028 0
+      vertex -5.70986 36.0506 0
+      vertex -4.57466 36.2122 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.96223 35.621 0
+      vertex -5.19046 27.2094 0
+      vertex -6.32532 26.9681 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.19046 27.2094 0
+      vertex -6.83942 35.8535 0
+      vertex -5.70986 36.0506 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.07718 35.3533 0
+      vertex -6.32532 26.9681 0
+      vertex -7.44908 26.6796 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.19046 27.2094 0
+      vertex -7.96223 35.621 0
+      vertex -6.83942 35.8535 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.1832 35.0507 0
+      vertex -7.44908 26.6796 0
+      vertex -8.55977 26.3443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.32532 26.9681 0
+      vertex -9.07718 35.3533 0
+      vertex -7.96223 35.621 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.3639 34.3421 0
+      vertex -8.55977 26.3443 0
+      vertex -9.65545 25.9627 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.44908 26.6796 0
+      vertex -10.1832 35.0507 0
+      vertex -9.07718 35.3533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.4365 33.9368 0
+      vertex -9.65545 25.9627 0
+      vertex -10.7342 25.5356 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.55977 26.3443 0
+      vertex -11.2791 34.7136 0
+      vertex -10.1832 35.0507 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.4959 33.498 0
+      vertex -10.7342 25.5356 0
+      vertex -11.7941 25.0637 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.55977 26.3443 0
+      vertex -12.3639 34.3421 0
+      vertex -11.2791 34.7136 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.5707 32.5217 0
+      vertex -11.7941 25.0637 0
+      vertex -12.8333 24.5478 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.65545 25.9627 0
+      vertex -13.4365 33.9368 0
+      vertex -12.3639 34.3421 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.584 31.9852 0
+      vertex -12.8333 24.5478 0
+      vertex -13.85 23.9889 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.7342 25.5356 0
+      vertex -14.4959 33.498 0
+      vertex -13.4365 33.9368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.58 31.4171 0
+      vertex -13.85 23.9889 0
+      vertex -14.8424 23.3879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7941 25.0637 0
+      vertex -15.5409 33.0262 0
+      vertex -14.4959 33.498 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.516 30.1884 0
+      vertex -14.8424 23.3879 0
+      vertex -15.8088 22.7458 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7941 25.0637 0
+      vertex -16.5707 32.5217 0
+      vertex -15.5409 33.0262 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.4542 29.5291 0
+      vertex -15.8088 22.7458 0
+      vertex -16.7474 22.0639 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.8333 24.5478 0
+      vertex -17.584 31.9852 0
+      vertex -16.5707 32.5217 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.3711 28.8407 0
+      vertex -16.7474 22.0639 0
+      vertex -17.6566 21.3432 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.1379 27.3791 0
+      vertex -17.6566 21.3432 0
+      vertex -18.5349 20.5851 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.85 23.9889 0
+      vertex -18.58 31.4171 0
+      vertex -17.584 31.9852 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.986 26.6074 0
+      vertex -18.5349 20.5851 0
+      vertex -19.3807 19.7909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8424 23.3879 0
+      vertex -19.5577 30.818 0
+      vertex -18.58 31.4171 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.8094 25.8094 0
+      vertex -19.3807 19.7909 0
+      vertex -20.1924 18.962 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8424 23.3879 0
+      vertex -20.516 30.1884 0
+      vertex -19.5577 30.818 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.3791 24.1379 0
+      vertex -20.1924 18.962 0
+      vertex -20.9688 18.0998 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8088 22.7458 0
+      vertex -21.4542 29.5291 0
+      vertex -20.516 30.1884 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.1237 23.266 0
+      vertex -20.9688 18.0998 0
+      vertex -21.7083 17.2058 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.7474 22.0639 0
+      vertex -22.3711 28.8407 0
+      vertex -21.4542 29.5291 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.8407 22.3711 0
+      vertex -21.7083 17.2058 0
+      vertex -22.4098 16.2817 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.1884 20.516 0
+      vertex -22.4098 16.2817 0
+      vertex -23.0719 15.3289 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.6566 21.3432 0
+      vertex -23.266 28.1237 0
+      vertex -22.3711 28.8407 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.818 19.5577 0
+      vertex -23.0719 15.3289 0
+      vertex -23.6936 14.3493 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.6566 21.3432 0
+      vertex -24.1379 27.3791 0
+      vertex -23.266 28.1237 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.4171 18.58 0
+      vertex -23.6936 14.3493 0
+      vertex -24.2737 13.3446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.5217 16.5707 0
+      vertex -24.2737 13.3446 0
+      vertex -24.8112 12.3164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5349 20.5851 0
+      vertex -24.986 26.6074 0
+      vertex -24.1379 27.3791 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.0262 15.5409 0
+      vertex -24.8112 12.3164 0
+      vertex -25.3052 11.2666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.498 14.4959 0
+      vertex -25.3052 11.2666 0
+      vertex -25.7548 10.1971 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3807 19.7909 0
+      vertex -25.8094 25.8094 0
+      vertex -24.986 26.6074 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -34.3421 12.3639 0
+      vertex -25.7548 10.1971 0
+      vertex -26.1592 9.10961 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -34.7136 11.2791 0
+      vertex -26.1592 9.10961 0
+      vertex -26.5177 8.00618 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1924 18.962 0
+      vertex -26.6074 24.986 0
+      vertex -25.8094 25.8094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.0507 10.1832 0
+      vertex -26.5177 8.00618 0
+      vertex -26.8298 6.88871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.621 7.96223 0
+      vertex -26.8298 6.88871 0
+      vertex -27.0947 5.75915 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.8535 6.83942 0
+      vertex -27.0947 5.75915 0
+      vertex -27.3121 4.61949 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1924 18.962 0
+      vertex -27.3791 24.1379 0
+      vertex -26.6074 24.986 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.0506 5.70986 0
+      vertex -27.3121 4.61949 0
+      vertex -27.4816 3.47173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.338 3.43495 0
+      vertex -27.4816 3.47173 0
+      vertex -27.6029 2.31788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.428 2.29185 0
+      vertex -27.6029 2.31788 0
+      vertex -27.6757 1.15996 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.482 1.14649 0
+      vertex -27.6757 1.15996 0
+      vertex -27.7 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.9368 -13.4365 0
+      vertex -25.7548 -10.1971 0
+      vertex -33.498 -14.4959 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.9688 18.0998 0
+      vertex -28.1237 23.266 0
+      vertex -27.3791 24.1379 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -34.3421 -12.3639 0
+      vertex -25.7548 -10.1971 0
+      vertex -33.9368 -13.4365 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.7083 17.2058 0
+      vertex -28.8407 22.3711 0
+      vertex -28.1237 23.266 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.7548 -10.1971 0
+      vertex -34.3421 -12.3639 0
+      vertex -26.1592 -9.10961 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.4098 16.2817 0
+      vertex -29.5291 21.4542 0
+      vertex -28.8407 22.3711 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -34.7136 -11.2791 0
+      vertex -26.1592 -9.10961 0
+      vertex -34.3421 -12.3639 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.4098 16.2817 0
+      vertex -30.1884 20.516 0
+      vertex -29.5291 21.4542 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.1592 -9.10961 0
+      vertex -34.7136 -11.2791 0
+      vertex -26.5177 -8.00618 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.0719 15.3289 0
+      vertex -30.818 19.5577 0
+      vertex -30.1884 20.516 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.0507 -10.1832 0
+      vertex -26.5177 -8.00618 0
+      vertex -34.7136 -11.2791 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.6936 14.3493 0
+      vertex -31.4171 18.58 0
+      vertex -30.818 19.5577 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.5177 -8.00618 0
+      vertex -35.0507 -10.1832 0
+      vertex -26.8298 -6.88871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.2737 13.3446 0
+      vertex -31.9852 17.584 0
+      vertex -31.4171 18.58 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.3533 -9.07718 0
+      vertex -26.8298 -6.88871 0
+      vertex -35.0507 -10.1832 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.2737 13.3446 0
+      vertex -32.5217 16.5707 0
+      vertex -31.9852 17.584 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.621 -7.96223 0
+      vertex -26.8298 -6.88871 0
+      vertex -35.3533 -9.07718 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.8112 12.3164 0
+      vertex -33.0262 15.5409 0
+      vertex -32.5217 16.5707 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.8298 -6.88871 0
+      vertex -35.621 -7.96223 0
+      vertex -27.0947 -5.75915 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.3052 11.2666 0
+      vertex -33.498 14.4959 0
+      vertex -33.0262 15.5409 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.8535 -6.83942 0
+      vertex -27.0947 -5.75915 0
+      vertex -35.621 -7.96223 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.7548 10.1971 0
+      vertex -33.9368 13.4365 0
+      vertex -33.498 14.4959 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.0947 -5.75915 0
+      vertex -35.8535 -6.83942 0
+      vertex -27.3121 -4.61949 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.7548 10.1971 0
+      vertex -34.3421 12.3639 0
+      vertex -33.9368 13.4365 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.0506 -5.70986 0
+      vertex -27.3121 -4.61949 0
+      vertex -35.8535 -6.83942 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.1592 9.10961 0
+      vertex -34.7136 11.2791 0
+      vertex -34.3421 12.3639 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.3121 -4.61949 0
+      vertex -36.0506 -5.70986 0
+      vertex -27.4816 -3.47173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.5177 8.00618 0
+      vertex -35.0507 10.1832 0
+      vertex -34.7136 11.2791 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.2122 -4.57466 0
+      vertex -27.4816 -3.47173 0
+      vertex -36.0506 -5.70986 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.8298 6.88871 0
+      vertex -35.3533 9.07718 0
+      vertex -35.0507 10.1832 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.338 -3.43495 0
+      vertex -27.4816 -3.47173 0
+      vertex -36.2122 -4.57466 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.8298 6.88871 0
+      vertex -35.621 7.96223 0
+      vertex -35.3533 9.07718 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.4816 -3.47173 0
+      vertex -36.338 -3.43495 0
+      vertex -27.6029 -2.31788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0947 5.75915 0
+      vertex -35.8535 6.83942 0
+      vertex -35.621 7.96223 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.428 -2.29185 0
+      vertex -27.6029 -2.31788 0
+      vertex -36.338 -3.43495 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.3121 4.61949 0
+      vertex -36.0506 5.70986 0
+      vertex -35.8535 6.83942 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6029 -2.31788 0
+      vertex -36.428 -2.29185 0
+      vertex -27.6757 -1.15996 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.4816 3.47173 0
+      vertex -36.2122 4.57466 0
+      vertex -36.0506 5.70986 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.482 -1.14649 0
+      vertex -27.6757 -1.15996 0
+      vertex -36.428 -2.29185 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.4816 3.47173 0
+      vertex -36.338 3.43495 0
+      vertex -36.2122 4.57466 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6757 -1.15996 0
+      vertex -36.482 -1.14649 0
+      vertex -27.7 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.6029 2.31788 0
+      vertex -36.428 2.29185 0
+      vertex -36.338 3.43495 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.5 0 0
+      vertex -27.7 0 0
+      vertex -36.482 -1.14649 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.6757 1.15996 0
+      vertex -36.482 1.14649 0
+      vertex -36.428 2.29185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.7 0 0
+      vertex -36.5 0 0
+      vertex -36.482 1.14649 0
+    endloop
+  endfacet
+  facet normal 0.818111 0.575 -0.00833197
+    outer loop
+      vertex 30.602 20.7971 60
+      vertex 29.5291 21.4542 0
+      vertex 29.9336 21.7481 60
+    endloop
+  endfacet
+  facet normal 0.323976 0.946028 -0.00833151
+    outer loop
+      vertex 12.3639 34.3421 0
+      vertex 11.2791 34.7136 0
+      vertex 11.4336 35.1891 60
+    endloop
+  endfacet
+  facet normal -0.467895 -0.883745 -0.00833123
+    outer loop
+      vertex -16.7976 -32.9672 60
+      vertex -17.8249 -32.4233 60
+      vertex -16.5707 -32.5217 0
+    endloop
+  endfacet
+  facet normal 0.233401 0.972345 -0.00833217
+    outer loop
+      vertex 9.07718 35.3533 0
+      vertex 8.0713 36.1089 60
+      vertex 9.20153 35.8376 60
+    endloop
+  endfacet
+  facet normal -0.979193 -0.202761 -0.00833106
+    outer loop
+      vertex -35.621 -7.96223 0
+      vertex -36.1089 -8.0713 60
+      vertex -35.8535 -6.83942 0
+    endloop
+  endfacet
+  facet normal 0.73961 0.672984 -0.00833071
+    outer loop
+      vertex 27.3791 24.1379 0
+      vertex 26.6074 24.986 0
+      vertex 27.7541 24.4685 60
+    endloop
+  endfacet
+  facet normal 0.985067 0.171972 -0.0083313
+    outer loop
+      vertex 36.5445 5.78807 60
+      vertex 35.8535 6.83942 0
+      vertex 36.3446 6.93311 60
+    endloop
+  endfacet
+  facet normal 0.868605 -0.495436 -0.00833144
+    outer loop
+      vertex 32.4233 -17.8249 60
+      vertex 31.4171 -18.58 0
+      vertex 31.9852 -17.584 0
+    endloop
+  endfacet
+  facet normal -0.467895 0.883745 -0.00833123
+    outer loop
+      vertex -16.5707 32.5217 0
+      vertex -17.8249 32.4233 60
+      vertex -16.7976 32.9672 60
+    endloop
+  endfacet
+  facet normal -0.0156976 -0.999842 -0.00833202
+    outer loop
+      vertex 0 -37 60
+      vertex -1.14649 -36.482 0
+      vertex 0 -36.5 0
+    endloop
+  endfacet
+  facet normal 0.979193 0.202761 -0.00833106
+    outer loop
+      vertex 35.8535 6.83942 0
+      vertex 35.621 7.96223 0
+      vertex 36.1089 8.0713 60
+    endloop
+  endfacet
+  facet normal -0.625208 0.780413 -0.00833149
+    outer loop
+      vertex -22.3711 28.8407 0
+      vertex -23.5847 28.509 60
+      vertex -22.6776 29.2357 60
+    endloop
+  endfacet
+  facet normal -0.95577 -0.293996 -0.00833152
+    outer loop
+      vertex -34.7136 -11.2791 0
+      vertex -35.1891 -11.4336 60
+      vertex -35.0507 -10.1832 0
+    endloop
+  endfacet
+  facet normal -0.946028 -0.323976 -0.00833151
+    outer loop
+      vertex -34.3421 -12.3639 0
+      vertex -35.1891 -11.4336 60
+      vertex -34.7136 -11.2791 0
+    endloop
+  endfacet
+  facet normal 0.799669 -0.600384 -0.00833145
+    outer loop
+      vertex 29.2357 -22.6776 60
+      vertex 28.8407 -22.3711 0
+      vertex 29.5291 -21.4542 0
+    endloop
+  endfacet
+  facet normal -0.522514 -0.85259 -0.00833224
+    outer loop
+      vertex -18.8345 -31.8475 60
+      vertex -19.8256 -31.2401 60
+      vertex -18.58 -31.4171 0
+    endloop
+  endfacet
+  facet normal -0.233457 -0.972331 -0.00833106
+    outer loop
+      vertex -8.0713 -36.1089 60
+      vertex -9.07718 -35.3533 0
+      vertex -7.96223 -35.621 0
+    endloop
+  endfacet
+  facet normal -0.868626 -0.495399 -0.00833226
+    outer loop
+      vertex -31.8475 -18.8345 60
+      vertex -32.4233 -17.8249 60
+      vertex -31.4171 -18.58 0
+    endloop
+  endfacet
+  facet normal -0.985081 -0.171889 -0.00833292
+    outer loop
+      vertex -35.8535 -6.83942 0
+      vertex -36.5445 -5.78807 60
+      vertex -36.0506 -5.70986 0
+    endloop
+  endfacet
+  facet normal -0.89798 -0.439957 -0.00833188
+    outer loop
+      vertex -32.9672 -16.7976 60
+      vertex -33.4786 -15.7538 60
+      vertex -33.0262 -15.5409 0
+    endloop
+  endfacet
+  facet normal -0.911369 -0.411506 -0.00833188
+    outer loop
+      vertex -33.4786 -15.7538 60
+      vertex -33.9569 -14.6945 60
+      vertex -33.0262 -15.5409 0
+    endloop
+  endfacet
+  facet normal 0.522514 0.85259 -0.00833224
+    outer loop
+      vertex 19.8256 31.2401 60
+      vertex 18.58 31.4171 0
+      vertex 18.8345 31.8475 60
+    endloop
+  endfacet
+  facet normal -0.780413 0.625208 -0.00833149
+    outer loop
+      vertex -28.8407 22.3711 0
+      vertex -29.2357 22.6776 60
+      vertex -28.509 23.5847 60
+    endloop
+  endfacet
+  facet normal -0.799669 0.600384 -0.00833145
+    outer loop
+      vertex -28.8407 22.3711 0
+      vertex -29.5291 21.4542 0
+      vertex -29.2357 22.6776 60
+    endloop
+  endfacet
+  facet normal 0.780382 0.625247 -0.00833246
+    outer loop
+      vertex 28.8407 22.3711 0
+      vertex 28.1237 23.266 0
+      vertex 28.509 23.5847 60
+    endloop
+  endfacet
+  facet normal 0.799669 0.600384 -0.00833145
+    outer loop
+      vertex 29.5291 21.4542 0
+      vertex 28.8407 22.3711 0
+      vertex 29.2357 22.6776 60
+    endloop
+  endfacet
+  facet normal -0.972331 0.233457 -0.00833106
+    outer loop
+      vertex -35.621 7.96223 0
+      vertex -36.1089 8.0713 60
+      vertex -35.3533 9.07718 0
+    endloop
+  endfacet
+  facet normal -0.868626 0.495399 -0.00833226
+    outer loop
+      vertex -31.4171 18.58 0
+      vertex -32.4233 17.8249 60
+      vertex -31.8475 18.8345 60
+    endloop
+  endfacet
+  facet normal -0.985067 -0.171972 -0.0083313
+    outer loop
+      vertex -36.3446 -6.93311 60
+      vertex -36.5445 -5.78807 60
+      vertex -35.8535 -6.83942 0
+    endloop
+  endfacet
+  facet normal -0.760411 0.649389 -0.0083307
+    outer loop
+      vertex -27.3791 24.1379 0
+      vertex -28.1237 23.266 0
+      vertex -27.7541 24.4685 60
+    endloop
+  endfacet
+  facet normal -0.467904 0.88374 -0.00833141
+    outer loop
+      vertex -17.584 31.9852 0
+      vertex -17.8249 32.4233 60
+      vertex -16.5707 32.5217 0
+    endloop
+  endfacet
+  facet normal -0.964518 -0.263886 -0.00833217
+    outer loop
+      vertex -35.0507 -10.1832 0
+      vertex -35.8376 -9.20153 60
+      vertex -35.3533 -9.07718 0
+    endloop
+  endfacet
+  facet normal -0.495436 -0.868605 -0.00833144
+    outer loop
+      vertex -17.8249 -32.4233 60
+      vertex -18.58 -31.4171 0
+      vertex -17.584 -31.9852 0
+    endloop
+  endfacet
+  facet normal 0.248664 0.96859 -0
+    outer loop
+      vertex -6.32532 -26.9681 0
+      vertex -7.44908 -26.6796 60
+      vertex -6.32532 -26.9681 60
+    endloop
+  endfacet
+  facet normal 0.248664 0.96859 0
+    outer loop
+      vertex -7.44908 -26.6796 60
+      vertex -6.32532 -26.9681 0
+      vertex -7.44908 -26.6796 0
+    endloop
+  endfacet
+  facet normal -0.973586 0.228322 0
+    outer loop
+      vertex 26.8298 -6.88871 0
+      vertex 27.0947 -5.75915 60
+      vertex 27.0947 -5.75915 0
+    endloop
+  endfacet
+  facet normal -0.973586 0.228322 0
+    outer loop
+      vertex 27.0947 -5.75915 60
+      vertex 26.8298 -6.88871 0
+      vertex 26.8298 -6.88871 60
+    endloop
+  endfacet
+  facet normal -0.796501 -0.604637 0
+    outer loop
+      vertex 22.4098 16.2817 0
+      vertex 21.7083 17.2058 60
+      vertex 21.7083 17.2058 0
+    endloop
+  endfacet
+  facet normal -0.796501 -0.604637 0
+    outer loop
+      vertex 21.7083 17.2058 60
+      vertex 22.4098 16.2817 0
+      vertex 22.4098 16.2817 60
+    endloop
+  endfacet
+  facet normal -0.998029 0.0627475 0
+    outer loop
+      vertex 27.6029 -2.31788 0
+      vertex 27.6757 -1.15996 60
+      vertex 27.6757 -1.15996 0
+    endloop
+  endfacet
+  facet normal -0.998029 0.0627475 0
+    outer loop
+      vertex 27.6757 -1.15996 60
+      vertex 27.6029 -2.31788 0
+      vertex 27.6029 -2.31788 60
+    endloop
+  endfacet
+  facet normal -0.821195 0.570648 0
+    outer loop
+      vertex 22.4098 -16.2817 0
+      vertex 23.0719 -15.3289 60
+      vertex 23.0719 -15.3289 0
+    endloop
+  endfacet
+  facet normal -0.821195 0.570648 0
+    outer loop
+      vertex 23.0719 -15.3289 60
+      vertex 22.4098 -16.2817 0
+      vertex 22.4098 -16.2817 60
+    endloop
+  endfacet
+  facet normal -0.0418888 -0.999122 0
+    outer loop
+      vertex 0.580105 27.6939 0
+      vertex 1.7393 27.6453 60
+      vertex 0.580105 27.6939 60
+    endloop
+  endfacet
+  facet normal -0.0418888 -0.999122 -0
+    outer loop
+      vertex 1.7393 27.6453 60
+      vertex 0.580105 27.6939 0
+      vertex 1.7393 27.6453 0
+    endloop
+  endfacet
+  facet normal -0.999781 -0.0209444 0
+    outer loop
+      vertex 27.7 0 0
+      vertex 27.6757 1.15996 60
+      vertex 27.6757 1.15996 0
+    endloop
+  endfacet
+  facet normal -0.999781 -0.0209444 0
+    outer loop
+      vertex 27.6757 1.15996 60
+      vertex 27.7 0 0
+      vertex 27.7 0 60
+    endloop
+  endfacet
+  facet normal 0.518015 -0.855371 0
+    outer loop
+      vertex -14.8424 23.3879 0
+      vertex -13.85 23.9889 60
+      vertex -14.8424 23.3879 60
+    endloop
+  endfacet
+  facet normal 0.518015 -0.855371 0
+    outer loop
+      vertex -13.85 23.9889 60
+      vertex -14.8424 23.3879 0
+      vertex -13.85 23.9889 0
+    endloop
+  endfacet
+  facet normal 0.125407 0.992105 -0
+    outer loop
+      vertex -2.89544 -27.5483 0
+      vertex -4.0465 -27.4028 60
+      vertex -2.89544 -27.5483 60
+    endloop
+  endfacet
+  facet normal 0.125407 0.992105 0
+    outer loop
+      vertex -4.0465 -27.4028 60
+      vertex -2.89544 -27.5483 0
+      vertex -4.0465 -27.4028 0
+    endloop
+  endfacet
+  facet normal -0.289003 -0.957328 0
+    outer loop
+      vertex 7.44908 26.6796 0
+      vertex 8.55977 26.3443 60
+      vertex 7.44908 26.6796 60
+    endloop
+  endfacet
+  facet normal -0.289003 -0.957328 -0
+    outer loop
+      vertex 8.55977 26.3443 60
+      vertex 7.44908 26.6796 0
+      vertex 8.55977 26.3443 0
+    endloop
+  endfacet
+  facet normal -0.937292 -0.348546 0
+    outer loop
+      vertex 26.1592 9.10961 0
+      vertex 25.7548 10.1971 60
+      vertex 25.7548 10.1971 0
+    endloop
+  endfacet
+  facet normal -0.937292 -0.348546 0
+    outer loop
+      vertex 25.7548 10.1971 60
+      vertex 26.1592 9.10961 0
+      vertex 26.1592 9.10961 60
+    endloop
+  endfacet
+  facet normal -0.207976 -0.978134 0
+    outer loop
+      vertex 5.19046 27.2094 0
+      vertex 6.32532 26.9681 60
+      vertex 5.19046 27.2094 60
+    endloop
+  endfacet
+  facet normal -0.207976 -0.978134 -0
+    outer loop
+      vertex 6.32532 26.9681 60
+      vertex 5.19046 27.2094 0
+      vertex 6.32532 26.9681 0
+    endloop
+  endfacet
+  facet normal 0.0836061 -0.996499 0
+    outer loop
+      vertex -2.89544 27.5483 0
+      vertex -1.7393 27.6453 60
+      vertex -2.89544 27.5483 60
+    endloop
+  endfacet
+  facet normal 0.0836061 -0.996499 0
+    outer loop
+      vertex -1.7393 27.6453 60
+      vertex -2.89544 27.5483 0
+      vertex -1.7393 27.6453 0
+    endloop
+  endfacet
+  facet normal -0.125407 0.992105 0
+    outer loop
+      vertex 4.0465 -27.4028 0
+      vertex 2.89544 -27.5483 60
+      vertex 4.0465 -27.4028 60
+    endloop
+  endfacet
+  facet normal -0.125407 0.992105 0
+    outer loop
+      vertex 2.89544 -27.5483 60
+      vertex 4.0465 -27.4028 0
+      vertex 2.89544 -27.5483 0
+    endloop
+  endfacet
+  facet normal -0.0836061 -0.996499 0
+    outer loop
+      vertex 1.7393 27.6453 0
+      vertex 2.89544 27.5483 60
+      vertex 1.7393 27.6453 60
+    endloop
+  endfacet
+  facet normal -0.0836061 -0.996499 -0
+    outer loop
+      vertex 2.89544 27.5483 60
+      vertex 1.7393 27.6453 0
+      vertex 2.89544 27.5483 0
+    endloop
+  endfacet
+  facet normal -0.743114 -0.669165 0
+    outer loop
+      vertex 20.9688 18.0998 0
+      vertex 20.1924 18.962 60
+      vertex 20.1924 18.962 0
+    endloop
+  endfacet
+  facet normal -0.743114 -0.669165 0
+    outer loop
+      vertex 20.1924 18.962 60
+      vertex 20.9688 18.0998 0
+      vertex 20.9688 18.0998 60
+    endloop
+  endfacet
+  facet normal 0.68452 -0.728994 0
+    outer loop
+      vertex -19.3807 19.7909 0
+      vertex -18.5349 20.5851 60
+      vertex -19.3807 19.7909 60
+    endloop
+  endfacet
+  facet normal 0.68452 -0.728994 0
+    outer loop
+      vertex -18.5349 20.5851 60
+      vertex -19.3807 19.7909 0
+      vertex -18.5349 20.5851 0
+    endloop
+  endfacet
+  facet normal 0.963141 -0.268997 0
+    outer loop
+      vertex -26.8298 6.88871 60
+      vertex -26.5177 8.00618 0
+      vertex -26.5177 8.00618 60
+    endloop
+  endfacet
+  facet normal 0.963141 -0.268997 0
+    outer loop
+      vertex -26.5177 8.00618 0
+      vertex -26.8298 6.88871 60
+      vertex -26.8298 6.88871 0
+    endloop
+  endfacet
+  facet normal -0.886214 -0.463276 0
+    outer loop
+      vertex 24.8112 12.3164 0
+      vertex 24.2737 13.3446 60
+      vertex 24.2737 13.3446 0
+    endloop
+  endfacet
+  facet normal -0.886214 -0.463276 0
+    outer loop
+      vertex 24.2737 13.3446 60
+      vertex 24.8112 12.3164 0
+      vertex 24.8112 12.3164 60
+    endloop
+  endfacet
+  facet normal 0.998029 0.0627475 0
+    outer loop
+      vertex -27.6029 -2.31788 60
+      vertex -27.6757 -1.15996 0
+      vertex -27.6757 -1.15996 60
+    endloop
+  endfacet
+  facet normal 0.998029 0.0627475 0
+    outer loop
+      vertex -27.6757 -1.15996 0
+      vertex -27.6029 -2.31788 60
+      vertex -27.6029 -2.31788 0
+    endloop
+  endfacet
+  facet normal 0.166696 -0.986008 0
+    outer loop
+      vertex -5.19046 27.2094 0
+      vertex -4.0465 27.4028 60
+      vertex -5.19046 27.2094 60
+    endloop
+  endfacet
+  facet normal 0.166696 -0.986008 0
+    outer loop
+      vertex -4.0465 27.4028 60
+      vertex -5.19046 27.2094 0
+      vertex -4.0465 27.4028 0
+    endloop
+  endfacet
+  facet normal -0.937292 0.348546 0
+    outer loop
+      vertex 25.7548 -10.1971 0
+      vertex 26.1592 -9.10961 60
+      vertex 26.1592 -9.10961 0
+    endloop
+  endfacet
+  facet normal -0.937292 0.348546 0
+    outer loop
+      vertex 26.1592 -9.10961 60
+      vertex 25.7548 -10.1971 0
+      vertex 25.7548 -10.1971 60
+    endloop
+  endfacet
+  facet normal 0.48173 -0.87632 0
+    outer loop
+      vertex -13.85 23.9889 0
+      vertex -12.8333 24.5478 60
+      vertex -13.85 23.9889 60
+    endloop
+  endfacet
+  facet normal 0.48173 -0.87632 0
+    outer loop
+      vertex -12.8333 24.5478 60
+      vertex -13.85 23.9889 0
+      vertex -12.8333 24.5478 0
+    endloop
+  endfacet
+  facet normal -0.951063 0.308997 0
+    outer loop
+      vertex 26.1592 -9.10961 0
+      vertex 26.5177 -8.00618 60
+      vertex 26.5177 -8.00618 0
+    endloop
+  endfacet
+  facet normal -0.951063 0.308997 0
+    outer loop
+      vertex 26.5177 -8.00618 60
+      vertex 26.1592 -9.10961 0
+      vertex 26.1592 -9.10961 60
+    endloop
+  endfacet
+  facet normal -0.289003 0.957328 0
+    outer loop
+      vertex 8.55977 -26.3443 0
+      vertex 7.44908 -26.6796 60
+      vertex 8.55977 -26.3443 60
+    endloop
+  endfacet
+  facet normal -0.289003 0.957328 0
+    outer loop
+      vertex 7.44908 -26.6796 60
+      vertex 8.55977 -26.3443 0
+      vertex 7.44908 -26.6796 0
+    endloop
+  endfacet
+  facet normal 0.714481 0.699655 0
+    outer loop
+      vertex -19.3807 -19.7909 60
+      vertex -20.1924 -18.962 0
+      vertex -20.1924 -18.962 60
+    endloop
+  endfacet
+  facet normal 0.714481 0.699655 0
+    outer loop
+      vertex -20.1924 -18.962 0
+      vertex -19.3807 -19.7909 60
+      vertex -19.3807 -19.7909 0
+    endloop
+  endfacet
+  facet normal 0.68452 0.728994 -0
+    outer loop
+      vertex -18.5349 -20.5851 0
+      vertex -19.3807 -19.7909 60
+      vertex -18.5349 -20.5851 60
+    endloop
+  endfacet
+  facet normal 0.68452 0.728994 0
+    outer loop
+      vertex -19.3807 -19.7909 60
+      vertex -18.5349 -20.5851 0
+      vertex -19.3807 -19.7909 0
+    endloop
+  endfacet
+  facet normal -0.444661 -0.895699 0
+    outer loop
+      vertex 11.7941 25.0637 0
+      vertex 12.8333 24.5478 60
+      vertex 11.7941 25.0637 60
+    endloop
+  endfacet
+  facet normal -0.444661 -0.895699 -0
+    outer loop
+      vertex 12.8333 24.5478 60
+      vertex 11.7941 25.0637 0
+      vertex 12.8333 24.5478 0
+    endloop
+  endfacet
+  facet normal -0.368119 0.929779 0
+    outer loop
+      vertex 10.7342 -25.5356 0
+      vertex 9.65545 -25.9627 60
+      vertex 10.7342 -25.5356 60
+    endloop
+  endfacet
+  facet normal -0.368119 0.929779 0
+    outer loop
+      vertex 9.65545 -25.9627 60
+      vertex 10.7342 -25.5356 0
+      vertex 9.65545 -25.9627 0
+    endloop
+  endfacet
+  facet normal 0.796501 -0.604637 0
+    outer loop
+      vertex -22.4098 16.2817 60
+      vertex -21.7083 17.2058 0
+      vertex -21.7083 17.2058 60
+    endloop
+  endfacet
+  facet normal 0.796501 -0.604637 0
+    outer loop
+      vertex -21.7083 17.2058 0
+      vertex -22.4098 16.2817 60
+      vertex -22.4098 16.2817 0
+    endloop
+  endfacet
+  facet normal -0.621189 -0.783661 0
+    outer loop
+      vertex 16.7474 22.0639 0
+      vertex 17.6566 21.3432 60
+      vertex 16.7474 22.0639 60
+    endloop
+  endfacet
+  facet normal -0.621189 -0.783661 -0
+    outer loop
+      vertex 17.6566 21.3432 60
+      vertex 16.7474 22.0639 0
+      vertex 17.6566 21.3432 0
+    endloop
+  endfacet
+  facet normal -0.553407 0.832911 0
+    outer loop
+      vertex 15.8088 -22.7458 0
+      vertex 14.8424 -23.3879 60
+      vertex 15.8088 -22.7458 60
+    endloop
+  endfacet
+  facet normal -0.553407 0.832911 0
+    outer loop
+      vertex 14.8424 -23.3879 60
+      vertex 15.8088 -22.7458 0
+      vertex 14.8424 -23.3879 0
+    endloop
+  endfacet
+  facet normal -0.821195 -0.570648 0
+    outer loop
+      vertex 23.0719 15.3289 0
+      vertex 22.4098 16.2817 60
+      vertex 22.4098 16.2817 0
+    endloop
+  endfacet
+  facet normal -0.821195 -0.570648 0
+    outer loop
+      vertex 22.4098 16.2817 60
+      vertex 23.0719 15.3289 0
+      vertex 23.0719 15.3289 60
+    endloop
+  endfacet
+  facet normal 0.3289 -0.944365 0
+    outer loop
+      vertex -9.65545 25.9627 0
+      vertex -8.55977 26.3443 60
+      vertex -9.65545 25.9627 60
+    endloop
+  endfacet
+  facet normal 0.3289 -0.944365 0
+    outer loop
+      vertex -8.55977 26.3443 60
+      vertex -9.65545 25.9627 0
+      vertex -8.55977 26.3443 0
+    endloop
+  endfacet
+  facet normal 0.289003 -0.957328 0
+    outer loop
+      vertex -8.55977 26.3443 0
+      vertex -7.44908 26.6796 60
+      vertex -8.55977 26.3443 60
+    endloop
+  endfacet
+  facet normal 0.289003 -0.957328 0
+    outer loop
+      vertex -7.44908 26.6796 60
+      vertex -8.55977 26.3443 0
+      vertex -7.44908 26.6796 0
+    endloop
+  endfacet
+  facet normal 0.866012 0.500023 0
+    outer loop
+      vertex -23.6936 -14.3493 60
+      vertex -24.2737 -13.3446 0
+      vertex -24.2737 -13.3446 60
+    endloop
+  endfacet
+  facet normal 0.866012 0.500023 0
+    outer loop
+      vertex -24.2737 -13.3446 0
+      vertex -23.6936 -14.3493 60
+      vertex -23.6936 -14.3493 0
+    endloop
+  endfacet
+  facet normal -0.587767 0.80903 0
+    outer loop
+      vertex 16.7474 -22.0639 0
+      vertex 15.8088 -22.7458 60
+      vertex 16.7474 -22.0639 60
+    endloop
+  endfacet
+  facet normal -0.587767 0.80903 0
+    outer loop
+      vertex 15.8088 -22.7458 60
+      vertex 16.7474 -22.0639 0
+      vertex 15.8088 -22.7458 0
+    endloop
+  endfacet
+  facet normal -0.982288 0.18738 0
+    outer loop
+      vertex 27.0947 -5.75915 0
+      vertex 27.3121 -4.61949 60
+      vertex 27.3121 -4.61949 0
+    endloop
+  endfacet
+  facet normal -0.982288 0.18738 0
+    outer loop
+      vertex 27.3121 -4.61949 60
+      vertex 27.0947 -5.75915 0
+      vertex 27.0947 -5.75915 60
+    endloop
+  endfacet
+  facet normal -0.989271 -0.146094 0
+    outer loop
+      vertex 27.4816 3.47173 0
+      vertex 27.3121 4.61949 60
+      vertex 27.3121 4.61949 0
+    endloop
+  endfacet
+  facet normal -0.989271 -0.146094 0
+    outer loop
+      vertex 27.3121 4.61949 60
+      vertex 27.4816 3.47173 0
+      vertex 27.4816 3.47173 60
+    endloop
+  endfacet
+  facet normal -0.989271 0.146094 0
+    outer loop
+      vertex 27.3121 -4.61949 0
+      vertex 27.4816 -3.47173 60
+      vertex 27.4816 -3.47173 0
+    endloop
+  endfacet
+  facet normal -0.989271 0.146094 0
+    outer loop
+      vertex 27.4816 -3.47173 60
+      vertex 27.3121 -4.61949 0
+      vertex 27.3121 -4.61949 60
+    endloop
+  endfacet
+  facet normal -0.653407 -0.757007 0
+    outer loop
+      vertex 17.6566 21.3432 0
+      vertex 18.5349 20.5851 60
+      vertex 17.6566 21.3432 60
+    endloop
+  endfacet
+  facet normal -0.653407 -0.757007 -0
+    outer loop
+      vertex 18.5349 20.5851 60
+      vertex 17.6566 21.3432 0
+      vertex 18.5349 20.5851 0
+    endloop
+  endfacet
+  facet normal 0.844317 0.535843 0
+    outer loop
+      vertex -23.0719 -15.3289 60
+      vertex -23.6936 -14.3493 0
+      vertex -23.6936 -14.3493 60
+    endloop
+  endfacet
+  facet normal 0.844317 0.535843 0
+    outer loop
+      vertex -23.6936 -14.3493 0
+      vertex -23.0719 -15.3289 60
+      vertex -23.0719 -15.3289 0
+    endloop
+  endfacet
+  facet normal 0.368119 -0.929779 0
+    outer loop
+      vertex -10.7342 25.5356 0
+      vertex -9.65545 25.9627 60
+      vertex -10.7342 25.5356 60
+    endloop
+  endfacet
+  facet normal 0.368119 -0.929779 0
+    outer loop
+      vertex -9.65545 25.9627 60
+      vertex -10.7342 25.5356 0
+      vertex -9.65545 25.9627 0
+    endloop
+  endfacet
+  facet normal 0.3289 0.944365 -0
+    outer loop
+      vertex -8.55977 -26.3443 0
+      vertex -9.65545 -25.9627 60
+      vertex -8.55977 -26.3443 60
+    endloop
+  endfacet
+  facet normal 0.3289 0.944365 0
+    outer loop
+      vertex -9.65545 -25.9627 60
+      vertex -8.55977 -26.3443 0
+      vertex -9.65545 -25.9627 0
+    endloop
+  endfacet
+  facet normal 0.48173 0.87632 -0
+    outer loop
+      vertex -12.8333 -24.5478 0
+      vertex -13.85 -23.9889 60
+      vertex -12.8333 -24.5478 60
+    endloop
+  endfacet
+  facet normal 0.48173 0.87632 0
+    outer loop
+      vertex -13.85 -23.9889 60
+      vertex -12.8333 -24.5478 0
+      vertex -13.85 -23.9889 0
+    endloop
+  endfacet
+  facet normal 0.0418888 0.999122 -0
+    outer loop
+      vertex -0.580105 -27.6939 0
+      vertex -1.7393 -27.6453 60
+      vertex -0.580105 -27.6939 60
+    endloop
+  endfacet
+  facet normal 0.0418888 0.999122 0
+    outer loop
+      vertex -1.7393 -27.6453 60
+      vertex -0.580105 -27.6939 0
+      vertex -1.7393 -27.6453 0
+    endloop
+  endfacet
+  facet normal -0.518015 -0.855371 0
+    outer loop
+      vertex 13.85 23.9889 0
+      vertex 14.8424 23.3879 60
+      vertex 13.85 23.9889 60
+    endloop
+  endfacet
+  facet normal -0.518015 -0.855371 -0
+    outer loop
+      vertex 14.8424 23.3879 60
+      vertex 13.85 23.9889 0
+      vertex 14.8424 23.3879 0
+    endloop
+  endfacet
+  facet normal 0.937292 -0.348546 0
+    outer loop
+      vertex -26.1592 9.10961 60
+      vertex -25.7548 10.1971 0
+      vertex -25.7548 10.1971 60
+    endloop
+  endfacet
+  facet normal 0.937292 -0.348546 0
+    outer loop
+      vertex -25.7548 10.1971 0
+      vertex -26.1592 9.10961 60
+      vertex -26.1592 9.10961 0
+    endloop
+  endfacet
+  facet normal -0.998029 -0.0627475 0
+    outer loop
+      vertex 27.6757 1.15996 0
+      vertex 27.6029 2.31788 60
+      vertex 27.6029 2.31788 0
+    endloop
+  endfacet
+  facet normal -0.998029 -0.0627475 0
+    outer loop
+      vertex 27.6029 2.31788 60
+      vertex 27.6757 1.15996 0
+      vertex 27.6757 1.15996 60
+    endloop
+  endfacet
+  facet normal -0.99452 -0.10455 0
+    outer loop
+      vertex 27.6029 2.31788 0
+      vertex 27.4816 3.47173 60
+      vertex 27.4816 3.47173 0
+    endloop
+  endfacet
+  facet normal -0.99452 -0.10455 0
+    outer loop
+      vertex 27.4816 3.47173 60
+      vertex 27.6029 2.31788 0
+      vertex 27.6029 2.31788 60
+    endloop
+  endfacet
+  facet normal -0.844317 -0.535843 0
+    outer loop
+      vertex 23.6936 14.3493 0
+      vertex 23.0719 15.3289 60
+      vertex 23.0719 15.3289 0
+    endloop
+  endfacet
+  facet normal -0.844317 -0.535843 0
+    outer loop
+      vertex 23.0719 15.3289 60
+      vertex 23.6936 14.3493 0
+      vertex 23.6936 14.3493 60
+    endloop
+  endfacet
+  facet normal -0.125407 -0.992105 0
+    outer loop
+      vertex 2.89544 27.5483 0
+      vertex 4.0465 27.4028 60
+      vertex 2.89544 27.5483 60
+    endloop
+  endfacet
+  facet normal -0.125407 -0.992105 -0
+    outer loop
+      vertex 4.0465 27.4028 60
+      vertex 2.89544 27.5483 0
+      vertex 4.0465 27.4028 0
+    endloop
+  endfacet
+  facet normal 0.289003 0.957328 -0
+    outer loop
+      vertex -7.44908 -26.6796 0
+      vertex -8.55977 -26.3443 60
+      vertex -7.44908 -26.6796 60
+    endloop
+  endfacet
+  facet normal 0.289003 0.957328 0
+    outer loop
+      vertex -8.55977 -26.3443 60
+      vertex -7.44908 -26.6796 0
+      vertex -8.55977 -26.3443 0
+    endloop
+  endfacet
+  facet normal -0.0418888 0.999122 0
+    outer loop
+      vertex 1.7393 -27.6453 0
+      vertex 0.580105 -27.6939 60
+      vertex 1.7393 -27.6453 60
+    endloop
+  endfacet
+  facet normal -0.0418888 0.999122 0
+    outer loop
+      vertex 0.580105 -27.6939 60
+      vertex 1.7393 -27.6453 0
+      vertex 0.580105 -27.6939 0
+    endloop
+  endfacet
+  facet normal 0.125407 -0.992105 0
+    outer loop
+      vertex -4.0465 27.4028 0
+      vertex -2.89544 27.5483 60
+      vertex -4.0465 27.4028 60
+    endloop
+  endfacet
+  facet normal 0.125407 -0.992105 0
+    outer loop
+      vertex -2.89544 27.5483 60
+      vertex -4.0465 27.4028 0
+      vertex -2.89544 27.5483 0
+    endloop
+  endfacet
+  facet normal -0.248664 0.96859 0
+    outer loop
+      vertex 7.44908 -26.6796 0
+      vertex 6.32532 -26.9681 60
+      vertex 7.44908 -26.6796 60
+    endloop
+  endfacet
+  facet normal -0.248664 0.96859 0
+    outer loop
+      vertex 6.32532 -26.9681 60
+      vertex 7.44908 -26.6796 0
+      vertex 6.32532 -26.9681 0
+    endloop
+  endfacet
+  facet normal -0.68452 -0.728994 0
+    outer loop
+      vertex 18.5349 20.5851 0
+      vertex 19.3807 19.7909 60
+      vertex 18.5349 20.5851 60
+    endloop
+  endfacet
+  facet normal -0.68452 -0.728994 -0
+    outer loop
+      vertex 19.3807 19.7909 60
+      vertex 18.5349 20.5851 0
+      vertex 19.3807 19.7909 0
+    endloop
+  endfacet
+  facet normal -0.3289 -0.944365 0
+    outer loop
+      vertex 8.55977 26.3443 0
+      vertex 9.65545 25.9627 60
+      vertex 8.55977 26.3443 60
+    endloop
+  endfacet
+  facet normal -0.3289 -0.944365 -0
+    outer loop
+      vertex 9.65545 25.9627 60
+      vertex 8.55977 26.3443 0
+      vertex 9.65545 25.9627 0
+    endloop
+  endfacet
+  facet normal -0.166696 -0.986008 0
+    outer loop
+      vertex 4.0465 27.4028 0
+      vertex 5.19046 27.2094 60
+      vertex 4.0465 27.4028 60
+    endloop
+  endfacet
+  facet normal -0.166696 -0.986008 -0
+    outer loop
+      vertex 5.19046 27.2094 60
+      vertex 4.0465 27.4028 0
+      vertex 5.19046 27.2094 0
+    endloop
+  endfacet
+  facet normal -0.770548 -0.637382 0
+    outer loop
+      vertex 21.7083 17.2058 0
+      vertex 20.9688 18.0998 60
+      vertex 20.9688 18.0998 0
+    endloop
+  endfacet
+  facet normal -0.770548 -0.637382 0
+    outer loop
+      vertex 20.9688 18.0998 60
+      vertex 21.7083 17.2058 0
+      vertex 21.7083 17.2058 60
+    endloop
+  endfacet
+  facet normal -0.951063 -0.308997 0
+    outer loop
+      vertex 26.5177 8.00618 0
+      vertex 26.1592 9.10961 60
+      vertex 26.1592 9.10961 0
+    endloop
+  endfacet
+  facet normal -0.951063 -0.308997 0
+    outer loop
+      vertex 26.1592 9.10961 60
+      vertex 26.5177 8.00618 0
+      vertex 26.5177 8.00618 60
+    endloop
+  endfacet
+  facet normal 0.770548 -0.637382 0
+    outer loop
+      vertex -21.7083 17.2058 60
+      vertex -20.9688 18.0998 0
+      vertex -20.9688 18.0998 60
+    endloop
+  endfacet
+  facet normal 0.770548 -0.637382 0
+    outer loop
+      vertex -20.9688 18.0998 0
+      vertex -21.7083 17.2058 60
+      vertex -21.7083 17.2058 0
+    endloop
+  endfacet
+  facet normal -0.999781 0.0209444 0
+    outer loop
+      vertex 27.6757 -1.15996 0
+      vertex 27.7 0 60
+      vertex 27.7 0 0
+    endloop
+  endfacet
+  facet normal -0.999781 0.0209444 0
+    outer loop
+      vertex 27.7 0 60
+      vertex 27.6757 -1.15996 0
+      vertex 27.6757 -1.15996 60
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 0.580105 -27.6939 0
+      vertex -0.580105 -27.6939 60
+      vertex 0.580105 -27.6939 60
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.580105 -27.6939 60
+      vertex 0.580105 -27.6939 0
+      vertex -0.580105 -27.6939 0
+    endloop
+  endfacet
+  facet normal -0.587767 -0.80903 0
+    outer loop
+      vertex 15.8088 22.7458 0
+      vertex 16.7474 22.0639 60
+      vertex 15.8088 22.7458 60
+    endloop
+  endfacet
+  facet normal -0.587767 -0.80903 -0
+    outer loop
+      vertex 16.7474 22.0639 60
+      vertex 15.8088 22.7458 0
+      vertex 16.7474 22.0639 0
+    endloop
+  endfacet
+  facet normal 0.770548 0.637382 0
+    outer loop
+      vertex -20.9688 -18.0998 60
+      vertex -21.7083 -17.2058 0
+      vertex -21.7083 -17.2058 60
+    endloop
+  endfacet
+  facet normal 0.770548 0.637382 0
+    outer loop
+      vertex -21.7083 -17.2058 0
+      vertex -20.9688 -18.0998 60
+      vertex -20.9688 -18.0998 0
+    endloop
+  endfacet
+  facet normal -0.368119 -0.929779 0
+    outer loop
+      vertex 9.65545 25.9627 0
+      vertex 10.7342 25.5356 60
+      vertex 9.65545 25.9627 60
+    endloop
+  endfacet
+  facet normal -0.368119 -0.929779 -0
+    outer loop
+      vertex 10.7342 25.5356 60
+      vertex 9.65545 25.9627 0
+      vertex 10.7342 25.5356 0
+    endloop
+  endfacet
+  facet normal -0.982288 -0.18738 0
+    outer loop
+      vertex 27.3121 4.61949 0
+      vertex 27.0947 5.75915 60
+      vertex 27.0947 5.75915 0
+    endloop
+  endfacet
+  facet normal -0.982288 -0.18738 0
+    outer loop
+      vertex 27.0947 5.75915 60
+      vertex 27.3121 4.61949 0
+      vertex 27.3121 4.61949 60
+    endloop
+  endfacet
+  facet normal 0.951063 0.308997 0
+    outer loop
+      vertex -26.1592 -9.10961 60
+      vertex -26.5177 -8.00618 0
+      vertex -26.5177 -8.00618 60
+    endloop
+  endfacet
+  facet normal 0.951063 0.308997 0
+    outer loop
+      vertex -26.5177 -8.00618 0
+      vertex -26.1592 -9.10961 60
+      vertex -26.1592 -9.10961 0
+    endloop
+  endfacet
+  facet normal -0.99452 0.10455 0
+    outer loop
+      vertex 27.4816 -3.47173 0
+      vertex 27.6029 -2.31788 60
+      vertex 27.6029 -2.31788 0
+    endloop
+  endfacet
+  facet normal -0.99452 0.10455 0
+    outer loop
+      vertex 27.6029 -2.31788 60
+      vertex 27.4816 -3.47173 0
+      vertex 27.4816 -3.47173 60
+    endloop
+  endfacet
+  facet normal -0.973586 -0.228322 0
+    outer loop
+      vertex 27.0947 5.75915 0
+      vertex 26.8298 6.88871 60
+      vertex 26.8298 6.88871 0
+    endloop
+  endfacet
+  facet normal -0.973586 -0.228322 0
+    outer loop
+      vertex 26.8298 6.88871 60
+      vertex 27.0947 5.75915 0
+      vertex 27.0947 5.75915 60
+    endloop
+  endfacet
+  facet normal -0.886214 0.463276 0
+    outer loop
+      vertex 24.2737 -13.3446 0
+      vertex 24.8112 -12.3164 60
+      vertex 24.8112 -12.3164 0
+    endloop
+  endfacet
+  facet normal -0.886214 0.463276 0
+    outer loop
+      vertex 24.8112 -12.3164 60
+      vertex 24.2737 -13.3446 0
+      vertex 24.2737 -13.3446 60
+    endloop
+  endfacet
+  facet normal 0.821195 0.570648 0
+    outer loop
+      vertex -22.4098 -16.2817 60
+      vertex -23.0719 -15.3289 0
+      vertex -23.0719 -15.3289 60
+    endloop
+  endfacet
+  facet normal 0.821195 0.570648 0
+    outer loop
+      vertex -23.0719 -15.3289 0
+      vertex -22.4098 -16.2817 60
+      vertex -22.4098 -16.2817 0
+    endloop
+  endfacet
+  facet normal 0.904827 0.42578 0
+    outer loop
+      vertex -24.8112 -12.3164 60
+      vertex -25.3052 -11.2666 0
+      vertex -25.3052 -11.2666 60
+    endloop
+  endfacet
+  facet normal 0.904827 0.42578 0
+    outer loop
+      vertex -25.3052 -11.2666 0
+      vertex -24.8112 -12.3164 60
+      vertex -24.8112 -12.3164 0
+    endloop
+  endfacet
+  facet normal -0.770548 0.637382 0
+    outer loop
+      vertex 20.9688 -18.0998 0
+      vertex 21.7083 -17.2058 60
+      vertex 21.7083 -17.2058 0
+    endloop
+  endfacet
+  facet normal -0.770548 0.637382 0
+    outer loop
+      vertex 21.7083 -17.2058 60
+      vertex 20.9688 -18.0998 0
+      vertex 20.9688 -18.0998 60
+    endloop
+  endfacet
+  facet normal -0.921856 -0.387533 0
+    outer loop
+      vertex 25.7548 10.1971 0
+      vertex 25.3052 11.2666 60
+      vertex 25.3052 11.2666 0
+    endloop
+  endfacet
+  facet normal -0.921856 -0.387533 0
+    outer loop
+      vertex 25.3052 11.2666 60
+      vertex 25.7548 10.1971 0
+      vertex 25.7548 10.1971 60
+    endloop
+  endfacet
+  facet normal -0.904827 0.42578 0
+    outer loop
+      vertex 24.8112 -12.3164 0
+      vertex 25.3052 -11.2666 60
+      vertex 25.3052 -11.2666 0
+    endloop
+  endfacet
+  facet normal -0.904827 0.42578 0
+    outer loop
+      vertex 25.3052 -11.2666 60
+      vertex 24.8112 -12.3164 0
+      vertex 24.8112 -12.3164 60
+    endloop
+  endfacet
+  facet normal -0.653407 0.757007 0
+    outer loop
+      vertex 18.5349 -20.5851 0
+      vertex 17.6566 -21.3432 60
+      vertex 18.5349 -20.5851 60
+    endloop
+  endfacet
+  facet normal -0.653407 0.757007 0
+    outer loop
+      vertex 17.6566 -21.3432 60
+      vertex 18.5349 -20.5851 0
+      vertex 17.6566 -21.3432 0
+    endloop
+  endfacet
+  facet normal -0.444661 0.895699 0
+    outer loop
+      vertex 12.8333 -24.5478 0
+      vertex 11.7941 -25.0637 60
+      vertex 12.8333 -24.5478 60
+    endloop
+  endfacet
+  facet normal -0.444661 0.895699 0
+    outer loop
+      vertex 11.7941 -25.0637 60
+      vertex 12.8333 -24.5478 0
+      vertex 11.7941 -25.0637 0
+    endloop
+  endfacet
+  facet normal -0.621189 0.783661 0
+    outer loop
+      vertex 17.6566 -21.3432 0
+      vertex 16.7474 -22.0639 60
+      vertex 17.6566 -21.3432 60
+    endloop
+  endfacet
+  facet normal -0.621189 0.783661 0
+    outer loop
+      vertex 16.7474 -22.0639 60
+      vertex 17.6566 -21.3432 0
+      vertex 16.7474 -22.0639 0
+    endloop
+  endfacet
+  facet normal -0.166696 0.986008 0
+    outer loop
+      vertex 5.19046 -27.2094 0
+      vertex 4.0465 -27.4028 60
+      vertex 5.19046 -27.2094 60
+    endloop
+  endfacet
+  facet normal -0.166696 0.986008 0
+    outer loop
+      vertex 4.0465 -27.4028 60
+      vertex 5.19046 -27.2094 0
+      vertex 4.0465 -27.4028 0
+    endloop
+  endfacet
+  facet normal 0.982288 0.18738 0
+    outer loop
+      vertex -27.0947 -5.75915 60
+      vertex -27.3121 -4.61949 0
+      vertex -27.3121 -4.61949 60
+    endloop
+  endfacet
+  facet normal 0.982288 0.18738 0
+    outer loop
+      vertex -27.3121 -4.61949 0
+      vertex -27.0947 -5.75915 60
+      vertex -27.0947 -5.75915 0
+    endloop
+  endfacet
+  facet normal 0.999781 -0.0209444 0
+    outer loop
+      vertex -27.7 0 60
+      vertex -27.6757 1.15996 0
+      vertex -27.6757 1.15996 60
+    endloop
+  endfacet
+  facet normal 0.999781 -0.0209444 0
+    outer loop
+      vertex -27.6757 1.15996 0
+      vertex -27.7 0 60
+      vertex -27.7 0 0
+    endloop
+  endfacet
+  facet normal -0.406738 0.913545 0
+    outer loop
+      vertex 11.7941 -25.0637 0
+      vertex 10.7342 -25.5356 60
+      vertex 11.7941 -25.0637 60
+    endloop
+  endfacet
+  facet normal -0.406738 0.913545 0
+    outer loop
+      vertex 10.7342 -25.5356 60
+      vertex 11.7941 -25.0637 0
+      vertex 10.7342 -25.5356 0
+    endloop
+  endfacet
+  facet normal -0.963141 -0.268997 0
+    outer loop
+      vertex 26.8298 6.88871 0
+      vertex 26.5177 8.00618 60
+      vertex 26.5177 8.00618 0
+    endloop
+  endfacet
+  facet normal -0.963141 -0.268997 0
+    outer loop
+      vertex 26.5177 8.00618 60
+      vertex 26.8298 6.88871 0
+      vertex 26.8298 6.88871 60
+    endloop
+  endfacet
+  facet normal -0.68452 0.728994 0
+    outer loop
+      vertex 19.3807 -19.7909 0
+      vertex 18.5349 -20.5851 60
+      vertex 19.3807 -19.7909 60
+    endloop
+  endfacet
+  facet normal -0.68452 0.728994 0
+    outer loop
+      vertex 18.5349 -20.5851 60
+      vertex 19.3807 -19.7909 0
+      vertex 18.5349 -20.5851 0
+    endloop
+  endfacet
+  facet normal 0.248664 -0.96859 0
+    outer loop
+      vertex -7.44908 26.6796 0
+      vertex -6.32532 26.9681 60
+      vertex -7.44908 26.6796 60
+    endloop
+  endfacet
+  facet normal 0.248664 -0.96859 0
+    outer loop
+      vertex -6.32532 26.9681 60
+      vertex -7.44908 26.6796 0
+      vertex -6.32532 26.9681 0
+    endloop
+  endfacet
+  facet normal -0.904827 -0.42578 0
+    outer loop
+      vertex 25.3052 11.2666 0
+      vertex 24.8112 12.3164 60
+      vertex 24.8112 12.3164 0
+    endloop
+  endfacet
+  facet normal -0.904827 -0.42578 0
+    outer loop
+      vertex 24.8112 12.3164 60
+      vertex 25.3052 11.2666 0
+      vertex 25.3052 11.2666 60
+    endloop
+  endfacet
+  facet normal -0.866012 -0.500023 0
+    outer loop
+      vertex 24.2737 13.3446 0
+      vertex 23.6936 14.3493 60
+      vertex 23.6936 14.3493 0
+    endloop
+  endfacet
+  facet normal -0.866012 -0.500023 0
+    outer loop
+      vertex 23.6936 14.3493 60
+      vertex 24.2737 13.3446 0
+      vertex 24.2737 13.3446 60
+    endloop
+  endfacet
+  facet normal -0.553407 -0.832911 0
+    outer loop
+      vertex 14.8424 23.3879 0
+      vertex 15.8088 22.7458 60
+      vertex 14.8424 23.3879 60
+    endloop
+  endfacet
+  facet normal -0.553407 -0.832911 -0
+    outer loop
+      vertex 15.8088 22.7458 60
+      vertex 14.8424 23.3879 0
+      vertex 15.8088 22.7458 0
+    endloop
+  endfacet
+  facet normal -0.406738 -0.913545 0
+    outer loop
+      vertex 10.7342 25.5356 0
+      vertex 11.7941 25.0637 60
+      vertex 10.7342 25.5356 60
+    endloop
+  endfacet
+  facet normal -0.406738 -0.913545 -0
+    outer loop
+      vertex 11.7941 25.0637 60
+      vertex 10.7342 25.5356 0
+      vertex 11.7941 25.0637 0
+    endloop
+  endfacet
+  facet normal 0.621189 0.783661 -0
+    outer loop
+      vertex -16.7474 -22.0639 0
+      vertex -17.6566 -21.3432 60
+      vertex -16.7474 -22.0639 60
+    endloop
+  endfacet
+  facet normal 0.621189 0.783661 0
+    outer loop
+      vertex -17.6566 -21.3432 60
+      vertex -16.7474 -22.0639 0
+      vertex -17.6566 -21.3432 0
+    endloop
+  endfacet
+  facet normal -0.48173 -0.87632 0
+    outer loop
+      vertex 12.8333 24.5478 0
+      vertex 13.85 23.9889 60
+      vertex 12.8333 24.5478 60
+    endloop
+  endfacet
+  facet normal -0.48173 -0.87632 -0
+    outer loop
+      vertex 13.85 23.9889 60
+      vertex 12.8333 24.5478 0
+      vertex 13.85 23.9889 0
+    endloop
+  endfacet
+  facet normal 0.587767 -0.80903 0
+    outer loop
+      vertex -16.7474 22.0639 0
+      vertex -15.8088 22.7458 60
+      vertex -16.7474 22.0639 60
+    endloop
+  endfacet
+  facet normal 0.587767 -0.80903 0
+    outer loop
+      vertex -15.8088 22.7458 60
+      vertex -16.7474 22.0639 0
+      vertex -15.8088 22.7458 0
+    endloop
+  endfacet
+  facet normal 0.0418888 -0.999122 0
+    outer loop
+      vertex -1.7393 27.6453 0
+      vertex -0.580105 27.6939 60
+      vertex -1.7393 27.6453 60
+    endloop
+  endfacet
+  facet normal 0.0418888 -0.999122 0
+    outer loop
+      vertex -0.580105 27.6939 60
+      vertex -1.7393 27.6453 0
+      vertex -0.580105 27.6939 0
+    endloop
+  endfacet
+  facet normal 0.951063 -0.308997 0
+    outer loop
+      vertex -26.5177 8.00618 60
+      vertex -26.1592 9.10961 0
+      vertex -26.1592 9.10961 60
+    endloop
+  endfacet
+  facet normal 0.951063 -0.308997 0
+    outer loop
+      vertex -26.1592 9.10961 0
+      vertex -26.5177 8.00618 60
+      vertex -26.5177 8.00618 0
+    endloop
+  endfacet
+  facet normal -0.743114 0.669165 0
+    outer loop
+      vertex 20.1924 -18.962 0
+      vertex 20.9688 -18.0998 60
+      vertex 20.9688 -18.0998 0
+    endloop
+  endfacet
+  facet normal -0.743114 0.669165 0
+    outer loop
+      vertex 20.9688 -18.0998 60
+      vertex 20.1924 -18.962 0
+      vertex 20.1924 -18.962 60
+    endloop
+  endfacet
+  facet normal -0.866012 0.500023 0
+    outer loop
+      vertex 23.6936 -14.3493 0
+      vertex 24.2737 -13.3446 60
+      vertex 24.2737 -13.3446 0
+    endloop
+  endfacet
+  facet normal -0.866012 0.500023 0
+    outer loop
+      vertex 24.2737 -13.3446 60
+      vertex 23.6936 -14.3493 0
+      vertex 23.6936 -14.3493 60
+    endloop
+  endfacet
+  facet normal 0.973586 0.228322 0
+    outer loop
+      vertex -26.8298 -6.88871 60
+      vertex -27.0947 -5.75915 0
+      vertex -27.0947 -5.75915 60
+    endloop
+  endfacet
+  facet normal 0.973586 0.228322 0
+    outer loop
+      vertex -27.0947 -5.75915 0
+      vertex -26.8298 -6.88871 60
+      vertex -26.8298 -6.88871 0
+    endloop
+  endfacet
+  facet normal 0.653407 0.757007 -0
+    outer loop
+      vertex -17.6566 -21.3432 0
+      vertex -18.5349 -20.5851 60
+      vertex -17.6566 -21.3432 60
+    endloop
+  endfacet
+  facet normal 0.653407 0.757007 0
+    outer loop
+      vertex -18.5349 -20.5851 60
+      vertex -17.6566 -21.3432 0
+      vertex -18.5349 -20.5851 0
+    endloop
+  endfacet
+  facet normal -0.3289 0.944365 0
+    outer loop
+      vertex 9.65545 -25.9627 0
+      vertex 8.55977 -26.3443 60
+      vertex 9.65545 -25.9627 60
+    endloop
+  endfacet
+  facet normal -0.3289 0.944365 0
+    outer loop
+      vertex 8.55977 -26.3443 60
+      vertex 9.65545 -25.9627 0
+      vertex 8.55977 -26.3443 0
+    endloop
+  endfacet
+  facet normal 0.653407 -0.757007 0
+    outer loop
+      vertex -18.5349 20.5851 0
+      vertex -17.6566 21.3432 60
+      vertex -18.5349 20.5851 60
+    endloop
+  endfacet
+  facet normal 0.653407 -0.757007 0
+    outer loop
+      vertex -17.6566 21.3432 60
+      vertex -18.5349 20.5851 0
+      vertex -17.6566 21.3432 0
+    endloop
+  endfacet
+  facet normal -0.796501 0.604637 0
+    outer loop
+      vertex 21.7083 -17.2058 0
+      vertex 22.4098 -16.2817 60
+      vertex 22.4098 -16.2817 0
+    endloop
+  endfacet
+  facet normal -0.796501 0.604637 0
+    outer loop
+      vertex 22.4098 -16.2817 60
+      vertex 21.7083 -17.2058 0
+      vertex 21.7083 -17.2058 60
+    endloop
+  endfacet
+  facet normal 0.406738 -0.913545 0
+    outer loop
+      vertex -11.7941 25.0637 0
+      vertex -10.7342 25.5356 60
+      vertex -11.7941 25.0637 60
+    endloop
+  endfacet
+  facet normal 0.406738 -0.913545 0
+    outer loop
+      vertex -10.7342 25.5356 60
+      vertex -11.7941 25.0637 0
+      vertex -10.7342 25.5356 0
+    endloop
+  endfacet
+  facet normal 0.999781 0.0209444 0
+    outer loop
+      vertex -27.6757 -1.15996 60
+      vertex -27.7 0 0
+      vertex -27.7 0 60
+    endloop
+  endfacet
+  facet normal 0.999781 0.0209444 0
+    outer loop
+      vertex -27.7 0 0
+      vertex -27.6757 -1.15996 60
+      vertex -27.6757 -1.15996 0
+    endloop
+  endfacet
+  facet normal 0.973586 -0.228322 0
+    outer loop
+      vertex -27.0947 5.75915 60
+      vertex -26.8298 6.88871 0
+      vertex -26.8298 6.88871 60
+    endloop
+  endfacet
+  facet normal 0.973586 -0.228322 0
+    outer loop
+      vertex -26.8298 6.88871 0
+      vertex -27.0947 5.75915 60
+      vertex -27.0947 5.75915 0
+    endloop
+  endfacet
+  facet normal 0.937292 0.348546 0
+    outer loop
+      vertex -25.7548 -10.1971 60
+      vertex -26.1592 -9.10961 0
+      vertex -26.1592 -9.10961 60
+    endloop
+  endfacet
+  facet normal 0.937292 0.348546 0
+    outer loop
+      vertex -26.1592 -9.10961 0
+      vertex -25.7548 -10.1971 60
+      vertex -25.7548 -10.1971 0
+    endloop
+  endfacet
+  facet normal 0.982288 -0.18738 0
+    outer loop
+      vertex -27.3121 4.61949 60
+      vertex -27.0947 5.75915 0
+      vertex -27.0947 5.75915 60
+    endloop
+  endfacet
+  facet normal 0.982288 -0.18738 0
+    outer loop
+      vertex -27.0947 5.75915 0
+      vertex -27.3121 4.61949 60
+      vertex -27.3121 4.61949 0
+    endloop
+  endfacet
+  facet normal 0.904827 -0.42578 0
+    outer loop
+      vertex -25.3052 11.2666 60
+      vertex -24.8112 12.3164 0
+      vertex -24.8112 12.3164 60
+    endloop
+  endfacet
+  facet normal 0.904827 -0.42578 0
+    outer loop
+      vertex -24.8112 12.3164 0
+      vertex -25.3052 11.2666 60
+      vertex -25.3052 11.2666 0
+    endloop
+  endfacet
+  facet normal 0.989271 0.146094 0
+    outer loop
+      vertex -27.3121 -4.61949 60
+      vertex -27.4816 -3.47173 0
+      vertex -27.4816 -3.47173 60
+    endloop
+  endfacet
+  facet normal 0.989271 0.146094 0
+    outer loop
+      vertex -27.4816 -3.47173 0
+      vertex -27.3121 -4.61949 60
+      vertex -27.3121 -4.61949 0
+    endloop
+  endfacet
+  facet normal 0.99452 0.10455 0
+    outer loop
+      vertex -27.4816 -3.47173 60
+      vertex -27.6029 -2.31788 0
+      vertex -27.6029 -2.31788 60
+    endloop
+  endfacet
+  facet normal 0.99452 0.10455 0
+    outer loop
+      vertex -27.6029 -2.31788 0
+      vertex -27.4816 -3.47173 60
+      vertex -27.4816 -3.47173 0
+    endloop
+  endfacet
+  facet normal -0.963141 0.268997 0
+    outer loop
+      vertex 26.5177 -8.00618 0
+      vertex 26.8298 -6.88871 60
+      vertex 26.8298 -6.88871 0
+    endloop
+  endfacet
+  facet normal -0.963141 0.268997 0
+    outer loop
+      vertex 26.8298 -6.88871 60
+      vertex 26.5177 -8.00618 0
+      vertex 26.5177 -8.00618 60
+    endloop
+  endfacet
+  facet normal 0.821195 -0.570648 0
+    outer loop
+      vertex -23.0719 15.3289 60
+      vertex -22.4098 16.2817 0
+      vertex -22.4098 16.2817 60
+    endloop
+  endfacet
+  facet normal 0.821195 -0.570648 0
+    outer loop
+      vertex -22.4098 16.2817 0
+      vertex -23.0719 15.3289 60
+      vertex -23.0719 15.3289 0
+    endloop
+  endfacet
+  facet normal -0.248664 -0.96859 0
+    outer loop
+      vertex 6.32532 26.9681 0
+      vertex 7.44908 26.6796 60
+      vertex 6.32532 26.9681 60
+    endloop
+  endfacet
+  facet normal -0.248664 -0.96859 -0
+    outer loop
+      vertex 7.44908 26.6796 60
+      vertex 6.32532 26.9681 0
+      vertex 7.44908 26.6796 0
+    endloop
+  endfacet
+  facet normal 0.368119 0.929779 -0
+    outer loop
+      vertex -9.65545 -25.9627 0
+      vertex -10.7342 -25.5356 60
+      vertex -9.65545 -25.9627 60
+    endloop
+  endfacet
+  facet normal 0.368119 0.929779 0
+    outer loop
+      vertex -10.7342 -25.5356 60
+      vertex -9.65545 -25.9627 0
+      vertex -10.7342 -25.5356 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.580105 27.6939 0
+      vertex 0.580105 27.6939 60
+      vertex -0.580105 27.6939 60
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 0.580105 27.6939 60
+      vertex -0.580105 27.6939 0
+      vertex 0.580105 27.6939 0
+    endloop
+  endfacet
+  facet normal 0.444661 0.895699 -0
+    outer loop
+      vertex -11.7941 -25.0637 0
+      vertex -12.8333 -24.5478 60
+      vertex -11.7941 -25.0637 60
+    endloop
+  endfacet
+  facet normal 0.444661 0.895699 0
+    outer loop
+      vertex -12.8333 -24.5478 60
+      vertex -11.7941 -25.0637 0
+      vertex -12.8333 -24.5478 0
+    endloop
+  endfacet
+  facet normal -0.714481 0.699655 0
+    outer loop
+      vertex 19.3807 -19.7909 0
+      vertex 20.1924 -18.962 60
+      vertex 20.1924 -18.962 0
+    endloop
+  endfacet
+  facet normal -0.714481 0.699655 0
+    outer loop
+      vertex 20.1924 -18.962 60
+      vertex 19.3807 -19.7909 0
+      vertex 19.3807 -19.7909 60
+    endloop
+  endfacet
+  facet normal 0.989271 -0.146094 0
+    outer loop
+      vertex -27.4816 3.47173 60
+      vertex -27.3121 4.61949 0
+      vertex -27.3121 4.61949 60
+    endloop
+  endfacet
+  facet normal 0.989271 -0.146094 0
+    outer loop
+      vertex -27.3121 4.61949 0
+      vertex -27.4816 3.47173 60
+      vertex -27.4816 3.47173 0
+    endloop
+  endfacet
+  facet normal 0.714481 -0.699655 0
+    outer loop
+      vertex -20.1924 18.962 60
+      vertex -19.3807 19.7909 0
+      vertex -19.3807 19.7909 60
+    endloop
+  endfacet
+  facet normal 0.714481 -0.699655 0
+    outer loop
+      vertex -19.3807 19.7909 0
+      vertex -20.1924 18.962 60
+      vertex -20.1924 18.962 0
+    endloop
+  endfacet
+  facet normal 0.553407 -0.832911 0
+    outer loop
+      vertex -15.8088 22.7458 0
+      vertex -14.8424 23.3879 60
+      vertex -15.8088 22.7458 60
+    endloop
+  endfacet
+  facet normal 0.553407 -0.832911 0
+    outer loop
+      vertex -14.8424 23.3879 60
+      vertex -15.8088 22.7458 0
+      vertex -14.8424 23.3879 0
+    endloop
+  endfacet
+  facet normal 0.99452 -0.10455 0
+    outer loop
+      vertex -27.6029 2.31788 60
+      vertex -27.4816 3.47173 0
+      vertex -27.4816 3.47173 60
+    endloop
+  endfacet
+  facet normal 0.99452 -0.10455 0
+    outer loop
+      vertex -27.4816 3.47173 0
+      vertex -27.6029 2.31788 60
+      vertex -27.6029 2.31788 0
+    endloop
+  endfacet
+  facet normal 0.921856 -0.387533 0
+    outer loop
+      vertex -25.7548 10.1971 60
+      vertex -25.3052 11.2666 0
+      vertex -25.3052 11.2666 60
+    endloop
+  endfacet
+  facet normal 0.921856 -0.387533 0
+    outer loop
+      vertex -25.3052 11.2666 0
+      vertex -25.7548 10.1971 60
+      vertex -25.7548 10.1971 0
+    endloop
+  endfacet
+  facet normal 0.207976 -0.978134 0
+    outer loop
+      vertex -6.32532 26.9681 0
+      vertex -5.19046 27.2094 60
+      vertex -6.32532 26.9681 60
+    endloop
+  endfacet
+  facet normal 0.207976 -0.978134 0
+    outer loop
+      vertex -5.19046 27.2094 60
+      vertex -6.32532 26.9681 0
+      vertex -5.19046 27.2094 0
+    endloop
+  endfacet
+  facet normal 0.886214 0.463276 0
+    outer loop
+      vertex -24.2737 -13.3446 60
+      vertex -24.8112 -12.3164 0
+      vertex -24.8112 -12.3164 60
+    endloop
+  endfacet
+  facet normal 0.886214 0.463276 0
+    outer loop
+      vertex -24.8112 -12.3164 0
+      vertex -24.2737 -13.3446 60
+      vertex -24.2737 -13.3446 0
+    endloop
+  endfacet
+  facet normal -0.921856 0.387533 0
+    outer loop
+      vertex 25.3052 -11.2666 0
+      vertex 25.7548 -10.1971 60
+      vertex 25.7548 -10.1971 0
+    endloop
+  endfacet
+  facet normal -0.921856 0.387533 0
+    outer loop
+      vertex 25.7548 -10.1971 60
+      vertex 25.3052 -11.2666 0
+      vertex 25.3052 -11.2666 60
+    endloop
+  endfacet
+  facet normal -0.844317 0.535843 0
+    outer loop
+      vertex 23.0719 -15.3289 0
+      vertex 23.6936 -14.3493 60
+      vertex 23.6936 -14.3493 0
+    endloop
+  endfacet
+  facet normal -0.844317 0.535843 0
+    outer loop
+      vertex 23.6936 -14.3493 60
+      vertex 23.0719 -15.3289 0
+      vertex 23.0719 -15.3289 60
+    endloop
+  endfacet
+  facet normal -0.0836061 0.996499 0
+    outer loop
+      vertex 2.89544 -27.5483 0
+      vertex 1.7393 -27.6453 60
+      vertex 2.89544 -27.5483 60
+    endloop
+  endfacet
+  facet normal -0.0836061 0.996499 0
+    outer loop
+      vertex 1.7393 -27.6453 60
+      vertex 2.89544 -27.5483 0
+      vertex 1.7393 -27.6453 0
+    endloop
+  endfacet
+  facet normal -0.48173 0.87632 0
+    outer loop
+      vertex 13.85 -23.9889 0
+      vertex 12.8333 -24.5478 60
+      vertex 13.85 -23.9889 60
+    endloop
+  endfacet
+  facet normal -0.48173 0.87632 0
+    outer loop
+      vertex 12.8333 -24.5478 60
+      vertex 13.85 -23.9889 0
+      vertex 12.8333 -24.5478 0
+    endloop
+  endfacet
+  facet normal -0.518015 0.855371 0
+    outer loop
+      vertex 14.8424 -23.3879 0
+      vertex 13.85 -23.9889 60
+      vertex 14.8424 -23.3879 60
+    endloop
+  endfacet
+  facet normal -0.518015 0.855371 0
+    outer loop
+      vertex 13.85 -23.9889 60
+      vertex 14.8424 -23.3879 0
+      vertex 13.85 -23.9889 0
+    endloop
+  endfacet
+  facet normal 0.743114 -0.669165 0
+    outer loop
+      vertex -20.9688 18.0998 60
+      vertex -20.1924 18.962 0
+      vertex -20.1924 18.962 60
+    endloop
+  endfacet
+  facet normal 0.743114 -0.669165 0
+    outer loop
+      vertex -20.1924 18.962 0
+      vertex -20.9688 18.0998 60
+      vertex -20.9688 18.0998 0
+    endloop
+  endfacet
+  facet normal -0.714481 -0.699655 0
+    outer loop
+      vertex 20.1924 18.962 0
+      vertex 19.3807 19.7909 60
+      vertex 19.3807 19.7909 0
+    endloop
+  endfacet
+  facet normal -0.714481 -0.699655 0
+    outer loop
+      vertex 19.3807 19.7909 60
+      vertex 20.1924 18.962 0
+      vertex 20.1924 18.962 60
+    endloop
+  endfacet
+  facet normal 0.743114 0.669165 0
+    outer loop
+      vertex -20.1924 -18.962 60
+      vertex -20.9688 -18.0998 0
+      vertex -20.9688 -18.0998 60
+    endloop
+  endfacet
+  facet normal 0.743114 0.669165 0
+    outer loop
+      vertex -20.9688 -18.0998 0
+      vertex -20.1924 -18.962 60
+      vertex -20.1924 -18.962 0
+    endloop
+  endfacet
+  facet normal 0.796501 0.604637 0
+    outer loop
+      vertex -21.7083 -17.2058 60
+      vertex -22.4098 -16.2817 0
+      vertex -22.4098 -16.2817 60
+    endloop
+  endfacet
+  facet normal 0.796501 0.604637 0
+    outer loop
+      vertex -22.4098 -16.2817 0
+      vertex -21.7083 -17.2058 60
+      vertex -21.7083 -17.2058 0
+    endloop
+  endfacet
+  facet normal -0.207976 0.978134 0
+    outer loop
+      vertex 6.32532 -26.9681 0
+      vertex 5.19046 -27.2094 60
+      vertex 6.32532 -26.9681 60
+    endloop
+  endfacet
+  facet normal -0.207976 0.978134 0
+    outer loop
+      vertex 5.19046 -27.2094 60
+      vertex 6.32532 -26.9681 0
+      vertex 5.19046 -27.2094 0
+    endloop
+  endfacet
+  facet normal 0.207976 0.978134 -0
+    outer loop
+      vertex -5.19046 -27.2094 0
+      vertex -6.32532 -26.9681 60
+      vertex -5.19046 -27.2094 60
+    endloop
+  endfacet
+  facet normal 0.207976 0.978134 0
+    outer loop
+      vertex -6.32532 -26.9681 60
+      vertex -5.19046 -27.2094 0
+      vertex -6.32532 -26.9681 0
+    endloop
+  endfacet
+  facet normal 0.587767 0.80903 -0
+    outer loop
+      vertex -15.8088 -22.7458 0
+      vertex -16.7474 -22.0639 60
+      vertex -15.8088 -22.7458 60
+    endloop
+  endfacet
+  facet normal 0.587767 0.80903 0
+    outer loop
+      vertex -16.7474 -22.0639 60
+      vertex -15.8088 -22.7458 0
+      vertex -16.7474 -22.0639 0
+    endloop
+  endfacet
+  facet normal 0.963141 0.268997 0
+    outer loop
+      vertex -26.5177 -8.00618 60
+      vertex -26.8298 -6.88871 0
+      vertex -26.8298 -6.88871 60
+    endloop
+  endfacet
+  facet normal 0.963141 0.268997 0
+    outer loop
+      vertex -26.8298 -6.88871 0
+      vertex -26.5177 -8.00618 60
+      vertex -26.5177 -8.00618 0
+    endloop
+  endfacet
+  facet normal 0.621189 -0.783661 0
+    outer loop
+      vertex -17.6566 21.3432 0
+      vertex -16.7474 22.0639 60
+      vertex -17.6566 21.3432 60
+    endloop
+  endfacet
+  facet normal 0.621189 -0.783661 0
+    outer loop
+      vertex -16.7474 22.0639 60
+      vertex -17.6566 21.3432 0
+      vertex -16.7474 22.0639 0
+    endloop
+  endfacet
+  facet normal 0.921856 0.387533 0
+    outer loop
+      vertex -25.3052 -11.2666 60
+      vertex -25.7548 -10.1971 0
+      vertex -25.7548 -10.1971 60
+    endloop
+  endfacet
+  facet normal 0.921856 0.387533 0
+    outer loop
+      vertex -25.7548 -10.1971 0
+      vertex -25.3052 -11.2666 60
+      vertex -25.3052 -11.2666 0
+    endloop
+  endfacet
+  facet normal 0.998029 -0.0627475 0
+    outer loop
+      vertex -27.6757 1.15996 60
+      vertex -27.6029 2.31788 0
+      vertex -27.6029 2.31788 60
+    endloop
+  endfacet
+  facet normal 0.998029 -0.0627475 0
+    outer loop
+      vertex -27.6029 2.31788 0
+      vertex -27.6757 1.15996 60
+      vertex -27.6757 1.15996 0
+    endloop
+  endfacet
+  facet normal 0.444661 -0.895699 0
+    outer loop
+      vertex -12.8333 24.5478 0
+      vertex -11.7941 25.0637 60
+      vertex -12.8333 24.5478 60
+    endloop
+  endfacet
+  facet normal 0.444661 -0.895699 0
+    outer loop
+      vertex -11.7941 25.0637 60
+      vertex -12.8333 24.5478 0
+      vertex -11.7941 25.0637 0
+    endloop
+  endfacet
+  facet normal 0.553407 0.832911 -0
+    outer loop
+      vertex -14.8424 -23.3879 0
+      vertex -15.8088 -22.7458 60
+      vertex -14.8424 -23.3879 60
+    endloop
+  endfacet
+  facet normal 0.553407 0.832911 0
+    outer loop
+      vertex -15.8088 -22.7458 60
+      vertex -14.8424 -23.3879 0
+      vertex -15.8088 -22.7458 0
+    endloop
+  endfacet
+  facet normal 0.0836061 0.996499 -0
+    outer loop
+      vertex -1.7393 -27.6453 0
+      vertex -2.89544 -27.5483 60
+      vertex -1.7393 -27.6453 60
+    endloop
+  endfacet
+  facet normal 0.0836061 0.996499 0
+    outer loop
+      vertex -2.89544 -27.5483 60
+      vertex -1.7393 -27.6453 0
+      vertex -2.89544 -27.5483 0
+    endloop
+  endfacet
+  facet normal 0.166696 0.986008 -0
+    outer loop
+      vertex -4.0465 -27.4028 0
+      vertex -5.19046 -27.2094 60
+      vertex -4.0465 -27.4028 60
+    endloop
+  endfacet
+  facet normal 0.166696 0.986008 0
+    outer loop
+      vertex -5.19046 -27.2094 60
+      vertex -4.0465 -27.4028 0
+      vertex -5.19046 -27.2094 0
+    endloop
+  endfacet
+  facet normal 0.406738 0.913545 -0
+    outer loop
+      vertex -10.7342 -25.5356 0
+      vertex -11.7941 -25.0637 60
+      vertex -10.7342 -25.5356 60
+    endloop
+  endfacet
+  facet normal 0.406738 0.913545 0
+    outer loop
+      vertex -11.7941 -25.0637 60
+      vertex -10.7342 -25.5356 0
+      vertex -11.7941 -25.0637 0
+    endloop
+  endfacet
+  facet normal 0.518015 0.855371 -0
+    outer loop
+      vertex -13.85 -23.9889 0
+      vertex -14.8424 -23.3879 60
+      vertex -13.85 -23.9889 60
+    endloop
+  endfacet
+  facet normal 0.518015 0.855371 0
+    outer loop
+      vertex -14.8424 -23.3879 60
+      vertex -13.85 -23.9889 0
+      vertex -14.8424 -23.3879 0
+    endloop
+  endfacet
+  facet normal 0.844317 -0.535843 0
+    outer loop
+      vertex -23.6936 14.3493 60
+      vertex -23.0719 15.3289 0
+      vertex -23.0719 15.3289 60
+    endloop
+  endfacet
+  facet normal 0.844317 -0.535843 0
+    outer loop
+      vertex -23.0719 15.3289 0
+      vertex -23.6936 14.3493 60
+      vertex -23.6936 14.3493 0
+    endloop
+  endfacet
+  facet normal 0.886214 -0.463276 0
+    outer loop
+      vertex -24.8112 12.3164 60
+      vertex -24.2737 13.3446 0
+      vertex -24.2737 13.3446 60
+    endloop
+  endfacet
+  facet normal 0.886214 -0.463276 0
+    outer loop
+      vertex -24.2737 13.3446 0
+      vertex -24.8112 12.3164 60
+      vertex -24.8112 12.3164 0
+    endloop
+  endfacet
+  facet normal 0.866012 -0.500023 0
+    outer loop
+      vertex -24.2737 13.3446 60
+      vertex -23.6936 14.3493 0
+      vertex -23.6936 14.3493 60
+    endloop
+  endfacet
+  facet normal 0.866012 -0.500023 0
+    outer loop
+      vertex -23.6936 14.3493 0
+      vertex -24.2737 13.3446 60
+      vertex -24.2737 13.3446 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/stl/spool_core_sleeve/sunlu55_to73cyl_len60.stl
+++ b/stl/spool_core_sleeve/sunlu55_to73cyl_len60.stl
@@ -1,0 +1,9802 @@
+solid OpenSCAD_Model
+  facet normal 0.99889 0.0470944 0
+    outer loop
+      vertex 36.482 1.14649 60
+      vertex 36.428 2.29185 0
+      vertex 36.428 2.29185 60
+    endloop
+  endfacet
+  facet normal 0.99889 0.0470944 0
+    outer loop
+      vertex 36.428 2.29185 0
+      vertex 36.482 1.14649 60
+      vertex 36.482 1.14649 0
+    endloop
+  endfacet
+  facet normal 0.999877 0.0156982 0
+    outer loop
+      vertex 36.5 0 60
+      vertex 36.482 1.14649 0
+      vertex 36.482 1.14649 60
+    endloop
+  endfacet
+  facet normal 0.999877 0.0156982 0
+    outer loop
+      vertex 36.482 1.14649 0
+      vertex 36.5 0 60
+      vertex 36.5 0 0
+    endloop
+  endfacet
+  facet normal 0.695944 0.718096 -0
+    outer loop
+      vertex 25.8094 25.8094 0
+      vertex 24.986 26.6074 60
+      vertex 25.8094 25.8094 60
+    endloop
+  endfacet
+  facet normal 0.695944 0.718096 0
+    outer loop
+      vertex 24.986 26.6074 60
+      vertex 25.8094 25.8094 0
+      vertex 24.986 26.6074 0
+    endloop
+  endfacet
+  facet normal -0.835762 0.549093 0
+    outer loop
+      vertex -30.818 19.5577 0
+      vertex -30.1884 20.516 60
+      vertex -30.1884 20.516 0
+    endloop
+  endfacet
+  facet normal -0.835762 0.549093 0
+    outer loop
+      vertex -30.1884 20.516 60
+      vertex -30.818 19.5577 0
+      vertex -30.818 19.5577 60
+    endloop
+  endfacet
+  facet normal 0.0784904 -0.996915 0
+    outer loop
+      vertex 2.29185 -36.428 0
+      vertex 3.43495 -36.338 60
+      vertex 2.29185 -36.428 60
+    endloop
+  endfacet
+  facet normal 0.0784904 -0.996915 0
+    outer loop
+      vertex 3.43495 -36.338 60
+      vertex 2.29185 -36.428 0
+      vertex 3.43495 -36.338 0
+    endloop
+  endfacet
+  facet normal -0.993963 0.109713 0
+    outer loop
+      vertex -36.338 3.43495 0
+      vertex -36.2122 4.57466 60
+      vertex -36.2122 4.57466 0
+    endloop
+  endfacet
+  facet normal -0.993963 0.109713 0
+    outer loop
+      vertex -36.2122 4.57466 60
+      vertex -36.338 3.43495 0
+      vertex -36.338 3.43495 60
+    endloop
+  endfacet
+  facet normal 0.600405 0.799696 -0
+    outer loop
+      vertex 22.3711 28.8407 0
+      vertex 21.4542 29.5291 60
+      vertex 22.3711 28.8407 60
+    endloop
+  endfacet
+  facet normal 0.600405 0.799696 0
+    outer loop
+      vertex 21.4542 29.5291 60
+      vertex 22.3711 28.8407 0
+      vertex 21.4542 29.5291 0
+    endloop
+  endfacet
+  facet normal -0.718096 -0.695944 0
+    outer loop
+      vertex -25.8094 -25.8094 0
+      vertex -26.6074 -24.986 60
+      vertex -26.6074 -24.986 0
+    endloop
+  endfacet
+  facet normal -0.718096 -0.695944 0
+    outer loop
+      vertex -26.6074 -24.986 60
+      vertex -25.8094 -25.8094 0
+      vertex -25.8094 -25.8094 60
+    endloop
+  endfacet
+  facet normal 0.868635 -0.495453 0
+    outer loop
+      vertex 31.4171 -18.58 60
+      vertex 31.9852 -17.584 0
+      vertex 31.9852 -17.584 60
+    endloop
+  endfacet
+  facet normal 0.868635 -0.495453 0
+    outer loop
+      vertex 31.9852 -17.584 0
+      vertex 31.4171 -18.58 60
+      vertex 31.4171 -18.58 0
+    endloop
+  endfacet
+  facet normal -0.883771 0.46792 0
+    outer loop
+      vertex -32.5217 16.5707 0
+      vertex -31.9852 17.584 60
+      vertex -31.9852 17.584 0
+    endloop
+  endfacet
+  facet normal -0.883771 0.46792 0
+    outer loop
+      vertex -31.9852 17.584 60
+      vertex -32.5217 16.5707 0
+      vertex -32.5217 16.5707 60
+    endloop
+  endfacet
+  facet normal 0.0470944 -0.99889 0
+    outer loop
+      vertex 1.14649 -36.482 0
+      vertex 2.29185 -36.428 60
+      vertex 1.14649 -36.482 60
+    endloop
+  endfacet
+  facet normal 0.0470944 -0.99889 0
+    outer loop
+      vertex 2.29185 -36.428 60
+      vertex 1.14649 -36.482 0
+      vertex 2.29185 -36.428 0
+    endloop
+  endfacet
+  facet normal 0.946061 0.323988 0
+    outer loop
+      vertex 34.7136 11.2791 60
+      vertex 34.3421 12.3639 0
+      vertex 34.3421 12.3639 60
+    endloop
+  endfacet
+  facet normal 0.946061 0.323988 0
+    outer loop
+      vertex 34.3421 12.3639 0
+      vertex 34.7136 11.2791 60
+      vertex 34.7136 11.2791 0
+    endloop
+  endfacet
+  facet normal -0.323988 0.946061 0
+    outer loop
+      vertex -11.2791 34.7136 0
+      vertex -12.3639 34.3421 60
+      vertex -11.2791 34.7136 60
+    endloop
+  endfacet
+  facet normal -0.323988 0.946061 0
+    outer loop
+      vertex -12.3639 34.3421 60
+      vertex -11.2791 34.7136 0
+      vertex -12.3639 34.3421 0
+    endloop
+  endfacet
+  facet normal 0.263895 -0.964551 0
+    outer loop
+      vertex 9.07718 -35.3533 0
+      vertex 10.1832 -35.0507 60
+      vertex 9.07718 -35.3533 60
+    endloop
+  endfacet
+  facet normal 0.263895 -0.964551 0
+    outer loop
+      vertex 10.1832 -35.0507 60
+      vertex 9.07718 -35.3533 0
+      vertex 10.1832 -35.0507 0
+    endloop
+  endfacet
+  facet normal 0.955804 0.294006 0
+    outer loop
+      vertex 35.0507 10.1832 60
+      vertex 34.7136 11.2791 0
+      vertex 34.7136 11.2791 60
+    endloop
+  endfacet
+  facet normal 0.955804 0.294006 0
+    outer loop
+      vertex 34.7136 11.2791 0
+      vertex 35.0507 10.1832 60
+      vertex 35.0507 10.1832 0
+    endloop
+  endfacet
+  facet normal 0.57496 0.818182 -0
+    outer loop
+      vertex 21.4542 29.5291 0
+      vertex 20.516 30.1884 60
+      vertex 21.4542 29.5291 60
+    endloop
+  endfacet
+  facet normal 0.57496 0.818182 0
+    outer loop
+      vertex 20.516 30.1884 60
+      vertex 21.4542 29.5291 0
+      vertex 20.516 30.1884 0
+    endloop
+  endfacet
+  facet normal 0.263895 0.964551 -0
+    outer loop
+      vertex 10.1832 35.0507 0
+      vertex 9.07718 35.3533 60
+      vertex 10.1832 35.0507 60
+    endloop
+  endfacet
+  facet normal 0.263895 0.964551 0
+    outer loop
+      vertex 9.07718 35.3533 60
+      vertex 10.1832 35.0507 0
+      vertex 9.07718 35.3533 0
+    endloop
+  endfacet
+  facet normal 0.911415 0.411489 0
+    outer loop
+      vertex 33.498 14.4959 60
+      vertex 33.0262 15.5409 0
+      vertex 33.0262 15.5409 60
+    endloop
+  endfacet
+  facet normal 0.911415 0.411489 0
+    outer loop
+      vertex 33.0262 15.5409 0
+      vertex 33.498 14.4959 60
+      vertex 33.498 14.4959 0
+    endloop
+  endfacet
+  facet normal 0.972365 0.233465 0
+    outer loop
+      vertex 35.621 7.96223 60
+      vertex 35.3533 9.07718 0
+      vertex 35.3533 9.07718 60
+    endloop
+  endfacet
+  facet normal 0.972365 0.233465 0
+    outer loop
+      vertex 35.3533 9.07718 0
+      vertex 35.621 7.96223 60
+      vertex 35.621 7.96223 0
+    endloop
+  endfacet
+  facet normal 0.990019 -0.140933 0
+    outer loop
+      vertex 36.0506 -5.70986 60
+      vertex 36.2122 -4.57466 0
+      vertex 36.2122 -4.57466 60
+    endloop
+  endfacet
+  facet normal 0.990019 -0.140933 0
+    outer loop
+      vertex 36.2122 -4.57466 0
+      vertex 36.0506 -5.70986 60
+      vertex 36.0506 -5.70986 0
+    endloop
+  endfacet
+  facet normal -0.522476 -0.852654 0
+    outer loop
+      vertex -19.5577 -30.818 0
+      vertex -18.58 -31.4171 60
+      vertex -19.5577 -30.818 60
+    endloop
+  endfacet
+  facet normal -0.522476 -0.852654 -0
+    outer loop
+      vertex -18.58 -31.4171 60
+      vertex -19.5577 -30.818 0
+      vertex -18.58 -31.4171 0
+    endloop
+  endfacet
+  facet normal -0.695944 0.718096 0
+    outer loop
+      vertex -24.986 26.6074 0
+      vertex -25.8094 25.8094 60
+      vertex -24.986 26.6074 60
+    endloop
+  endfacet
+  facet normal -0.695944 0.718096 0
+    outer loop
+      vertex -25.8094 25.8094 60
+      vertex -24.986 26.6074 0
+      vertex -25.8094 25.8094 0
+    endloop
+  endfacet
+  facet normal 0.673007 0.739636 -0
+    outer loop
+      vertex 24.986 26.6074 0
+      vertex 24.1379 27.3791 60
+      vertex 24.986 26.6074 60
+    endloop
+  endfacet
+  facet normal 0.673007 0.739636 0
+    outer loop
+      vertex 24.1379 27.3791 60
+      vertex 24.986 26.6074 0
+      vertex 24.1379 27.3791 0
+    endloop
+  endfacet
+  facet normal 0.780409 0.625269 0
+    outer loop
+      vertex 28.8407 22.3711 60
+      vertex 28.1237 23.266 0
+      vertex 28.1237 23.266 60
+    endloop
+  endfacet
+  facet normal 0.780409 0.625269 0
+    outer loop
+      vertex 28.1237 23.266 0
+      vertex 28.8407 22.3711 60
+      vertex 28.8407 22.3711 0
+    endloop
+  endfacet
+  facet normal -0.263895 0.964551 0
+    outer loop
+      vertex -9.07718 35.3533 0
+      vertex -10.1832 35.0507 60
+      vertex -9.07718 35.3533 60
+    endloop
+  endfacet
+  facet normal -0.263895 0.964551 0
+    outer loop
+      vertex -10.1832 35.0507 60
+      vertex -9.07718 35.3533 0
+      vertex -10.1832 35.0507 0
+    endloop
+  endfacet
+  facet normal -0.57496 -0.818182 0
+    outer loop
+      vertex -21.4542 -29.5291 0
+      vertex -20.516 -30.1884 60
+      vertex -21.4542 -29.5291 60
+    endloop
+  endfacet
+  facet normal -0.57496 -0.818182 -0
+    outer loop
+      vertex -20.516 -30.1884 60
+      vertex -21.4542 -29.5291 0
+      vertex -20.516 -30.1884 0
+    endloop
+  endfacet
+  facet normal 0.911415 -0.411489 0
+    outer loop
+      vertex 33.0262 -15.5409 60
+      vertex 33.498 -14.4959 0
+      vertex 33.498 -14.4959 60
+    endloop
+  endfacet
+  facet normal 0.911415 -0.411489 0
+    outer loop
+      vertex 33.498 -14.4959 0
+      vertex 33.0262 -15.5409 60
+      vertex 33.0262 -15.5409 0
+    endloop
+  endfacet
+  facet normal 0.760437 0.649411 0
+    outer loop
+      vertex 28.1237 23.266 60
+      vertex 27.3791 24.1379 0
+      vertex 27.3791 24.1379 60
+    endloop
+  endfacet
+  facet normal 0.760437 0.649411 0
+    outer loop
+      vertex 27.3791 24.1379 0
+      vertex 28.1237 23.266 60
+      vertex 28.1237 23.266 0
+    endloop
+  endfacet
+  facet normal 0.964551 -0.263895 0
+    outer loop
+      vertex 35.0507 -10.1832 60
+      vertex 35.3533 -9.07718 0
+      vertex 35.3533 -9.07718 60
+    endloop
+  endfacet
+  facet normal 0.964551 -0.263895 0
+    outer loop
+      vertex 35.3533 -9.07718 0
+      vertex 35.0507 -10.1832 60
+      vertex 35.0507 -10.1832 0
+    endloop
+  endfacet
+  facet normal 0.0784904 0.996915 -0
+    outer loop
+      vertex 3.43495 36.338 0
+      vertex 2.29185 36.428 60
+      vertex 3.43495 36.338 60
+    endloop
+  endfacet
+  facet normal 0.0784904 0.996915 0
+    outer loop
+      vertex 2.29185 36.428 60
+      vertex 3.43495 36.338 0
+      vertex 2.29185 36.428 0
+    endloop
+  endfacet
+  facet normal -0.233465 0.972365 0
+    outer loop
+      vertex -7.96223 35.621 0
+      vertex -9.07718 35.3533 60
+      vertex -7.96223 35.621 60
+    endloop
+  endfacet
+  facet normal -0.233465 0.972365 0
+    outer loop
+      vertex -9.07718 35.3533 60
+      vertex -7.96223 35.621 0
+      vertex -9.07718 35.3533 0
+    endloop
+  endfacet
+  facet normal -0.202768 0.979227 0
+    outer loop
+      vertex -6.83942 35.8535 0
+      vertex -7.96223 35.621 60
+      vertex -6.83942 35.8535 60
+    endloop
+  endfacet
+  facet normal -0.202768 0.979227 0
+    outer loop
+      vertex -7.96223 35.621 60
+      vertex -6.83942 35.8535 0
+      vertex -7.96223 35.621 0
+    endloop
+  endfacet
+  facet normal -0.993963 -0.109713 0
+    outer loop
+      vertex -36.2122 -4.57466 0
+      vertex -36.338 -3.43495 60
+      vertex -36.338 -3.43495 0
+    endloop
+  endfacet
+  facet normal -0.993963 -0.109713 0
+    outer loop
+      vertex -36.338 -3.43495 60
+      vertex -36.2122 -4.57466 0
+      vertex -36.2122 -4.57466 60
+    endloop
+  endfacet
+  facet normal 0.439944 -0.898025 0
+    outer loop
+      vertex 15.5409 -33.0262 0
+      vertex 16.5707 -32.5217 60
+      vertex 15.5409 -33.0262 60
+    endloop
+  endfacet
+  facet normal 0.439944 -0.898025 0
+    outer loop
+      vertex 16.5707 -32.5217 60
+      vertex 15.5409 -33.0262 0
+      vertex 16.5707 -32.5217 0
+    endloop
+  endfacet
+  facet normal -0.625269 0.780409 0
+    outer loop
+      vertex -22.3711 28.8407 0
+      vertex -23.266 28.1237 60
+      vertex -22.3711 28.8407 60
+    endloop
+  endfacet
+  facet normal -0.625269 0.780409 0
+    outer loop
+      vertex -23.266 28.1237 60
+      vertex -22.3711 28.8407 0
+      vertex -23.266 28.1237 0
+    endloop
+  endfacet
+  facet normal -0.852654 0.522476 0
+    outer loop
+      vertex -31.4171 18.58 0
+      vertex -30.818 19.5577 60
+      vertex -30.818 19.5577 0
+    endloop
+  endfacet
+  facet normal -0.852654 0.522476 0
+    outer loop
+      vertex -30.818 19.5577 60
+      vertex -31.4171 18.58 0
+      vertex -31.4171 18.58 60
+    endloop
+  endfacet
+  facet normal 0.57496 -0.818182 0
+    outer loop
+      vertex 20.516 -30.1884 0
+      vertex 21.4542 -29.5291 60
+      vertex 20.516 -30.1884 60
+    endloop
+  endfacet
+  facet normal 0.57496 -0.818182 0
+    outer loop
+      vertex 21.4542 -29.5291 60
+      vertex 20.516 -30.1884 0
+      vertex 21.4542 -29.5291 0
+    endloop
+  endfacet
+  facet normal -0.739636 -0.673007 0
+    outer loop
+      vertex -26.6074 -24.986 0
+      vertex -27.3791 -24.1379 60
+      vertex -27.3791 -24.1379 0
+    endloop
+  endfacet
+  facet normal -0.739636 -0.673007 0
+    outer loop
+      vertex -27.3791 -24.1379 60
+      vertex -26.6074 -24.986 0
+      vertex -26.6074 -24.986 60
+    endloop
+  endfacet
+  facet normal 0.600405 -0.799696 0
+    outer loop
+      vertex 21.4542 -29.5291 0
+      vertex 22.3711 -28.8407 60
+      vertex 21.4542 -29.5291 60
+    endloop
+  endfacet
+  facet normal 0.600405 -0.799696 0
+    outer loop
+      vertex 22.3711 -28.8407 60
+      vertex 21.4542 -29.5291 0
+      vertex 22.3711 -28.8407 0
+    endloop
+  endfacet
+  facet normal -0.972365 -0.233465 0
+    outer loop
+      vertex -35.3533 -9.07718 0
+      vertex -35.621 -7.96223 60
+      vertex -35.621 -7.96223 0
+    endloop
+  endfacet
+  facet normal -0.972365 -0.233465 0
+    outer loop
+      vertex -35.621 -7.96223 60
+      vertex -35.3533 -9.07718 0
+      vertex -35.3533 -9.07718 60
+    endloop
+  endfacet
+  facet normal -0.99889 -0.0470944 0
+    outer loop
+      vertex -36.428 -2.29185 0
+      vertex -36.482 -1.14649 60
+      vertex -36.482 -1.14649 0
+    endloop
+  endfacet
+  facet normal -0.99889 -0.0470944 0
+    outer loop
+      vertex -36.482 -1.14649 60
+      vertex -36.428 -2.29185 0
+      vertex -36.428 -2.29185 60
+    endloop
+  endfacet
+  facet normal 0.799696 -0.600405 0
+    outer loop
+      vertex 28.8407 -22.3711 60
+      vertex 29.5291 -21.4542 0
+      vertex 29.5291 -21.4542 60
+    endloop
+  endfacet
+  facet normal 0.799696 -0.600405 0
+    outer loop
+      vertex 29.5291 -21.4542 0
+      vertex 28.8407 -22.3711 60
+      vertex 28.8407 -22.3711 0
+    endloop
+  endfacet
+  facet normal 0.883771 0.46792 0
+    outer loop
+      vertex 32.5217 16.5707 60
+      vertex 31.9852 17.584 0
+      vertex 31.9852 17.584 60
+    endloop
+  endfacet
+  facet normal 0.883771 0.46792 0
+    outer loop
+      vertex 31.9852 17.584 0
+      vertex 32.5217 16.5707 60
+      vertex 32.5217 16.5707 0
+    endloop
+  endfacet
+  facet normal -0.923885 0.38267 0
+    outer loop
+      vertex -33.9368 13.4365 0
+      vertex -33.498 14.4959 60
+      vertex -33.498 14.4959 0
+    endloop
+  endfacet
+  facet normal -0.923885 0.38267 0
+    outer loop
+      vertex -33.498 14.4959 60
+      vertex -33.9368 13.4365 0
+      vertex -33.9368 13.4365 60
+    endloop
+  endfacet
+  facet normal 0.883771 -0.46792 0
+    outer loop
+      vertex 31.9852 -17.584 60
+      vertex 32.5217 -16.5707 0
+      vertex 32.5217 -16.5707 60
+    endloop
+  endfacet
+  facet normal 0.883771 -0.46792 0
+    outer loop
+      vertex 32.5217 -16.5707 0
+      vertex 31.9852 -17.584 60
+      vertex 31.9852 -17.584 0
+    endloop
+  endfacet
+  facet normal 0.718096 -0.695944 0
+    outer loop
+      vertex 25.8094 -25.8094 60
+      vertex 26.6074 -24.986 0
+      vertex 26.6074 -24.986 60
+    endloop
+  endfacet
+  facet normal 0.718096 -0.695944 0
+    outer loop
+      vertex 26.6074 -24.986 0
+      vertex 25.8094 -25.8094 60
+      vertex 25.8094 -25.8094 0
+    endloop
+  endfacet
+  facet normal -0.818182 -0.57496 0
+    outer loop
+      vertex -29.5291 -21.4542 0
+      vertex -30.1884 -20.516 60
+      vertex -30.1884 -20.516 0
+    endloop
+  endfacet
+  facet normal -0.818182 -0.57496 0
+    outer loop
+      vertex -30.1884 -20.516 60
+      vertex -29.5291 -21.4542 0
+      vertex -29.5291 -21.4542 60
+    endloop
+  endfacet
+  facet normal 0.935445 0.353473 0
+    outer loop
+      vertex 34.3421 12.3639 60
+      vertex 33.9368 13.4365 0
+      vertex 33.9368 13.4365 60
+    endloop
+  endfacet
+  facet normal 0.935445 0.353473 0
+    outer loop
+      vertex 33.9368 13.4365 0
+      vertex 34.3421 12.3639 60
+      vertex 34.3421 12.3639 0
+    endloop
+  endfacet
+  facet normal 0.294006 0.955804 -0
+    outer loop
+      vertex 11.2791 34.7136 0
+      vertex 10.1832 35.0507 60
+      vertex 11.2791 34.7136 60
+    endloop
+  endfacet
+  facet normal 0.294006 0.955804 0
+    outer loop
+      vertex 10.1832 35.0507 60
+      vertex 11.2791 34.7136 0
+      vertex 10.1832 35.0507 0
+    endloop
+  endfacet
+  facet normal -0.996915 -0.0784904 0
+    outer loop
+      vertex -36.338 -3.43495 0
+      vertex -36.428 -2.29185 60
+      vertex -36.428 -2.29185 0
+    endloop
+  endfacet
+  facet normal -0.996915 -0.0784904 0
+    outer loop
+      vertex -36.428 -2.29185 60
+      vertex -36.338 -3.43495 0
+      vertex -36.338 -3.43495 60
+    endloop
+  endfacet
+  facet normal 0.979227 -0.202768 0
+    outer loop
+      vertex 35.621 -7.96223 60
+      vertex 35.8535 -6.83942 0
+      vertex 35.8535 -6.83942 60
+    endloop
+  endfacet
+  facet normal 0.979227 -0.202768 0
+    outer loop
+      vertex 35.8535 -6.83942 0
+      vertex 35.621 -7.96223 60
+      vertex 35.621 -7.96223 0
+    endloop
+  endfacet
+  facet normal -0.868635 -0.495453 0
+    outer loop
+      vertex -31.4171 -18.58 0
+      vertex -31.9852 -17.584 60
+      vertex -31.9852 -17.584 0
+    endloop
+  endfacet
+  facet normal -0.868635 -0.495453 0
+    outer loop
+      vertex -31.9852 -17.584 60
+      vertex -31.4171 -18.58 0
+      vertex -31.4171 -18.58 60
+    endloop
+  endfacet
+  facet normal -0.140933 -0.990019 0
+    outer loop
+      vertex -5.70986 -36.0506 0
+      vertex -4.57466 -36.2122 60
+      vertex -5.70986 -36.0506 60
+    endloop
+  endfacet
+  facet normal -0.140933 -0.990019 -0
+    outer loop
+      vertex -4.57466 -36.2122 60
+      vertex -5.70986 -36.0506 0
+      vertex -4.57466 -36.2122 0
+    endloop
+  endfacet
+  facet normal 0.999877 -0.0156982 0
+    outer loop
+      vertex 36.482 -1.14649 60
+      vertex 36.5 0 0
+      vertex 36.5 0 60
+    endloop
+  endfacet
+  facet normal 0.999877 -0.0156982 0
+    outer loop
+      vertex 36.5 0 0
+      vertex 36.482 -1.14649 60
+      vertex 36.482 -1.14649 0
+    endloop
+  endfacet
+  facet normal -0.946061 0.323988 0
+    outer loop
+      vertex -34.7136 11.2791 0
+      vertex -34.3421 12.3639 60
+      vertex -34.3421 12.3639 0
+    endloop
+  endfacet
+  facet normal -0.946061 0.323988 0
+    outer loop
+      vertex -34.3421 12.3639 60
+      vertex -34.7136 11.2791 0
+      vertex -34.7136 11.2791 60
+    endloop
+  endfacet
+  facet normal -0.946061 -0.323988 0
+    outer loop
+      vertex -34.3421 -12.3639 0
+      vertex -34.7136 -11.2791 60
+      vertex -34.7136 -11.2791 0
+    endloop
+  endfacet
+  facet normal -0.946061 -0.323988 0
+    outer loop
+      vertex -34.7136 -11.2791 60
+      vertex -34.3421 -12.3639 0
+      vertex -34.3421 -12.3639 60
+    endloop
+  endfacet
+  facet normal 0.411489 0.911415 -0
+    outer loop
+      vertex 15.5409 33.0262 0
+      vertex 14.4959 33.498 60
+      vertex 15.5409 33.0262 60
+    endloop
+  endfacet
+  facet normal 0.411489 0.911415 0
+    outer loop
+      vertex 14.4959 33.498 60
+      vertex 15.5409 33.0262 0
+      vertex 14.4959 33.498 0
+    endloop
+  endfacet
+  facet normal 0.495453 0.868635 -0
+    outer loop
+      vertex 18.58 31.4171 0
+      vertex 17.584 31.9852 60
+      vertex 18.58 31.4171 60
+    endloop
+  endfacet
+  facet normal 0.495453 0.868635 0
+    outer loop
+      vertex 17.584 31.9852 60
+      vertex 18.58 31.4171 0
+      vertex 17.584 31.9852 0
+    endloop
+  endfacet
+  facet normal 0.985115 -0.171895 0
+    outer loop
+      vertex 35.8535 -6.83942 60
+      vertex 36.0506 -5.70986 0
+      vertex 36.0506 -5.70986 60
+    endloop
+  endfacet
+  facet normal 0.985115 -0.171895 0
+    outer loop
+      vertex 36.0506 -5.70986 0
+      vertex 35.8535 -6.83942 60
+      vertex 35.8535 -6.83942 0
+    endloop
+  endfacet
+  facet normal 0.649411 0.760437 -0
+    outer loop
+      vertex 24.1379 27.3791 0
+      vertex 23.266 28.1237 60
+      vertex 24.1379 27.3791 60
+    endloop
+  endfacet
+  facet normal 0.649411 0.760437 0
+    outer loop
+      vertex 23.266 28.1237 60
+      vertex 24.1379 27.3791 0
+      vertex 23.266 28.1237 0
+    endloop
+  endfacet
+  facet normal 0.0156982 0.999877 -0
+    outer loop
+      vertex 1.14649 36.482 0
+      vertex 0 36.5 60
+      vertex 1.14649 36.482 60
+    endloop
+  endfacet
+  facet normal 0.0156982 0.999877 0
+    outer loop
+      vertex 0 36.5 60
+      vertex 1.14649 36.482 0
+      vertex 0 36.5 0
+    endloop
+  endfacet
+  facet normal -0.171895 -0.985115 0
+    outer loop
+      vertex -6.83942 -35.8535 0
+      vertex -5.70986 -36.0506 60
+      vertex -6.83942 -35.8535 60
+    endloop
+  endfacet
+  facet normal -0.171895 -0.985115 -0
+    outer loop
+      vertex -5.70986 -36.0506 60
+      vertex -6.83942 -35.8535 0
+      vertex -5.70986 -36.0506 0
+    endloop
+  endfacet
+  facet normal -0.353473 0.935445 0
+    outer loop
+      vertex -12.3639 34.3421 0
+      vertex -13.4365 33.9368 60
+      vertex -12.3639 34.3421 60
+    endloop
+  endfacet
+  facet normal -0.353473 0.935445 0
+    outer loop
+      vertex -13.4365 33.9368 60
+      vertex -12.3639 34.3421 0
+      vertex -13.4365 33.9368 0
+    endloop
+  endfacet
+  facet normal 0.993963 0.109713 0
+    outer loop
+      vertex 36.338 3.43495 60
+      vertex 36.2122 4.57466 0
+      vertex 36.2122 4.57466 60
+    endloop
+  endfacet
+  facet normal 0.993963 0.109713 0
+    outer loop
+      vertex 36.2122 4.57466 0
+      vertex 36.338 3.43495 60
+      vertex 36.338 3.43495 0
+    endloop
+  endfacet
+  facet normal 0.964551 0.263895 0
+    outer loop
+      vertex 35.3533 9.07718 60
+      vertex 35.0507 10.1832 0
+      vertex 35.0507 10.1832 60
+    endloop
+  endfacet
+  facet normal 0.964551 0.263895 0
+    outer loop
+      vertex 35.0507 10.1832 0
+      vertex 35.3533 9.07718 60
+      vertex 35.3533 9.07718 0
+    endloop
+  endfacet
+  facet normal 0.946061 -0.323988 0
+    outer loop
+      vertex 34.3421 -12.3639 60
+      vertex 34.7136 -11.2791 0
+      vertex 34.7136 -11.2791 60
+    endloop
+  endfacet
+  facet normal 0.946061 -0.323988 0
+    outer loop
+      vertex 34.7136 -11.2791 0
+      vertex 34.3421 -12.3639 60
+      vertex 34.3421 -12.3639 0
+    endloop
+  endfacet
+  facet normal 0.46792 0.883771 -0
+    outer loop
+      vertex 17.584 31.9852 0
+      vertex 16.5707 32.5217 60
+      vertex 17.584 31.9852 60
+    endloop
+  endfacet
+  facet normal 0.46792 0.883771 0
+    outer loop
+      vertex 16.5707 32.5217 60
+      vertex 17.584 31.9852 0
+      vertex 16.5707 32.5217 0
+    endloop
+  endfacet
+  facet normal -0.852654 -0.522476 0
+    outer loop
+      vertex -30.818 -19.5577 0
+      vertex -31.4171 -18.58 60
+      vertex -31.4171 -18.58 0
+    endloop
+  endfacet
+  facet normal -0.852654 -0.522476 0
+    outer loop
+      vertex -31.4171 -18.58 60
+      vertex -30.818 -19.5577 0
+      vertex -30.818 -19.5577 60
+    endloop
+  endfacet
+  facet normal 0.955804 -0.294006 0
+    outer loop
+      vertex 34.7136 -11.2791 60
+      vertex 35.0507 -10.1832 0
+      vertex 35.0507 -10.1832 60
+    endloop
+  endfacet
+  facet normal 0.955804 -0.294006 0
+    outer loop
+      vertex 35.0507 -10.1832 0
+      vertex 34.7136 -11.2791 60
+      vertex 34.7136 -11.2791 0
+    endloop
+  endfacet
+  facet normal 0.868635 0.495453 0
+    outer loop
+      vertex 31.9852 17.584 60
+      vertex 31.4171 18.58 0
+      vertex 31.4171 18.58 60
+    endloop
+  endfacet
+  facet normal 0.868635 0.495453 0
+    outer loop
+      vertex 31.4171 18.58 0
+      vertex 31.9852 17.584 60
+      vertex 31.9852 17.584 0
+    endloop
+  endfacet
+  facet normal 0.0156982 -0.999877 0
+    outer loop
+      vertex 0 -36.5 0
+      vertex 1.14649 -36.482 60
+      vertex 0 -36.5 60
+    endloop
+  endfacet
+  facet normal 0.0156982 -0.999877 0
+    outer loop
+      vertex 1.14649 -36.482 60
+      vertex 0 -36.5 0
+      vertex 1.14649 -36.482 0
+    endloop
+  endfacet
+  facet normal -0.999877 0.0156982 0
+    outer loop
+      vertex -36.5 0 0
+      vertex -36.482 1.14649 60
+      vertex -36.482 1.14649 0
+    endloop
+  endfacet
+  facet normal -0.999877 0.0156982 0
+    outer loop
+      vertex -36.482 1.14649 60
+      vertex -36.5 0 0
+      vertex -36.5 0 60
+    endloop
+  endfacet
+  facet normal -0.353473 -0.935445 0
+    outer loop
+      vertex -13.4365 -33.9368 0
+      vertex -12.3639 -34.3421 60
+      vertex -13.4365 -33.9368 60
+    endloop
+  endfacet
+  facet normal -0.353473 -0.935445 -0
+    outer loop
+      vertex -12.3639 -34.3421 60
+      vertex -13.4365 -33.9368 0
+      vertex -12.3639 -34.3421 0
+    endloop
+  endfacet
+  facet normal 0.990019 0.140933 0
+    outer loop
+      vertex 36.2122 4.57466 60
+      vertex 36.0506 5.70986 0
+      vertex 36.0506 5.70986 60
+    endloop
+  endfacet
+  facet normal 0.990019 0.140933 0
+    outer loop
+      vertex 36.0506 5.70986 0
+      vertex 36.2122 4.57466 60
+      vertex 36.2122 4.57466 0
+    endloop
+  endfacet
+  facet normal -0.171895 0.985115 0
+    outer loop
+      vertex -5.70986 36.0506 0
+      vertex -6.83942 35.8535 60
+      vertex -5.70986 36.0506 60
+    endloop
+  endfacet
+  facet normal -0.171895 0.985115 0
+    outer loop
+      vertex -6.83942 35.8535 60
+      vertex -5.70986 36.0506 0
+      vertex -6.83942 35.8535 0
+    endloop
+  endfacet
+  facet normal -0.38267 -0.923885 0
+    outer loop
+      vertex -14.4959 -33.498 0
+      vertex -13.4365 -33.9368 60
+      vertex -14.4959 -33.498 60
+    endloop
+  endfacet
+  facet normal -0.38267 -0.923885 -0
+    outer loop
+      vertex -13.4365 -33.9368 60
+      vertex -14.4959 -33.498 0
+      vertex -13.4365 -33.9368 0
+    endloop
+  endfacet
+  facet normal 0.760437 -0.649411 0
+    outer loop
+      vertex 27.3791 -24.1379 60
+      vertex 28.1237 -23.266 0
+      vertex 28.1237 -23.266 60
+    endloop
+  endfacet
+  facet normal 0.760437 -0.649411 0
+    outer loop
+      vertex 28.1237 -23.266 0
+      vertex 27.3791 -24.1379 60
+      vertex 27.3791 -24.1379 0
+    endloop
+  endfacet
+  facet normal 0.852654 0.522476 0
+    outer loop
+      vertex 31.4171 18.58 60
+      vertex 30.818 19.5577 0
+      vertex 30.818 19.5577 60
+    endloop
+  endfacet
+  facet normal 0.852654 0.522476 0
+    outer loop
+      vertex 30.818 19.5577 0
+      vertex 31.4171 18.58 60
+      vertex 31.4171 18.58 0
+    endloop
+  endfacet
+  facet normal -0.0156982 0.999877 0
+    outer loop
+      vertex 0 36.5 0
+      vertex -1.14649 36.482 60
+      vertex 0 36.5 60
+    endloop
+  endfacet
+  facet normal -0.0156982 0.999877 0
+    outer loop
+      vertex -1.14649 36.482 60
+      vertex 0 36.5 0
+      vertex -1.14649 36.482 0
+    endloop
+  endfacet
+  facet normal -0.999877 -0.0156982 0
+    outer loop
+      vertex -36.482 -1.14649 0
+      vertex -36.5 0 60
+      vertex -36.5 0 0
+    endloop
+  endfacet
+  facet normal -0.999877 -0.0156982 0
+    outer loop
+      vertex -36.5 0 60
+      vertex -36.482 -1.14649 0
+      vertex -36.482 -1.14649 60
+    endloop
+  endfacet
+  facet normal 0.852654 -0.522476 0
+    outer loop
+      vertex 30.818 -19.5577 60
+      vertex 31.4171 -18.58 0
+      vertex 31.4171 -18.58 60
+    endloop
+  endfacet
+  facet normal 0.852654 -0.522476 0
+    outer loop
+      vertex 31.4171 -18.58 0
+      vertex 30.818 -19.5577 60
+      vertex 30.818 -19.5577 0
+    endloop
+  endfacet
+  facet normal -0.985115 -0.171895 0
+    outer loop
+      vertex -35.8535 -6.83942 0
+      vertex -36.0506 -5.70986 60
+      vertex -36.0506 -5.70986 0
+    endloop
+  endfacet
+  facet normal -0.985115 -0.171895 0
+    outer loop
+      vertex -36.0506 -5.70986 60
+      vertex -35.8535 -6.83942 0
+      vertex -35.8535 -6.83942 60
+    endloop
+  endfacet
+  facet normal 0.0470944 0.99889 -0
+    outer loop
+      vertex 2.29185 36.428 0
+      vertex 1.14649 36.482 60
+      vertex 2.29185 36.428 60
+    endloop
+  endfacet
+  facet normal 0.0470944 0.99889 0
+    outer loop
+      vertex 1.14649 36.482 60
+      vertex 2.29185 36.428 0
+      vertex 1.14649 36.482 0
+    endloop
+  endfacet
+  facet normal -0.990019 0.140933 0
+    outer loop
+      vertex -36.2122 4.57466 0
+      vertex -36.0506 5.70986 60
+      vertex -36.0506 5.70986 0
+    endloop
+  endfacet
+  facet normal -0.990019 0.140933 0
+    outer loop
+      vertex -36.0506 5.70986 60
+      vertex -36.2122 4.57466 0
+      vertex -36.2122 4.57466 60
+    endloop
+  endfacet
+  facet normal -0.780409 -0.625269 0
+    outer loop
+      vertex -28.1237 -23.266 0
+      vertex -28.8407 -22.3711 60
+      vertex -28.8407 -22.3711 0
+    endloop
+  endfacet
+  facet normal -0.780409 -0.625269 0
+    outer loop
+      vertex -28.8407 -22.3711 60
+      vertex -28.1237 -23.266 0
+      vertex -28.1237 -23.266 60
+    endloop
+  endfacet
+  facet normal 0.835762 0.549093 0
+    outer loop
+      vertex 30.818 19.5577 60
+      vertex 30.1884 20.516 0
+      vertex 30.1884 20.516 60
+    endloop
+  endfacet
+  facet normal 0.835762 0.549093 0
+    outer loop
+      vertex 30.1884 20.516 0
+      vertex 30.818 19.5577 60
+      vertex 30.818 19.5577 0
+    endloop
+  endfacet
+  facet normal -0.868635 0.495453 0
+    outer loop
+      vertex -31.9852 17.584 0
+      vertex -31.4171 18.58 60
+      vertex -31.4171 18.58 0
+    endloop
+  endfacet
+  facet normal -0.868635 0.495453 0
+    outer loop
+      vertex -31.4171 18.58 60
+      vertex -31.9852 17.584 0
+      vertex -31.9852 17.584 60
+    endloop
+  endfacet
+  facet normal 0.233465 0.972365 -0
+    outer loop
+      vertex 9.07718 35.3533 0
+      vertex 7.96223 35.621 60
+      vertex 9.07718 35.3533 60
+    endloop
+  endfacet
+  facet normal 0.233465 0.972365 0
+    outer loop
+      vertex 7.96223 35.621 60
+      vertex 9.07718 35.3533 0
+      vertex 7.96223 35.621 0
+    endloop
+  endfacet
+  facet normal 0.140933 -0.990019 0
+    outer loop
+      vertex 4.57466 -36.2122 0
+      vertex 5.70986 -36.0506 60
+      vertex 4.57466 -36.2122 60
+    endloop
+  endfacet
+  facet normal 0.140933 -0.990019 0
+    outer loop
+      vertex 5.70986 -36.0506 60
+      vertex 4.57466 -36.2122 0
+      vertex 5.70986 -36.0506 0
+    endloop
+  endfacet
+  facet normal -0.38267 0.923885 0
+    outer loop
+      vertex -13.4365 33.9368 0
+      vertex -14.4959 33.498 60
+      vertex -13.4365 33.9368 60
+    endloop
+  endfacet
+  facet normal -0.38267 0.923885 0
+    outer loop
+      vertex -14.4959 33.498 60
+      vertex -13.4365 33.9368 0
+      vertex -14.4959 33.498 0
+    endloop
+  endfacet
+  facet normal -0.0784904 0.996915 0
+    outer loop
+      vertex -2.29185 36.428 0
+      vertex -3.43495 36.338 60
+      vertex -2.29185 36.428 60
+    endloop
+  endfacet
+  facet normal -0.0784904 0.996915 0
+    outer loop
+      vertex -3.43495 36.338 60
+      vertex -2.29185 36.428 0
+      vertex -3.43495 36.338 0
+    endloop
+  endfacet
+  facet normal -0.964551 -0.263895 0
+    outer loop
+      vertex -35.0507 -10.1832 0
+      vertex -35.3533 -9.07718 60
+      vertex -35.3533 -9.07718 0
+    endloop
+  endfacet
+  facet normal -0.964551 -0.263895 0
+    outer loop
+      vertex -35.3533 -9.07718 60
+      vertex -35.0507 -10.1832 0
+      vertex -35.0507 -10.1832 60
+    endloop
+  endfacet
+  facet normal 0.140933 0.990019 -0
+    outer loop
+      vertex 5.70986 36.0506 0
+      vertex 4.57466 36.2122 60
+      vertex 5.70986 36.0506 60
+    endloop
+  endfacet
+  facet normal 0.140933 0.990019 0
+    outer loop
+      vertex 4.57466 36.2122 60
+      vertex 5.70986 36.0506 0
+      vertex 4.57466 36.2122 0
+    endloop
+  endfacet
+  facet normal -0.985115 0.171895 0
+    outer loop
+      vertex -36.0506 5.70986 0
+      vertex -35.8535 6.83942 60
+      vertex -35.8535 6.83942 0
+    endloop
+  endfacet
+  facet normal -0.985115 0.171895 0
+    outer loop
+      vertex -35.8535 6.83942 60
+      vertex -36.0506 5.70986 0
+      vertex -36.0506 5.70986 60
+    endloop
+  endfacet
+  facet normal -0.923885 -0.38267 0
+    outer loop
+      vertex -33.498 -14.4959 0
+      vertex -33.9368 -13.4365 60
+      vertex -33.9368 -13.4365 0
+    endloop
+  endfacet
+  facet normal -0.923885 -0.38267 0
+    outer loop
+      vertex -33.9368 -13.4365 60
+      vertex -33.498 -14.4959 0
+      vertex -33.498 -14.4959 60
+    endloop
+  endfacet
+  facet normal 0.202768 -0.979227 0
+    outer loop
+      vertex 6.83942 -35.8535 0
+      vertex 7.96223 -35.621 60
+      vertex 6.83942 -35.8535 60
+    endloop
+  endfacet
+  facet normal 0.202768 -0.979227 0
+    outer loop
+      vertex 7.96223 -35.621 60
+      vertex 6.83942 -35.8535 0
+      vertex 7.96223 -35.621 0
+    endloop
+  endfacet
+  facet normal -0.935445 -0.353473 0
+    outer loop
+      vertex -33.9368 -13.4365 0
+      vertex -34.3421 -12.3639 60
+      vertex -34.3421 -12.3639 0
+    endloop
+  endfacet
+  facet normal -0.935445 -0.353473 0
+    outer loop
+      vertex -34.3421 -12.3639 60
+      vertex -33.9368 -13.4365 0
+      vertex -33.9368 -13.4365 60
+    endloop
+  endfacet
+  facet normal -0.600405 -0.799696 0
+    outer loop
+      vertex -22.3711 -28.8407 0
+      vertex -21.4542 -29.5291 60
+      vertex -22.3711 -28.8407 60
+    endloop
+  endfacet
+  facet normal -0.600405 -0.799696 -0
+    outer loop
+      vertex -21.4542 -29.5291 60
+      vertex -22.3711 -28.8407 0
+      vertex -21.4542 -29.5291 0
+    endloop
+  endfacet
+  facet normal 0.625269 0.780409 -0
+    outer loop
+      vertex 23.266 28.1237 0
+      vertex 22.3711 28.8407 60
+      vertex 23.266 28.1237 60
+    endloop
+  endfacet
+  facet normal 0.625269 0.780409 0
+    outer loop
+      vertex 22.3711 28.8407 60
+      vertex 23.266 28.1237 0
+      vertex 22.3711 28.8407 0
+    endloop
+  endfacet
+  facet normal 0.898025 0.439944 0
+    outer loop
+      vertex 33.0262 15.5409 60
+      vertex 32.5217 16.5707 0
+      vertex 32.5217 16.5707 60
+    endloop
+  endfacet
+  facet normal 0.898025 0.439944 0
+    outer loop
+      vertex 32.5217 16.5707 0
+      vertex 33.0262 15.5409 60
+      vertex 33.0262 15.5409 0
+    endloop
+  endfacet
+  facet normal 0.996915 -0.0784904 0
+    outer loop
+      vertex 36.338 -3.43495 60
+      vertex 36.428 -2.29185 0
+      vertex 36.428 -2.29185 60
+    endloop
+  endfacet
+  facet normal 0.996915 -0.0784904 0
+    outer loop
+      vertex 36.428 -2.29185 0
+      vertex 36.338 -3.43495 60
+      vertex 36.338 -3.43495 0
+    endloop
+  endfacet
+  facet normal 0.171895 -0.985115 0
+    outer loop
+      vertex 5.70986 -36.0506 0
+      vertex 6.83942 -35.8535 60
+      vertex 5.70986 -36.0506 60
+    endloop
+  endfacet
+  facet normal 0.171895 -0.985115 0
+    outer loop
+      vertex 6.83942 -35.8535 60
+      vertex 5.70986 -36.0506 0
+      vertex 6.83942 -35.8535 0
+    endloop
+  endfacet
+  facet normal -0.625269 -0.780409 0
+    outer loop
+      vertex -23.266 -28.1237 0
+      vertex -22.3711 -28.8407 60
+      vertex -23.266 -28.1237 60
+    endloop
+  endfacet
+  facet normal -0.625269 -0.780409 -0
+    outer loop
+      vertex -22.3711 -28.8407 60
+      vertex -23.266 -28.1237 0
+      vertex -22.3711 -28.8407 0
+    endloop
+  endfacet
+  facet normal -0.935445 0.353473 0
+    outer loop
+      vertex -34.3421 12.3639 0
+      vertex -33.9368 13.4365 60
+      vertex -33.9368 13.4365 0
+    endloop
+  endfacet
+  facet normal -0.935445 0.353473 0
+    outer loop
+      vertex -33.9368 13.4365 60
+      vertex -34.3421 12.3639 0
+      vertex -34.3421 12.3639 60
+    endloop
+  endfacet
+  facet normal 0.46792 -0.883771 0
+    outer loop
+      vertex 16.5707 -32.5217 0
+      vertex 17.584 -31.9852 60
+      vertex 16.5707 -32.5217 60
+    endloop
+  endfacet
+  facet normal 0.46792 -0.883771 0
+    outer loop
+      vertex 17.584 -31.9852 60
+      vertex 16.5707 -32.5217 0
+      vertex 17.584 -31.9852 0
+    endloop
+  endfacet
+  facet normal -0.835762 -0.549093 0
+    outer loop
+      vertex -30.1884 -20.516 0
+      vertex -30.818 -19.5577 60
+      vertex -30.818 -19.5577 0
+    endloop
+  endfacet
+  facet normal -0.835762 -0.549093 0
+    outer loop
+      vertex -30.818 -19.5577 60
+      vertex -30.1884 -20.516 0
+      vertex -30.1884 -20.516 60
+    endloop
+  endfacet
+  facet normal 0.818182 -0.57496 0
+    outer loop
+      vertex 29.5291 -21.4542 60
+      vertex 30.1884 -20.516 0
+      vertex 30.1884 -20.516 60
+    endloop
+  endfacet
+  facet normal 0.818182 -0.57496 0
+    outer loop
+      vertex 30.1884 -20.516 0
+      vertex 29.5291 -21.4542 60
+      vertex 29.5291 -21.4542 0
+    endloop
+  endfacet
+  facet normal 0.99889 -0.0470944 0
+    outer loop
+      vertex 36.428 -2.29185 60
+      vertex 36.482 -1.14649 0
+      vertex 36.482 -1.14649 60
+    endloop
+  endfacet
+  facet normal 0.99889 -0.0470944 0
+    outer loop
+      vertex 36.482 -1.14649 0
+      vertex 36.428 -2.29185 60
+      vertex 36.428 -2.29185 0
+    endloop
+  endfacet
+  facet normal -0.972365 0.233465 0
+    outer loop
+      vertex -35.621 7.96223 0
+      vertex -35.3533 9.07718 60
+      vertex -35.3533 9.07718 0
+    endloop
+  endfacet
+  facet normal -0.972365 0.233465 0
+    outer loop
+      vertex -35.3533 9.07718 60
+      vertex -35.621 7.96223 0
+      vertex -35.621 7.96223 60
+    endloop
+  endfacet
+  facet normal 0.818182 0.57496 0
+    outer loop
+      vertex 30.1884 20.516 60
+      vertex 29.5291 21.4542 0
+      vertex 29.5291 21.4542 60
+    endloop
+  endfacet
+  facet normal 0.818182 0.57496 0
+    outer loop
+      vertex 29.5291 21.4542 0
+      vertex 30.1884 20.516 60
+      vertex 30.1884 20.516 0
+    endloop
+  endfacet
+  facet normal -0.964551 0.263895 0
+    outer loop
+      vertex -35.3533 9.07718 0
+      vertex -35.0507 10.1832 60
+      vertex -35.0507 10.1832 0
+    endloop
+  endfacet
+  facet normal -0.964551 0.263895 0
+    outer loop
+      vertex -35.0507 10.1832 60
+      vertex -35.3533 9.07718 0
+      vertex -35.3533 9.07718 60
+    endloop
+  endfacet
+  facet normal 0.898025 -0.439944 0
+    outer loop
+      vertex 32.5217 -16.5707 60
+      vertex 33.0262 -15.5409 0
+      vertex 33.0262 -15.5409 60
+    endloop
+  endfacet
+  facet normal 0.898025 -0.439944 0
+    outer loop
+      vertex 33.0262 -15.5409 0
+      vertex 32.5217 -16.5707 60
+      vertex 32.5217 -16.5707 0
+    endloop
+  endfacet
+  facet normal 0.625269 -0.780409 0
+    outer loop
+      vertex 22.3711 -28.8407 0
+      vertex 23.266 -28.1237 60
+      vertex 22.3711 -28.8407 60
+    endloop
+  endfacet
+  facet normal 0.625269 -0.780409 0
+    outer loop
+      vertex 23.266 -28.1237 60
+      vertex 22.3711 -28.8407 0
+      vertex 23.266 -28.1237 0
+    endloop
+  endfacet
+  facet normal -0.673007 0.739636 0
+    outer loop
+      vertex -24.1379 27.3791 0
+      vertex -24.986 26.6074 60
+      vertex -24.1379 27.3791 60
+    endloop
+  endfacet
+  facet normal -0.673007 0.739636 0
+    outer loop
+      vertex -24.986 26.6074 60
+      vertex -24.1379 27.3791 0
+      vertex -24.986 26.6074 0
+    endloop
+  endfacet
+  facet normal 0.649411 -0.760437 0
+    outer loop
+      vertex 23.266 -28.1237 0
+      vertex 24.1379 -27.3791 60
+      vertex 23.266 -28.1237 60
+    endloop
+  endfacet
+  facet normal 0.649411 -0.760437 0
+    outer loop
+      vertex 24.1379 -27.3791 60
+      vertex 23.266 -28.1237 0
+      vertex 24.1379 -27.3791 0
+    endloop
+  endfacet
+  facet normal 0.353473 0.935445 -0
+    outer loop
+      vertex 13.4365 33.9368 0
+      vertex 12.3639 34.3421 60
+      vertex 13.4365 33.9368 60
+    endloop
+  endfacet
+  facet normal 0.353473 0.935445 0
+    outer loop
+      vertex 12.3639 34.3421 60
+      vertex 13.4365 33.9368 0
+      vertex 12.3639 34.3421 0
+    endloop
+  endfacet
+  facet normal 0.739636 -0.673007 0
+    outer loop
+      vertex 26.6074 -24.986 60
+      vertex 27.3791 -24.1379 0
+      vertex 27.3791 -24.1379 60
+    endloop
+  endfacet
+  facet normal 0.739636 -0.673007 0
+    outer loop
+      vertex 27.3791 -24.1379 0
+      vertex 26.6074 -24.986 60
+      vertex 26.6074 -24.986 0
+    endloop
+  endfacet
+  facet normal 0.993963 -0.109713 0
+    outer loop
+      vertex 36.2122 -4.57466 60
+      vertex 36.338 -3.43495 0
+      vertex 36.338 -3.43495 60
+    endloop
+  endfacet
+  facet normal 0.993963 -0.109713 0
+    outer loop
+      vertex 36.338 -3.43495 0
+      vertex 36.2122 -4.57466 60
+      vertex 36.2122 -4.57466 0
+    endloop
+  endfacet
+  facet normal -0.718096 0.695944 0
+    outer loop
+      vertex -26.6074 24.986 0
+      vertex -25.8094 25.8094 60
+      vertex -25.8094 25.8094 0
+    endloop
+  endfacet
+  facet normal -0.718096 0.695944 0
+    outer loop
+      vertex -25.8094 25.8094 60
+      vertex -26.6074 24.986 0
+      vertex -26.6074 24.986 60
+    endloop
+  endfacet
+  facet normal -0.495453 0.868635 0
+    outer loop
+      vertex -17.584 31.9852 0
+      vertex -18.58 31.4171 60
+      vertex -17.584 31.9852 60
+    endloop
+  endfacet
+  facet normal -0.495453 0.868635 0
+    outer loop
+      vertex -18.58 31.4171 60
+      vertex -17.584 31.9852 0
+      vertex -18.58 31.4171 0
+    endloop
+  endfacet
+  facet normal 0.171895 0.985115 -0
+    outer loop
+      vertex 6.83942 35.8535 0
+      vertex 5.70986 36.0506 60
+      vertex 6.83942 35.8535 60
+    endloop
+  endfacet
+  facet normal 0.171895 0.985115 0
+    outer loop
+      vertex 5.70986 36.0506 60
+      vertex 6.83942 35.8535 0
+      vertex 5.70986 36.0506 0
+    endloop
+  endfacet
+  facet normal 0.972365 -0.233465 0
+    outer loop
+      vertex 35.3533 -9.07718 60
+      vertex 35.621 -7.96223 0
+      vertex 35.621 -7.96223 60
+    endloop
+  endfacet
+  facet normal 0.972365 -0.233465 0
+    outer loop
+      vertex 35.621 -7.96223 0
+      vertex 35.3533 -9.07718 60
+      vertex 35.3533 -9.07718 0
+    endloop
+  endfacet
+  facet normal -0.140933 0.990019 0
+    outer loop
+      vertex -4.57466 36.2122 0
+      vertex -5.70986 36.0506 60
+      vertex -4.57466 36.2122 60
+    endloop
+  endfacet
+  facet normal -0.140933 0.990019 0
+    outer loop
+      vertex -5.70986 36.0506 60
+      vertex -4.57466 36.2122 0
+      vertex -5.70986 36.0506 0
+    endloop
+  endfacet
+  facet normal -0.263895 -0.964551 0
+    outer loop
+      vertex -10.1832 -35.0507 0
+      vertex -9.07718 -35.3533 60
+      vertex -10.1832 -35.0507 60
+    endloop
+  endfacet
+  facet normal -0.263895 -0.964551 -0
+    outer loop
+      vertex -9.07718 -35.3533 60
+      vertex -10.1832 -35.0507 0
+      vertex -9.07718 -35.3533 0
+    endloop
+  endfacet
+  facet normal -0.411489 -0.911415 0
+    outer loop
+      vertex -15.5409 -33.0262 0
+      vertex -14.4959 -33.498 60
+      vertex -15.5409 -33.0262 60
+    endloop
+  endfacet
+  facet normal -0.411489 -0.911415 -0
+    outer loop
+      vertex -14.4959 -33.498 60
+      vertex -15.5409 -33.0262 0
+      vertex -14.4959 -33.498 0
+    endloop
+  endfacet
+  facet normal 0.718096 0.695944 0
+    outer loop
+      vertex 26.6074 24.986 60
+      vertex 25.8094 25.8094 0
+      vertex 25.8094 25.8094 60
+    endloop
+  endfacet
+  facet normal 0.718096 0.695944 0
+    outer loop
+      vertex 25.8094 25.8094 0
+      vertex 26.6074 24.986 60
+      vertex 26.6074 24.986 0
+    endloop
+  endfacet
+  facet normal 0.780409 -0.625269 0
+    outer loop
+      vertex 28.1237 -23.266 60
+      vertex 28.8407 -22.3711 0
+      vertex 28.8407 -22.3711 60
+    endloop
+  endfacet
+  facet normal 0.780409 -0.625269 0
+    outer loop
+      vertex 28.8407 -22.3711 0
+      vertex 28.1237 -23.266 60
+      vertex 28.1237 -23.266 0
+    endloop
+  endfacet
+  facet normal 0.439944 0.898025 -0
+    outer loop
+      vertex 16.5707 32.5217 0
+      vertex 15.5409 33.0262 60
+      vertex 16.5707 32.5217 60
+    endloop
+  endfacet
+  facet normal 0.439944 0.898025 0
+    outer loop
+      vertex 15.5409 33.0262 60
+      vertex 16.5707 32.5217 0
+      vertex 15.5409 33.0262 0
+    endloop
+  endfacet
+  facet normal -0.799696 -0.600405 0
+    outer loop
+      vertex -28.8407 -22.3711 0
+      vertex -29.5291 -21.4542 60
+      vertex -29.5291 -21.4542 0
+    endloop
+  endfacet
+  facet normal -0.799696 -0.600405 0
+    outer loop
+      vertex -29.5291 -21.4542 60
+      vertex -28.8407 -22.3711 0
+      vertex -28.8407 -22.3711 60
+    endloop
+  endfacet
+  facet normal -0.99889 0.0470944 0
+    outer loop
+      vertex -36.482 1.14649 0
+      vertex -36.428 2.29185 60
+      vertex -36.428 2.29185 0
+    endloop
+  endfacet
+  facet normal -0.99889 0.0470944 0
+    outer loop
+      vertex -36.428 2.29185 60
+      vertex -36.482 1.14649 0
+      vertex -36.482 1.14649 60
+    endloop
+  endfacet
+  facet normal -0.0156982 -0.999877 0
+    outer loop
+      vertex -1.14649 -36.482 0
+      vertex 0 -36.5 60
+      vertex -1.14649 -36.482 60
+    endloop
+  endfacet
+  facet normal -0.0156982 -0.999877 -0
+    outer loop
+      vertex 0 -36.5 60
+      vertex -1.14649 -36.482 0
+      vertex 0 -36.5 0
+    endloop
+  endfacet
+  facet normal -0.495453 -0.868635 0
+    outer loop
+      vertex -18.58 -31.4171 0
+      vertex -17.584 -31.9852 60
+      vertex -18.58 -31.4171 60
+    endloop
+  endfacet
+  facet normal -0.495453 -0.868635 -0
+    outer loop
+      vertex -17.584 -31.9852 60
+      vertex -18.58 -31.4171 0
+      vertex -17.584 -31.9852 0
+    endloop
+  endfacet
+  facet normal 0.411489 -0.911415 0
+    outer loop
+      vertex 14.4959 -33.498 0
+      vertex 15.5409 -33.0262 60
+      vertex 14.4959 -33.498 60
+    endloop
+  endfacet
+  facet normal 0.411489 -0.911415 0
+    outer loop
+      vertex 15.5409 -33.0262 60
+      vertex 14.4959 -33.498 0
+      vertex 15.5409 -33.0262 0
+    endloop
+  endfacet
+  facet normal 0.996915 0.0784904 0
+    outer loop
+      vertex 36.428 2.29185 60
+      vertex 36.338 3.43495 0
+      vertex 36.338 3.43495 60
+    endloop
+  endfacet
+  facet normal 0.996915 0.0784904 0
+    outer loop
+      vertex 36.338 3.43495 0
+      vertex 36.428 2.29185 60
+      vertex 36.428 2.29185 0
+    endloop
+  endfacet
+  facet normal 0.323988 -0.946061 0
+    outer loop
+      vertex 11.2791 -34.7136 0
+      vertex 12.3639 -34.3421 60
+      vertex 11.2791 -34.7136 60
+    endloop
+  endfacet
+  facet normal 0.323988 -0.946061 0
+    outer loop
+      vertex 12.3639 -34.3421 60
+      vertex 11.2791 -34.7136 0
+      vertex 12.3639 -34.3421 0
+    endloop
+  endfacet
+  facet normal -0.649411 -0.760437 0
+    outer loop
+      vertex -24.1379 -27.3791 0
+      vertex -23.266 -28.1237 60
+      vertex -24.1379 -27.3791 60
+    endloop
+  endfacet
+  facet normal -0.649411 -0.760437 -0
+    outer loop
+      vertex -23.266 -28.1237 60
+      vertex -24.1379 -27.3791 0
+      vertex -23.266 -28.1237 0
+    endloop
+  endfacet
+  facet normal -0.695944 -0.718096 0
+    outer loop
+      vertex -25.8094 -25.8094 0
+      vertex -24.986 -26.6074 60
+      vertex -25.8094 -25.8094 60
+    endloop
+  endfacet
+  facet normal -0.695944 -0.718096 -0
+    outer loop
+      vertex -24.986 -26.6074 60
+      vertex -25.8094 -25.8094 0
+      vertex -24.986 -26.6074 0
+    endloop
+  endfacet
+  facet normal -0.818182 0.57496 0
+    outer loop
+      vertex -30.1884 20.516 0
+      vertex -29.5291 21.4542 60
+      vertex -29.5291 21.4542 0
+    endloop
+  endfacet
+  facet normal -0.818182 0.57496 0
+    outer loop
+      vertex -29.5291 21.4542 60
+      vertex -30.1884 20.516 0
+      vertex -30.1884 20.516 60
+    endloop
+  endfacet
+  facet normal 0.979227 0.202768 0
+    outer loop
+      vertex 35.8535 6.83942 60
+      vertex 35.621 7.96223 0
+      vertex 35.621 7.96223 60
+    endloop
+  endfacet
+  facet normal 0.979227 0.202768 0
+    outer loop
+      vertex 35.621 7.96223 0
+      vertex 35.8535 6.83942 60
+      vertex 35.8535 6.83942 0
+    endloop
+  endfacet
+  facet normal 0.38267 0.923885 -0
+    outer loop
+      vertex 14.4959 33.498 0
+      vertex 13.4365 33.9368 60
+      vertex 14.4959 33.498 60
+    endloop
+  endfacet
+  facet normal 0.38267 0.923885 0
+    outer loop
+      vertex 13.4365 33.9368 60
+      vertex 14.4959 33.498 0
+      vertex 13.4365 33.9368 0
+    endloop
+  endfacet
+  facet normal 0.233465 -0.972365 0
+    outer loop
+      vertex 7.96223 -35.621 0
+      vertex 9.07718 -35.3533 60
+      vertex 7.96223 -35.621 60
+    endloop
+  endfacet
+  facet normal 0.233465 -0.972365 0
+    outer loop
+      vertex 9.07718 -35.3533 60
+      vertex 7.96223 -35.621 0
+      vertex 9.07718 -35.3533 0
+    endloop
+  endfacet
+  facet normal -0.600405 0.799696 0
+    outer loop
+      vertex -21.4542 29.5291 0
+      vertex -22.3711 28.8407 60
+      vertex -21.4542 29.5291 60
+    endloop
+  endfacet
+  facet normal -0.600405 0.799696 0
+    outer loop
+      vertex -22.3711 28.8407 60
+      vertex -21.4542 29.5291 0
+      vertex -22.3711 28.8407 0
+    endloop
+  endfacet
+  facet normal -0.57496 0.818182 0
+    outer loop
+      vertex -20.516 30.1884 0
+      vertex -21.4542 29.5291 60
+      vertex -20.516 30.1884 60
+    endloop
+  endfacet
+  facet normal -0.57496 0.818182 0
+    outer loop
+      vertex -21.4542 29.5291 60
+      vertex -20.516 30.1884 0
+      vertex -21.4542 29.5291 0
+    endloop
+  endfacet
+  facet normal -0.109713 0.993963 0
+    outer loop
+      vertex -3.43495 36.338 0
+      vertex -4.57466 36.2122 60
+      vertex -3.43495 36.338 60
+    endloop
+  endfacet
+  facet normal -0.109713 0.993963 0
+    outer loop
+      vertex -4.57466 36.2122 60
+      vertex -3.43495 36.338 0
+      vertex -4.57466 36.2122 0
+    endloop
+  endfacet
+  facet normal -0.323988 -0.946061 0
+    outer loop
+      vertex -12.3639 -34.3421 0
+      vertex -11.2791 -34.7136 60
+      vertex -12.3639 -34.3421 60
+    endloop
+  endfacet
+  facet normal -0.323988 -0.946061 -0
+    outer loop
+      vertex -11.2791 -34.7136 60
+      vertex -12.3639 -34.3421 0
+      vertex -11.2791 -34.7136 0
+    endloop
+  endfacet
+  facet normal 0.353473 -0.935445 0
+    outer loop
+      vertex 12.3639 -34.3421 0
+      vertex 13.4365 -33.9368 60
+      vertex 12.3639 -34.3421 60
+    endloop
+  endfacet
+  facet normal 0.353473 -0.935445 0
+    outer loop
+      vertex 13.4365 -33.9368 60
+      vertex 12.3639 -34.3421 0
+      vertex 13.4365 -33.9368 0
+    endloop
+  endfacet
+  facet normal -0.996915 0.0784904 0
+    outer loop
+      vertex -36.428 2.29185 0
+      vertex -36.338 3.43495 60
+      vertex -36.338 3.43495 0
+    endloop
+  endfacet
+  facet normal -0.996915 0.0784904 0
+    outer loop
+      vertex -36.338 3.43495 60
+      vertex -36.428 2.29185 0
+      vertex -36.428 2.29185 60
+    endloop
+  endfacet
+  facet normal -0.522476 0.852654 0
+    outer loop
+      vertex -18.58 31.4171 0
+      vertex -19.5577 30.818 60
+      vertex -18.58 31.4171 60
+    endloop
+  endfacet
+  facet normal -0.522476 0.852654 0
+    outer loop
+      vertex -19.5577 30.818 60
+      vertex -18.58 31.4171 0
+      vertex -19.5577 30.818 0
+    endloop
+  endfacet
+  facet normal 0.109713 -0.993963 0
+    outer loop
+      vertex 3.43495 -36.338 0
+      vertex 4.57466 -36.2122 60
+      vertex 3.43495 -36.338 60
+    endloop
+  endfacet
+  facet normal 0.109713 -0.993963 0
+    outer loop
+      vertex 4.57466 -36.2122 60
+      vertex 3.43495 -36.338 0
+      vertex 4.57466 -36.2122 0
+    endloop
+  endfacet
+  facet normal -0.799696 0.600405 0
+    outer loop
+      vertex -29.5291 21.4542 0
+      vertex -28.8407 22.3711 60
+      vertex -28.8407 22.3711 0
+    endloop
+  endfacet
+  facet normal -0.799696 0.600405 0
+    outer loop
+      vertex -28.8407 22.3711 60
+      vertex -29.5291 21.4542 0
+      vertex -29.5291 21.4542 60
+    endloop
+  endfacet
+  facet normal 0.985115 0.171895 0
+    outer loop
+      vertex 36.0506 5.70986 60
+      vertex 35.8535 6.83942 0
+      vertex 35.8535 6.83942 60
+    endloop
+  endfacet
+  facet normal 0.985115 0.171895 0
+    outer loop
+      vertex 35.8535 6.83942 0
+      vertex 36.0506 5.70986 60
+      vertex 36.0506 5.70986 0
+    endloop
+  endfacet
+  facet normal -0.898025 -0.439944 0
+    outer loop
+      vertex -32.5217 -16.5707 0
+      vertex -33.0262 -15.5409 60
+      vertex -33.0262 -15.5409 0
+    endloop
+  endfacet
+  facet normal -0.898025 -0.439944 0
+    outer loop
+      vertex -33.0262 -15.5409 60
+      vertex -32.5217 -16.5707 0
+      vertex -32.5217 -16.5707 60
+    endloop
+  endfacet
+  facet normal -0.0470944 0.99889 0
+    outer loop
+      vertex -1.14649 36.482 0
+      vertex -2.29185 36.428 60
+      vertex -1.14649 36.482 60
+    endloop
+  endfacet
+  facet normal -0.0470944 0.99889 0
+    outer loop
+      vertex -2.29185 36.428 60
+      vertex -1.14649 36.482 0
+      vertex -2.29185 36.428 0
+    endloop
+  endfacet
+  facet normal 0.799696 0.600405 0
+    outer loop
+      vertex 29.5291 21.4542 60
+      vertex 28.8407 22.3711 0
+      vertex 28.8407 22.3711 60
+    endloop
+  endfacet
+  facet normal 0.799696 0.600405 0
+    outer loop
+      vertex 28.8407 22.3711 0
+      vertex 29.5291 21.4542 60
+      vertex 29.5291 21.4542 0
+    endloop
+  endfacet
+  facet normal 0.495453 -0.868635 0
+    outer loop
+      vertex 17.584 -31.9852 0
+      vertex 18.58 -31.4171 60
+      vertex 17.584 -31.9852 60
+    endloop
+  endfacet
+  facet normal 0.495453 -0.868635 0
+    outer loop
+      vertex 18.58 -31.4171 60
+      vertex 17.584 -31.9852 0
+      vertex 18.58 -31.4171 0
+    endloop
+  endfacet
+  facet normal -0.0784904 -0.996915 0
+    outer loop
+      vertex -3.43495 -36.338 0
+      vertex -2.29185 -36.428 60
+      vertex -3.43495 -36.338 60
+    endloop
+  endfacet
+  facet normal -0.0784904 -0.996915 -0
+    outer loop
+      vertex -2.29185 -36.428 60
+      vertex -3.43495 -36.338 0
+      vertex -2.29185 -36.428 0
+    endloop
+  endfacet
+  facet normal -0.760437 0.649411 0
+    outer loop
+      vertex -28.1237 23.266 0
+      vertex -27.3791 24.1379 60
+      vertex -27.3791 24.1379 0
+    endloop
+  endfacet
+  facet normal -0.760437 0.649411 0
+    outer loop
+      vertex -27.3791 24.1379 60
+      vertex -28.1237 23.266 0
+      vertex -28.1237 23.266 60
+    endloop
+  endfacet
+  facet normal -0.990019 -0.140933 0
+    outer loop
+      vertex -36.0506 -5.70986 0
+      vertex -36.2122 -4.57466 60
+      vertex -36.2122 -4.57466 0
+    endloop
+  endfacet
+  facet normal -0.990019 -0.140933 0
+    outer loop
+      vertex -36.2122 -4.57466 60
+      vertex -36.0506 -5.70986 0
+      vertex -36.0506 -5.70986 60
+    endloop
+  endfacet
+  facet normal 0.323988 0.946061 -0
+    outer loop
+      vertex 12.3639 34.3421 0
+      vertex 11.2791 34.7136 60
+      vertex 12.3639 34.3421 60
+    endloop
+  endfacet
+  facet normal 0.323988 0.946061 0
+    outer loop
+      vertex 11.2791 34.7136 60
+      vertex 12.3639 34.3421 0
+      vertex 11.2791 34.7136 0
+    endloop
+  endfacet
+  facet normal 0.935445 -0.353473 0
+    outer loop
+      vertex 33.9368 -13.4365 60
+      vertex 34.3421 -12.3639 0
+      vertex 34.3421 -12.3639 60
+    endloop
+  endfacet
+  facet normal 0.935445 -0.353473 0
+    outer loop
+      vertex 34.3421 -12.3639 0
+      vertex 33.9368 -13.4365 60
+      vertex 33.9368 -13.4365 0
+    endloop
+  endfacet
+  facet normal -0.911415 0.411489 0
+    outer loop
+      vertex -33.498 14.4959 0
+      vertex -33.0262 15.5409 60
+      vertex -33.0262 15.5409 0
+    endloop
+  endfacet
+  facet normal -0.911415 0.411489 0
+    outer loop
+      vertex -33.0262 15.5409 60
+      vertex -33.498 14.4959 0
+      vertex -33.498 14.4959 60
+    endloop
+  endfacet
+  facet normal -0.673007 -0.739636 0
+    outer loop
+      vertex -24.986 -26.6074 0
+      vertex -24.1379 -27.3791 60
+      vertex -24.986 -26.6074 60
+    endloop
+  endfacet
+  facet normal -0.673007 -0.739636 -0
+    outer loop
+      vertex -24.1379 -27.3791 60
+      vertex -24.986 -26.6074 0
+      vertex -24.1379 -27.3791 0
+    endloop
+  endfacet
+  facet normal 0.923885 0.38267 0
+    outer loop
+      vertex 33.9368 13.4365 60
+      vertex 33.498 14.4959 0
+      vertex 33.498 14.4959 60
+    endloop
+  endfacet
+  facet normal 0.923885 0.38267 0
+    outer loop
+      vertex 33.498 14.4959 0
+      vertex 33.9368 13.4365 60
+      vertex 33.9368 13.4365 0
+    endloop
+  endfacet
+  facet normal 0.673007 -0.739636 0
+    outer loop
+      vertex 24.1379 -27.3791 0
+      vertex 24.986 -26.6074 60
+      vertex 24.1379 -27.3791 60
+    endloop
+  endfacet
+  facet normal 0.673007 -0.739636 0
+    outer loop
+      vertex 24.986 -26.6074 60
+      vertex 24.1379 -27.3791 0
+      vertex 24.986 -26.6074 0
+    endloop
+  endfacet
+  facet normal -0.439944 0.898025 0
+    outer loop
+      vertex -15.5409 33.0262 0
+      vertex -16.5707 32.5217 60
+      vertex -15.5409 33.0262 60
+    endloop
+  endfacet
+  facet normal -0.439944 0.898025 0
+    outer loop
+      vertex -16.5707 32.5217 60
+      vertex -15.5409 33.0262 0
+      vertex -16.5707 32.5217 0
+    endloop
+  endfacet
+  facet normal -0.883771 -0.46792 0
+    outer loop
+      vertex -31.9852 -17.584 0
+      vertex -32.5217 -16.5707 60
+      vertex -32.5217 -16.5707 0
+    endloop
+  endfacet
+  facet normal -0.883771 -0.46792 0
+    outer loop
+      vertex -32.5217 -16.5707 60
+      vertex -31.9852 -17.584 0
+      vertex -31.9852 -17.584 60
+    endloop
+  endfacet
+  facet normal 0.38267 -0.923885 0
+    outer loop
+      vertex 13.4365 -33.9368 0
+      vertex 14.4959 -33.498 60
+      vertex 13.4365 -33.9368 60
+    endloop
+  endfacet
+  facet normal 0.38267 -0.923885 0
+    outer loop
+      vertex 14.4959 -33.498 60
+      vertex 13.4365 -33.9368 0
+      vertex 14.4959 -33.498 0
+    endloop
+  endfacet
+  facet normal 0.739636 0.673007 0
+    outer loop
+      vertex 27.3791 24.1379 60
+      vertex 26.6074 24.986 0
+      vertex 26.6074 24.986 60
+    endloop
+  endfacet
+  facet normal 0.739636 0.673007 0
+    outer loop
+      vertex 26.6074 24.986 0
+      vertex 27.3791 24.1379 60
+      vertex 27.3791 24.1379 0
+    endloop
+  endfacet
+  facet normal -0.549093 -0.835762 0
+    outer loop
+      vertex -20.516 -30.1884 0
+      vertex -19.5577 -30.818 60
+      vertex -20.516 -30.1884 60
+    endloop
+  endfacet
+  facet normal -0.549093 -0.835762 -0
+    outer loop
+      vertex -19.5577 -30.818 60
+      vertex -20.516 -30.1884 0
+      vertex -19.5577 -30.818 0
+    endloop
+  endfacet
+  facet normal -0.294006 -0.955804 0
+    outer loop
+      vertex -11.2791 -34.7136 0
+      vertex -10.1832 -35.0507 60
+      vertex -11.2791 -34.7136 60
+    endloop
+  endfacet
+  facet normal -0.294006 -0.955804 -0
+    outer loop
+      vertex -10.1832 -35.0507 60
+      vertex -11.2791 -34.7136 0
+      vertex -10.1832 -35.0507 0
+    endloop
+  endfacet
+  facet normal -0.760437 -0.649411 0
+    outer loop
+      vertex -27.3791 -24.1379 0
+      vertex -28.1237 -23.266 60
+      vertex -28.1237 -23.266 0
+    endloop
+  endfacet
+  facet normal -0.760437 -0.649411 0
+    outer loop
+      vertex -28.1237 -23.266 60
+      vertex -27.3791 -24.1379 0
+      vertex -27.3791 -24.1379 60
+    endloop
+  endfacet
+  facet normal 0.695944 -0.718096 0
+    outer loop
+      vertex 24.986 -26.6074 0
+      vertex 25.8094 -25.8094 60
+      vertex 24.986 -26.6074 60
+    endloop
+  endfacet
+  facet normal 0.695944 -0.718096 0
+    outer loop
+      vertex 25.8094 -25.8094 60
+      vertex 24.986 -26.6074 0
+      vertex 25.8094 -25.8094 0
+    endloop
+  endfacet
+  facet normal -0.955804 0.294006 0
+    outer loop
+      vertex -35.0507 10.1832 0
+      vertex -34.7136 11.2791 60
+      vertex -34.7136 11.2791 0
+    endloop
+  endfacet
+  facet normal -0.955804 0.294006 0
+    outer loop
+      vertex -34.7136 11.2791 60
+      vertex -35.0507 10.1832 0
+      vertex -35.0507 10.1832 60
+    endloop
+  endfacet
+  facet normal -0.979227 -0.202768 0
+    outer loop
+      vertex -35.621 -7.96223 0
+      vertex -35.8535 -6.83942 60
+      vertex -35.8535 -6.83942 0
+    endloop
+  endfacet
+  facet normal -0.979227 -0.202768 0
+    outer loop
+      vertex -35.8535 -6.83942 60
+      vertex -35.621 -7.96223 0
+      vertex -35.621 -7.96223 60
+    endloop
+  endfacet
+  facet normal 0.835762 -0.549093 0
+    outer loop
+      vertex 30.1884 -20.516 60
+      vertex 30.818 -19.5577 0
+      vertex 30.818 -19.5577 60
+    endloop
+  endfacet
+  facet normal 0.835762 -0.549093 0
+    outer loop
+      vertex 30.818 -19.5577 0
+      vertex 30.1884 -20.516 60
+      vertex 30.1884 -20.516 0
+    endloop
+  endfacet
+  facet normal 0.202768 0.979227 -0
+    outer loop
+      vertex 7.96223 35.621 0
+      vertex 6.83942 35.8535 60
+      vertex 7.96223 35.621 60
+    endloop
+  endfacet
+  facet normal 0.202768 0.979227 0
+    outer loop
+      vertex 6.83942 35.8535 60
+      vertex 7.96223 35.621 0
+      vertex 6.83942 35.8535 0
+    endloop
+  endfacet
+  facet normal -0.549093 0.835762 0
+    outer loop
+      vertex -19.5577 30.818 0
+      vertex -20.516 30.1884 60
+      vertex -19.5577 30.818 60
+    endloop
+  endfacet
+  facet normal -0.549093 0.835762 0
+    outer loop
+      vertex -20.516 30.1884 60
+      vertex -19.5577 30.818 0
+      vertex -20.516 30.1884 0
+    endloop
+  endfacet
+  facet normal -0.46792 0.883771 0
+    outer loop
+      vertex -16.5707 32.5217 0
+      vertex -17.584 31.9852 60
+      vertex -16.5707 32.5217 60
+    endloop
+  endfacet
+  facet normal -0.46792 0.883771 0
+    outer loop
+      vertex -17.584 31.9852 60
+      vertex -16.5707 32.5217 0
+      vertex -17.584 31.9852 0
+    endloop
+  endfacet
+  facet normal -0.649411 0.760437 0
+    outer loop
+      vertex -23.266 28.1237 0
+      vertex -24.1379 27.3791 60
+      vertex -23.266 28.1237 60
+    endloop
+  endfacet
+  facet normal -0.649411 0.760437 0
+    outer loop
+      vertex -24.1379 27.3791 60
+      vertex -23.266 28.1237 0
+      vertex -24.1379 27.3791 0
+    endloop
+  endfacet
+  facet normal 0.549093 -0.835762 0
+    outer loop
+      vertex 19.5577 -30.818 0
+      vertex 20.516 -30.1884 60
+      vertex 19.5577 -30.818 60
+    endloop
+  endfacet
+  facet normal 0.549093 -0.835762 0
+    outer loop
+      vertex 20.516 -30.1884 60
+      vertex 19.5577 -30.818 0
+      vertex 20.516 -30.1884 0
+    endloop
+  endfacet
+  facet normal -0.0470944 -0.99889 0
+    outer loop
+      vertex -2.29185 -36.428 0
+      vertex -1.14649 -36.482 60
+      vertex -2.29185 -36.428 60
+    endloop
+  endfacet
+  facet normal -0.0470944 -0.99889 -0
+    outer loop
+      vertex -1.14649 -36.482 60
+      vertex -2.29185 -36.428 0
+      vertex -1.14649 -36.482 0
+    endloop
+  endfacet
+  facet normal 0.522476 0.852654 -0
+    outer loop
+      vertex 19.5577 30.818 0
+      vertex 18.58 31.4171 60
+      vertex 19.5577 30.818 60
+    endloop
+  endfacet
+  facet normal 0.522476 0.852654 0
+    outer loop
+      vertex 18.58 31.4171 60
+      vertex 19.5577 30.818 0
+      vertex 18.58 31.4171 0
+    endloop
+  endfacet
+  facet normal -0.979227 0.202768 0
+    outer loop
+      vertex -35.8535 6.83942 0
+      vertex -35.621 7.96223 60
+      vertex -35.621 7.96223 0
+    endloop
+  endfacet
+  facet normal -0.979227 0.202768 0
+    outer loop
+      vertex -35.621 7.96223 60
+      vertex -35.8535 6.83942 0
+      vertex -35.8535 6.83942 60
+    endloop
+  endfacet
+  facet normal -0.294006 0.955804 0
+    outer loop
+      vertex -10.1832 35.0507 0
+      vertex -11.2791 34.7136 60
+      vertex -10.1832 35.0507 60
+    endloop
+  endfacet
+  facet normal -0.294006 0.955804 0
+    outer loop
+      vertex -11.2791 34.7136 60
+      vertex -10.1832 35.0507 0
+      vertex -11.2791 34.7136 0
+    endloop
+  endfacet
+  facet normal -0.739636 0.673007 0
+    outer loop
+      vertex -27.3791 24.1379 0
+      vertex -26.6074 24.986 60
+      vertex -26.6074 24.986 0
+    endloop
+  endfacet
+  facet normal -0.739636 0.673007 0
+    outer loop
+      vertex -26.6074 24.986 60
+      vertex -27.3791 24.1379 0
+      vertex -27.3791 24.1379 60
+    endloop
+  endfacet
+  facet normal -0.439944 -0.898025 0
+    outer loop
+      vertex -16.5707 -32.5217 0
+      vertex -15.5409 -33.0262 60
+      vertex -16.5707 -32.5217 60
+    endloop
+  endfacet
+  facet normal -0.439944 -0.898025 -0
+    outer loop
+      vertex -15.5409 -33.0262 60
+      vertex -16.5707 -32.5217 0
+      vertex -15.5409 -33.0262 0
+    endloop
+  endfacet
+  facet normal -0.911415 -0.411489 0
+    outer loop
+      vertex -33.0262 -15.5409 0
+      vertex -33.498 -14.4959 60
+      vertex -33.498 -14.4959 0
+    endloop
+  endfacet
+  facet normal -0.911415 -0.411489 0
+    outer loop
+      vertex -33.498 -14.4959 60
+      vertex -33.0262 -15.5409 0
+      vertex -33.0262 -15.5409 60
+    endloop
+  endfacet
+  facet normal -0.780409 0.625269 0
+    outer loop
+      vertex -28.8407 22.3711 0
+      vertex -28.1237 23.266 60
+      vertex -28.1237 23.266 0
+    endloop
+  endfacet
+  facet normal -0.780409 0.625269 0
+    outer loop
+      vertex -28.1237 23.266 60
+      vertex -28.8407 22.3711 0
+      vertex -28.8407 22.3711 60
+    endloop
+  endfacet
+  facet normal 0.109713 0.993963 -0
+    outer loop
+      vertex 4.57466 36.2122 0
+      vertex 3.43495 36.338 60
+      vertex 4.57466 36.2122 60
+    endloop
+  endfacet
+  facet normal 0.109713 0.993963 0
+    outer loop
+      vertex 3.43495 36.338 60
+      vertex 4.57466 36.2122 0
+      vertex 3.43495 36.338 0
+    endloop
+  endfacet
+  facet normal -0.898025 0.439944 0
+    outer loop
+      vertex -33.0262 15.5409 0
+      vertex -32.5217 16.5707 60
+      vertex -32.5217 16.5707 0
+    endloop
+  endfacet
+  facet normal -0.898025 0.439944 0
+    outer loop
+      vertex -32.5217 16.5707 60
+      vertex -33.0262 15.5409 0
+      vertex -33.0262 15.5409 60
+    endloop
+  endfacet
+  facet normal 0.522476 -0.852654 0
+    outer loop
+      vertex 18.58 -31.4171 0
+      vertex 19.5577 -30.818 60
+      vertex 18.58 -31.4171 60
+    endloop
+  endfacet
+  facet normal 0.522476 -0.852654 0
+    outer loop
+      vertex 19.5577 -30.818 60
+      vertex 18.58 -31.4171 0
+      vertex 19.5577 -30.818 0
+    endloop
+  endfacet
+  facet normal -0.955804 -0.294006 0
+    outer loop
+      vertex -34.7136 -11.2791 0
+      vertex -35.0507 -10.1832 60
+      vertex -35.0507 -10.1832 0
+    endloop
+  endfacet
+  facet normal -0.955804 -0.294006 0
+    outer loop
+      vertex -35.0507 -10.1832 60
+      vertex -34.7136 -11.2791 0
+      vertex -34.7136 -11.2791 60
+    endloop
+  endfacet
+  facet normal 0.294006 -0.955804 0
+    outer loop
+      vertex 10.1832 -35.0507 0
+      vertex 11.2791 -34.7136 60
+      vertex 10.1832 -35.0507 60
+    endloop
+  endfacet
+  facet normal 0.294006 -0.955804 0
+    outer loop
+      vertex 11.2791 -34.7136 60
+      vertex 10.1832 -35.0507 0
+      vertex 11.2791 -34.7136 0
+    endloop
+  endfacet
+  facet normal -0.46792 -0.883771 0
+    outer loop
+      vertex -17.584 -31.9852 0
+      vertex -16.5707 -32.5217 60
+      vertex -17.584 -31.9852 60
+    endloop
+  endfacet
+  facet normal -0.46792 -0.883771 -0
+    outer loop
+      vertex -16.5707 -32.5217 60
+      vertex -17.584 -31.9852 0
+      vertex -16.5707 -32.5217 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.7 0 60
+      vertex 36.5 0 60
+      vertex 36.482 1.14649 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.6757 1.15996 60
+      vertex 36.482 1.14649 60
+      vertex 36.428 2.29185 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.5 0 60
+      vertex 27.7 0 60
+      vertex 36.482 -1.14649 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.6029 2.31788 60
+      vertex 36.428 2.29185 60
+      vertex 36.338 3.43495 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.6757 -1.15996 60
+      vertex 36.482 -1.14649 60
+      vertex 27.7 0 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.4816 3.47173 60
+      vertex 36.338 3.43495 60
+      vertex 36.2122 4.57466 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.482 -1.14649 60
+      vertex 27.6757 -1.15996 60
+      vertex 36.428 -2.29185 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.4816 3.47173 60
+      vertex 36.2122 4.57466 60
+      vertex 36.0506 5.70986 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.6029 -2.31788 60
+      vertex 36.428 -2.29185 60
+      vertex 27.6757 -1.15996 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.3121 4.61949 60
+      vertex 36.0506 5.70986 60
+      vertex 35.8535 6.83942 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.428 -2.29185 60
+      vertex 27.6029 -2.31788 60
+      vertex 36.338 -3.43495 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.0947 5.75915 60
+      vertex 35.8535 6.83942 60
+      vertex 35.621 7.96223 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.4816 -3.47173 60
+      vertex 36.338 -3.43495 60
+      vertex 27.6029 -2.31788 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.8298 6.88871 60
+      vertex 35.621 7.96223 60
+      vertex 35.3533 9.07718 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.338 -3.43495 60
+      vertex 27.4816 -3.47173 60
+      vertex 36.2122 -4.57466 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.8298 6.88871 60
+      vertex 35.3533 9.07718 60
+      vertex 35.0507 10.1832 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.2122 -4.57466 60
+      vertex 27.4816 -3.47173 60
+      vertex 36.0506 -5.70986 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.5177 8.00618 60
+      vertex 35.0507 10.1832 60
+      vertex 34.7136 11.2791 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.3121 -4.61949 60
+      vertex 36.0506 -5.70986 60
+      vertex 27.4816 -3.47173 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.1592 9.10961 60
+      vertex 34.7136 11.2791 60
+      vertex 34.3421 12.3639 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.0506 -5.70986 60
+      vertex 27.3121 -4.61949 60
+      vertex 35.8535 -6.83942 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.7548 10.1971 60
+      vertex 34.3421 12.3639 60
+      vertex 33.9368 13.4365 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.0947 -5.75915 60
+      vertex 35.8535 -6.83942 60
+      vertex 27.3121 -4.61949 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.7548 10.1971 60
+      vertex 33.9368 13.4365 60
+      vertex 33.498 14.4959 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.8535 -6.83942 60
+      vertex 27.0947 -5.75915 60
+      vertex 35.621 -7.96223 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.3052 11.2666 60
+      vertex 33.498 14.4959 60
+      vertex 33.0262 15.5409 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.8298 -6.88871 60
+      vertex 35.621 -7.96223 60
+      vertex 27.0947 -5.75915 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8112 12.3164 60
+      vertex 33.0262 15.5409 60
+      vertex 32.5217 16.5707 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.621 -7.96223 60
+      vertex 26.8298 -6.88871 60
+      vertex 35.3533 -9.07718 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.2737 13.3446 60
+      vertex 32.5217 16.5707 60
+      vertex 31.9852 17.584 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.3533 -9.07718 60
+      vertex 26.8298 -6.88871 60
+      vertex 35.0507 -10.1832 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.2737 13.3446 60
+      vertex 31.9852 17.584 60
+      vertex 31.4171 18.58 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.5177 -8.00618 60
+      vertex 35.0507 -10.1832 60
+      vertex 26.8298 -6.88871 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.6936 14.3493 60
+      vertex 31.4171 18.58 60
+      vertex 30.818 19.5577 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.0507 -10.1832 60
+      vertex 26.5177 -8.00618 60
+      vertex 34.7136 -11.2791 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.0719 15.3289 60
+      vertex 30.818 19.5577 60
+      vertex 30.1884 20.516 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.1592 -9.10961 60
+      vertex 34.7136 -11.2791 60
+      vertex 26.5177 -8.00618 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.4098 16.2817 60
+      vertex 30.1884 20.516 60
+      vertex 29.5291 21.4542 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.7136 -11.2791 60
+      vertex 26.1592 -9.10961 60
+      vertex 34.3421 -12.3639 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.4098 16.2817 60
+      vertex 29.5291 21.4542 60
+      vertex 28.8407 22.3711 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.7548 -10.1971 60
+      vertex 34.3421 -12.3639 60
+      vertex 26.1592 -9.10961 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.7083 17.2058 60
+      vertex 28.8407 22.3711 60
+      vertex 28.1237 23.266 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.3421 -12.3639 60
+      vertex 25.7548 -10.1971 60
+      vertex 33.9368 -13.4365 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.9368 -13.4365 60
+      vertex 25.7548 -10.1971 60
+      vertex 33.498 -14.4959 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.482 1.14649 60
+      vertex 27.6757 1.15996 60
+      vertex 27.7 0 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.428 2.29185 60
+      vertex 27.6029 2.31788 60
+      vertex 27.6757 1.15996 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.338 3.43495 60
+      vertex 27.4816 3.47173 60
+      vertex 27.6029 2.31788 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.9688 18.0998 60
+      vertex 28.1237 23.266 60
+      vertex 27.3791 24.1379 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.0506 5.70986 60
+      vertex 27.3121 4.61949 60
+      vertex 27.4816 3.47173 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.8535 6.83942 60
+      vertex 27.0947 5.75915 60
+      vertex 27.3121 4.61949 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.621 7.96223 60
+      vertex 26.8298 6.88871 60
+      vertex 27.0947 5.75915 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1924 18.962 60
+      vertex 27.3791 24.1379 60
+      vertex 26.6074 24.986 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.0507 10.1832 60
+      vertex 26.5177 8.00618 60
+      vertex 26.8298 6.88871 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.7136 11.2791 60
+      vertex 26.1592 9.10961 60
+      vertex 26.5177 8.00618 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1924 18.962 60
+      vertex 26.6074 24.986 60
+      vertex 25.8094 25.8094 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.3421 12.3639 60
+      vertex 25.7548 10.1971 60
+      vertex 26.1592 9.10961 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.498 14.4959 60
+      vertex 25.3052 11.2666 60
+      vertex 25.7548 10.1971 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3807 19.7909 60
+      vertex 25.8094 25.8094 60
+      vertex 24.986 26.6074 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.0262 15.5409 60
+      vertex 24.8112 12.3164 60
+      vertex 25.3052 11.2666 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 32.5217 16.5707 60
+      vertex 24.2737 13.3446 60
+      vertex 24.8112 12.3164 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5349 20.5851 60
+      vertex 24.986 26.6074 60
+      vertex 24.1379 27.3791 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.4171 18.58 60
+      vertex 23.6936 14.3493 60
+      vertex 24.2737 13.3446 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6566 21.3432 60
+      vertex 24.1379 27.3791 60
+      vertex 23.266 28.1237 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.818 19.5577 60
+      vertex 23.0719 15.3289 60
+      vertex 23.6936 14.3493 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.1884 20.516 60
+      vertex 22.4098 16.2817 60
+      vertex 23.0719 15.3289 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6566 21.3432 60
+      vertex 23.266 28.1237 60
+      vertex 22.3711 28.8407 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.8407 22.3711 60
+      vertex 21.7083 17.2058 60
+      vertex 22.4098 16.2817 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.7474 22.0639 60
+      vertex 22.3711 28.8407 60
+      vertex 21.4542 29.5291 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.1237 23.266 60
+      vertex 20.9688 18.0998 60
+      vertex 21.7083 17.2058 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.8088 22.7458 60
+      vertex 21.4542 29.5291 60
+      vertex 20.516 30.1884 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.3791 24.1379 60
+      vertex 20.1924 18.962 60
+      vertex 20.9688 18.0998 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8424 23.3879 60
+      vertex 20.516 30.1884 60
+      vertex 19.5577 30.818 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.8094 25.8094 60
+      vertex 19.3807 19.7909 60
+      vertex 20.1924 18.962 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8424 23.3879 60
+      vertex 19.5577 30.818 60
+      vertex 18.58 31.4171 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.986 26.6074 60
+      vertex 18.5349 20.5851 60
+      vertex 19.3807 19.7909 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.1379 27.3791 60
+      vertex 17.6566 21.3432 60
+      vertex 18.5349 20.5851 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.85 23.9889 60
+      vertex 18.58 31.4171 60
+      vertex 17.584 31.9852 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.3711 28.8407 60
+      vertex 16.7474 22.0639 60
+      vertex 17.6566 21.3432 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.8333 24.5478 60
+      vertex 17.584 31.9852 60
+      vertex 16.5707 32.5217 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.4542 29.5291 60
+      vertex 15.8088 22.7458 60
+      vertex 16.7474 22.0639 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7941 25.0637 60
+      vertex 16.5707 32.5217 60
+      vertex 15.5409 33.0262 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.516 30.1884 60
+      vertex 14.8424 23.3879 60
+      vertex 15.8088 22.7458 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7941 25.0637 60
+      vertex 15.5409 33.0262 60
+      vertex 14.4959 33.498 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.58 31.4171 60
+      vertex 13.85 23.9889 60
+      vertex 14.8424 23.3879 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.7342 25.5356 60
+      vertex 14.4959 33.498 60
+      vertex 13.4365 33.9368 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.584 31.9852 60
+      vertex 12.8333 24.5478 60
+      vertex 13.85 23.9889 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.65545 25.9627 60
+      vertex 13.4365 33.9368 60
+      vertex 12.3639 34.3421 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.5707 32.5217 60
+      vertex 11.7941 25.0637 60
+      vertex 12.8333 24.5478 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.55977 26.3443 60
+      vertex 12.3639 34.3421 60
+      vertex 11.2791 34.7136 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4959 33.498 60
+      vertex 10.7342 25.5356 60
+      vertex 11.7941 25.0637 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.55977 26.3443 60
+      vertex 11.2791 34.7136 60
+      vertex 10.1832 35.0507 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.4365 33.9368 60
+      vertex 9.65545 25.9627 60
+      vertex 10.7342 25.5356 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.44908 26.6796 60
+      vertex 10.1832 35.0507 60
+      vertex 9.07718 35.3533 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3639 34.3421 60
+      vertex 8.55977 26.3443 60
+      vertex 9.65545 25.9627 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.32532 26.9681 60
+      vertex 9.07718 35.3533 60
+      vertex 7.96223 35.621 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.1832 35.0507 60
+      vertex 7.44908 26.6796 60
+      vertex 8.55977 26.3443 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.19046 27.2094 60
+      vertex 7.96223 35.621 60
+      vertex 6.83942 35.8535 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.07718 35.3533 60
+      vertex 6.32532 26.9681 60
+      vertex 7.44908 26.6796 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.19046 27.2094 60
+      vertex 6.83942 35.8535 60
+      vertex 5.70986 36.0506 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.96223 35.621 60
+      vertex 5.19046 27.2094 60
+      vertex 6.32532 26.9681 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.0465 27.4028 60
+      vertex 5.70986 36.0506 60
+      vertex 4.57466 36.2122 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.70986 36.0506 60
+      vertex 4.0465 27.4028 60
+      vertex 5.19046 27.2094 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.89544 27.5483 60
+      vertex 4.57466 36.2122 60
+      vertex 3.43495 36.338 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.57466 36.2122 60
+      vertex 2.89544 27.5483 60
+      vertex 4.0465 27.4028 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.7393 27.6453 60
+      vertex 3.43495 36.338 60
+      vertex 2.29185 36.428 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.43495 36.338 60
+      vertex 1.7393 27.6453 60
+      vertex 2.89544 27.5483 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.14649 36.482 60
+      vertex 1.7393 27.6453 60
+      vertex 2.29185 36.428 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.14649 36.482 60
+      vertex 0.580105 27.6939 60
+      vertex 1.7393 27.6453 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 36.5 60
+      vertex 0.580105 27.6939 60
+      vertex 1.14649 36.482 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 36.5 60
+      vertex -0.580105 27.6939 60
+      vertex 0.580105 27.6939 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.14649 36.482 60
+      vertex -0.580105 27.6939 60
+      vertex 0 36.5 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.14649 36.482 60
+      vertex -1.7393 27.6453 60
+      vertex -0.580105 27.6939 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.29185 36.428 60
+      vertex -1.7393 27.6453 60
+      vertex -1.14649 36.482 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3.43495 36.338 60
+      vertex -1.7393 27.6453 60
+      vertex -2.29185 36.428 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.7393 27.6453 60
+      vertex -3.43495 36.338 60
+      vertex -2.89544 27.5483 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -4.57466 36.2122 60
+      vertex -2.89544 27.5483 60
+      vertex -3.43495 36.338 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.89544 27.5483 60
+      vertex -4.57466 36.2122 60
+      vertex -4.0465 27.4028 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.70986 36.0506 60
+      vertex -4.0465 27.4028 60
+      vertex -4.57466 36.2122 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.0465 27.4028 60
+      vertex -5.70986 36.0506 60
+      vertex -5.19046 27.2094 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -6.83942 35.8535 60
+      vertex -5.19046 27.2094 60
+      vertex -5.70986 36.0506 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -7.96223 35.621 60
+      vertex -5.19046 27.2094 60
+      vertex -6.83942 35.8535 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.19046 27.2094 60
+      vertex -7.96223 35.621 60
+      vertex -6.32532 26.9681 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.07718 35.3533 60
+      vertex -6.32532 26.9681 60
+      vertex -7.96223 35.621 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.32532 26.9681 60
+      vertex -9.07718 35.3533 60
+      vertex -7.44908 26.6796 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.1832 35.0507 60
+      vertex -7.44908 26.6796 60
+      vertex -9.07718 35.3533 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.44908 26.6796 60
+      vertex -10.1832 35.0507 60
+      vertex -8.55977 26.3443 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.2791 34.7136 60
+      vertex -8.55977 26.3443 60
+      vertex -10.1832 35.0507 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.3639 34.3421 60
+      vertex -8.55977 26.3443 60
+      vertex -11.2791 34.7136 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.55977 26.3443 60
+      vertex -12.3639 34.3421 60
+      vertex -9.65545 25.9627 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.4365 33.9368 60
+      vertex -9.65545 25.9627 60
+      vertex -12.3639 34.3421 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.65545 25.9627 60
+      vertex -13.4365 33.9368 60
+      vertex -10.7342 25.5356 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.4959 33.498 60
+      vertex -10.7342 25.5356 60
+      vertex -13.4365 33.9368 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.7342 25.5356 60
+      vertex -14.4959 33.498 60
+      vertex -11.7941 25.0637 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.5409 33.0262 60
+      vertex -11.7941 25.0637 60
+      vertex -14.4959 33.498 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.5707 32.5217 60
+      vertex -11.7941 25.0637 60
+      vertex -15.5409 33.0262 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7941 25.0637 60
+      vertex -16.5707 32.5217 60
+      vertex -12.8333 24.5478 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.584 31.9852 60
+      vertex -12.8333 24.5478 60
+      vertex -16.5707 32.5217 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.8333 24.5478 60
+      vertex -17.584 31.9852 60
+      vertex -13.85 23.9889 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.58 31.4171 60
+      vertex -13.85 23.9889 60
+      vertex -17.584 31.9852 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.85 23.9889 60
+      vertex -18.58 31.4171 60
+      vertex -14.8424 23.3879 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.5577 30.818 60
+      vertex -14.8424 23.3879 60
+      vertex -18.58 31.4171 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.516 30.1884 60
+      vertex -14.8424 23.3879 60
+      vertex -19.5577 30.818 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8424 23.3879 60
+      vertex -20.516 30.1884 60
+      vertex -15.8088 22.7458 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.4542 29.5291 60
+      vertex -15.8088 22.7458 60
+      vertex -20.516 30.1884 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.8088 22.7458 60
+      vertex -21.4542 29.5291 60
+      vertex -16.7474 22.0639 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.3711 28.8407 60
+      vertex -16.7474 22.0639 60
+      vertex -21.4542 29.5291 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.7474 22.0639 60
+      vertex -22.3711 28.8407 60
+      vertex -17.6566 21.3432 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.266 28.1237 60
+      vertex -17.6566 21.3432 60
+      vertex -22.3711 28.8407 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.1379 27.3791 60
+      vertex -17.6566 21.3432 60
+      vertex -23.266 28.1237 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6566 21.3432 60
+      vertex -24.1379 27.3791 60
+      vertex -18.5349 20.5851 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.986 26.6074 60
+      vertex -18.5349 20.5851 60
+      vertex -24.1379 27.3791 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5349 20.5851 60
+      vertex -24.986 26.6074 60
+      vertex -19.3807 19.7909 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -25.8094 25.8094 60
+      vertex -19.3807 19.7909 60
+      vertex -24.986 26.6074 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3807 19.7909 60
+      vertex -25.8094 25.8094 60
+      vertex -20.1924 18.962 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -26.6074 24.986 60
+      vertex -20.1924 18.962 60
+      vertex -25.8094 25.8094 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.3791 24.1379 60
+      vertex -20.1924 18.962 60
+      vertex -26.6074 24.986 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1924 18.962 60
+      vertex -27.3791 24.1379 60
+      vertex -20.9688 18.0998 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.1237 23.266 60
+      vertex -20.9688 18.0998 60
+      vertex -27.3791 24.1379 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.9688 18.0998 60
+      vertex -28.1237 23.266 60
+      vertex -21.7083 17.2058 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.8407 22.3711 60
+      vertex -21.7083 17.2058 60
+      vertex -28.1237 23.266 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.7083 17.2058 60
+      vertex -28.8407 22.3711 60
+      vertex -22.4098 16.2817 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -29.5291 21.4542 60
+      vertex -22.4098 16.2817 60
+      vertex -28.8407 22.3711 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.1884 20.516 60
+      vertex -22.4098 16.2817 60
+      vertex -29.5291 21.4542 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.4098 16.2817 60
+      vertex -30.1884 20.516 60
+      vertex -23.0719 15.3289 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.818 19.5577 60
+      vertex -23.0719 15.3289 60
+      vertex -30.1884 20.516 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0719 15.3289 60
+      vertex -30.818 19.5577 60
+      vertex -23.6936 14.3493 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.4171 18.58 60
+      vertex -23.6936 14.3493 60
+      vertex -30.818 19.5577 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.6936 14.3493 60
+      vertex -31.4171 18.58 60
+      vertex -24.2737 13.3446 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.9852 17.584 60
+      vertex -24.2737 13.3446 60
+      vertex -31.4171 18.58 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -32.5217 16.5707 60
+      vertex -24.2737 13.3446 60
+      vertex -31.9852 17.584 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.2737 13.3446 60
+      vertex -32.5217 16.5707 60
+      vertex -24.8112 12.3164 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -33.0262 15.5409 60
+      vertex -24.8112 12.3164 60
+      vertex -32.5217 16.5707 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8112 12.3164 60
+      vertex -33.0262 15.5409 60
+      vertex -25.3052 11.2666 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -33.498 14.4959 60
+      vertex -25.3052 11.2666 60
+      vertex -33.0262 15.5409 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3052 11.2666 60
+      vertex -33.498 14.4959 60
+      vertex -25.7548 10.1971 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.3052 -11.2666 60
+      vertex 33.498 -14.4959 60
+      vertex 25.7548 -10.1971 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.498 -14.4959 60
+      vertex 25.3052 -11.2666 60
+      vertex 33.0262 -15.5409 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.8112 -12.3164 60
+      vertex 33.0262 -15.5409 60
+      vertex 25.3052 -11.2666 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.0262 -15.5409 60
+      vertex 24.8112 -12.3164 60
+      vertex 32.5217 -16.5707 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.2737 -13.3446 60
+      vertex 32.5217 -16.5707 60
+      vertex 24.8112 -12.3164 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 32.5217 -16.5707 60
+      vertex 24.2737 -13.3446 60
+      vertex 31.9852 -17.584 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.9852 -17.584 60
+      vertex 24.2737 -13.3446 60
+      vertex 31.4171 -18.58 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.6936 -14.3493 60
+      vertex 31.4171 -18.58 60
+      vertex 24.2737 -13.3446 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.4171 -18.58 60
+      vertex 23.6936 -14.3493 60
+      vertex 30.818 -19.5577 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.0719 -15.3289 60
+      vertex 30.818 -19.5577 60
+      vertex 23.6936 -14.3493 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.818 -19.5577 60
+      vertex 23.0719 -15.3289 60
+      vertex 30.1884 -20.516 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.4098 -16.2817 60
+      vertex 30.1884 -20.516 60
+      vertex 23.0719 -15.3289 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.1884 -20.516 60
+      vertex 22.4098 -16.2817 60
+      vertex 29.5291 -21.4542 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.5291 -21.4542 60
+      vertex 22.4098 -16.2817 60
+      vertex 28.8407 -22.3711 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.7083 -17.2058 60
+      vertex 28.8407 -22.3711 60
+      vertex 22.4098 -16.2817 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.8407 -22.3711 60
+      vertex 21.7083 -17.2058 60
+      vertex 28.1237 -23.266 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.9688 -18.0998 60
+      vertex 28.1237 -23.266 60
+      vertex 21.7083 -17.2058 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.1237 -23.266 60
+      vertex 20.9688 -18.0998 60
+      vertex 27.3791 -24.1379 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.1924 -18.962 60
+      vertex 27.3791 -24.1379 60
+      vertex 20.9688 -18.0998 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.3791 -24.1379 60
+      vertex 20.1924 -18.962 60
+      vertex 26.6074 -24.986 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6074 -24.986 60
+      vertex 20.1924 -18.962 60
+      vertex 25.8094 -25.8094 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.3807 -19.7909 60
+      vertex 25.8094 -25.8094 60
+      vertex 20.1924 -18.962 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.8094 -25.8094 60
+      vertex 19.3807 -19.7909 60
+      vertex 24.986 -26.6074 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.5349 -20.5851 60
+      vertex 24.986 -26.6074 60
+      vertex 19.3807 -19.7909 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.986 -26.6074 60
+      vertex 18.5349 -20.5851 60
+      vertex 24.1379 -27.3791 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.6566 -21.3432 60
+      vertex 24.1379 -27.3791 60
+      vertex 18.5349 -20.5851 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.1379 -27.3791 60
+      vertex 17.6566 -21.3432 60
+      vertex 23.266 -28.1237 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.266 -28.1237 60
+      vertex 17.6566 -21.3432 60
+      vertex 22.3711 -28.8407 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.7474 -22.0639 60
+      vertex 22.3711 -28.8407 60
+      vertex 17.6566 -21.3432 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.3711 -28.8407 60
+      vertex 16.7474 -22.0639 60
+      vertex 21.4542 -29.5291 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.8088 -22.7458 60
+      vertex 21.4542 -29.5291 60
+      vertex 16.7474 -22.0639 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.4542 -29.5291 60
+      vertex 15.8088 -22.7458 60
+      vertex 20.516 -30.1884 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.8424 -23.3879 60
+      vertex 20.516 -30.1884 60
+      vertex 15.8088 -22.7458 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.516 -30.1884 60
+      vertex 14.8424 -23.3879 60
+      vertex 19.5577 -30.818 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.5577 -30.818 60
+      vertex 14.8424 -23.3879 60
+      vertex 18.58 -31.4171 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.85 -23.9889 60
+      vertex 18.58 -31.4171 60
+      vertex 14.8424 -23.3879 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.58 -31.4171 60
+      vertex 13.85 -23.9889 60
+      vertex 17.584 -31.9852 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.8333 -24.5478 60
+      vertex 17.584 -31.9852 60
+      vertex 13.85 -23.9889 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.584 -31.9852 60
+      vertex 12.8333 -24.5478 60
+      vertex 16.5707 -32.5217 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.7941 -25.0637 60
+      vertex 16.5707 -32.5217 60
+      vertex 12.8333 -24.5478 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.5707 -32.5217 60
+      vertex 11.7941 -25.0637 60
+      vertex 15.5409 -33.0262 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.5409 -33.0262 60
+      vertex 11.7941 -25.0637 60
+      vertex 14.4959 -33.498 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.7342 -25.5356 60
+      vertex 14.4959 -33.498 60
+      vertex 11.7941 -25.0637 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4959 -33.498 60
+      vertex 10.7342 -25.5356 60
+      vertex 13.4365 -33.9368 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.65545 -25.9627 60
+      vertex 13.4365 -33.9368 60
+      vertex 10.7342 -25.5356 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.4365 -33.9368 60
+      vertex 9.65545 -25.9627 60
+      vertex 12.3639 -34.3421 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 8.55977 -26.3443 60
+      vertex 12.3639 -34.3421 60
+      vertex 9.65545 -25.9627 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3639 -34.3421 60
+      vertex 8.55977 -26.3443 60
+      vertex 11.2791 -34.7136 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.2791 -34.7136 60
+      vertex 8.55977 -26.3443 60
+      vertex 10.1832 -35.0507 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 7.44908 -26.6796 60
+      vertex 10.1832 -35.0507 60
+      vertex 8.55977 -26.3443 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.1832 -35.0507 60
+      vertex 7.44908 -26.6796 60
+      vertex 9.07718 -35.3533 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 6.32532 -26.9681 60
+      vertex 9.07718 -35.3533 60
+      vertex 7.44908 -26.6796 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.07718 -35.3533 60
+      vertex 6.32532 -26.9681 60
+      vertex 7.96223 -35.621 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.19046 -27.2094 60
+      vertex 7.96223 -35.621 60
+      vertex 6.32532 -26.9681 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.96223 -35.621 60
+      vertex 5.19046 -27.2094 60
+      vertex 6.83942 -35.8535 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.83942 -35.8535 60
+      vertex 5.19046 -27.2094 60
+      vertex 5.70986 -36.0506 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.0465 -27.4028 60
+      vertex 5.70986 -36.0506 60
+      vertex 5.19046 -27.2094 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.70986 -36.0506 60
+      vertex 4.0465 -27.4028 60
+      vertex 4.57466 -36.2122 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.89544 -27.5483 60
+      vertex 4.57466 -36.2122 60
+      vertex 4.0465 -27.4028 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.57466 -36.2122 60
+      vertex 2.89544 -27.5483 60
+      vertex 3.43495 -36.338 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.7393 -27.6453 60
+      vertex 3.43495 -36.338 60
+      vertex 2.89544 -27.5483 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.43495 -36.338 60
+      vertex 1.7393 -27.6453 60
+      vertex 2.29185 -36.428 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.7393 -27.6453 60
+      vertex 1.14649 -36.482 60
+      vertex 2.29185 -36.428 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.580105 -27.6939 60
+      vertex 1.14649 -36.482 60
+      vertex 1.7393 -27.6453 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.580105 -27.6939 60
+      vertex 0 -36.5 60
+      vertex 1.14649 -36.482 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.580105 -27.6939 60
+      vertex 0 -36.5 60
+      vertex 0.580105 -27.6939 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.580105 -27.6939 60
+      vertex -1.14649 -36.482 60
+      vertex 0 -36.5 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.7393 -27.6453 60
+      vertex -1.14649 -36.482 60
+      vertex -0.580105 -27.6939 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.7393 -27.6453 60
+      vertex -2.29185 -36.428 60
+      vertex -1.14649 -36.482 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.43495 -36.338 60
+      vertex -1.7393 -27.6453 60
+      vertex -2.89544 -27.5483 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.7393 -27.6453 60
+      vertex -3.43495 -36.338 60
+      vertex -2.29185 -36.428 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.57466 -36.2122 60
+      vertex -2.89544 -27.5483 60
+      vertex -4.0465 -27.4028 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.89544 -27.5483 60
+      vertex -4.57466 -36.2122 60
+      vertex -3.43495 -36.338 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.70986 -36.0506 60
+      vertex -4.0465 -27.4028 60
+      vertex -5.19046 -27.2094 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.0465 -27.4028 60
+      vertex -5.70986 -36.0506 60
+      vertex -4.57466 -36.2122 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.96223 -35.621 60
+      vertex -5.19046 -27.2094 60
+      vertex -6.32532 -26.9681 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.19046 -27.2094 60
+      vertex -6.83942 -35.8535 60
+      vertex -5.70986 -36.0506 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.07718 -35.3533 60
+      vertex -6.32532 -26.9681 60
+      vertex -7.44908 -26.6796 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.19046 -27.2094 60
+      vertex -7.96223 -35.621 60
+      vertex -6.83942 -35.8535 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.1832 -35.0507 60
+      vertex -7.44908 -26.6796 60
+      vertex -8.55977 -26.3443 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.32532 -26.9681 60
+      vertex -9.07718 -35.3533 60
+      vertex -7.96223 -35.621 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.3639 -34.3421 60
+      vertex -8.55977 -26.3443 60
+      vertex -9.65545 -25.9627 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.44908 -26.6796 60
+      vertex -10.1832 -35.0507 60
+      vertex -9.07718 -35.3533 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.4365 -33.9368 60
+      vertex -9.65545 -25.9627 60
+      vertex -10.7342 -25.5356 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.55977 -26.3443 60
+      vertex -11.2791 -34.7136 60
+      vertex -10.1832 -35.0507 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.4959 -33.498 60
+      vertex -10.7342 -25.5356 60
+      vertex -11.7941 -25.0637 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.55977 -26.3443 60
+      vertex -12.3639 -34.3421 60
+      vertex -11.2791 -34.7136 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.5707 -32.5217 60
+      vertex -11.7941 -25.0637 60
+      vertex -12.8333 -24.5478 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.65545 -25.9627 60
+      vertex -13.4365 -33.9368 60
+      vertex -12.3639 -34.3421 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.584 -31.9852 60
+      vertex -12.8333 -24.5478 60
+      vertex -13.85 -23.9889 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.7342 -25.5356 60
+      vertex -14.4959 -33.498 60
+      vertex -13.4365 -33.9368 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.58 -31.4171 60
+      vertex -13.85 -23.9889 60
+      vertex -14.8424 -23.3879 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7941 -25.0637 60
+      vertex -15.5409 -33.0262 60
+      vertex -14.4959 -33.498 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.516 -30.1884 60
+      vertex -14.8424 -23.3879 60
+      vertex -15.8088 -22.7458 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7941 -25.0637 60
+      vertex -16.5707 -32.5217 60
+      vertex -15.5409 -33.0262 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.4542 -29.5291 60
+      vertex -15.8088 -22.7458 60
+      vertex -16.7474 -22.0639 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.8333 -24.5478 60
+      vertex -17.584 -31.9852 60
+      vertex -16.5707 -32.5217 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.3711 -28.8407 60
+      vertex -16.7474 -22.0639 60
+      vertex -17.6566 -21.3432 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.1379 -27.3791 60
+      vertex -17.6566 -21.3432 60
+      vertex -18.5349 -20.5851 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.85 -23.9889 60
+      vertex -18.58 -31.4171 60
+      vertex -17.584 -31.9852 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.986 -26.6074 60
+      vertex -18.5349 -20.5851 60
+      vertex -19.3807 -19.7909 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8424 -23.3879 60
+      vertex -19.5577 -30.818 60
+      vertex -18.58 -31.4171 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.8094 -25.8094 60
+      vertex -19.3807 -19.7909 60
+      vertex -20.1924 -18.962 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8424 -23.3879 60
+      vertex -20.516 -30.1884 60
+      vertex -19.5577 -30.818 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3791 -24.1379 60
+      vertex -20.1924 -18.962 60
+      vertex -20.9688 -18.0998 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.8088 -22.7458 60
+      vertex -21.4542 -29.5291 60
+      vertex -20.516 -30.1884 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.1237 -23.266 60
+      vertex -20.9688 -18.0998 60
+      vertex -21.7083 -17.2058 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.7474 -22.0639 60
+      vertex -22.3711 -28.8407 60
+      vertex -21.4542 -29.5291 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.8407 -22.3711 60
+      vertex -21.7083 -17.2058 60
+      vertex -22.4098 -16.2817 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.1884 -20.516 60
+      vertex -22.4098 -16.2817 60
+      vertex -23.0719 -15.3289 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6566 -21.3432 60
+      vertex -23.266 -28.1237 60
+      vertex -22.3711 -28.8407 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.818 -19.5577 60
+      vertex -23.0719 -15.3289 60
+      vertex -23.6936 -14.3493 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6566 -21.3432 60
+      vertex -24.1379 -27.3791 60
+      vertex -23.266 -28.1237 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.4171 -18.58 60
+      vertex -23.6936 -14.3493 60
+      vertex -24.2737 -13.3446 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -32.5217 -16.5707 60
+      vertex -24.2737 -13.3446 60
+      vertex -24.8112 -12.3164 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5349 -20.5851 60
+      vertex -24.986 -26.6074 60
+      vertex -24.1379 -27.3791 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.0262 -15.5409 60
+      vertex -24.8112 -12.3164 60
+      vertex -25.3052 -11.2666 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.498 -14.4959 60
+      vertex -25.3052 -11.2666 60
+      vertex -25.7548 -10.1971 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3807 -19.7909 60
+      vertex -25.8094 -25.8094 60
+      vertex -24.986 -26.6074 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.3421 -12.3639 60
+      vertex -25.7548 -10.1971 60
+      vertex -26.1592 -9.10961 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.7136 -11.2791 60
+      vertex -26.1592 -9.10961 60
+      vertex -26.5177 -8.00618 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1924 -18.962 60
+      vertex -26.6074 -24.986 60
+      vertex -25.8094 -25.8094 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.0507 -10.1832 60
+      vertex -26.5177 -8.00618 60
+      vertex -26.8298 -6.88871 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.621 -7.96223 60
+      vertex -26.8298 -6.88871 60
+      vertex -27.0947 -5.75915 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.8535 -6.83942 60
+      vertex -27.0947 -5.75915 60
+      vertex -27.3121 -4.61949 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1924 -18.962 60
+      vertex -27.3791 -24.1379 60
+      vertex -26.6074 -24.986 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -36.0506 -5.70986 60
+      vertex -27.3121 -4.61949 60
+      vertex -27.4816 -3.47173 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -36.338 -3.43495 60
+      vertex -27.4816 -3.47173 60
+      vertex -27.6029 -2.31788 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -36.428 -2.29185 60
+      vertex -27.6029 -2.31788 60
+      vertex -27.6757 -1.15996 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -36.482 -1.14649 60
+      vertex -27.6757 -1.15996 60
+      vertex -27.7 0 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -33.9368 13.4365 60
+      vertex -25.7548 10.1971 60
+      vertex -33.498 14.4959 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.9688 -18.0998 60
+      vertex -28.1237 -23.266 60
+      vertex -27.3791 -24.1379 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -34.3421 12.3639 60
+      vertex -25.7548 10.1971 60
+      vertex -33.9368 13.4365 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.7083 -17.2058 60
+      vertex -28.8407 -22.3711 60
+      vertex -28.1237 -23.266 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.7548 10.1971 60
+      vertex -34.3421 12.3639 60
+      vertex -26.1592 9.10961 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.4098 -16.2817 60
+      vertex -29.5291 -21.4542 60
+      vertex -28.8407 -22.3711 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -34.7136 11.2791 60
+      vertex -26.1592 9.10961 60
+      vertex -34.3421 12.3639 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.4098 -16.2817 60
+      vertex -30.1884 -20.516 60
+      vertex -29.5291 -21.4542 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1592 9.10961 60
+      vertex -34.7136 11.2791 60
+      vertex -26.5177 8.00618 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0719 -15.3289 60
+      vertex -30.818 -19.5577 60
+      vertex -30.1884 -20.516 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -35.0507 10.1832 60
+      vertex -26.5177 8.00618 60
+      vertex -34.7136 11.2791 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.6936 -14.3493 60
+      vertex -31.4171 -18.58 60
+      vertex -30.818 -19.5577 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.5177 8.00618 60
+      vertex -35.0507 10.1832 60
+      vertex -26.8298 6.88871 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.2737 -13.3446 60
+      vertex -31.9852 -17.584 60
+      vertex -31.4171 -18.58 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -35.3533 9.07718 60
+      vertex -26.8298 6.88871 60
+      vertex -35.0507 10.1832 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.2737 -13.3446 60
+      vertex -32.5217 -16.5707 60
+      vertex -31.9852 -17.584 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -35.621 7.96223 60
+      vertex -26.8298 6.88871 60
+      vertex -35.3533 9.07718 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8112 -12.3164 60
+      vertex -33.0262 -15.5409 60
+      vertex -32.5217 -16.5707 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8298 6.88871 60
+      vertex -35.621 7.96223 60
+      vertex -27.0947 5.75915 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3052 -11.2666 60
+      vertex -33.498 -14.4959 60
+      vertex -33.0262 -15.5409 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -35.8535 6.83942 60
+      vertex -27.0947 5.75915 60
+      vertex -35.621 7.96223 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.7548 -10.1971 60
+      vertex -33.9368 -13.4365 60
+      vertex -33.498 -14.4959 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0947 5.75915 60
+      vertex -35.8535 6.83942 60
+      vertex -27.3121 4.61949 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.7548 -10.1971 60
+      vertex -34.3421 -12.3639 60
+      vertex -33.9368 -13.4365 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -36.0506 5.70986 60
+      vertex -27.3121 4.61949 60
+      vertex -35.8535 6.83942 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1592 -9.10961 60
+      vertex -34.7136 -11.2791 60
+      vertex -34.3421 -12.3639 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3121 4.61949 60
+      vertex -36.0506 5.70986 60
+      vertex -27.4816 3.47173 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.5177 -8.00618 60
+      vertex -35.0507 -10.1832 60
+      vertex -34.7136 -11.2791 60
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -36.2122 4.57466 60
+      vertex -27.4816 3.47173 60
+      vertex -36.0506 5.70986 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8298 -6.88871 60
+      vertex -35.3533 -9.07718 60
+      vertex -35.0507 -10.1832 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -36.338 3.43495 60
+      vertex -27.4816 3.47173 60
+      vertex -36.2122 4.57466 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8298 -6.88871 60
+      vertex -35.621 -7.96223 60
+      vertex -35.3533 -9.07718 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.4816 3.47173 60
+      vertex -36.338 3.43495 60
+      vertex -27.6029 2.31788 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0947 -5.75915 60
+      vertex -35.8535 -6.83942 60
+      vertex -35.621 -7.96223 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -36.428 2.29185 60
+      vertex -27.6029 2.31788 60
+      vertex -36.338 3.43495 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3121 -4.61949 60
+      vertex -36.0506 -5.70986 60
+      vertex -35.8535 -6.83942 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6029 2.31788 60
+      vertex -36.428 2.29185 60
+      vertex -27.6757 1.15996 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.4816 -3.47173 60
+      vertex -36.2122 -4.57466 60
+      vertex -36.0506 -5.70986 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -36.482 1.14649 60
+      vertex -27.6757 1.15996 60
+      vertex -36.428 2.29185 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.4816 -3.47173 60
+      vertex -36.338 -3.43495 60
+      vertex -36.2122 -4.57466 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6757 1.15996 60
+      vertex -36.482 1.14649 60
+      vertex -27.7 0 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6029 -2.31788 60
+      vertex -36.428 -2.29185 60
+      vertex -36.338 -3.43495 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -36.5 0 60
+      vertex -27.7 0 60
+      vertex -36.482 1.14649 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6757 -1.15996 60
+      vertex -36.482 -1.14649 60
+      vertex -36.428 -2.29185 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.7 0 60
+      vertex -36.5 0 60
+      vertex -36.482 -1.14649 60
+    endloop
+  endfacet
+  facet normal -0.109713 -0.993963 0
+    outer loop
+      vertex -4.57466 -36.2122 0
+      vertex -3.43495 -36.338 60
+      vertex -4.57466 -36.2122 60
+    endloop
+  endfacet
+  facet normal -0.109713 -0.993963 -0
+    outer loop
+      vertex -3.43495 -36.338 60
+      vertex -4.57466 -36.2122 0
+      vertex -3.43495 -36.338 0
+    endloop
+  endfacet
+  facet normal 0.549093 0.835762 -0
+    outer loop
+      vertex 20.516 30.1884 0
+      vertex 19.5577 30.818 60
+      vertex 20.516 30.1884 60
+    endloop
+  endfacet
+  facet normal 0.549093 0.835762 0
+    outer loop
+      vertex 19.5577 30.818 60
+      vertex 20.516 30.1884 0
+      vertex 19.5577 30.818 0
+    endloop
+  endfacet
+  facet normal -0.411489 0.911415 0
+    outer loop
+      vertex -14.4959 33.498 0
+      vertex -15.5409 33.0262 60
+      vertex -14.4959 33.498 60
+    endloop
+  endfacet
+  facet normal -0.411489 0.911415 0
+    outer loop
+      vertex -15.5409 33.0262 60
+      vertex -14.4959 33.498 0
+      vertex -15.5409 33.0262 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.7 0 0
+      vertex 36.5 0 0
+      vertex 36.482 -1.14649 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.6757 -1.15996 0
+      vertex 36.482 -1.14649 0
+      vertex 36.428 -2.29185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 36.5 0 0
+      vertex 27.7 0 0
+      vertex 36.482 1.14649 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.6029 -2.31788 0
+      vertex 36.428 -2.29185 0
+      vertex 36.338 -3.43495 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.6757 1.15996 0
+      vertex 36.482 1.14649 0
+      vertex 27.7 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.4816 -3.47173 0
+      vertex 36.338 -3.43495 0
+      vertex 36.2122 -4.57466 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 36.482 1.14649 0
+      vertex 27.6757 1.15996 0
+      vertex 36.428 2.29185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.4816 -3.47173 0
+      vertex 36.2122 -4.57466 0
+      vertex 36.0506 -5.70986 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.6029 2.31788 0
+      vertex 36.428 2.29185 0
+      vertex 27.6757 1.15996 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3121 -4.61949 0
+      vertex 36.0506 -5.70986 0
+      vertex 35.8535 -6.83942 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 36.428 2.29185 0
+      vertex 27.6029 2.31788 0
+      vertex 36.338 3.43495 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0947 -5.75915 0
+      vertex 35.8535 -6.83942 0
+      vertex 35.621 -7.96223 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.4816 3.47173 0
+      vertex 36.338 3.43495 0
+      vertex 27.6029 2.31788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8298 -6.88871 0
+      vertex 35.621 -7.96223 0
+      vertex 35.3533 -9.07718 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 36.338 3.43495 0
+      vertex 27.4816 3.47173 0
+      vertex 36.2122 4.57466 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8298 -6.88871 0
+      vertex 35.3533 -9.07718 0
+      vertex 35.0507 -10.1832 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 36.2122 4.57466 0
+      vertex 27.4816 3.47173 0
+      vertex 36.0506 5.70986 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.5177 -8.00618 0
+      vertex 35.0507 -10.1832 0
+      vertex 34.7136 -11.2791 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3121 4.61949 0
+      vertex 36.0506 5.70986 0
+      vertex 27.4816 3.47173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1592 -9.10961 0
+      vertex 34.7136 -11.2791 0
+      vertex 34.3421 -12.3639 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 36.0506 5.70986 0
+      vertex 27.3121 4.61949 0
+      vertex 35.8535 6.83942 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.7548 -10.1971 0
+      vertex 34.3421 -12.3639 0
+      vertex 33.9368 -13.4365 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0947 5.75915 0
+      vertex 35.8535 6.83942 0
+      vertex 27.3121 4.61949 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.7548 -10.1971 0
+      vertex 33.9368 -13.4365 0
+      vertex 33.498 -14.4959 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 35.8535 6.83942 0
+      vertex 27.0947 5.75915 0
+      vertex 35.621 7.96223 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.3052 -11.2666 0
+      vertex 33.498 -14.4959 0
+      vertex 33.0262 -15.5409 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8298 6.88871 0
+      vertex 35.621 7.96223 0
+      vertex 27.0947 5.75915 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8112 -12.3164 0
+      vertex 33.0262 -15.5409 0
+      vertex 32.5217 -16.5707 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 35.621 7.96223 0
+      vertex 26.8298 6.88871 0
+      vertex 35.3533 9.07718 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.2737 -13.3446 0
+      vertex 32.5217 -16.5707 0
+      vertex 31.9852 -17.584 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 35.3533 9.07718 0
+      vertex 26.8298 6.88871 0
+      vertex 35.0507 10.1832 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.2737 -13.3446 0
+      vertex 31.9852 -17.584 0
+      vertex 31.4171 -18.58 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.5177 8.00618 0
+      vertex 35.0507 10.1832 0
+      vertex 26.8298 6.88871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.6936 -14.3493 0
+      vertex 31.4171 -18.58 0
+      vertex 30.818 -19.5577 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 35.0507 10.1832 0
+      vertex 26.5177 8.00618 0
+      vertex 34.7136 11.2791 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.0719 -15.3289 0
+      vertex 30.818 -19.5577 0
+      vertex 30.1884 -20.516 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1592 9.10961 0
+      vertex 34.7136 11.2791 0
+      vertex 26.5177 8.00618 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.4098 -16.2817 0
+      vertex 30.1884 -20.516 0
+      vertex 29.5291 -21.4542 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 34.7136 11.2791 0
+      vertex 26.1592 9.10961 0
+      vertex 34.3421 12.3639 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.4098 -16.2817 0
+      vertex 29.5291 -21.4542 0
+      vertex 28.8407 -22.3711 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.7548 10.1971 0
+      vertex 34.3421 12.3639 0
+      vertex 26.1592 9.10961 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.7083 -17.2058 0
+      vertex 28.8407 -22.3711 0
+      vertex 28.1237 -23.266 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 34.3421 12.3639 0
+      vertex 25.7548 10.1971 0
+      vertex 33.9368 13.4365 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 33.9368 13.4365 0
+      vertex 25.7548 10.1971 0
+      vertex 33.498 14.4959 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 36.482 -1.14649 0
+      vertex 27.6757 -1.15996 0
+      vertex 27.7 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 36.428 -2.29185 0
+      vertex 27.6029 -2.31788 0
+      vertex 27.6757 -1.15996 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 36.338 -3.43495 0
+      vertex 27.4816 -3.47173 0
+      vertex 27.6029 -2.31788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.9688 -18.0998 0
+      vertex 28.1237 -23.266 0
+      vertex 27.3791 -24.1379 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 36.0506 -5.70986 0
+      vertex 27.3121 -4.61949 0
+      vertex 27.4816 -3.47173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.8535 -6.83942 0
+      vertex 27.0947 -5.75915 0
+      vertex 27.3121 -4.61949 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.621 -7.96223 0
+      vertex 26.8298 -6.88871 0
+      vertex 27.0947 -5.75915 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1924 -18.962 0
+      vertex 27.3791 -24.1379 0
+      vertex 26.6074 -24.986 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.0507 -10.1832 0
+      vertex 26.5177 -8.00618 0
+      vertex 26.8298 -6.88871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 34.7136 -11.2791 0
+      vertex 26.1592 -9.10961 0
+      vertex 26.5177 -8.00618 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1924 -18.962 0
+      vertex 26.6074 -24.986 0
+      vertex 25.8094 -25.8094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 34.3421 -12.3639 0
+      vertex 25.7548 -10.1971 0
+      vertex 26.1592 -9.10961 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 33.498 -14.4959 0
+      vertex 25.3052 -11.2666 0
+      vertex 25.7548 -10.1971 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3807 -19.7909 0
+      vertex 25.8094 -25.8094 0
+      vertex 24.986 -26.6074 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 33.0262 -15.5409 0
+      vertex 24.8112 -12.3164 0
+      vertex 25.3052 -11.2666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.5217 -16.5707 0
+      vertex 24.2737 -13.3446 0
+      vertex 24.8112 -12.3164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5349 -20.5851 0
+      vertex 24.986 -26.6074 0
+      vertex 24.1379 -27.3791 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31.4171 -18.58 0
+      vertex 23.6936 -14.3493 0
+      vertex 24.2737 -13.3446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.6566 -21.3432 0
+      vertex 24.1379 -27.3791 0
+      vertex 23.266 -28.1237 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.818 -19.5577 0
+      vertex 23.0719 -15.3289 0
+      vertex 23.6936 -14.3493 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.1884 -20.516 0
+      vertex 22.4098 -16.2817 0
+      vertex 23.0719 -15.3289 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.6566 -21.3432 0
+      vertex 23.266 -28.1237 0
+      vertex 22.3711 -28.8407 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.8407 -22.3711 0
+      vertex 21.7083 -17.2058 0
+      vertex 22.4098 -16.2817 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.7474 -22.0639 0
+      vertex 22.3711 -28.8407 0
+      vertex 21.4542 -29.5291 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.1237 -23.266 0
+      vertex 20.9688 -18.0998 0
+      vertex 21.7083 -17.2058 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8088 -22.7458 0
+      vertex 21.4542 -29.5291 0
+      vertex 20.516 -30.1884 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3791 -24.1379 0
+      vertex 20.1924 -18.962 0
+      vertex 20.9688 -18.0998 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8424 -23.3879 0
+      vertex 20.516 -30.1884 0
+      vertex 19.5577 -30.818 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.8094 -25.8094 0
+      vertex 19.3807 -19.7909 0
+      vertex 20.1924 -18.962 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8424 -23.3879 0
+      vertex 19.5577 -30.818 0
+      vertex 18.58 -31.4171 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.986 -26.6074 0
+      vertex 18.5349 -20.5851 0
+      vertex 19.3807 -19.7909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.1379 -27.3791 0
+      vertex 17.6566 -21.3432 0
+      vertex 18.5349 -20.5851 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.85 -23.9889 0
+      vertex 18.58 -31.4171 0
+      vertex 17.584 -31.9852 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.3711 -28.8407 0
+      vertex 16.7474 -22.0639 0
+      vertex 17.6566 -21.3432 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.8333 -24.5478 0
+      vertex 17.584 -31.9852 0
+      vertex 16.5707 -32.5217 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.4542 -29.5291 0
+      vertex 15.8088 -22.7458 0
+      vertex 16.7474 -22.0639 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.7941 -25.0637 0
+      vertex 16.5707 -32.5217 0
+      vertex 15.5409 -33.0262 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.516 -30.1884 0
+      vertex 14.8424 -23.3879 0
+      vertex 15.8088 -22.7458 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.7941 -25.0637 0
+      vertex 15.5409 -33.0262 0
+      vertex 14.4959 -33.498 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.58 -31.4171 0
+      vertex 13.85 -23.9889 0
+      vertex 14.8424 -23.3879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.7342 -25.5356 0
+      vertex 14.4959 -33.498 0
+      vertex 13.4365 -33.9368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.584 -31.9852 0
+      vertex 12.8333 -24.5478 0
+      vertex 13.85 -23.9889 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.65545 -25.9627 0
+      vertex 13.4365 -33.9368 0
+      vertex 12.3639 -34.3421 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.5707 -32.5217 0
+      vertex 11.7941 -25.0637 0
+      vertex 12.8333 -24.5478 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.55977 -26.3443 0
+      vertex 12.3639 -34.3421 0
+      vertex 11.2791 -34.7136 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.4959 -33.498 0
+      vertex 10.7342 -25.5356 0
+      vertex 11.7941 -25.0637 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.55977 -26.3443 0
+      vertex 11.2791 -34.7136 0
+      vertex 10.1832 -35.0507 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.4365 -33.9368 0
+      vertex 9.65545 -25.9627 0
+      vertex 10.7342 -25.5356 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.44908 -26.6796 0
+      vertex 10.1832 -35.0507 0
+      vertex 9.07718 -35.3533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.3639 -34.3421 0
+      vertex 8.55977 -26.3443 0
+      vertex 9.65545 -25.9627 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.32532 -26.9681 0
+      vertex 9.07718 -35.3533 0
+      vertex 7.96223 -35.621 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.1832 -35.0507 0
+      vertex 7.44908 -26.6796 0
+      vertex 8.55977 -26.3443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.19046 -27.2094 0
+      vertex 7.96223 -35.621 0
+      vertex 6.83942 -35.8535 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.07718 -35.3533 0
+      vertex 6.32532 -26.9681 0
+      vertex 7.44908 -26.6796 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.19046 -27.2094 0
+      vertex 6.83942 -35.8535 0
+      vertex 5.70986 -36.0506 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.96223 -35.621 0
+      vertex 5.19046 -27.2094 0
+      vertex 6.32532 -26.9681 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.0465 -27.4028 0
+      vertex 5.70986 -36.0506 0
+      vertex 4.57466 -36.2122 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.70986 -36.0506 0
+      vertex 4.0465 -27.4028 0
+      vertex 5.19046 -27.2094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.89544 -27.5483 0
+      vertex 4.57466 -36.2122 0
+      vertex 3.43495 -36.338 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.57466 -36.2122 0
+      vertex 2.89544 -27.5483 0
+      vertex 4.0465 -27.4028 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.7393 -27.6453 0
+      vertex 3.43495 -36.338 0
+      vertex 2.29185 -36.428 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.43495 -36.338 0
+      vertex 1.7393 -27.6453 0
+      vertex 2.89544 -27.5483 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.14649 -36.482 0
+      vertex 1.7393 -27.6453 0
+      vertex 2.29185 -36.428 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.14649 -36.482 0
+      vertex 0.580105 -27.6939 0
+      vertex 1.7393 -27.6453 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -36.5 0
+      vertex 0.580105 -27.6939 0
+      vertex 1.14649 -36.482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -36.5 0
+      vertex -0.580105 -27.6939 0
+      vertex 0.580105 -27.6939 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.14649 -36.482 0
+      vertex -0.580105 -27.6939 0
+      vertex 0 -36.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.14649 -36.482 0
+      vertex -1.7393 -27.6453 0
+      vertex -0.580105 -27.6939 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.29185 -36.428 0
+      vertex -1.7393 -27.6453 0
+      vertex -1.14649 -36.482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.43495 -36.338 0
+      vertex -1.7393 -27.6453 0
+      vertex -2.29185 -36.428 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.7393 -27.6453 0
+      vertex -3.43495 -36.338 0
+      vertex -2.89544 -27.5483 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.57466 -36.2122 0
+      vertex -2.89544 -27.5483 0
+      vertex -3.43495 -36.338 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -2.89544 -27.5483 0
+      vertex -4.57466 -36.2122 0
+      vertex -4.0465 -27.4028 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.70986 -36.0506 0
+      vertex -4.0465 -27.4028 0
+      vertex -4.57466 -36.2122 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -4.0465 -27.4028 0
+      vertex -5.70986 -36.0506 0
+      vertex -5.19046 -27.2094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.83942 -35.8535 0
+      vertex -5.19046 -27.2094 0
+      vertex -5.70986 -36.0506 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.96223 -35.621 0
+      vertex -5.19046 -27.2094 0
+      vertex -6.83942 -35.8535 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.19046 -27.2094 0
+      vertex -7.96223 -35.621 0
+      vertex -6.32532 -26.9681 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.07718 -35.3533 0
+      vertex -6.32532 -26.9681 0
+      vertex -7.96223 -35.621 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -6.32532 -26.9681 0
+      vertex -9.07718 -35.3533 0
+      vertex -7.44908 -26.6796 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.1832 -35.0507 0
+      vertex -7.44908 -26.6796 0
+      vertex -9.07718 -35.3533 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -7.44908 -26.6796 0
+      vertex -10.1832 -35.0507 0
+      vertex -8.55977 -26.3443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.2791 -34.7136 0
+      vertex -8.55977 -26.3443 0
+      vertex -10.1832 -35.0507 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.3639 -34.3421 0
+      vertex -8.55977 -26.3443 0
+      vertex -11.2791 -34.7136 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.55977 -26.3443 0
+      vertex -12.3639 -34.3421 0
+      vertex -9.65545 -25.9627 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.4365 -33.9368 0
+      vertex -9.65545 -25.9627 0
+      vertex -12.3639 -34.3421 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.65545 -25.9627 0
+      vertex -13.4365 -33.9368 0
+      vertex -10.7342 -25.5356 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.4959 -33.498 0
+      vertex -10.7342 -25.5356 0
+      vertex -13.4365 -33.9368 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -10.7342 -25.5356 0
+      vertex -14.4959 -33.498 0
+      vertex -11.7941 -25.0637 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.5409 -33.0262 0
+      vertex -11.7941 -25.0637 0
+      vertex -14.4959 -33.498 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.5707 -32.5217 0
+      vertex -11.7941 -25.0637 0
+      vertex -15.5409 -33.0262 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -11.7941 -25.0637 0
+      vertex -16.5707 -32.5217 0
+      vertex -12.8333 -24.5478 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.584 -31.9852 0
+      vertex -12.8333 -24.5478 0
+      vertex -16.5707 -32.5217 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -12.8333 -24.5478 0
+      vertex -17.584 -31.9852 0
+      vertex -13.85 -23.9889 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.58 -31.4171 0
+      vertex -13.85 -23.9889 0
+      vertex -17.584 -31.9852 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.85 -23.9889 0
+      vertex -18.58 -31.4171 0
+      vertex -14.8424 -23.3879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.5577 -30.818 0
+      vertex -14.8424 -23.3879 0
+      vertex -18.58 -31.4171 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.516 -30.1884 0
+      vertex -14.8424 -23.3879 0
+      vertex -19.5577 -30.818 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.8424 -23.3879 0
+      vertex -20.516 -30.1884 0
+      vertex -15.8088 -22.7458 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.4542 -29.5291 0
+      vertex -15.8088 -22.7458 0
+      vertex -20.516 -30.1884 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.8088 -22.7458 0
+      vertex -21.4542 -29.5291 0
+      vertex -16.7474 -22.0639 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.3711 -28.8407 0
+      vertex -16.7474 -22.0639 0
+      vertex -21.4542 -29.5291 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.7474 -22.0639 0
+      vertex -22.3711 -28.8407 0
+      vertex -17.6566 -21.3432 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.266 -28.1237 0
+      vertex -17.6566 -21.3432 0
+      vertex -22.3711 -28.8407 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.1379 -27.3791 0
+      vertex -17.6566 -21.3432 0
+      vertex -23.266 -28.1237 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -17.6566 -21.3432 0
+      vertex -24.1379 -27.3791 0
+      vertex -18.5349 -20.5851 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.986 -26.6074 0
+      vertex -18.5349 -20.5851 0
+      vertex -24.1379 -27.3791 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.5349 -20.5851 0
+      vertex -24.986 -26.6074 0
+      vertex -19.3807 -19.7909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.8094 -25.8094 0
+      vertex -19.3807 -19.7909 0
+      vertex -24.986 -26.6074 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.3807 -19.7909 0
+      vertex -25.8094 -25.8094 0
+      vertex -20.1924 -18.962 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.6074 -24.986 0
+      vertex -20.1924 -18.962 0
+      vertex -25.8094 -25.8094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.3791 -24.1379 0
+      vertex -20.1924 -18.962 0
+      vertex -26.6074 -24.986 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -20.1924 -18.962 0
+      vertex -27.3791 -24.1379 0
+      vertex -20.9688 -18.0998 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.1237 -23.266 0
+      vertex -20.9688 -18.0998 0
+      vertex -27.3791 -24.1379 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -20.9688 -18.0998 0
+      vertex -28.1237 -23.266 0
+      vertex -21.7083 -17.2058 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.8407 -22.3711 0
+      vertex -21.7083 -17.2058 0
+      vertex -28.1237 -23.266 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -21.7083 -17.2058 0
+      vertex -28.8407 -22.3711 0
+      vertex -22.4098 -16.2817 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.5291 -21.4542 0
+      vertex -22.4098 -16.2817 0
+      vertex -28.8407 -22.3711 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.1884 -20.516 0
+      vertex -22.4098 -16.2817 0
+      vertex -29.5291 -21.4542 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -22.4098 -16.2817 0
+      vertex -30.1884 -20.516 0
+      vertex -23.0719 -15.3289 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.818 -19.5577 0
+      vertex -23.0719 -15.3289 0
+      vertex -30.1884 -20.516 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.0719 -15.3289 0
+      vertex -30.818 -19.5577 0
+      vertex -23.6936 -14.3493 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.4171 -18.58 0
+      vertex -23.6936 -14.3493 0
+      vertex -30.818 -19.5577 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.6936 -14.3493 0
+      vertex -31.4171 -18.58 0
+      vertex -24.2737 -13.3446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.9852 -17.584 0
+      vertex -24.2737 -13.3446 0
+      vertex -31.4171 -18.58 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.5217 -16.5707 0
+      vertex -24.2737 -13.3446 0
+      vertex -31.9852 -17.584 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.2737 -13.3446 0
+      vertex -32.5217 -16.5707 0
+      vertex -24.8112 -12.3164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.0262 -15.5409 0
+      vertex -24.8112 -12.3164 0
+      vertex -32.5217 -16.5707 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.8112 -12.3164 0
+      vertex -33.0262 -15.5409 0
+      vertex -25.3052 -11.2666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.498 -14.4959 0
+      vertex -25.3052 -11.2666 0
+      vertex -33.0262 -15.5409 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.3052 -11.2666 0
+      vertex -33.498 -14.4959 0
+      vertex -25.7548 -10.1971 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.3052 11.2666 0
+      vertex 33.498 14.4959 0
+      vertex 25.7548 10.1971 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 33.498 14.4959 0
+      vertex 25.3052 11.2666 0
+      vertex 33.0262 15.5409 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8112 12.3164 0
+      vertex 33.0262 15.5409 0
+      vertex 25.3052 11.2666 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 33.0262 15.5409 0
+      vertex 24.8112 12.3164 0
+      vertex 32.5217 16.5707 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.2737 13.3446 0
+      vertex 32.5217 16.5707 0
+      vertex 24.8112 12.3164 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 32.5217 16.5707 0
+      vertex 24.2737 13.3446 0
+      vertex 31.9852 17.584 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 31.9852 17.584 0
+      vertex 24.2737 13.3446 0
+      vertex 31.4171 18.58 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.6936 14.3493 0
+      vertex 31.4171 18.58 0
+      vertex 24.2737 13.3446 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 31.4171 18.58 0
+      vertex 23.6936 14.3493 0
+      vertex 30.818 19.5577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.0719 15.3289 0
+      vertex 30.818 19.5577 0
+      vertex 23.6936 14.3493 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 30.818 19.5577 0
+      vertex 23.0719 15.3289 0
+      vertex 30.1884 20.516 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.4098 16.2817 0
+      vertex 30.1884 20.516 0
+      vertex 23.0719 15.3289 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 30.1884 20.516 0
+      vertex 22.4098 16.2817 0
+      vertex 29.5291 21.4542 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 29.5291 21.4542 0
+      vertex 22.4098 16.2817 0
+      vertex 28.8407 22.3711 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.7083 17.2058 0
+      vertex 28.8407 22.3711 0
+      vertex 22.4098 16.2817 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.8407 22.3711 0
+      vertex 21.7083 17.2058 0
+      vertex 28.1237 23.266 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.9688 18.0998 0
+      vertex 28.1237 23.266 0
+      vertex 21.7083 17.2058 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.1237 23.266 0
+      vertex 20.9688 18.0998 0
+      vertex 27.3791 24.1379 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1924 18.962 0
+      vertex 27.3791 24.1379 0
+      vertex 20.9688 18.0998 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 27.3791 24.1379 0
+      vertex 20.1924 18.962 0
+      vertex 26.6074 24.986 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 26.6074 24.986 0
+      vertex 20.1924 18.962 0
+      vertex 25.8094 25.8094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3807 19.7909 0
+      vertex 25.8094 25.8094 0
+      vertex 20.1924 18.962 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 25.8094 25.8094 0
+      vertex 19.3807 19.7909 0
+      vertex 24.986 26.6074 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5349 20.5851 0
+      vertex 24.986 26.6074 0
+      vertex 19.3807 19.7909 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 24.986 26.6074 0
+      vertex 18.5349 20.5851 0
+      vertex 24.1379 27.3791 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.6566 21.3432 0
+      vertex 24.1379 27.3791 0
+      vertex 18.5349 20.5851 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 24.1379 27.3791 0
+      vertex 17.6566 21.3432 0
+      vertex 23.266 28.1237 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 23.266 28.1237 0
+      vertex 17.6566 21.3432 0
+      vertex 22.3711 28.8407 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.7474 22.0639 0
+      vertex 22.3711 28.8407 0
+      vertex 17.6566 21.3432 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 22.3711 28.8407 0
+      vertex 16.7474 22.0639 0
+      vertex 21.4542 29.5291 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8088 22.7458 0
+      vertex 21.4542 29.5291 0
+      vertex 16.7474 22.0639 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 21.4542 29.5291 0
+      vertex 15.8088 22.7458 0
+      vertex 20.516 30.1884 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8424 23.3879 0
+      vertex 20.516 30.1884 0
+      vertex 15.8088 22.7458 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.516 30.1884 0
+      vertex 14.8424 23.3879 0
+      vertex 19.5577 30.818 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.5577 30.818 0
+      vertex 14.8424 23.3879 0
+      vertex 18.58 31.4171 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.85 23.9889 0
+      vertex 18.58 31.4171 0
+      vertex 14.8424 23.3879 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 18.58 31.4171 0
+      vertex 13.85 23.9889 0
+      vertex 17.584 31.9852 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.8333 24.5478 0
+      vertex 17.584 31.9852 0
+      vertex 13.85 23.9889 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.584 31.9852 0
+      vertex 12.8333 24.5478 0
+      vertex 16.5707 32.5217 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.7941 25.0637 0
+      vertex 16.5707 32.5217 0
+      vertex 12.8333 24.5478 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 16.5707 32.5217 0
+      vertex 11.7941 25.0637 0
+      vertex 15.5409 33.0262 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.5409 33.0262 0
+      vertex 11.7941 25.0637 0
+      vertex 14.4959 33.498 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.7342 25.5356 0
+      vertex 14.4959 33.498 0
+      vertex 11.7941 25.0637 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14.4959 33.498 0
+      vertex 10.7342 25.5356 0
+      vertex 13.4365 33.9368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.65545 25.9627 0
+      vertex 13.4365 33.9368 0
+      vertex 10.7342 25.5356 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 13.4365 33.9368 0
+      vertex 9.65545 25.9627 0
+      vertex 12.3639 34.3421 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.55977 26.3443 0
+      vertex 12.3639 34.3421 0
+      vertex 9.65545 25.9627 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 12.3639 34.3421 0
+      vertex 8.55977 26.3443 0
+      vertex 11.2791 34.7136 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.2791 34.7136 0
+      vertex 8.55977 26.3443 0
+      vertex 10.1832 35.0507 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.44908 26.6796 0
+      vertex 10.1832 35.0507 0
+      vertex 8.55977 26.3443 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.1832 35.0507 0
+      vertex 7.44908 26.6796 0
+      vertex 9.07718 35.3533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.32532 26.9681 0
+      vertex 9.07718 35.3533 0
+      vertex 7.44908 26.6796 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 9.07718 35.3533 0
+      vertex 6.32532 26.9681 0
+      vertex 7.96223 35.621 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.19046 27.2094 0
+      vertex 7.96223 35.621 0
+      vertex 6.32532 26.9681 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 7.96223 35.621 0
+      vertex 5.19046 27.2094 0
+      vertex 6.83942 35.8535 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 6.83942 35.8535 0
+      vertex 5.19046 27.2094 0
+      vertex 5.70986 36.0506 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.0465 27.4028 0
+      vertex 5.70986 36.0506 0
+      vertex 5.19046 27.2094 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 5.70986 36.0506 0
+      vertex 4.0465 27.4028 0
+      vertex 4.57466 36.2122 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.89544 27.5483 0
+      vertex 4.57466 36.2122 0
+      vertex 4.0465 27.4028 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 4.57466 36.2122 0
+      vertex 2.89544 27.5483 0
+      vertex 3.43495 36.338 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.7393 27.6453 0
+      vertex 3.43495 36.338 0
+      vertex 2.89544 27.5483 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 3.43495 36.338 0
+      vertex 1.7393 27.6453 0
+      vertex 2.29185 36.428 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.7393 27.6453 0
+      vertex 1.14649 36.482 0
+      vertex 2.29185 36.428 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.580105 27.6939 0
+      vertex 1.14649 36.482 0
+      vertex 1.7393 27.6453 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.580105 27.6939 0
+      vertex 0 36.5 0
+      vertex 1.14649 36.482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.580105 27.6939 0
+      vertex 0 36.5 0
+      vertex 0.580105 27.6939 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.580105 27.6939 0
+      vertex -1.14649 36.482 0
+      vertex 0 36.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.7393 27.6453 0
+      vertex -1.14649 36.482 0
+      vertex -0.580105 27.6939 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.7393 27.6453 0
+      vertex -2.29185 36.428 0
+      vertex -1.14649 36.482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.43495 36.338 0
+      vertex -1.7393 27.6453 0
+      vertex -2.89544 27.5483 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.7393 27.6453 0
+      vertex -3.43495 36.338 0
+      vertex -2.29185 36.428 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.57466 36.2122 0
+      vertex -2.89544 27.5483 0
+      vertex -4.0465 27.4028 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.89544 27.5483 0
+      vertex -4.57466 36.2122 0
+      vertex -3.43495 36.338 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.70986 36.0506 0
+      vertex -4.0465 27.4028 0
+      vertex -5.19046 27.2094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.0465 27.4028 0
+      vertex -5.70986 36.0506 0
+      vertex -4.57466 36.2122 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.96223 35.621 0
+      vertex -5.19046 27.2094 0
+      vertex -6.32532 26.9681 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.19046 27.2094 0
+      vertex -6.83942 35.8535 0
+      vertex -5.70986 36.0506 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.07718 35.3533 0
+      vertex -6.32532 26.9681 0
+      vertex -7.44908 26.6796 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.19046 27.2094 0
+      vertex -7.96223 35.621 0
+      vertex -6.83942 35.8535 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.1832 35.0507 0
+      vertex -7.44908 26.6796 0
+      vertex -8.55977 26.3443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.32532 26.9681 0
+      vertex -9.07718 35.3533 0
+      vertex -7.96223 35.621 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.3639 34.3421 0
+      vertex -8.55977 26.3443 0
+      vertex -9.65545 25.9627 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.44908 26.6796 0
+      vertex -10.1832 35.0507 0
+      vertex -9.07718 35.3533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.4365 33.9368 0
+      vertex -9.65545 25.9627 0
+      vertex -10.7342 25.5356 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.55977 26.3443 0
+      vertex -11.2791 34.7136 0
+      vertex -10.1832 35.0507 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.4959 33.498 0
+      vertex -10.7342 25.5356 0
+      vertex -11.7941 25.0637 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.55977 26.3443 0
+      vertex -12.3639 34.3421 0
+      vertex -11.2791 34.7136 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.5707 32.5217 0
+      vertex -11.7941 25.0637 0
+      vertex -12.8333 24.5478 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.65545 25.9627 0
+      vertex -13.4365 33.9368 0
+      vertex -12.3639 34.3421 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.584 31.9852 0
+      vertex -12.8333 24.5478 0
+      vertex -13.85 23.9889 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.7342 25.5356 0
+      vertex -14.4959 33.498 0
+      vertex -13.4365 33.9368 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.58 31.4171 0
+      vertex -13.85 23.9889 0
+      vertex -14.8424 23.3879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7941 25.0637 0
+      vertex -15.5409 33.0262 0
+      vertex -14.4959 33.498 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.516 30.1884 0
+      vertex -14.8424 23.3879 0
+      vertex -15.8088 22.7458 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7941 25.0637 0
+      vertex -16.5707 32.5217 0
+      vertex -15.5409 33.0262 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.4542 29.5291 0
+      vertex -15.8088 22.7458 0
+      vertex -16.7474 22.0639 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.8333 24.5478 0
+      vertex -17.584 31.9852 0
+      vertex -16.5707 32.5217 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.3711 28.8407 0
+      vertex -16.7474 22.0639 0
+      vertex -17.6566 21.3432 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.1379 27.3791 0
+      vertex -17.6566 21.3432 0
+      vertex -18.5349 20.5851 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.85 23.9889 0
+      vertex -18.58 31.4171 0
+      vertex -17.584 31.9852 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.986 26.6074 0
+      vertex -18.5349 20.5851 0
+      vertex -19.3807 19.7909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8424 23.3879 0
+      vertex -19.5577 30.818 0
+      vertex -18.58 31.4171 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.8094 25.8094 0
+      vertex -19.3807 19.7909 0
+      vertex -20.1924 18.962 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8424 23.3879 0
+      vertex -20.516 30.1884 0
+      vertex -19.5577 30.818 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.3791 24.1379 0
+      vertex -20.1924 18.962 0
+      vertex -20.9688 18.0998 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8088 22.7458 0
+      vertex -21.4542 29.5291 0
+      vertex -20.516 30.1884 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.1237 23.266 0
+      vertex -20.9688 18.0998 0
+      vertex -21.7083 17.2058 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.7474 22.0639 0
+      vertex -22.3711 28.8407 0
+      vertex -21.4542 29.5291 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.8407 22.3711 0
+      vertex -21.7083 17.2058 0
+      vertex -22.4098 16.2817 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.1884 20.516 0
+      vertex -22.4098 16.2817 0
+      vertex -23.0719 15.3289 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.6566 21.3432 0
+      vertex -23.266 28.1237 0
+      vertex -22.3711 28.8407 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.818 19.5577 0
+      vertex -23.0719 15.3289 0
+      vertex -23.6936 14.3493 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.6566 21.3432 0
+      vertex -24.1379 27.3791 0
+      vertex -23.266 28.1237 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.4171 18.58 0
+      vertex -23.6936 14.3493 0
+      vertex -24.2737 13.3446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.5217 16.5707 0
+      vertex -24.2737 13.3446 0
+      vertex -24.8112 12.3164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5349 20.5851 0
+      vertex -24.986 26.6074 0
+      vertex -24.1379 27.3791 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.0262 15.5409 0
+      vertex -24.8112 12.3164 0
+      vertex -25.3052 11.2666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.498 14.4959 0
+      vertex -25.3052 11.2666 0
+      vertex -25.7548 10.1971 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3807 19.7909 0
+      vertex -25.8094 25.8094 0
+      vertex -24.986 26.6074 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -34.3421 12.3639 0
+      vertex -25.7548 10.1971 0
+      vertex -26.1592 9.10961 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -34.7136 11.2791 0
+      vertex -26.1592 9.10961 0
+      vertex -26.5177 8.00618 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1924 18.962 0
+      vertex -26.6074 24.986 0
+      vertex -25.8094 25.8094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.0507 10.1832 0
+      vertex -26.5177 8.00618 0
+      vertex -26.8298 6.88871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.621 7.96223 0
+      vertex -26.8298 6.88871 0
+      vertex -27.0947 5.75915 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.8535 6.83942 0
+      vertex -27.0947 5.75915 0
+      vertex -27.3121 4.61949 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1924 18.962 0
+      vertex -27.3791 24.1379 0
+      vertex -26.6074 24.986 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.0506 5.70986 0
+      vertex -27.3121 4.61949 0
+      vertex -27.4816 3.47173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.338 3.43495 0
+      vertex -27.4816 3.47173 0
+      vertex -27.6029 2.31788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.428 2.29185 0
+      vertex -27.6029 2.31788 0
+      vertex -27.6757 1.15996 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.482 1.14649 0
+      vertex -27.6757 1.15996 0
+      vertex -27.7 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.9368 -13.4365 0
+      vertex -25.7548 -10.1971 0
+      vertex -33.498 -14.4959 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.9688 18.0998 0
+      vertex -28.1237 23.266 0
+      vertex -27.3791 24.1379 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -34.3421 -12.3639 0
+      vertex -25.7548 -10.1971 0
+      vertex -33.9368 -13.4365 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.7083 17.2058 0
+      vertex -28.8407 22.3711 0
+      vertex -28.1237 23.266 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.7548 -10.1971 0
+      vertex -34.3421 -12.3639 0
+      vertex -26.1592 -9.10961 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.4098 16.2817 0
+      vertex -29.5291 21.4542 0
+      vertex -28.8407 22.3711 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -34.7136 -11.2791 0
+      vertex -26.1592 -9.10961 0
+      vertex -34.3421 -12.3639 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.4098 16.2817 0
+      vertex -30.1884 20.516 0
+      vertex -29.5291 21.4542 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.1592 -9.10961 0
+      vertex -34.7136 -11.2791 0
+      vertex -26.5177 -8.00618 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.0719 15.3289 0
+      vertex -30.818 19.5577 0
+      vertex -30.1884 20.516 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.0507 -10.1832 0
+      vertex -26.5177 -8.00618 0
+      vertex -34.7136 -11.2791 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.6936 14.3493 0
+      vertex -31.4171 18.58 0
+      vertex -30.818 19.5577 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.5177 -8.00618 0
+      vertex -35.0507 -10.1832 0
+      vertex -26.8298 -6.88871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.2737 13.3446 0
+      vertex -31.9852 17.584 0
+      vertex -31.4171 18.58 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.3533 -9.07718 0
+      vertex -26.8298 -6.88871 0
+      vertex -35.0507 -10.1832 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.2737 13.3446 0
+      vertex -32.5217 16.5707 0
+      vertex -31.9852 17.584 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.621 -7.96223 0
+      vertex -26.8298 -6.88871 0
+      vertex -35.3533 -9.07718 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.8112 12.3164 0
+      vertex -33.0262 15.5409 0
+      vertex -32.5217 16.5707 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.8298 -6.88871 0
+      vertex -35.621 -7.96223 0
+      vertex -27.0947 -5.75915 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.3052 11.2666 0
+      vertex -33.498 14.4959 0
+      vertex -33.0262 15.5409 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.8535 -6.83942 0
+      vertex -27.0947 -5.75915 0
+      vertex -35.621 -7.96223 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.7548 10.1971 0
+      vertex -33.9368 13.4365 0
+      vertex -33.498 14.4959 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.0947 -5.75915 0
+      vertex -35.8535 -6.83942 0
+      vertex -27.3121 -4.61949 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.7548 10.1971 0
+      vertex -34.3421 12.3639 0
+      vertex -33.9368 13.4365 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.0506 -5.70986 0
+      vertex -27.3121 -4.61949 0
+      vertex -35.8535 -6.83942 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.1592 9.10961 0
+      vertex -34.7136 11.2791 0
+      vertex -34.3421 12.3639 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.3121 -4.61949 0
+      vertex -36.0506 -5.70986 0
+      vertex -27.4816 -3.47173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.5177 8.00618 0
+      vertex -35.0507 10.1832 0
+      vertex -34.7136 11.2791 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.2122 -4.57466 0
+      vertex -27.4816 -3.47173 0
+      vertex -36.0506 -5.70986 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.8298 6.88871 0
+      vertex -35.3533 9.07718 0
+      vertex -35.0507 10.1832 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.338 -3.43495 0
+      vertex -27.4816 -3.47173 0
+      vertex -36.2122 -4.57466 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.8298 6.88871 0
+      vertex -35.621 7.96223 0
+      vertex -35.3533 9.07718 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.4816 -3.47173 0
+      vertex -36.338 -3.43495 0
+      vertex -27.6029 -2.31788 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0947 5.75915 0
+      vertex -35.8535 6.83942 0
+      vertex -35.621 7.96223 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.428 -2.29185 0
+      vertex -27.6029 -2.31788 0
+      vertex -36.338 -3.43495 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.3121 4.61949 0
+      vertex -36.0506 5.70986 0
+      vertex -35.8535 6.83942 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6029 -2.31788 0
+      vertex -36.428 -2.29185 0
+      vertex -27.6757 -1.15996 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.4816 3.47173 0
+      vertex -36.2122 4.57466 0
+      vertex -36.0506 5.70986 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.482 -1.14649 0
+      vertex -27.6757 -1.15996 0
+      vertex -36.428 -2.29185 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.4816 3.47173 0
+      vertex -36.338 3.43495 0
+      vertex -36.2122 4.57466 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6757 -1.15996 0
+      vertex -36.482 -1.14649 0
+      vertex -27.7 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.6029 2.31788 0
+      vertex -36.428 2.29185 0
+      vertex -36.338 3.43495 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.5 0 0
+      vertex -27.7 0 0
+      vertex -36.482 -1.14649 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.6757 1.15996 0
+      vertex -36.482 1.14649 0
+      vertex -36.428 2.29185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.7 0 0
+      vertex -36.5 0 0
+      vertex -36.482 1.14649 0
+    endloop
+  endfacet
+  facet normal 0.923885 -0.38267 0
+    outer loop
+      vertex 33.498 -14.4959 60
+      vertex 33.9368 -13.4365 0
+      vertex 33.9368 -13.4365 60
+    endloop
+  endfacet
+  facet normal 0.923885 -0.38267 0
+    outer loop
+      vertex 33.9368 -13.4365 0
+      vertex 33.498 -14.4959 60
+      vertex 33.498 -14.4959 0
+    endloop
+  endfacet
+  facet normal -0.202768 -0.979227 0
+    outer loop
+      vertex -7.96223 -35.621 0
+      vertex -6.83942 -35.8535 60
+      vertex -7.96223 -35.621 60
+    endloop
+  endfacet
+  facet normal -0.202768 -0.979227 -0
+    outer loop
+      vertex -6.83942 -35.8535 60
+      vertex -7.96223 -35.621 0
+      vertex -6.83942 -35.8535 0
+    endloop
+  endfacet
+  facet normal -0.233465 -0.972365 0
+    outer loop
+      vertex -9.07718 -35.3533 0
+      vertex -7.96223 -35.621 60
+      vertex -9.07718 -35.3533 60
+    endloop
+  endfacet
+  facet normal -0.233465 -0.972365 -0
+    outer loop
+      vertex -7.96223 -35.621 60
+      vertex -9.07718 -35.3533 0
+      vertex -7.96223 -35.621 0
+    endloop
+  endfacet
+  facet normal 0.48173 0.87632 -0
+    outer loop
+      vertex -12.8333 -24.5478 0
+      vertex -13.85 -23.9889 60
+      vertex -12.8333 -24.5478 60
+    endloop
+  endfacet
+  facet normal 0.48173 0.87632 0
+    outer loop
+      vertex -13.85 -23.9889 60
+      vertex -12.8333 -24.5478 0
+      vertex -13.85 -23.9889 0
+    endloop
+  endfacet
+  facet normal 0.951063 0.308997 0
+    outer loop
+      vertex -26.1592 -9.10961 60
+      vertex -26.5177 -8.00618 0
+      vertex -26.5177 -8.00618 60
+    endloop
+  endfacet
+  facet normal 0.951063 0.308997 0
+    outer loop
+      vertex -26.5177 -8.00618 0
+      vertex -26.1592 -9.10961 60
+      vertex -26.1592 -9.10961 0
+    endloop
+  endfacet
+  facet normal -0.998029 -0.0627475 0
+    outer loop
+      vertex 27.6757 1.15996 0
+      vertex 27.6029 2.31788 60
+      vertex 27.6029 2.31788 0
+    endloop
+  endfacet
+  facet normal -0.998029 -0.0627475 0
+    outer loop
+      vertex 27.6029 2.31788 60
+      vertex 27.6757 1.15996 0
+      vertex 27.6757 1.15996 60
+    endloop
+  endfacet
+  facet normal -0.999781 -0.0209444 0
+    outer loop
+      vertex 27.7 0 0
+      vertex 27.6757 1.15996 60
+      vertex 27.6757 1.15996 0
+    endloop
+  endfacet
+  facet normal -0.999781 -0.0209444 0
+    outer loop
+      vertex 27.6757 1.15996 60
+      vertex 27.7 0 0
+      vertex 27.7 0 60
+    endloop
+  endfacet
+  facet normal -0.99452 -0.10455 0
+    outer loop
+      vertex 27.6029 2.31788 0
+      vertex 27.4816 3.47173 60
+      vertex 27.4816 3.47173 0
+    endloop
+  endfacet
+  facet normal -0.99452 -0.10455 0
+    outer loop
+      vertex 27.4816 3.47173 60
+      vertex 27.6029 2.31788 0
+      vertex 27.6029 2.31788 60
+    endloop
+  endfacet
+  facet normal -0.844317 0.535843 0
+    outer loop
+      vertex 23.0719 -15.3289 0
+      vertex 23.6936 -14.3493 60
+      vertex 23.6936 -14.3493 0
+    endloop
+  endfacet
+  facet normal -0.844317 0.535843 0
+    outer loop
+      vertex 23.6936 -14.3493 60
+      vertex 23.0719 -15.3289 0
+      vertex 23.0719 -15.3289 60
+    endloop
+  endfacet
+  facet normal -0.714481 0.699655 0
+    outer loop
+      vertex 19.3807 -19.7909 0
+      vertex 20.1924 -18.962 60
+      vertex 20.1924 -18.962 0
+    endloop
+  endfacet
+  facet normal -0.714481 0.699655 0
+    outer loop
+      vertex 20.1924 -18.962 60
+      vertex 19.3807 -19.7909 0
+      vertex 19.3807 -19.7909 60
+    endloop
+  endfacet
+  facet normal -0.0836061 0.996499 0
+    outer loop
+      vertex 2.89544 -27.5483 0
+      vertex 1.7393 -27.6453 60
+      vertex 2.89544 -27.5483 60
+    endloop
+  endfacet
+  facet normal -0.0836061 0.996499 0
+    outer loop
+      vertex 1.7393 -27.6453 60
+      vertex 2.89544 -27.5483 0
+      vertex 1.7393 -27.6453 0
+    endloop
+  endfacet
+  facet normal 0.921856 -0.387533 0
+    outer loop
+      vertex -25.7548 10.1971 60
+      vertex -25.3052 11.2666 0
+      vertex -25.3052 11.2666 60
+    endloop
+  endfacet
+  facet normal 0.921856 -0.387533 0
+    outer loop
+      vertex -25.3052 11.2666 0
+      vertex -25.7548 10.1971 60
+      vertex -25.7548 10.1971 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.580105 27.6939 0
+      vertex 0.580105 27.6939 60
+      vertex -0.580105 27.6939 60
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 0.580105 27.6939 60
+      vertex -0.580105 27.6939 0
+      vertex 0.580105 27.6939 0
+    endloop
+  endfacet
+  facet normal 0.68452 0.728994 -0
+    outer loop
+      vertex -18.5349 -20.5851 0
+      vertex -19.3807 -19.7909 60
+      vertex -18.5349 -20.5851 60
+    endloop
+  endfacet
+  facet normal 0.68452 0.728994 0
+    outer loop
+      vertex -19.3807 -19.7909 60
+      vertex -18.5349 -20.5851 0
+      vertex -19.3807 -19.7909 0
+    endloop
+  endfacet
+  facet normal 0.587767 -0.80903 0
+    outer loop
+      vertex -16.7474 22.0639 0
+      vertex -15.8088 22.7458 60
+      vertex -16.7474 22.0639 60
+    endloop
+  endfacet
+  facet normal 0.587767 -0.80903 0
+    outer loop
+      vertex -15.8088 22.7458 60
+      vertex -16.7474 22.0639 0
+      vertex -15.8088 22.7458 0
+    endloop
+  endfacet
+  facet normal -0.653407 -0.757007 0
+    outer loop
+      vertex 17.6566 21.3432 0
+      vertex 18.5349 20.5851 60
+      vertex 17.6566 21.3432 60
+    endloop
+  endfacet
+  facet normal -0.653407 -0.757007 -0
+    outer loop
+      vertex 18.5349 20.5851 60
+      vertex 17.6566 21.3432 0
+      vertex 18.5349 20.5851 0
+    endloop
+  endfacet
+  facet normal -0.368119 0.929779 0
+    outer loop
+      vertex 10.7342 -25.5356 0
+      vertex 9.65545 -25.9627 60
+      vertex 10.7342 -25.5356 60
+    endloop
+  endfacet
+  facet normal -0.368119 0.929779 0
+    outer loop
+      vertex 9.65545 -25.9627 60
+      vertex 10.7342 -25.5356 0
+      vertex 9.65545 -25.9627 0
+    endloop
+  endfacet
+  facet normal 0.653407 -0.757007 0
+    outer loop
+      vertex -18.5349 20.5851 0
+      vertex -17.6566 21.3432 60
+      vertex -18.5349 20.5851 60
+    endloop
+  endfacet
+  facet normal 0.653407 -0.757007 0
+    outer loop
+      vertex -17.6566 21.3432 60
+      vertex -18.5349 20.5851 0
+      vertex -17.6566 21.3432 0
+    endloop
+  endfacet
+  facet normal 0.207976 0.978134 -0
+    outer loop
+      vertex -5.19046 -27.2094 0
+      vertex -6.32532 -26.9681 60
+      vertex -5.19046 -27.2094 60
+    endloop
+  endfacet
+  facet normal 0.207976 0.978134 0
+    outer loop
+      vertex -6.32532 -26.9681 60
+      vertex -5.19046 -27.2094 0
+      vertex -6.32532 -26.9681 0
+    endloop
+  endfacet
+  facet normal 0.714481 0.699655 0
+    outer loop
+      vertex -19.3807 -19.7909 60
+      vertex -20.1924 -18.962 0
+      vertex -20.1924 -18.962 60
+    endloop
+  endfacet
+  facet normal 0.714481 0.699655 0
+    outer loop
+      vertex -20.1924 -18.962 0
+      vertex -19.3807 -19.7909 60
+      vertex -19.3807 -19.7909 0
+    endloop
+  endfacet
+  facet normal -0.921856 0.387533 0
+    outer loop
+      vertex 25.3052 -11.2666 0
+      vertex 25.7548 -10.1971 60
+      vertex 25.7548 -10.1971 0
+    endloop
+  endfacet
+  facet normal -0.921856 0.387533 0
+    outer loop
+      vertex 25.7548 -10.1971 60
+      vertex 25.3052 -11.2666 0
+      vertex 25.3052 -11.2666 60
+    endloop
+  endfacet
+  facet normal -0.963141 -0.268997 0
+    outer loop
+      vertex 26.8298 6.88871 0
+      vertex 26.5177 8.00618 60
+      vertex 26.5177 8.00618 0
+    endloop
+  endfacet
+  facet normal -0.963141 -0.268997 0
+    outer loop
+      vertex 26.5177 8.00618 60
+      vertex 26.8298 6.88871 0
+      vertex 26.8298 6.88871 60
+    endloop
+  endfacet
+  facet normal -0.553407 0.832911 0
+    outer loop
+      vertex 15.8088 -22.7458 0
+      vertex 14.8424 -23.3879 60
+      vertex 15.8088 -22.7458 60
+    endloop
+  endfacet
+  facet normal -0.553407 0.832911 0
+    outer loop
+      vertex 14.8424 -23.3879 60
+      vertex 15.8088 -22.7458 0
+      vertex 14.8424 -23.3879 0
+    endloop
+  endfacet
+  facet normal -0.904827 0.42578 0
+    outer loop
+      vertex 24.8112 -12.3164 0
+      vertex 25.3052 -11.2666 60
+      vertex 25.3052 -11.2666 0
+    endloop
+  endfacet
+  facet normal -0.904827 0.42578 0
+    outer loop
+      vertex 25.3052 -11.2666 60
+      vertex 24.8112 -12.3164 0
+      vertex 24.8112 -12.3164 60
+    endloop
+  endfacet
+  facet normal -0.166696 -0.986008 0
+    outer loop
+      vertex 4.0465 27.4028 0
+      vertex 5.19046 27.2094 60
+      vertex 4.0465 27.4028 60
+    endloop
+  endfacet
+  facet normal -0.166696 -0.986008 -0
+    outer loop
+      vertex 5.19046 27.2094 60
+      vertex 4.0465 27.4028 0
+      vertex 5.19046 27.2094 0
+    endloop
+  endfacet
+  facet normal 0.368119 0.929779 -0
+    outer loop
+      vertex -9.65545 -25.9627 0
+      vertex -10.7342 -25.5356 60
+      vertex -9.65545 -25.9627 60
+    endloop
+  endfacet
+  facet normal 0.368119 0.929779 0
+    outer loop
+      vertex -10.7342 -25.5356 60
+      vertex -9.65545 -25.9627 0
+      vertex -10.7342 -25.5356 0
+    endloop
+  endfacet
+  facet normal 0.998029 0.0627475 0
+    outer loop
+      vertex -27.6029 -2.31788 60
+      vertex -27.6757 -1.15996 0
+      vertex -27.6757 -1.15996 60
+    endloop
+  endfacet
+  facet normal 0.998029 0.0627475 0
+    outer loop
+      vertex -27.6757 -1.15996 0
+      vertex -27.6029 -2.31788 60
+      vertex -27.6029 -2.31788 0
+    endloop
+  endfacet
+  facet normal -0.821195 0.570648 0
+    outer loop
+      vertex 22.4098 -16.2817 0
+      vertex 23.0719 -15.3289 60
+      vertex 23.0719 -15.3289 0
+    endloop
+  endfacet
+  facet normal -0.821195 0.570648 0
+    outer loop
+      vertex 23.0719 -15.3289 60
+      vertex 22.4098 -16.2817 0
+      vertex 22.4098 -16.2817 60
+    endloop
+  endfacet
+  facet normal -0.951063 -0.308997 0
+    outer loop
+      vertex 26.5177 8.00618 0
+      vertex 26.1592 9.10961 60
+      vertex 26.1592 9.10961 0
+    endloop
+  endfacet
+  facet normal -0.951063 -0.308997 0
+    outer loop
+      vertex 26.1592 9.10961 60
+      vertex 26.5177 8.00618 0
+      vertex 26.5177 8.00618 60
+    endloop
+  endfacet
+  facet normal 0.125407 0.992105 -0
+    outer loop
+      vertex -2.89544 -27.5483 0
+      vertex -4.0465 -27.4028 60
+      vertex -2.89544 -27.5483 60
+    endloop
+  endfacet
+  facet normal 0.125407 0.992105 0
+    outer loop
+      vertex -4.0465 -27.4028 60
+      vertex -2.89544 -27.5483 0
+      vertex -4.0465 -27.4028 0
+    endloop
+  endfacet
+  facet normal -0.844317 -0.535843 0
+    outer loop
+      vertex 23.6936 14.3493 0
+      vertex 23.0719 15.3289 60
+      vertex 23.0719 15.3289 0
+    endloop
+  endfacet
+  facet normal -0.844317 -0.535843 0
+    outer loop
+      vertex 23.0719 15.3289 60
+      vertex 23.6936 14.3493 0
+      vertex 23.6936 14.3493 60
+    endloop
+  endfacet
+  facet normal 0.99452 0.10455 0
+    outer loop
+      vertex -27.4816 -3.47173 60
+      vertex -27.6029 -2.31788 0
+      vertex -27.6029 -2.31788 60
+    endloop
+  endfacet
+  facet normal 0.99452 0.10455 0
+    outer loop
+      vertex -27.6029 -2.31788 0
+      vertex -27.4816 -3.47173 60
+      vertex -27.4816 -3.47173 0
+    endloop
+  endfacet
+  facet normal 0.821195 0.570648 0
+    outer loop
+      vertex -22.4098 -16.2817 60
+      vertex -23.0719 -15.3289 0
+      vertex -23.0719 -15.3289 60
+    endloop
+  endfacet
+  facet normal 0.821195 0.570648 0
+    outer loop
+      vertex -23.0719 -15.3289 0
+      vertex -22.4098 -16.2817 60
+      vertex -22.4098 -16.2817 0
+    endloop
+  endfacet
+  facet normal -0.406738 -0.913545 0
+    outer loop
+      vertex 10.7342 25.5356 0
+      vertex 11.7941 25.0637 60
+      vertex 10.7342 25.5356 60
+    endloop
+  endfacet
+  facet normal -0.406738 -0.913545 -0
+    outer loop
+      vertex 11.7941 25.0637 60
+      vertex 10.7342 25.5356 0
+      vertex 11.7941 25.0637 0
+    endloop
+  endfacet
+  facet normal -0.998029 0.0627475 0
+    outer loop
+      vertex 27.6029 -2.31788 0
+      vertex 27.6757 -1.15996 60
+      vertex 27.6757 -1.15996 0
+    endloop
+  endfacet
+  facet normal -0.998029 0.0627475 0
+    outer loop
+      vertex 27.6757 -1.15996 60
+      vertex 27.6029 -2.31788 0
+      vertex 27.6029 -2.31788 60
+    endloop
+  endfacet
+  facet normal -0.68452 0.728994 0
+    outer loop
+      vertex 19.3807 -19.7909 0
+      vertex 18.5349 -20.5851 60
+      vertex 19.3807 -19.7909 60
+    endloop
+  endfacet
+  facet normal -0.68452 0.728994 0
+    outer loop
+      vertex 18.5349 -20.5851 60
+      vertex 19.3807 -19.7909 0
+      vertex 18.5349 -20.5851 0
+    endloop
+  endfacet
+  facet normal 0.770548 -0.637382 0
+    outer loop
+      vertex -21.7083 17.2058 60
+      vertex -20.9688 18.0998 0
+      vertex -20.9688 18.0998 60
+    endloop
+  endfacet
+  facet normal 0.770548 -0.637382 0
+    outer loop
+      vertex -20.9688 18.0998 0
+      vertex -21.7083 17.2058 60
+      vertex -21.7083 17.2058 0
+    endloop
+  endfacet
+  facet normal -0.125407 0.992105 0
+    outer loop
+      vertex 4.0465 -27.4028 0
+      vertex 2.89544 -27.5483 60
+      vertex 4.0465 -27.4028 60
+    endloop
+  endfacet
+  facet normal -0.125407 0.992105 0
+    outer loop
+      vertex 2.89544 -27.5483 60
+      vertex 4.0465 -27.4028 0
+      vertex 2.89544 -27.5483 0
+    endloop
+  endfacet
+  facet normal -0.3289 -0.944365 0
+    outer loop
+      vertex 8.55977 26.3443 0
+      vertex 9.65545 25.9627 60
+      vertex 8.55977 26.3443 60
+    endloop
+  endfacet
+  facet normal -0.3289 -0.944365 -0
+    outer loop
+      vertex 9.65545 25.9627 60
+      vertex 8.55977 26.3443 0
+      vertex 9.65545 25.9627 0
+    endloop
+  endfacet
+  facet normal 0.444661 -0.895699 0
+    outer loop
+      vertex -12.8333 24.5478 0
+      vertex -11.7941 25.0637 60
+      vertex -12.8333 24.5478 60
+    endloop
+  endfacet
+  facet normal 0.444661 -0.895699 0
+    outer loop
+      vertex -11.7941 25.0637 60
+      vertex -12.8333 24.5478 0
+      vertex -11.7941 25.0637 0
+    endloop
+  endfacet
+  facet normal -0.518015 -0.855371 0
+    outer loop
+      vertex 13.85 23.9889 0
+      vertex 14.8424 23.3879 60
+      vertex 13.85 23.9889 60
+    endloop
+  endfacet
+  facet normal -0.518015 -0.855371 -0
+    outer loop
+      vertex 14.8424 23.3879 60
+      vertex 13.85 23.9889 0
+      vertex 14.8424 23.3879 0
+    endloop
+  endfacet
+  facet normal 0.48173 -0.87632 0
+    outer loop
+      vertex -13.85 23.9889 0
+      vertex -12.8333 24.5478 60
+      vertex -13.85 23.9889 60
+    endloop
+  endfacet
+  facet normal 0.48173 -0.87632 0
+    outer loop
+      vertex -12.8333 24.5478 60
+      vertex -13.85 23.9889 0
+      vertex -12.8333 24.5478 0
+    endloop
+  endfacet
+  facet normal -0.963141 0.268997 0
+    outer loop
+      vertex 26.5177 -8.00618 0
+      vertex 26.8298 -6.88871 60
+      vertex 26.8298 -6.88871 0
+    endloop
+  endfacet
+  facet normal -0.963141 0.268997 0
+    outer loop
+      vertex 26.8298 -6.88871 60
+      vertex 26.5177 -8.00618 0
+      vertex 26.5177 -8.00618 60
+    endloop
+  endfacet
+  facet normal 0.518015 0.855371 -0
+    outer loop
+      vertex -13.85 -23.9889 0
+      vertex -14.8424 -23.3879 60
+      vertex -13.85 -23.9889 60
+    endloop
+  endfacet
+  facet normal 0.518015 0.855371 0
+    outer loop
+      vertex -14.8424 -23.3879 60
+      vertex -13.85 -23.9889 0
+      vertex -14.8424 -23.3879 0
+    endloop
+  endfacet
+  facet normal -0.866012 -0.500023 0
+    outer loop
+      vertex 24.2737 13.3446 0
+      vertex 23.6936 14.3493 60
+      vertex 23.6936 14.3493 0
+    endloop
+  endfacet
+  facet normal -0.866012 -0.500023 0
+    outer loop
+      vertex 23.6936 14.3493 60
+      vertex 24.2737 13.3446 0
+      vertex 24.2737 13.3446 60
+    endloop
+  endfacet
+  facet normal 0.866012 -0.500023 0
+    outer loop
+      vertex -24.2737 13.3446 60
+      vertex -23.6936 14.3493 0
+      vertex -23.6936 14.3493 60
+    endloop
+  endfacet
+  facet normal 0.866012 -0.500023 0
+    outer loop
+      vertex -23.6936 14.3493 0
+      vertex -24.2737 13.3446 60
+      vertex -24.2737 13.3446 0
+    endloop
+  endfacet
+  facet normal -0.714481 -0.699655 0
+    outer loop
+      vertex 20.1924 18.962 0
+      vertex 19.3807 19.7909 60
+      vertex 19.3807 19.7909 0
+    endloop
+  endfacet
+  facet normal -0.714481 -0.699655 0
+    outer loop
+      vertex 19.3807 19.7909 60
+      vertex 20.1924 18.962 0
+      vertex 20.1924 18.962 60
+    endloop
+  endfacet
+  facet normal -0.207976 -0.978134 0
+    outer loop
+      vertex 5.19046 27.2094 0
+      vertex 6.32532 26.9681 60
+      vertex 5.19046 27.2094 60
+    endloop
+  endfacet
+  facet normal -0.207976 -0.978134 -0
+    outer loop
+      vertex 6.32532 26.9681 60
+      vertex 5.19046 27.2094 0
+      vertex 6.32532 26.9681 0
+    endloop
+  endfacet
+  facet normal -0.0418888 -0.999122 0
+    outer loop
+      vertex 0.580105 27.6939 0
+      vertex 1.7393 27.6453 60
+      vertex 0.580105 27.6939 60
+    endloop
+  endfacet
+  facet normal -0.0418888 -0.999122 -0
+    outer loop
+      vertex 1.7393 27.6453 60
+      vertex 0.580105 27.6939 0
+      vertex 1.7393 27.6453 0
+    endloop
+  endfacet
+  facet normal -0.3289 0.944365 0
+    outer loop
+      vertex 9.65545 -25.9627 0
+      vertex 8.55977 -26.3443 60
+      vertex 9.65545 -25.9627 60
+    endloop
+  endfacet
+  facet normal -0.3289 0.944365 0
+    outer loop
+      vertex 8.55977 -26.3443 60
+      vertex 9.65545 -25.9627 0
+      vertex 8.55977 -26.3443 0
+    endloop
+  endfacet
+  facet normal 0.844317 -0.535843 0
+    outer loop
+      vertex -23.6936 14.3493 60
+      vertex -23.0719 15.3289 0
+      vertex -23.0719 15.3289 60
+    endloop
+  endfacet
+  facet normal 0.844317 -0.535843 0
+    outer loop
+      vertex -23.0719 15.3289 0
+      vertex -23.6936 14.3493 60
+      vertex -23.6936 14.3493 0
+    endloop
+  endfacet
+  facet normal -0.999781 0.0209444 0
+    outer loop
+      vertex 27.6757 -1.15996 0
+      vertex 27.7 0 60
+      vertex 27.7 0 0
+    endloop
+  endfacet
+  facet normal -0.999781 0.0209444 0
+    outer loop
+      vertex 27.7 0 60
+      vertex 27.6757 -1.15996 0
+      vertex 27.6757 -1.15996 60
+    endloop
+  endfacet
+  facet normal 0.518015 -0.855371 0
+    outer loop
+      vertex -14.8424 23.3879 0
+      vertex -13.85 23.9889 60
+      vertex -14.8424 23.3879 60
+    endloop
+  endfacet
+  facet normal 0.518015 -0.855371 0
+    outer loop
+      vertex -13.85 23.9889 60
+      vertex -14.8424 23.3879 0
+      vertex -13.85 23.9889 0
+    endloop
+  endfacet
+  facet normal 0.796501 0.604637 0
+    outer loop
+      vertex -21.7083 -17.2058 60
+      vertex -22.4098 -16.2817 0
+      vertex -22.4098 -16.2817 60
+    endloop
+  endfacet
+  facet normal 0.796501 0.604637 0
+    outer loop
+      vertex -22.4098 -16.2817 0
+      vertex -21.7083 -17.2058 60
+      vertex -21.7083 -17.2058 0
+    endloop
+  endfacet
+  facet normal -0.368119 -0.929779 0
+    outer loop
+      vertex 9.65545 25.9627 0
+      vertex 10.7342 25.5356 60
+      vertex 9.65545 25.9627 60
+    endloop
+  endfacet
+  facet normal -0.368119 -0.929779 -0
+    outer loop
+      vertex 10.7342 25.5356 60
+      vertex 9.65545 25.9627 0
+      vertex 10.7342 25.5356 0
+    endloop
+  endfacet
+  facet normal -0.48173 0.87632 0
+    outer loop
+      vertex 13.85 -23.9889 0
+      vertex 12.8333 -24.5478 60
+      vertex 13.85 -23.9889 60
+    endloop
+  endfacet
+  facet normal -0.48173 0.87632 0
+    outer loop
+      vertex 12.8333 -24.5478 60
+      vertex 13.85 -23.9889 0
+      vertex 12.8333 -24.5478 0
+    endloop
+  endfacet
+  facet normal -0.653407 0.757007 0
+    outer loop
+      vertex 18.5349 -20.5851 0
+      vertex 17.6566 -21.3432 60
+      vertex 18.5349 -20.5851 60
+    endloop
+  endfacet
+  facet normal -0.653407 0.757007 0
+    outer loop
+      vertex 17.6566 -21.3432 60
+      vertex 18.5349 -20.5851 0
+      vertex 17.6566 -21.3432 0
+    endloop
+  endfacet
+  facet normal 0.973586 0.228322 0
+    outer loop
+      vertex -26.8298 -6.88871 60
+      vertex -27.0947 -5.75915 0
+      vertex -27.0947 -5.75915 60
+    endloop
+  endfacet
+  facet normal 0.973586 0.228322 0
+    outer loop
+      vertex -27.0947 -5.75915 0
+      vertex -26.8298 -6.88871 60
+      vertex -26.8298 -6.88871 0
+    endloop
+  endfacet
+  facet normal 0.289003 0.957328 -0
+    outer loop
+      vertex -7.44908 -26.6796 0
+      vertex -8.55977 -26.3443 60
+      vertex -7.44908 -26.6796 60
+    endloop
+  endfacet
+  facet normal 0.289003 0.957328 0
+    outer loop
+      vertex -8.55977 -26.3443 60
+      vertex -7.44908 -26.6796 0
+      vertex -8.55977 -26.3443 0
+    endloop
+  endfacet
+  facet normal -0.444661 -0.895699 0
+    outer loop
+      vertex 11.7941 25.0637 0
+      vertex 12.8333 24.5478 60
+      vertex 11.7941 25.0637 60
+    endloop
+  endfacet
+  facet normal -0.444661 -0.895699 -0
+    outer loop
+      vertex 12.8333 24.5478 60
+      vertex 11.7941 25.0637 0
+      vertex 12.8333 24.5478 0
+    endloop
+  endfacet
+  facet normal -0.289003 0.957328 0
+    outer loop
+      vertex 8.55977 -26.3443 0
+      vertex 7.44908 -26.6796 60
+      vertex 8.55977 -26.3443 60
+    endloop
+  endfacet
+  facet normal -0.289003 0.957328 0
+    outer loop
+      vertex 7.44908 -26.6796 60
+      vertex 8.55977 -26.3443 0
+      vertex 7.44908 -26.6796 0
+    endloop
+  endfacet
+  facet normal -0.0418888 0.999122 0
+    outer loop
+      vertex 1.7393 -27.6453 0
+      vertex 0.580105 -27.6939 60
+      vertex 1.7393 -27.6453 60
+    endloop
+  endfacet
+  facet normal -0.0418888 0.999122 0
+    outer loop
+      vertex 0.580105 -27.6939 60
+      vertex 1.7393 -27.6453 0
+      vertex 0.580105 -27.6939 0
+    endloop
+  endfacet
+  facet normal -0.166696 0.986008 0
+    outer loop
+      vertex 5.19046 -27.2094 0
+      vertex 4.0465 -27.4028 60
+      vertex 5.19046 -27.2094 60
+    endloop
+  endfacet
+  facet normal -0.166696 0.986008 0
+    outer loop
+      vertex 4.0465 -27.4028 60
+      vertex 5.19046 -27.2094 0
+      vertex 4.0465 -27.4028 0
+    endloop
+  endfacet
+  facet normal -0.989271 -0.146094 0
+    outer loop
+      vertex 27.4816 3.47173 0
+      vertex 27.3121 4.61949 60
+      vertex 27.3121 4.61949 0
+    endloop
+  endfacet
+  facet normal -0.989271 -0.146094 0
+    outer loop
+      vertex 27.3121 4.61949 60
+      vertex 27.4816 3.47173 0
+      vertex 27.4816 3.47173 60
+    endloop
+  endfacet
+  facet normal 0.621189 0.783661 -0
+    outer loop
+      vertex -16.7474 -22.0639 0
+      vertex -17.6566 -21.3432 60
+      vertex -16.7474 -22.0639 60
+    endloop
+  endfacet
+  facet normal 0.621189 0.783661 0
+    outer loop
+      vertex -17.6566 -21.3432 60
+      vertex -16.7474 -22.0639 0
+      vertex -17.6566 -21.3432 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 0.580105 -27.6939 0
+      vertex -0.580105 -27.6939 60
+      vertex 0.580105 -27.6939 60
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.580105 -27.6939 60
+      vertex 0.580105 -27.6939 0
+      vertex -0.580105 -27.6939 0
+    endloop
+  endfacet
+  facet normal 0.621189 -0.783661 0
+    outer loop
+      vertex -17.6566 21.3432 0
+      vertex -16.7474 22.0639 60
+      vertex -17.6566 21.3432 60
+    endloop
+  endfacet
+  facet normal 0.621189 -0.783661 0
+    outer loop
+      vertex -16.7474 22.0639 60
+      vertex -17.6566 21.3432 0
+      vertex -16.7474 22.0639 0
+    endloop
+  endfacet
+  facet normal -0.886214 -0.463276 0
+    outer loop
+      vertex 24.8112 12.3164 0
+      vertex 24.2737 13.3446 60
+      vertex 24.2737 13.3446 0
+    endloop
+  endfacet
+  facet normal -0.886214 -0.463276 0
+    outer loop
+      vertex 24.2737 13.3446 60
+      vertex 24.8112 12.3164 0
+      vertex 24.8112 12.3164 60
+    endloop
+  endfacet
+  facet normal -0.770548 0.637382 0
+    outer loop
+      vertex 20.9688 -18.0998 0
+      vertex 21.7083 -17.2058 60
+      vertex 21.7083 -17.2058 0
+    endloop
+  endfacet
+  facet normal -0.770548 0.637382 0
+    outer loop
+      vertex 21.7083 -17.2058 60
+      vertex 20.9688 -18.0998 0
+      vertex 20.9688 -18.0998 60
+    endloop
+  endfacet
+  facet normal 0.0418888 0.999122 -0
+    outer loop
+      vertex -0.580105 -27.6939 0
+      vertex -1.7393 -27.6453 60
+      vertex -0.580105 -27.6939 60
+    endloop
+  endfacet
+  facet normal 0.0418888 0.999122 0
+    outer loop
+      vertex -1.7393 -27.6453 60
+      vertex -0.580105 -27.6939 0
+      vertex -1.7393 -27.6453 0
+    endloop
+  endfacet
+  facet normal -0.621189 -0.783661 0
+    outer loop
+      vertex 16.7474 22.0639 0
+      vertex 17.6566 21.3432 60
+      vertex 16.7474 22.0639 60
+    endloop
+  endfacet
+  facet normal -0.621189 -0.783661 -0
+    outer loop
+      vertex 17.6566 21.3432 60
+      vertex 16.7474 22.0639 0
+      vertex 17.6566 21.3432 0
+    endloop
+  endfacet
+  facet normal -0.904827 -0.42578 0
+    outer loop
+      vertex 25.3052 11.2666 0
+      vertex 24.8112 12.3164 60
+      vertex 24.8112 12.3164 0
+    endloop
+  endfacet
+  facet normal -0.904827 -0.42578 0
+    outer loop
+      vertex 24.8112 12.3164 60
+      vertex 25.3052 11.2666 0
+      vertex 25.3052 11.2666 60
+    endloop
+  endfacet
+  facet normal -0.770548 -0.637382 0
+    outer loop
+      vertex 21.7083 17.2058 0
+      vertex 20.9688 18.0998 60
+      vertex 20.9688 18.0998 0
+    endloop
+  endfacet
+  facet normal -0.770548 -0.637382 0
+    outer loop
+      vertex 20.9688 18.0998 60
+      vertex 21.7083 17.2058 0
+      vertex 21.7083 17.2058 60
+    endloop
+  endfacet
+  facet normal -0.982288 -0.18738 0
+    outer loop
+      vertex 27.3121 4.61949 0
+      vertex 27.0947 5.75915 60
+      vertex 27.0947 5.75915 0
+    endloop
+  endfacet
+  facet normal -0.982288 -0.18738 0
+    outer loop
+      vertex 27.0947 5.75915 60
+      vertex 27.3121 4.61949 0
+      vertex 27.3121 4.61949 60
+    endloop
+  endfacet
+  facet normal -0.973586 -0.228322 0
+    outer loop
+      vertex 27.0947 5.75915 0
+      vertex 26.8298 6.88871 60
+      vertex 26.8298 6.88871 0
+    endloop
+  endfacet
+  facet normal -0.973586 -0.228322 0
+    outer loop
+      vertex 26.8298 6.88871 60
+      vertex 27.0947 5.75915 0
+      vertex 27.0947 5.75915 60
+    endloop
+  endfacet
+  facet normal -0.587767 -0.80903 0
+    outer loop
+      vertex 15.8088 22.7458 0
+      vertex 16.7474 22.0639 60
+      vertex 15.8088 22.7458 60
+    endloop
+  endfacet
+  facet normal -0.587767 -0.80903 -0
+    outer loop
+      vertex 16.7474 22.0639 60
+      vertex 15.8088 22.7458 0
+      vertex 16.7474 22.0639 0
+    endloop
+  endfacet
+  facet normal -0.973586 0.228322 0
+    outer loop
+      vertex 26.8298 -6.88871 0
+      vertex 27.0947 -5.75915 60
+      vertex 27.0947 -5.75915 0
+    endloop
+  endfacet
+  facet normal -0.973586 0.228322 0
+    outer loop
+      vertex 27.0947 -5.75915 60
+      vertex 26.8298 -6.88871 0
+      vertex 26.8298 -6.88871 60
+    endloop
+  endfacet
+  facet normal -0.866012 0.500023 0
+    outer loop
+      vertex 23.6936 -14.3493 0
+      vertex 24.2737 -13.3446 60
+      vertex 24.2737 -13.3446 0
+    endloop
+  endfacet
+  facet normal -0.866012 0.500023 0
+    outer loop
+      vertex 24.2737 -13.3446 60
+      vertex 23.6936 -14.3493 0
+      vertex 23.6936 -14.3493 60
+    endloop
+  endfacet
+  facet normal -0.553407 -0.832911 0
+    outer loop
+      vertex 14.8424 23.3879 0
+      vertex 15.8088 22.7458 60
+      vertex 14.8424 23.3879 60
+    endloop
+  endfacet
+  facet normal -0.553407 -0.832911 -0
+    outer loop
+      vertex 15.8088 22.7458 60
+      vertex 14.8424 23.3879 0
+      vertex 15.8088 22.7458 0
+    endloop
+  endfacet
+  facet normal -0.743114 0.669165 0
+    outer loop
+      vertex 20.1924 -18.962 0
+      vertex 20.9688 -18.0998 60
+      vertex 20.9688 -18.0998 0
+    endloop
+  endfacet
+  facet normal -0.743114 0.669165 0
+    outer loop
+      vertex 20.9688 -18.0998 60
+      vertex 20.1924 -18.962 0
+      vertex 20.1924 -18.962 60
+    endloop
+  endfacet
+  facet normal -0.99452 0.10455 0
+    outer loop
+      vertex 27.4816 -3.47173 0
+      vertex 27.6029 -2.31788 60
+      vertex 27.6029 -2.31788 0
+    endloop
+  endfacet
+  facet normal -0.99452 0.10455 0
+    outer loop
+      vertex 27.6029 -2.31788 60
+      vertex 27.4816 -3.47173 0
+      vertex 27.4816 -3.47173 60
+    endloop
+  endfacet
+  facet normal -0.406738 0.913545 0
+    outer loop
+      vertex 11.7941 -25.0637 0
+      vertex 10.7342 -25.5356 60
+      vertex 11.7941 -25.0637 60
+    endloop
+  endfacet
+  facet normal -0.406738 0.913545 0
+    outer loop
+      vertex 10.7342 -25.5356 60
+      vertex 11.7941 -25.0637 0
+      vertex 10.7342 -25.5356 0
+    endloop
+  endfacet
+  facet normal 0.998029 -0.0627475 0
+    outer loop
+      vertex -27.6757 1.15996 60
+      vertex -27.6029 2.31788 0
+      vertex -27.6029 2.31788 60
+    endloop
+  endfacet
+  facet normal 0.998029 -0.0627475 0
+    outer loop
+      vertex -27.6029 2.31788 0
+      vertex -27.6757 1.15996 60
+      vertex -27.6757 1.15996 0
+    endloop
+  endfacet
+  facet normal -0.989271 0.146094 0
+    outer loop
+      vertex 27.3121 -4.61949 0
+      vertex 27.4816 -3.47173 60
+      vertex 27.4816 -3.47173 0
+    endloop
+  endfacet
+  facet normal -0.989271 0.146094 0
+    outer loop
+      vertex 27.4816 -3.47173 60
+      vertex 27.3121 -4.61949 0
+      vertex 27.3121 -4.61949 60
+    endloop
+  endfacet
+  facet normal 0.0836061 -0.996499 0
+    outer loop
+      vertex -2.89544 27.5483 0
+      vertex -1.7393 27.6453 60
+      vertex -2.89544 27.5483 60
+    endloop
+  endfacet
+  facet normal 0.0836061 -0.996499 0
+    outer loop
+      vertex -1.7393 27.6453 60
+      vertex -2.89544 27.5483 0
+      vertex -1.7393 27.6453 0
+    endloop
+  endfacet
+  facet normal 0.963141 -0.268997 0
+    outer loop
+      vertex -26.8298 6.88871 60
+      vertex -26.5177 8.00618 0
+      vertex -26.5177 8.00618 60
+    endloop
+  endfacet
+  facet normal 0.963141 -0.268997 0
+    outer loop
+      vertex -26.5177 8.00618 0
+      vertex -26.8298 6.88871 60
+      vertex -26.8298 6.88871 0
+    endloop
+  endfacet
+  facet normal 0.444661 0.895699 -0
+    outer loop
+      vertex -11.7941 -25.0637 0
+      vertex -12.8333 -24.5478 60
+      vertex -11.7941 -25.0637 60
+    endloop
+  endfacet
+  facet normal 0.444661 0.895699 0
+    outer loop
+      vertex -12.8333 -24.5478 60
+      vertex -11.7941 -25.0637 0
+      vertex -12.8333 -24.5478 0
+    endloop
+  endfacet
+  facet normal -0.68452 -0.728994 0
+    outer loop
+      vertex 18.5349 20.5851 0
+      vertex 19.3807 19.7909 60
+      vertex 18.5349 20.5851 60
+    endloop
+  endfacet
+  facet normal -0.68452 -0.728994 -0
+    outer loop
+      vertex 19.3807 19.7909 60
+      vertex 18.5349 20.5851 0
+      vertex 19.3807 19.7909 0
+    endloop
+  endfacet
+  facet normal 0.289003 -0.957328 0
+    outer loop
+      vertex -8.55977 26.3443 0
+      vertex -7.44908 26.6796 60
+      vertex -8.55977 26.3443 60
+    endloop
+  endfacet
+  facet normal 0.289003 -0.957328 0
+    outer loop
+      vertex -7.44908 26.6796 60
+      vertex -8.55977 26.3443 0
+      vertex -7.44908 26.6796 0
+    endloop
+  endfacet
+  facet normal 0.166696 -0.986008 0
+    outer loop
+      vertex -5.19046 27.2094 0
+      vertex -4.0465 27.4028 60
+      vertex -5.19046 27.2094 60
+    endloop
+  endfacet
+  facet normal 0.166696 -0.986008 0
+    outer loop
+      vertex -4.0465 27.4028 60
+      vertex -5.19046 27.2094 0
+      vertex -4.0465 27.4028 0
+    endloop
+  endfacet
+  facet normal -0.248664 0.96859 0
+    outer loop
+      vertex 7.44908 -26.6796 0
+      vertex 6.32532 -26.9681 60
+      vertex 7.44908 -26.6796 60
+    endloop
+  endfacet
+  facet normal -0.248664 0.96859 0
+    outer loop
+      vertex 6.32532 -26.9681 60
+      vertex 7.44908 -26.6796 0
+      vertex 6.32532 -26.9681 0
+    endloop
+  endfacet
+  facet normal 0.68452 -0.728994 0
+    outer loop
+      vertex -19.3807 19.7909 0
+      vertex -18.5349 20.5851 60
+      vertex -19.3807 19.7909 60
+    endloop
+  endfacet
+  facet normal 0.68452 -0.728994 0
+    outer loop
+      vertex -18.5349 20.5851 60
+      vertex -19.3807 19.7909 0
+      vertex -18.5349 20.5851 0
+    endloop
+  endfacet
+  facet normal 0.0418888 -0.999122 0
+    outer loop
+      vertex -1.7393 27.6453 0
+      vertex -0.580105 27.6939 60
+      vertex -1.7393 27.6453 60
+    endloop
+  endfacet
+  facet normal 0.0418888 -0.999122 0
+    outer loop
+      vertex -0.580105 27.6939 60
+      vertex -1.7393 27.6453 0
+      vertex -0.580105 27.6939 0
+    endloop
+  endfacet
+  facet normal 0.125407 -0.992105 0
+    outer loop
+      vertex -4.0465 27.4028 0
+      vertex -2.89544 27.5483 60
+      vertex -4.0465 27.4028 60
+    endloop
+  endfacet
+  facet normal 0.125407 -0.992105 0
+    outer loop
+      vertex -2.89544 27.5483 60
+      vertex -4.0465 27.4028 0
+      vertex -2.89544 27.5483 0
+    endloop
+  endfacet
+  facet normal -0.587767 0.80903 0
+    outer loop
+      vertex 16.7474 -22.0639 0
+      vertex 15.8088 -22.7458 60
+      vertex 16.7474 -22.0639 60
+    endloop
+  endfacet
+  facet normal -0.587767 0.80903 0
+    outer loop
+      vertex 15.8088 -22.7458 60
+      vertex 16.7474 -22.0639 0
+      vertex 15.8088 -22.7458 0
+    endloop
+  endfacet
+  facet normal 0.973586 -0.228322 0
+    outer loop
+      vertex -27.0947 5.75915 60
+      vertex -26.8298 6.88871 0
+      vertex -26.8298 6.88871 60
+    endloop
+  endfacet
+  facet normal 0.973586 -0.228322 0
+    outer loop
+      vertex -26.8298 6.88871 0
+      vertex -27.0947 5.75915 60
+      vertex -27.0947 5.75915 0
+    endloop
+  endfacet
+  facet normal 0.921856 0.387533 0
+    outer loop
+      vertex -25.3052 -11.2666 60
+      vertex -25.7548 -10.1971 0
+      vertex -25.7548 -10.1971 60
+    endloop
+  endfacet
+  facet normal 0.921856 0.387533 0
+    outer loop
+      vertex -25.7548 -10.1971 0
+      vertex -25.3052 -11.2666 60
+      vertex -25.3052 -11.2666 0
+    endloop
+  endfacet
+  facet normal 0.937292 0.348546 0
+    outer loop
+      vertex -25.7548 -10.1971 60
+      vertex -26.1592 -9.10961 0
+      vertex -26.1592 -9.10961 60
+    endloop
+  endfacet
+  facet normal 0.937292 0.348546 0
+    outer loop
+      vertex -26.1592 -9.10961 0
+      vertex -25.7548 -10.1971 60
+      vertex -25.7548 -10.1971 0
+    endloop
+  endfacet
+  facet normal 0.989271 0.146094 0
+    outer loop
+      vertex -27.3121 -4.61949 60
+      vertex -27.4816 -3.47173 0
+      vertex -27.4816 -3.47173 60
+    endloop
+  endfacet
+  facet normal 0.989271 0.146094 0
+    outer loop
+      vertex -27.4816 -3.47173 0
+      vertex -27.3121 -4.61949 60
+      vertex -27.3121 -4.61949 0
+    endloop
+  endfacet
+  facet normal 0.982288 0.18738 0
+    outer loop
+      vertex -27.0947 -5.75915 60
+      vertex -27.3121 -4.61949 0
+      vertex -27.3121 -4.61949 60
+    endloop
+  endfacet
+  facet normal 0.982288 0.18738 0
+    outer loop
+      vertex -27.3121 -4.61949 0
+      vertex -27.0947 -5.75915 60
+      vertex -27.0947 -5.75915 0
+    endloop
+  endfacet
+  facet normal 0.937292 -0.348546 0
+    outer loop
+      vertex -26.1592 9.10961 60
+      vertex -25.7548 10.1971 0
+      vertex -25.7548 10.1971 60
+    endloop
+  endfacet
+  facet normal 0.937292 -0.348546 0
+    outer loop
+      vertex -25.7548 10.1971 0
+      vertex -26.1592 9.10961 60
+      vertex -26.1592 9.10961 0
+    endloop
+  endfacet
+  facet normal 0.553407 -0.832911 0
+    outer loop
+      vertex -15.8088 22.7458 0
+      vertex -14.8424 23.3879 60
+      vertex -15.8088 22.7458 60
+    endloop
+  endfacet
+  facet normal 0.553407 -0.832911 0
+    outer loop
+      vertex -14.8424 23.3879 60
+      vertex -15.8088 22.7458 0
+      vertex -14.8424 23.3879 0
+    endloop
+  endfacet
+  facet normal -0.248664 -0.96859 0
+    outer loop
+      vertex 6.32532 26.9681 0
+      vertex 7.44908 26.6796 60
+      vertex 6.32532 26.9681 60
+    endloop
+  endfacet
+  facet normal -0.248664 -0.96859 -0
+    outer loop
+      vertex 7.44908 26.6796 60
+      vertex 6.32532 26.9681 0
+      vertex 7.44908 26.6796 0
+    endloop
+  endfacet
+  facet normal 0.886214 -0.463276 0
+    outer loop
+      vertex -24.8112 12.3164 60
+      vertex -24.2737 13.3446 0
+      vertex -24.2737 13.3446 60
+    endloop
+  endfacet
+  facet normal 0.886214 -0.463276 0
+    outer loop
+      vertex -24.2737 13.3446 0
+      vertex -24.8112 12.3164 60
+      vertex -24.8112 12.3164 0
+    endloop
+  endfacet
+  facet normal -0.921856 -0.387533 0
+    outer loop
+      vertex 25.7548 10.1971 0
+      vertex 25.3052 11.2666 60
+      vertex 25.3052 11.2666 0
+    endloop
+  endfacet
+  facet normal -0.921856 -0.387533 0
+    outer loop
+      vertex 25.3052 11.2666 60
+      vertex 25.7548 10.1971 0
+      vertex 25.7548 10.1971 60
+    endloop
+  endfacet
+  facet normal 0.99452 -0.10455 0
+    outer loop
+      vertex -27.6029 2.31788 60
+      vertex -27.4816 3.47173 0
+      vertex -27.4816 3.47173 60
+    endloop
+  endfacet
+  facet normal 0.99452 -0.10455 0
+    outer loop
+      vertex -27.4816 3.47173 0
+      vertex -27.6029 2.31788 60
+      vertex -27.6029 2.31788 0
+    endloop
+  endfacet
+  facet normal 0.770548 0.637382 0
+    outer loop
+      vertex -20.9688 -18.0998 60
+      vertex -21.7083 -17.2058 0
+      vertex -21.7083 -17.2058 60
+    endloop
+  endfacet
+  facet normal 0.770548 0.637382 0
+    outer loop
+      vertex -21.7083 -17.2058 0
+      vertex -20.9688 -18.0998 60
+      vertex -20.9688 -18.0998 0
+    endloop
+  endfacet
+  facet normal 0.951063 -0.308997 0
+    outer loop
+      vertex -26.5177 8.00618 60
+      vertex -26.1592 9.10961 0
+      vertex -26.1592 9.10961 60
+    endloop
+  endfacet
+  facet normal 0.951063 -0.308997 0
+    outer loop
+      vertex -26.1592 9.10961 0
+      vertex -26.5177 8.00618 60
+      vertex -26.5177 8.00618 0
+    endloop
+  endfacet
+  facet normal 0.999781 -0.0209444 0
+    outer loop
+      vertex -27.7 0 60
+      vertex -27.6757 1.15996 0
+      vertex -27.6757 1.15996 60
+    endloop
+  endfacet
+  facet normal 0.999781 -0.0209444 0
+    outer loop
+      vertex -27.6757 1.15996 0
+      vertex -27.7 0 60
+      vertex -27.7 0 0
+    endloop
+  endfacet
+  facet normal -0.289003 -0.957328 0
+    outer loop
+      vertex 7.44908 26.6796 0
+      vertex 8.55977 26.3443 60
+      vertex 7.44908 26.6796 60
+    endloop
+  endfacet
+  facet normal -0.289003 -0.957328 -0
+    outer loop
+      vertex 8.55977 26.3443 60
+      vertex 7.44908 26.6796 0
+      vertex 8.55977 26.3443 0
+    endloop
+  endfacet
+  facet normal -0.796501 0.604637 0
+    outer loop
+      vertex 21.7083 -17.2058 0
+      vertex 22.4098 -16.2817 60
+      vertex 22.4098 -16.2817 0
+    endloop
+  endfacet
+  facet normal -0.796501 0.604637 0
+    outer loop
+      vertex 22.4098 -16.2817 60
+      vertex 21.7083 -17.2058 0
+      vertex 21.7083 -17.2058 60
+    endloop
+  endfacet
+  facet normal 0.3289 -0.944365 0
+    outer loop
+      vertex -9.65545 25.9627 0
+      vertex -8.55977 26.3443 60
+      vertex -9.65545 25.9627 60
+    endloop
+  endfacet
+  facet normal 0.3289 -0.944365 0
+    outer loop
+      vertex -8.55977 26.3443 60
+      vertex -9.65545 25.9627 0
+      vertex -8.55977 26.3443 0
+    endloop
+  endfacet
+  facet normal -0.444661 0.895699 0
+    outer loop
+      vertex 12.8333 -24.5478 0
+      vertex 11.7941 -25.0637 60
+      vertex 12.8333 -24.5478 60
+    endloop
+  endfacet
+  facet normal -0.444661 0.895699 0
+    outer loop
+      vertex 11.7941 -25.0637 60
+      vertex 12.8333 -24.5478 0
+      vertex 11.7941 -25.0637 0
+    endloop
+  endfacet
+  facet normal -0.951063 0.308997 0
+    outer loop
+      vertex 26.1592 -9.10961 0
+      vertex 26.5177 -8.00618 60
+      vertex 26.5177 -8.00618 0
+    endloop
+  endfacet
+  facet normal -0.951063 0.308997 0
+    outer loop
+      vertex 26.5177 -8.00618 60
+      vertex 26.1592 -9.10961 0
+      vertex 26.1592 -9.10961 60
+    endloop
+  endfacet
+  facet normal -0.886214 0.463276 0
+    outer loop
+      vertex 24.2737 -13.3446 0
+      vertex 24.8112 -12.3164 60
+      vertex 24.8112 -12.3164 0
+    endloop
+  endfacet
+  facet normal -0.886214 0.463276 0
+    outer loop
+      vertex 24.8112 -12.3164 60
+      vertex 24.2737 -13.3446 0
+      vertex 24.2737 -13.3446 60
+    endloop
+  endfacet
+  facet normal -0.796501 -0.604637 0
+    outer loop
+      vertex 22.4098 16.2817 0
+      vertex 21.7083 17.2058 60
+      vertex 21.7083 17.2058 0
+    endloop
+  endfacet
+  facet normal -0.796501 -0.604637 0
+    outer loop
+      vertex 21.7083 17.2058 60
+      vertex 22.4098 16.2817 0
+      vertex 22.4098 16.2817 60
+    endloop
+  endfacet
+  facet normal -0.743114 -0.669165 0
+    outer loop
+      vertex 20.9688 18.0998 0
+      vertex 20.1924 18.962 60
+      vertex 20.1924 18.962 0
+    endloop
+  endfacet
+  facet normal -0.743114 -0.669165 0
+    outer loop
+      vertex 20.1924 18.962 60
+      vertex 20.9688 18.0998 0
+      vertex 20.9688 18.0998 60
+    endloop
+  endfacet
+  facet normal -0.48173 -0.87632 0
+    outer loop
+      vertex 12.8333 24.5478 0
+      vertex 13.85 23.9889 60
+      vertex 12.8333 24.5478 60
+    endloop
+  endfacet
+  facet normal -0.48173 -0.87632 -0
+    outer loop
+      vertex 13.85 23.9889 60
+      vertex 12.8333 24.5478 0
+      vertex 13.85 23.9889 0
+    endloop
+  endfacet
+  facet normal -0.621189 0.783661 0
+    outer loop
+      vertex 17.6566 -21.3432 0
+      vertex 16.7474 -22.0639 60
+      vertex 17.6566 -21.3432 60
+    endloop
+  endfacet
+  facet normal -0.621189 0.783661 0
+    outer loop
+      vertex 16.7474 -22.0639 60
+      vertex 17.6566 -21.3432 0
+      vertex 16.7474 -22.0639 0
+    endloop
+  endfacet
+  facet normal 0.904827 0.42578 0
+    outer loop
+      vertex -24.8112 -12.3164 60
+      vertex -25.3052 -11.2666 0
+      vertex -25.3052 -11.2666 60
+    endloop
+  endfacet
+  facet normal 0.904827 0.42578 0
+    outer loop
+      vertex -25.3052 -11.2666 0
+      vertex -24.8112 -12.3164 60
+      vertex -24.8112 -12.3164 0
+    endloop
+  endfacet
+  facet normal 0.368119 -0.929779 0
+    outer loop
+      vertex -10.7342 25.5356 0
+      vertex -9.65545 25.9627 60
+      vertex -10.7342 25.5356 60
+    endloop
+  endfacet
+  facet normal 0.368119 -0.929779 0
+    outer loop
+      vertex -9.65545 25.9627 60
+      vertex -10.7342 25.5356 0
+      vertex -9.65545 25.9627 0
+    endloop
+  endfacet
+  facet normal 0.207976 -0.978134 0
+    outer loop
+      vertex -6.32532 26.9681 0
+      vertex -5.19046 27.2094 60
+      vertex -6.32532 26.9681 60
+    endloop
+  endfacet
+  facet normal 0.207976 -0.978134 0
+    outer loop
+      vertex -5.19046 27.2094 60
+      vertex -6.32532 26.9681 0
+      vertex -5.19046 27.2094 0
+    endloop
+  endfacet
+  facet normal 0.982288 -0.18738 0
+    outer loop
+      vertex -27.3121 4.61949 60
+      vertex -27.0947 5.75915 0
+      vertex -27.0947 5.75915 60
+    endloop
+  endfacet
+  facet normal 0.982288 -0.18738 0
+    outer loop
+      vertex -27.0947 5.75915 0
+      vertex -27.3121 4.61949 60
+      vertex -27.3121 4.61949 0
+    endloop
+  endfacet
+  facet normal 0.989271 -0.146094 0
+    outer loop
+      vertex -27.4816 3.47173 60
+      vertex -27.3121 4.61949 0
+      vertex -27.3121 4.61949 60
+    endloop
+  endfacet
+  facet normal 0.989271 -0.146094 0
+    outer loop
+      vertex -27.3121 4.61949 0
+      vertex -27.4816 3.47173 60
+      vertex -27.4816 3.47173 0
+    endloop
+  endfacet
+  facet normal 0.714481 -0.699655 0
+    outer loop
+      vertex -20.1924 18.962 60
+      vertex -19.3807 19.7909 0
+      vertex -19.3807 19.7909 60
+    endloop
+  endfacet
+  facet normal 0.714481 -0.699655 0
+    outer loop
+      vertex -19.3807 19.7909 0
+      vertex -20.1924 18.962 60
+      vertex -20.1924 18.962 0
+    endloop
+  endfacet
+  facet normal 0.553407 0.832911 -0
+    outer loop
+      vertex -14.8424 -23.3879 0
+      vertex -15.8088 -22.7458 60
+      vertex -14.8424 -23.3879 60
+    endloop
+  endfacet
+  facet normal 0.553407 0.832911 0
+    outer loop
+      vertex -15.8088 -22.7458 60
+      vertex -14.8424 -23.3879 0
+      vertex -15.8088 -22.7458 0
+    endloop
+  endfacet
+  facet normal -0.937292 0.348546 0
+    outer loop
+      vertex 25.7548 -10.1971 0
+      vertex 26.1592 -9.10961 60
+      vertex 26.1592 -9.10961 0
+    endloop
+  endfacet
+  facet normal -0.937292 0.348546 0
+    outer loop
+      vertex 26.1592 -9.10961 60
+      vertex 25.7548 -10.1971 0
+      vertex 25.7548 -10.1971 60
+    endloop
+  endfacet
+  facet normal 0.3289 0.944365 -0
+    outer loop
+      vertex -8.55977 -26.3443 0
+      vertex -9.65545 -25.9627 60
+      vertex -8.55977 -26.3443 60
+    endloop
+  endfacet
+  facet normal 0.3289 0.944365 0
+    outer loop
+      vertex -9.65545 -25.9627 60
+      vertex -8.55977 -26.3443 0
+      vertex -9.65545 -25.9627 0
+    endloop
+  endfacet
+  facet normal 0.406738 0.913545 -0
+    outer loop
+      vertex -10.7342 -25.5356 0
+      vertex -11.7941 -25.0637 60
+      vertex -10.7342 -25.5356 60
+    endloop
+  endfacet
+  facet normal 0.406738 0.913545 0
+    outer loop
+      vertex -11.7941 -25.0637 60
+      vertex -10.7342 -25.5356 0
+      vertex -11.7941 -25.0637 0
+    endloop
+  endfacet
+  facet normal -0.518015 0.855371 0
+    outer loop
+      vertex 14.8424 -23.3879 0
+      vertex 13.85 -23.9889 60
+      vertex 14.8424 -23.3879 60
+    endloop
+  endfacet
+  facet normal -0.518015 0.855371 0
+    outer loop
+      vertex 13.85 -23.9889 60
+      vertex 14.8424 -23.3879 0
+      vertex 13.85 -23.9889 0
+    endloop
+  endfacet
+  facet normal 0.248664 -0.96859 0
+    outer loop
+      vertex -7.44908 26.6796 0
+      vertex -6.32532 26.9681 60
+      vertex -7.44908 26.6796 60
+    endloop
+  endfacet
+  facet normal 0.248664 -0.96859 0
+    outer loop
+      vertex -6.32532 26.9681 60
+      vertex -7.44908 26.6796 0
+      vertex -6.32532 26.9681 0
+    endloop
+  endfacet
+  facet normal -0.982288 0.18738 0
+    outer loop
+      vertex 27.0947 -5.75915 0
+      vertex 27.3121 -4.61949 60
+      vertex 27.3121 -4.61949 0
+    endloop
+  endfacet
+  facet normal -0.982288 0.18738 0
+    outer loop
+      vertex 27.3121 -4.61949 60
+      vertex 27.0947 -5.75915 0
+      vertex 27.0947 -5.75915 60
+    endloop
+  endfacet
+  facet normal 0.999781 0.0209444 0
+    outer loop
+      vertex -27.6757 -1.15996 60
+      vertex -27.7 0 0
+      vertex -27.7 0 60
+    endloop
+  endfacet
+  facet normal 0.999781 0.0209444 0
+    outer loop
+      vertex -27.7 0 0
+      vertex -27.6757 -1.15996 60
+      vertex -27.6757 -1.15996 0
+    endloop
+  endfacet
+  facet normal -0.937292 -0.348546 0
+    outer loop
+      vertex 26.1592 9.10961 0
+      vertex 25.7548 10.1971 60
+      vertex 25.7548 10.1971 0
+    endloop
+  endfacet
+  facet normal -0.937292 -0.348546 0
+    outer loop
+      vertex 25.7548 10.1971 60
+      vertex 26.1592 9.10961 0
+      vertex 26.1592 9.10961 60
+    endloop
+  endfacet
+  facet normal 0.587767 0.80903 -0
+    outer loop
+      vertex -15.8088 -22.7458 0
+      vertex -16.7474 -22.0639 60
+      vertex -15.8088 -22.7458 60
+    endloop
+  endfacet
+  facet normal 0.587767 0.80903 0
+    outer loop
+      vertex -16.7474 -22.0639 60
+      vertex -15.8088 -22.7458 0
+      vertex -16.7474 -22.0639 0
+    endloop
+  endfacet
+  facet normal -0.821195 -0.570648 0
+    outer loop
+      vertex 23.0719 15.3289 0
+      vertex 22.4098 16.2817 60
+      vertex 22.4098 16.2817 0
+    endloop
+  endfacet
+  facet normal -0.821195 -0.570648 0
+    outer loop
+      vertex 22.4098 16.2817 60
+      vertex 23.0719 15.3289 0
+      vertex 23.0719 15.3289 60
+    endloop
+  endfacet
+  facet normal 0.796501 -0.604637 0
+    outer loop
+      vertex -22.4098 16.2817 60
+      vertex -21.7083 17.2058 0
+      vertex -21.7083 17.2058 60
+    endloop
+  endfacet
+  facet normal 0.796501 -0.604637 0
+    outer loop
+      vertex -21.7083 17.2058 0
+      vertex -22.4098 16.2817 60
+      vertex -22.4098 16.2817 0
+    endloop
+  endfacet
+  facet normal 0.866012 0.500023 0
+    outer loop
+      vertex -23.6936 -14.3493 60
+      vertex -24.2737 -13.3446 0
+      vertex -24.2737 -13.3446 60
+    endloop
+  endfacet
+  facet normal 0.866012 0.500023 0
+    outer loop
+      vertex -24.2737 -13.3446 0
+      vertex -23.6936 -14.3493 60
+      vertex -23.6936 -14.3493 0
+    endloop
+  endfacet
+  facet normal 0.844317 0.535843 0
+    outer loop
+      vertex -23.0719 -15.3289 60
+      vertex -23.6936 -14.3493 0
+      vertex -23.6936 -14.3493 60
+    endloop
+  endfacet
+  facet normal 0.844317 0.535843 0
+    outer loop
+      vertex -23.6936 -14.3493 0
+      vertex -23.0719 -15.3289 60
+      vertex -23.0719 -15.3289 0
+    endloop
+  endfacet
+  facet normal 0.743114 0.669165 0
+    outer loop
+      vertex -20.1924 -18.962 60
+      vertex -20.9688 -18.0998 0
+      vertex -20.9688 -18.0998 60
+    endloop
+  endfacet
+  facet normal 0.743114 0.669165 0
+    outer loop
+      vertex -20.9688 -18.0998 0
+      vertex -20.1924 -18.962 60
+      vertex -20.1924 -18.962 0
+    endloop
+  endfacet
+  facet normal 0.821195 -0.570648 0
+    outer loop
+      vertex -23.0719 15.3289 60
+      vertex -22.4098 16.2817 0
+      vertex -22.4098 16.2817 60
+    endloop
+  endfacet
+  facet normal 0.821195 -0.570648 0
+    outer loop
+      vertex -22.4098 16.2817 0
+      vertex -23.0719 15.3289 60
+      vertex -23.0719 15.3289 0
+    endloop
+  endfacet
+  facet normal 0.904827 -0.42578 0
+    outer loop
+      vertex -25.3052 11.2666 60
+      vertex -24.8112 12.3164 0
+      vertex -24.8112 12.3164 60
+    endloop
+  endfacet
+  facet normal 0.904827 -0.42578 0
+    outer loop
+      vertex -24.8112 12.3164 0
+      vertex -25.3052 11.2666 60
+      vertex -25.3052 11.2666 0
+    endloop
+  endfacet
+  facet normal -0.207976 0.978134 0
+    outer loop
+      vertex 6.32532 -26.9681 0
+      vertex 5.19046 -27.2094 60
+      vertex 6.32532 -26.9681 60
+    endloop
+  endfacet
+  facet normal -0.207976 0.978134 0
+    outer loop
+      vertex 5.19046 -27.2094 60
+      vertex 6.32532 -26.9681 0
+      vertex 5.19046 -27.2094 0
+    endloop
+  endfacet
+  facet normal 0.248664 0.96859 -0
+    outer loop
+      vertex -6.32532 -26.9681 0
+      vertex -7.44908 -26.6796 60
+      vertex -6.32532 -26.9681 60
+    endloop
+  endfacet
+  facet normal 0.248664 0.96859 0
+    outer loop
+      vertex -7.44908 -26.6796 60
+      vertex -6.32532 -26.9681 0
+      vertex -7.44908 -26.6796 0
+    endloop
+  endfacet
+  facet normal 0.963141 0.268997 0
+    outer loop
+      vertex -26.5177 -8.00618 60
+      vertex -26.8298 -6.88871 0
+      vertex -26.8298 -6.88871 60
+    endloop
+  endfacet
+  facet normal 0.963141 0.268997 0
+    outer loop
+      vertex -26.8298 -6.88871 0
+      vertex -26.5177 -8.00618 60
+      vertex -26.5177 -8.00618 0
+    endloop
+  endfacet
+  facet normal 0.0836061 0.996499 -0
+    outer loop
+      vertex -1.7393 -27.6453 0
+      vertex -2.89544 -27.5483 60
+      vertex -1.7393 -27.6453 60
+    endloop
+  endfacet
+  facet normal 0.0836061 0.996499 0
+    outer loop
+      vertex -2.89544 -27.5483 60
+      vertex -1.7393 -27.6453 0
+      vertex -2.89544 -27.5483 0
+    endloop
+  endfacet
+  facet normal -0.125407 -0.992105 0
+    outer loop
+      vertex 2.89544 27.5483 0
+      vertex 4.0465 27.4028 60
+      vertex 2.89544 27.5483 60
+    endloop
+  endfacet
+  facet normal -0.125407 -0.992105 -0
+    outer loop
+      vertex 4.0465 27.4028 60
+      vertex 2.89544 27.5483 0
+      vertex 4.0465 27.4028 0
+    endloop
+  endfacet
+  facet normal 0.166696 0.986008 -0
+    outer loop
+      vertex -4.0465 -27.4028 0
+      vertex -5.19046 -27.2094 60
+      vertex -4.0465 -27.4028 60
+    endloop
+  endfacet
+  facet normal 0.166696 0.986008 0
+    outer loop
+      vertex -5.19046 -27.2094 60
+      vertex -4.0465 -27.4028 0
+      vertex -5.19046 -27.2094 0
+    endloop
+  endfacet
+  facet normal 0.406738 -0.913545 0
+    outer loop
+      vertex -11.7941 25.0637 0
+      vertex -10.7342 25.5356 60
+      vertex -11.7941 25.0637 60
+    endloop
+  endfacet
+  facet normal 0.406738 -0.913545 0
+    outer loop
+      vertex -10.7342 25.5356 60
+      vertex -11.7941 25.0637 0
+      vertex -10.7342 25.5356 0
+    endloop
+  endfacet
+  facet normal 0.743114 -0.669165 0
+    outer loop
+      vertex -20.9688 18.0998 60
+      vertex -20.1924 18.962 0
+      vertex -20.1924 18.962 60
+    endloop
+  endfacet
+  facet normal 0.743114 -0.669165 0
+    outer loop
+      vertex -20.1924 18.962 0
+      vertex -20.9688 18.0998 60
+      vertex -20.9688 18.0998 0
+    endloop
+  endfacet
+  facet normal -0.0836061 -0.996499 0
+    outer loop
+      vertex 1.7393 27.6453 0
+      vertex 2.89544 27.5483 60
+      vertex 1.7393 27.6453 60
+    endloop
+  endfacet
+  facet normal -0.0836061 -0.996499 -0
+    outer loop
+      vertex 2.89544 27.5483 60
+      vertex 1.7393 27.6453 0
+      vertex 2.89544 27.5483 0
+    endloop
+  endfacet
+  facet normal 0.653407 0.757007 -0
+    outer loop
+      vertex -17.6566 -21.3432 0
+      vertex -18.5349 -20.5851 60
+      vertex -17.6566 -21.3432 60
+    endloop
+  endfacet
+  facet normal 0.653407 0.757007 0
+    outer loop
+      vertex -18.5349 -20.5851 60
+      vertex -17.6566 -21.3432 0
+      vertex -18.5349 -20.5851 0
+    endloop
+  endfacet
+  facet normal 0.886214 0.463276 0
+    outer loop
+      vertex -24.2737 -13.3446 60
+      vertex -24.8112 -12.3164 0
+      vertex -24.8112 -12.3164 60
+    endloop
+  endfacet
+  facet normal 0.886214 0.463276 0
+    outer loop
+      vertex -24.8112 -12.3164 0
+      vertex -24.2737 -13.3446 60
+      vertex -24.2737 -13.3446 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/tests/cad/test_spool_core_sleeve.sh
+++ b/tests/cad/test_spool_core_sleeve.sh
@@ -5,7 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 # Render known presets and check echo'd wall thicknesses
-for PRESET in sunlu55_to63_len60 sunlu55_to63cyl_len60; do
+for PRESET in sunlu55_to63_len60 sunlu55_to63cyl_len60 \
+               sunlu55_to73_len60 sunlu55_to73cyl_len60; do
     bash "${REPO_ROOT}/scripts/openscad_render_spool_core_sleeve.sh" || true
     PRESET="${PRESET}" bash "${REPO_ROOT}/scripts/openscad_render_spool_core_sleeve.sh"
 
@@ -14,15 +15,23 @@ for PRESET in sunlu55_to63_len60 sunlu55_to63cyl_len60; do
 
     [[ -s "${STL}" ]] || { echo "FAIL: STL missing for ${PRESET}"; exit 1; }
 
-    if [[ "${PRESET}" == "sunlu55_to63_len60" ]]; then
-        # Expect wall thickness start/end = 4 mm -> 4.5 mm
-        grep -E 'Radial wall thickness: +4(\.0+)? +mm -> +4\.5(\.0+)? +mm' "${LOG}" >/dev/null \
-            || { echo "FAIL: unexpected wall thickness (see ${LOG})"; exit 1; }
-    else
-        # Expect wall thickness start/end = 4 mm -> 4 mm
-        grep -E 'Radial wall thickness: +4(\.0+)? +mm -> +4(\.0+)? +mm' "${LOG}" >/dev/null \
-            || { echo "FAIL: unexpected wall thickness (see ${LOG})"; exit 1; }
-    fi
+    case "${PRESET}" in
+        sunlu55_to63_len60)
+            EXPECT='Radial wall thickness: +4(\.0+)? +mm -> +4\.5(\.0+)? +mm'
+            ;;
+        sunlu55_to63cyl_len60)
+            EXPECT='Radial wall thickness: +4(\.0+)? +mm -> +4(\.0+)? +mm'
+            ;;
+        sunlu55_to73_len60)
+            EXPECT='Radial wall thickness: +9(\.0+)? +mm -> +9\.5(\.0+)? +mm'
+            ;;
+        sunlu55_to73cyl_len60)
+            EXPECT='Radial wall thickness: +9(\.0+)? +mm -> +9(\.0+)? +mm'
+            ;;
+    esac
+
+    grep -E "${EXPECT}" "${LOG}" >/dev/null \
+        || { echo "FAIL: unexpected wall thickness (see ${LOG})"; exit 1; }
 done
 
 echo "All checks passed."


### PR DESCRIPTION
## Summary
- add 73→74 mm Sunlu spool core sleeve and matching removal cylinder
- document spool sleeve naming and presets
- cover new presets in CAD tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh` *(fails: Process from config.webServer exited early)*

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68ae405754d4832faf2cee0d1183c61b