### PR TITLE
🔧 : rebase summary before push

### DIFF
--- a/.github/workflows/04-update-summary.yml
+++ b/.github/workflows/04-update-summary.yml
@@ -50,4 +50,5 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add docs/repo-feature-summary.md
           git commit -m "📝 : update repo feature summary" || exit 0
+          git pull --rebase origin main
           git push


### PR DESCRIPTION
## What
- rebase before pushing repo feature summary to avoid non-fast-forward failures

## Why
- keep scheduled summary job from failing when `main` moves underneath

## How to Test
- `pre-commit run --all-files` *(fails: module 'typer' has no attribute 'rich_utils')*
- `pytest -q`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh` *(in progress; apt install logs)*

------
https://chatgpt.com/codex/tasks/task_e_68b53e219670832fa473193fa6ba2651