### PR TITLE
📝 : clarify pre-commit docs and update dictionary

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -222,3 +222,9 @@ linters
 
 Vitest
 vitest
+
+aspell
+lowercasing
+finiteness
+AMS
+Bambu

--- a/docs/best_practices_catalog.md
+++ b/docs/best_practices_catalog.md
@@ -10,11 +10,15 @@ Each section covers three points:
 
 ## Pre-commit Hooks
 
-**Why:** Running `pre-commit` before every push keeps formatting and tests consistent. It helps avoid CI failures and encourages small, clean commits.
+**Why:** Running `pre-commit` before every push keeps formatting and tests consistent.
+It helps avoid CI failures and encourages small, clean commits.
 
-**How it works:** The `.pre-commit-config.yaml` file lists hooks for `flake8`, `isort`, `black`, `pytest`, and link checking. When you run `pre-commit run --all-files` the hooks format code, lint for errors, and run tests locally.
+**How it works:** The `.pre-commit-config.yaml` file lists hooks for `flake8`, `isort`,
+`black`, `pytest`, and link checking. When you run `pre-commit run --all-files`, the
+hooks format code, lint for errors, and run tests locally.
 
-**Maintenance:** Add new lint or test tools to `.pre-commit-config.yaml` and update `scripts/checks.sh`. LLM agents should check hook output and suggest fixes.
+**Maintenance:** Add new lint or test tools to `.pre-commit-config.yaml` and update
+`scripts/checks.sh`. LLM agents should check hook output and suggest fixes.
 
 ## Style Guides
 

--- a/docs/prompts/codex/merge-conflicts.md
+++ b/docs/prompts/codex/merge-conflicts.md
@@ -10,13 +10,13 @@ Type: evergreen
 Use this prompt to resolve Git merge conflicts without altering unrelated code.
 
 ```text
-Resolve the merge conflict in the code snippet below. 
+Resolve the merge conflict in the code snippet below.
 
-- Remove the conflict markers.  
-- Preserve existing formatting, imports, and surrounding code.  
-- Do not modify lines outside the conflict.  
-- When resolving, prefer the version consistent with naming conventions and other docs in this repo.  
-- If both versions are valid and a manual choice is required, include both in the merged code as commented alternatives marked with `// MANUAL DECISION REQUIRED`.  
+- Remove the conflict markers.
+- Preserve existing formatting, imports, and surrounding code.
+- Do not modify lines outside the conflict.
+- When resolving, prefer the version consistent with naming conventions and other docs in this repo.
+- If both versions are valid and a manual choice is required, include both in the merged code as commented alternatives marked with `// MANUAL DECISION REQUIRED`.
 - After the code, summarize the differences between the two sides and explain why you resolved them this way.
 
 ```
@@ -34,13 +34,13 @@ Review the following code snippet or prompt, refine its clarity and accuracy, th
 
 After updating, run these lightweight checks:
 
-- `pre-commit run --all-files`  
-- `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)  
-- `linkchecker --no-warnings README.md docs/`  
+- `pre-commit run --all-files`
+- `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
+- `linkchecker --no-warnings README.md docs/`
 - `git diff --cached | ./scripts/scan-secrets.py`
 
-If everything passes, output:  
-`“All lightweight checks passed. Ready for CI.”`  
+If everything passes, output:
+`“All lightweight checks passed. Ready for CI.”`
 Otherwise, list the failing steps with concise explanations.
 
 _*Note: Full test suites (`pytest`, `npm test`, `python -m flywheel.fit`) should be run separately in CI, not here.*_


### PR DESCRIPTION
What: refine Pre-commit Hooks doc, clean merge-conflicts prompt whitespace, extend spelling allowlist.
Why: improve clarity and keep repo checks green.
How to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/; git diff --cached | ./scripts/scan-secrets.py
Refs:


------
https://chatgpt.com/codex/tasks/task_e_68b7ec778810832f9f4dee494955ac41