### PR TITLE
📝 docs: exclude PM docs from salient prompt

### DIFF
--- a/docs/prompts-salient.md
+++ b/docs/prompts-salient.md
@@ -12,6 +12,8 @@ Please review:
 - https://github.com/futuroptimist/flywheel/blob/main/docs/prompt-docs-summary.md
 - https://github.com/futuroptimist/flywheel/blob/main/docs/repo-feature-summary.md
 
+Ignore any files under `docs/pms/`; PM docs are archival and should not inform prompts.
+
 Return an ordered list (high to low) of 20–100 prompt URLs representing
 low-hanging fruit or urgent high-severity tasks. If fewer than 20 qualify,
 list all of them. Output only the URLs.


### PR DESCRIPTION
## Summary
- note that PM docs in `docs/pms/` are archival and should be ignored when generating salient prompts

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh` *(fails: linkchecker: command not found; bandit, safety not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68afe911ef7c832f9dada44d95c3f77a