### PR TITLE
📝: clarify prompt style docs

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -32,6 +32,17 @@ python scripts/update_prompt_docs_summary.py --repos-from docs/repo_list.txt --o
 | one-off   | prompts to implement features or make recommended changes (glorified TODO; remove after cleanup) |
 | unknown   | catch-all; refine into another category or create a new one                                      |
 
+### Prompt styles
+
+Most prompts listed here are **agentic**: they direct the model to perform tasks step by step,
+such as [docs/prompts/codex/automation.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/automation.md).
+The only **conversational** example currently tracked is
+[docs/prompts/codex/merge-conflicts.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/merge-conflicts.md),
+which frames the request as a dialogue.
+
+Future prompt docs should clearly state whether they are agentic or conversational to reduce
+ambiguity.
+
 ## **[futuroptimist/flywheel](https://github.com/futuroptimist/flywheel)**
 
 | Path                                                                                                                                                         | Prompt                                                                                                                                                                               | Type          | One-click?   |

--- a/docs/prompts-salient.md
+++ b/docs/prompts-salient.md
@@ -1,0 +1,18 @@
+---
+title: "Salient Prompt Launcher"
+slug: "prompts-salient"
+conversational: true
+---
+
+# Salient Prompt Launcher
+Type: evergreen
+
+```text
+Please review:
+- https://github.com/futuroptimist/flywheel/blob/main/docs/prompt-docs-summary.md
+- https://github.com/futuroptimist/flywheel/blob/main/docs/repo-feature-summary.md
+
+Return an ordered list (high to low) of 20–100 prompt URLs representing
+low-hanging fruit or urgent high-severity tasks. If fewer than 20 qualify,
+list all of them. Output only the URLs.
+```


### PR DESCRIPTION
## Summary
- distinguish agentic vs conversational in prompt index
- streamline salient prompt launcher instructions

## Testing
- `pre-commit run --all-files`
- `npm run lint`
- `npm run test:ci`
- `pytest -q`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`
- `git diff --cached | ./scripts/scan-secrets.py` *(missing script; scanned with detect-secrets)*

------
https://chatgpt.com/codex/tasks/task_e_68afe081cc48832f910627500120a514