### PR TITLE
🔧 : rebase summary before push

### DIFF
--- a/.github/workflows/04-update-summary.yml
+++ b/.github/workflows/04-update-summary.yml
@@ -50,4 +50,5 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add docs/repo-feature-summary.md
           git commit -m "📝 : update repo feature summary" || exit 0
+          git pull --rebase origin main
           git push

--- a/tests/update-summary-workflow.test.mjs
+++ b/tests/update-summary-workflow.test.mjs
@@ -6,3 +6,7 @@ const workflow = readFileSync(new URL('../.github/workflows/04-update-summary.ym
 test('summary workflow skips run-checks hook', () => {
   expect(workflow).toMatch(/SKIP: run-checks/);
 });
+
+test('summary workflow rebases before pushing', () => {
+  expect(workflow).toMatch(/git pull --rebase origin main/);
+});


### PR DESCRIPTION
## What
- rebase before pushing repo feature summary to avoid non-fast-forward failures
- add regression test to ensure the workflow rebases before push

## Why
- keep scheduled summary job from failing when `main` moves underneath
- guard against accidental removal of rebase step

## How to Test
- `SKIP=run-checks pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci` *(partial: playwright dependencies installing)*
- `python -m flywheel.fit`
- `RUN_SECURITY_ONLY=1 bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b53e219670832fa473193fa6ba2651