### PR TITLE
CAD: spool_core_sleeve.scad — preview‑stable (anti z‑fighting), AMS Lite sleeve

### DIFF
--- a/cad/spool_core_sleeve/README.md
+++ b/cad/spool_core_sleeve/README.md
@@ -1,13 +1,14 @@
-# Sunlu Spool Core Sleeves
+# Spool Core Sleeves
 
-These OpenSCAD presets adapt Sunlu-branded filament spools to the Bambu Lab AMS.
-They wrap the 55 mm AMS hub and expand to the measured spool diameter.
+These OpenSCAD presets adapt common filament spools to the Bambu Lab AMS and AMS Lite.
+They wrap the AMS hub (55 mm or 55.5 mm) and expand to the measured spool diameter.
 
 ## Naming convention
 
-`sunlu55_to<OD>[cyl]_len<length>.scad`
+`<brand><ID>_to<OD>[cyl]_len<length>.scad`
 
-- `55` – inner bore diameter (AMS hub)
+- `<brand>` – spool brand (e.g., `sunlu`, `bambu`)
+- `<ID>` – inner bore diameter; `55p5` denotes 55.5 mm for AMS Lite
 - `<OD>` – starting outer diameter of the sleeve
 - `cyl` – optional straight cylinder used to push out a tapered sleeve
 - `len<length>` – axial length of the part in millimeters
@@ -20,3 +21,5 @@ They wrap the 55 mm AMS hub and expand to the measured spool diameter.
 | `sunlu55_to63cyl_len60.scad` | straight 63 mm removal cylinder |
 | `sunlu55_to73_len60.scad` | 73→74 mm tapered adapter |
 | `sunlu55_to73cyl_len60.scad` | straight 73 mm removal cylinder |
+| `bambu55p5_to63_len58.scad` | 63 mm sleeve for AMS Lite |
+| `bambu55p5_to73_len59.scad` | 73 mm sleeve for AMS Lite |

--- a/cad/spool_core_sleeve/bambu55p5_to63_len58.scad
+++ b/cad/spool_core_sleeve/bambu55p5_to63_len58.scad
@@ -1,0 +1,7 @@
+/*
+Bambu AMS Lite sleeve preset.
+Render with:
+  openscad -o out.stl -D ID=55.5 -D OD=63 -D LEN=58 -D TOL=0.20 \
+    cad/spool_core_sleeve/bambu55p5_to63_len58.scad
+*/
+include <../utils/spool_core_sleeve.scad>;

--- a/cad/spool_core_sleeve/bambu55p5_to73_len59.scad
+++ b/cad/spool_core_sleeve/bambu55p5_to73_len59.scad
@@ -1,0 +1,7 @@
+/*
+Bambu AMS Lite sleeve preset.
+Render with:
+  openscad -o out.stl -D ID=55.5 -D OD=73 -D LEN=59 -D TOL=0.20 \
+    cad/spool_core_sleeve/bambu55p5_to73_len59.scad
+*/
+include <../utils/spool_core_sleeve.scad>;

--- a/cad/utils/spool_core_sleeve.scad
+++ b/cad/utils/spool_core_sleeve.scad
@@ -114,6 +114,58 @@ module sleeve(od, id, h) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Legacy wrapper modules (for examples & external callers)
+// ---------------------------------------------------------------------------
+
+module spool_core_sleeve(
+    inner_id      = 55.5,
+    target_od     = 63.0,
+    target_od_end = undef,
+    length        = 58.0,
+    clearance     = 0.20,
+    $fn_outer     = 160,
+    $fn_inner     = 160
+) {
+    // New geometry does not support taper; use the larger diameter.
+    target_od_end = is_undef(target_od_end) ? target_od : target_od_end;
+    if (target_od != target_od_end)
+        echo("NOTE: target_od_end ignored; using max diameter for constant OD sleeve.");
+
+    od = max(target_od, target_od_end);
+    $fn = min($fn_outer, $fn_inner);
+
+    // "clearance" in the legacy API is diametral; apply directly.
+    sleeve(od, inner_id + clearance, length);
+}
+
+function _spool_core_sleeve_preset(preset) =
+    (preset == "sunlu55_to63_len60")    ? [55,   63, 63, 60, 0.20] :
+    (preset == "sunlu55_to63cyl_len60") ? [55,   63, 63, 60, 0.20] :
+    (preset == "sunlu55_to73_len60")    ? [55,   73, 73, 60, 0.20] :
+    (preset == "sunlu55_to73cyl_len60") ? [55,   73, 73, 60, 0.20] :
+    (preset == "bambu55p5_to63_len58")  ? [55.5, 63, 63, 58, 0.40] :
+    (preset == "bambu55p5_to73_len59")  ? [55.5, 73, 73, 59, 0.40] :
+    undef;
+
+module spool_core_sleeve_preset(
+    preset    = "sunlu55_to63_len60",
+    $fn_outer = 160,
+    $fn_inner = 160
+) {
+    p = _spool_core_sleeve_preset(preset);
+    assert(p != undef, str("unknown preset: ", preset));
+    spool_core_sleeve(
+        inner_id      = p[0],
+        target_od     = p[1],
+        target_od_end = p[2],
+        length        = p[3],
+        clearance     = p[4],
+        $fn_outer     = $fn_outer,
+        $fn_inner     = $fn_inner
+    );
+}
+
 // -------------------- Render --------------------
 final_h = (mode == "ring") ? RING_H : LEN;
 sleeve(OD_EFF, ID_EFF, final_h);

--- a/cad/utils/spool_core_sleeve.scad
+++ b/cad/utils/spool_core_sleeve.scad
@@ -1,84 +1,119 @@
-/*
-//--------------------------------------------------------------
-//  Core‑Sleeve Spool Adapter  ✧  v1.1  (CC0‑1.0 / public domain)
-//  Library module for parametric spool-core sleeves.
-//  Example usage:
-//      use <../utils/spool_core_sleeve.scad>;
-//      spool_core_sleeve(inner_id=55, target_od=63, target_od_end=64,
-//                        length=60, clearance=0.20);
 //
-//  Parameters:
-//    inner_id   — measured bore ID (mm), e.g. 55 (≈AMS axle)
-//    target_od      — outer diameter at z=0 (mm), e.g. 63 (Sunlu spool)
-//    target_od_end  — outer diameter at z=length (mm); defaults to target_od
-//    length         — axial length (mm), e.g. 60
-//    clearance  — extra diameter added to bore (total), default 0.20
-//    $fn_outer  — circle resolution for outer cylinder
-//    $fn_inner  — circle resolution for inner bore
+// Spool Core Sleeve (AMS Lite compatible) — anti–z‑fighting edition
+// SPDX-License-Identifier: MIT
+// Units: mm
 //
-//  Notes:
-//  • "clearance" is applied to the *diameter* of the bore (2× radial).
-//  • Echoes computed wall thickness so test scripts can sanity-check values.
-//--------------------------------------------------------------
-*/
+// Public interface (back‑compat with CI):
+//   -D ID=... -D OD=... -D LEN=... -D TOL=...
+// Optional: -D TOL_ID=..., -D TOL_OD=..., -D mode="ring" -D RING_H=10, -D SEGMENTS=160
+//
 
-module spool_core_sleeve(
-    inner_id      = 55,
-    target_od     = 63,
-    target_od_end = undef,
-    length        = 60,
-    clearance     = 0.20,
-    $fn_outer     = 200,
-    $fn_inner     = 150
-) {
-    target_od_end = is_undef(target_od_end) ? target_od : target_od_end;
+// -------------------- User Parameters (override with -D) --------------------
+ID      = 55.5;   // Inner diameter to fit AMS Lite spindle (53–58 mm window)
+OD      = 63.0;   // Outer diameter to match YOUR spool hub hole
+LEN     = 58.0;   // Overall length (57–60 mm typical for 1 kg spools)
 
-    // Basic parameter validation
-    assert(
-        min(target_od, target_od_end) > inner_id + 2 * clearance,
-        str("invalid dims: outer diameters (", target_od, ", ", target_od_end,
-            ") must exceed inner_id + 2*clearance (",
-            inner_id + 2 * clearance, ")")
-    );
+TOL     = 0.00;   // Global radial tol: + on ID (looser on spindle), - on OD (looser in hub)
+TOL_ID  = is_undef(TOL_ID) ? TOL : TOL_ID;
+TOL_OD  = is_undef(TOL_OD) ? TOL : TOL_OD;
 
-    wall_start = (target_od - inner_id) / 2;
-    wall_end   = (target_od_end - inner_id) / 2;
-    echo(str("Radial wall thickness: ", wall_start, " mm -> ",
-             wall_end, " mm"));
+OUTER_CH = 0.8;   // Outer 45° chamfer height (and radial)
+INNER_CH = 0.6;   // Inner 45° chamfer height (and radial)
 
-    difference() {
-        // OUTER – linearly interpolate between diameters
-        cylinder(d1 = target_od, d2 = target_od_end, h = length, $fn = $fn_outer);
-        // BORE — extended ±1mm to avoid z-fusing
-        translate([0, 0, -1])
-            cylinder(
-                d = inner_id + 2 * clearance, h = length + 2, $fn = $fn_inner
-            );
+MIN_WALL = 2.4;   // Warn if wall gets thinner than this
+
+// Optional features
+split_sleeve = false;  // Add a narrow axial slit for a light press fit
+SLIT_GAP     = 0.60;   // Slit width if enabled
+slot_count   = 0;      // Lightening slots (0 = off)
+
+// Resolution
+$fn = is_undef(SEGMENTS) ? 160 : SEGMENTS;
+
+// Quick iteration
+mode   = is_undef(mode) ? "full" : mode; // "full" or "ring"
+RING_H = is_undef(RING_H) ? 10 : RING_H;
+
+// -------------------- Preview-only epsilons --------------------
+// Eliminate OpenCSG z-fighting in Preview by ensuring overlaps.
+// In final Render (F6/CGAL), these collapse to zero and do not change geometry.
+EPS_R = $preview ? 0.05 : 0.0;   // radial epsilon
+EPS_Z = $preview ? 0.10 : 0.0;   // axial epsilon
+
+// -------------------- Derived values --------------------
+ID_EFF = ID + TOL_ID;
+OD_EFF = OD - TOL_OD;
+
+function clamp(x, a, b) = x < a ? a : (x > b ? b : x);
+function ch_outer(h) = clamp(OUTER_CH, 0, h/2 - 0.01);
+function ch_inner(h) = clamp(INNER_CH, 0, h/2 - 0.01);
+
+// Sanity echoes
+echo("---- Spool Core Sleeve ----");
+echo(str("ID (effective): ", ID_EFF, " mm"));
+echo(str("OD (effective): ", OD_EFF, " mm"));
+echo(str("LEN: ", LEN, " mm"));
+echo(str("Nominal wall: ", (OD_EFF - ID_EFF)/2, " mm"));
+if ( (OD_EFF - ID_EFF)/2 < MIN_WALL )
+    echo("WARNING: Wall thinner than MIN_WALL; consider increasing OD or decreasing ID.");
+
+// -------------------- Geometry helpers --------------------
+module outer_profile(od, h, oc) {
+    r = od/2;
+    oc_ = ch_outer(h);
+    union() {
+        translate([0,0,oc_]) cylinder(h = h - 2*oc_, r = r);
+        if (oc_ > 0) cylinder(h = oc_, r1 = r - oc_, r2 = r);
+        if (oc_ > 0) translate([0,0,h-oc_]) cylinder(h = oc_, r1 = r, r2 = r - oc_);
     }
 }
 
-// Optional named presets (extend as you collect measurements)
-function _spool_core_sleeve_preset(preset) =
-    (preset == "sunlu55_to63_len60") ? [55, 63, 64, 60, 0.20] :
-    (preset == "sunlu55_to63cyl_len60") ? [55, 63, 63, 60, 0.20] :
-    (preset == "sunlu55_to73_len60") ? [55, 73, 74, 60, 0.20] :
-    (preset == "sunlu55_to73cyl_len60") ? [55, 73, 73, 60, 0.20] :
-    undef;
-
-module spool_core_sleeve_preset(
-    preset = "sunlu55_to63_len60", $fn_outer = 200, $fn_inner = 150
-) {
-    p = _spool_core_sleeve_preset(preset);
-    assert(p != undef, str("unknown preset: ", preset));
-    spool_core_sleeve(
-        inner_id      = p[0],
-        target_od     = p[1],
-        target_od_end = p[2],
-        length        = p[3],
-        clearance     = p[4],
-        $fn_outer     = $fn_outer,
-        $fn_inner     = $fn_inner
-    );
+module inner_profile(id, h, ic) {
+    // Subtractive core with preview-only oversizing to avoid coplanar faces.
+    r = id/2;
+    ic_ = ch_inner(h);
+    union() {
+        // Center tube: stretch by ±EPS_Z axially, enlarge by EPS_R radially
+        translate([0,0,max(ic_ - EPS_Z, 0)])
+            cylinder(h = (h - 2*ic_) + 2*EPS_Z, r = r + EPS_R);
+        // Bottom chamfer: extend slightly below zero during preview
+        if (ic_ > 0)
+            translate([0,0,-EPS_Z])
+                cylinder(h = ic_ + EPS_Z, r1 = r + EPS_R, r2 = r + ic_ + EPS_R);
+        // Top chamfer: extend slightly beyond h during preview
+        if (ic_ > 0)
+            translate([0,0,h - ic_])
+                cylinder(h = ic_ + EPS_Z, r1 = r + ic_ + EPS_R, r2 = r + EPS_R);
+    }
 }
 
-// End of library
+module axial_slit(od, h, gap, extra=0.6) {
+    // Remove a narrow axial slot to allow slight compression
+    translate([0,0,h/2])
+        cube([od + 2*extra, gap, h + 2*extra], center = true);
+}
+
+module weight_slots(od, id, h, count=6, slot_w=8, keep_margin=1.2) {
+    if (count > 0) {
+        r_mid = (od + id)/4;
+        radial_len = (od - id)/2 - keep_margin;
+        for (i = [0:count-1]) {
+            rotate([0,0, i*360/count])
+                translate([r_mid, 0, h/2])
+                    cube([slot_w, radial_len, h*0.6], center = true);
+        }
+    }
+}
+
+module sleeve(od, id, h) {
+    difference() {
+        outer_profile(od, h, OUTER_CH);
+        inner_profile(id, h, INNER_CH); // subtractor overlaps by EPS_* in preview
+        if (split_sleeve) axial_slit(od, h, SLIT_GAP);
+        if (slot_count > 0) weight_slots(od, id, h, count=slot_count);
+    }
+}
+
+// -------------------- Render --------------------
+final_h = (mode == "ring") ? RING_H : LEN;
+sleeve(OD_EFF, ID_EFF, final_h);

--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -228,3 +228,4 @@ lowercasing
 finiteness
 AMS
 Bambu
+Lightening

--- a/stl/spool_core_sleeve/.gitignore
+++ b/stl/spool_core_sleeve/.gitignore
@@ -4,3 +4,5 @@
 !sunlu55_to63cyl_len60.stl
 !sunlu55_to73_len60.stl
 !sunlu55_to73cyl_len60.stl
+!bambu55p5_to63_len58.stl
+!bambu55p5_to73_len59.stl

--- a/stl/spool_core_sleeve/bambu55p5_to63_len58.stl
+++ b/stl/spool_core_sleeve/bambu55p5_to63_len58.stl
@@ -1,0 +1,22402 @@
+solid OpenSCAD_Model
+  facet normal 0.998265 0.0588808 0
+    outer loop
+      vertex 31.3758 1.23276 57.2
+      vertex 31.3032 2.46362 0.799999
+      vertex 31.3032 2.46362 57.2
+    endloop
+  endfacet
+  facet normal 0.998265 0.0588808 0
+    outer loop
+      vertex 31.3032 2.46362 0.799999
+      vertex 31.3758 1.23276 57.2
+      vertex 31.3758 1.23276 0.799999
+    endloop
+  endfacet
+  facet normal 0.999807 0.019627 0
+    outer loop
+      vertex 31.4 0 57.2
+      vertex 31.3758 1.23276 0.799999
+      vertex 31.3758 1.23276 57.2
+    endloop
+  endfacet
+  facet normal 0.999807 0.019627 0
+    outer loop
+      vertex 31.3758 1.23276 0.799999
+      vertex 31.4 0 57.2
+      vertex 31.4 0 0.799999
+    endloop
+  endfacet
+  facet normal 0.995189 0.0979739 0
+    outer loop
+      vertex 31.3032 2.46362 57.2
+      vertex 31.1824 3.69067 0.799999
+      vertex 31.1824 3.69067 57.2
+    endloop
+  endfacet
+  facet normal 0.995189 0.0979739 0
+    outer loop
+      vertex 31.1824 3.69067 0.799999
+      vertex 31.3032 2.46362 57.2
+      vertex 31.3032 2.46362 0.799999
+    endloop
+  endfacet
+  facet normal 0.436411 0.899748 -0
+    outer loop
+      vertex 14.2553 27.9776 0.799999
+      vertex 13.1459 28.5157 57.2
+      vertex 14.2553 27.9776 57.2
+    endloop
+  endfacet
+  facet normal 0.436411 0.899748 0
+    outer loop
+      vertex 13.1459 28.5157 57.2
+      vertex 14.2553 27.9776 0.799999
+      vertex 13.1459 28.5157 0.799999
+    endloop
+  endfacet
+  facet normal 0.327647 -0.9448 0
+    outer loop
+      vertex 9.70313 -29.8632 0.799999
+      vertex 10.8681 -29.4592 57.2
+      vertex 9.70313 -29.8632 57.2
+    endloop
+  endfacet
+  facet normal 0.327647 -0.9448 0
+    outer loop
+      vertex 10.8681 -29.4592 57.2
+      vertex 9.70313 -29.8632 0.799999
+      vertex 10.8681 -29.4592 0.799999
+    endloop
+  endfacet
+  facet normal 0.214355 0.976756 -0
+    outer loop
+      vertex 7.33018 30.5324 0.799999
+      vertex 6.12584 30.7967 57.2
+      vertex 7.33018 30.5324 57.2
+    endloop
+  endfacet
+  facet normal 0.214355 0.976756 0
+    outer loop
+      vertex 6.12584 30.7967 57.2
+      vertex 7.33018 30.5324 0.799999
+      vertex 6.12584 30.7967 0.799999
+    endloop
+  endfacet
+  facet normal 0.214355 -0.976756 0
+    outer loop
+      vertex 6.12584 -30.7967 0.799999
+      vertex 7.33018 -30.5324 57.2
+      vertex 6.12584 -30.7967 57.2
+    endloop
+  endfacet
+  facet normal 0.214355 -0.976756 0
+    outer loop
+      vertex 7.33018 -30.5324 57.2
+      vertex 6.12584 -30.7967 0.799999
+      vertex 7.33018 -30.5324 0.799999
+    endloop
+  endfacet
+  facet normal -0.967603 -0.252475 0
+    outer loop
+      vertex -30.2211 -8.52323 0.799999
+      vertex -30.5324 -7.33018 57.2
+      vertex -30.5324 -7.33018 0.799999
+    endloop
+  endfacet
+  facet normal -0.967603 -0.252475 0
+    outer loop
+      vertex -30.5324 -7.33018 57.2
+      vertex -30.2211 -8.52323 0.799999
+      vertex -30.2211 -8.52323 57.2
+    endloop
+  endfacet
+  facet normal 0.998265 -0.0588808 0
+    outer loop
+      vertex 31.3032 -2.46362 57.2
+      vertex 31.3758 -1.23276 0.799999
+      vertex 31.3758 -1.23276 57.2
+    endloop
+  endfacet
+  facet normal 0.998265 -0.0588808 0
+    outer loop
+      vertex 31.3758 -1.23276 0.799999
+      vertex 31.3032 -2.46362 57.2
+      vertex 31.3032 -2.46362 0.799999
+    endloop
+  endfacet
+  facet normal -0.60355 -0.797325 0
+    outer loop
+      vertex -19.4395 -24.659 0.799999
+      vertex -18.4565 -25.4031 57.2
+      vertex -19.4395 -24.659 57.2
+    endloop
+  endfacet
+  facet normal -0.60355 -0.797325 -0
+    outer loop
+      vertex -18.4565 -25.4031 57.2
+      vertex -19.4395 -24.659 0.799999
+      vertex -18.4565 -25.4031 0.799999
+    endloop
+  endfacet
+  facet normal 0.175751 -0.984435 0
+    outer loop
+      vertex 4.91204 -31.0134 0.799999
+      vertex 6.12584 -30.7967 57.2
+      vertex 4.91204 -31.0134 57.2
+    endloop
+  endfacet
+  facet normal 0.175751 -0.984435 0
+    outer loop
+      vertex 6.12584 -30.7967 57.2
+      vertex 4.91204 -31.0134 0.799999
+      vertex 6.12584 -30.7967 0.799999
+    endloop
+  endfacet
+  facet normal -0.772999 0.634407 0
+    outer loop
+      vertex -24.659 19.4395 0.799999
+      vertex -23.8767 20.3927 57.2
+      vertex -23.8767 20.3927 0.799999
+    endloop
+  endfacet
+  facet normal -0.772999 0.634407 0
+    outer loop
+      vertex -23.8767 20.3927 57.2
+      vertex -24.659 19.4395 0.799999
+      vertex -24.659 19.4395 57.2
+    endloop
+  endfacet
+  facet normal 0.137063 -0.990562 0
+    outer loop
+      vertex 3.69067 -31.1824 0.799999
+      vertex 4.91204 -31.0134 57.2
+      vertex 3.69067 -31.1824 57.2
+    endloop
+  endfacet
+  facet normal 0.137063 -0.990562 0
+    outer loop
+      vertex 4.91204 -31.0134 57.2
+      vertex 3.69067 -31.1824 0.799999
+      vertex 4.91204 -31.0134 0.799999
+    endloop
+  endfacet
+  facet normal -0.862736 0.505655 0
+    outer loop
+      vertex -27.3964 15.3427 0.799999
+      vertex -26.7729 16.4065 57.2
+      vertex -26.7729 16.4065 0.799999
+    endloop
+  endfacet
+  facet normal -0.862736 0.505655 0
+    outer loop
+      vertex -26.7729 16.4065 57.2
+      vertex -27.3964 15.3427 0.799999
+      vertex -27.3964 15.3427 57.2
+    endloop
+  endfacet
+  facet normal 0.820419 0.571763 0
+    outer loop
+      vertex 26.1081 17.4449 57.2
+      vertex 25.4031 18.4565 0.799999
+      vertex 25.4031 18.4565 57.2
+    endloop
+  endfacet
+  facet normal 0.820419 0.571763 0
+    outer loop
+      vertex 25.4031 18.4565 0.799999
+      vertex 26.1081 17.4449 57.2
+      vertex 26.1081 17.4449 0.799999
+    endloop
+  endfacet
+  facet normal -0.916187 0.400751 0
+    outer loop
+      vertex -29.0098 12.0163 0.799999
+      vertex -28.5157 13.1459 57.2
+      vertex -28.5157 13.1459 0.799999
+    endloop
+  endfacet
+  facet normal -0.916187 0.400751 0
+    outer loop
+      vertex -28.5157 13.1459 57.2
+      vertex -29.0098 12.0163 0.799999
+      vertex -29.0098 12.0163 57.2
+    endloop
+  endfacet
+  facet normal 0.842189 -0.539183 0
+    outer loop
+      vertex 26.1081 -17.4449 57.2
+      vertex 26.7729 -16.4065 0.799999
+      vertex 26.7729 -16.4065 57.2
+    endloop
+  endfacet
+  facet normal 0.842189 -0.539183 0
+    outer loop
+      vertex 26.7729 -16.4065 0.799999
+      vertex 26.1081 -17.4449 57.2
+      vertex 26.1081 -17.4449 0.799999
+    endloop
+  endfacet
+  facet normal -0.772999 -0.634407 0
+    outer loop
+      vertex -23.8767 -20.3927 0.799999
+      vertex -24.659 -19.4395 57.2
+      vertex -24.659 -19.4395 0.799999
+    endloop
+  endfacet
+  facet normal -0.772999 -0.634407 0
+    outer loop
+      vertex -24.659 -19.4395 57.2
+      vertex -23.8767 -20.3927 0.799999
+      vertex -23.8767 -20.3927 57.2
+    endloop
+  endfacet
+  facet normal -0.400751 0.916187 0
+    outer loop
+      vertex -12.0163 29.0098 0.799999
+      vertex -13.1459 28.5157 57.2
+      vertex -12.0163 29.0098 57.2
+    endloop
+  endfacet
+  facet normal -0.400751 0.916187 0
+    outer loop
+      vertex -13.1459 28.5157 57.2
+      vertex -12.0163 29.0098 0.799999
+      vertex -13.1459 28.5157 0.799999
+    endloop
+  endfacet
+  facet normal 0.571763 -0.820419 0
+    outer loop
+      vertex 17.4449 -26.1081 0.799999
+      vertex 18.4565 -25.4031 57.2
+      vertex 17.4449 -26.1081 57.2
+    endloop
+  endfacet
+  facet normal 0.571763 -0.820419 0
+    outer loop
+      vertex 18.4565 -25.4031 57.2
+      vertex 17.4449 -26.1081 0.799999
+      vertex 18.4565 -25.4031 0.799999
+    endloop
+  endfacet
+  facet normal -0.571763 -0.820419 0
+    outer loop
+      vertex -18.4565 -25.4031 0.799999
+      vertex -17.4449 -26.1081 57.2
+      vertex -18.4565 -25.4031 57.2
+    endloop
+  endfacet
+  facet normal -0.571763 -0.820419 -0
+    outer loop
+      vertex -17.4449 -26.1081 57.2
+      vertex -18.4565 -25.4031 0.799999
+      vertex -17.4449 -26.1081 0.799999
+    endloop
+  endfacet
+  facet normal 0.137063 0.990562 -0
+    outer loop
+      vertex 4.91204 31.0134 0.799999
+      vertex 3.69067 31.1824 57.2
+      vertex 4.91204 31.0134 57.2
+    endloop
+  endfacet
+  facet normal 0.137063 0.990562 0
+    outer loop
+      vertex 3.69067 31.1824 57.2
+      vertex 4.91204 31.0134 0.799999
+      vertex 3.69067 31.1824 0.799999
+    endloop
+  endfacet
+  facet normal 0.956945 0.290271 0
+    outer loop
+      vertex 30.2211 8.52323 57.2
+      vertex 29.8632 9.70313 0.799999
+      vertex 29.8632 9.70313 57.2
+    endloop
+  endfacet
+  facet normal 0.956945 0.290271 0
+    outer loop
+      vertex 29.8632 9.70313 0.799999
+      vertex 30.2211 8.52323 57.2
+      vertex 30.2211 8.52323 0.799999
+    endloop
+  endfacet
+  facet normal 0.290271 0.956945 -0
+    outer loop
+      vertex 9.70313 29.8632 0.799999
+      vertex 8.52323 30.2211 57.2
+      vertex 9.70313 29.8632 57.2
+    endloop
+  endfacet
+  facet normal 0.290271 0.956945 0
+    outer loop
+      vertex 8.52323 30.2211 57.2
+      vertex 9.70313 29.8632 0.799999
+      vertex 8.52323 30.2211 0.799999
+    endloop
+  endfacet
+  facet normal 0.0979739 -0.995189 0
+    outer loop
+      vertex 2.46362 -31.3032 0.799999
+      vertex 3.69067 -31.1824 57.2
+      vertex 2.46362 -31.3032 57.2
+    endloop
+  endfacet
+  facet normal 0.0979739 -0.995189 0
+    outer loop
+      vertex 3.69067 -31.1824 57.2
+      vertex 2.46362 -31.3032 0.799999
+      vertex 3.69067 -31.1824 0.799999
+    endloop
+  endfacet
+  facet normal 0.967603 -0.252475 0
+    outer loop
+      vertex 30.2211 -8.52323 57.2
+      vertex 30.5324 -7.33018 0.799999
+      vertex 30.5324 -7.33018 57.2
+    endloop
+  endfacet
+  facet normal 0.967603 -0.252475 0
+    outer loop
+      vertex 30.5324 -7.33018 0.799999
+      vertex 30.2211 -8.52323 57.2
+      vertex 30.2211 -8.52323 0.799999
+    endloop
+  endfacet
+  facet normal -0.881931 -0.471379 0
+    outer loop
+      vertex -27.3964 -15.3427 0.799999
+      vertex -27.9776 -14.2553 57.2
+      vertex -27.9776 -14.2553 0.799999
+    endloop
+  endfacet
+  facet normal -0.881931 -0.471379 0
+    outer loop
+      vertex -27.9776 -14.2553 57.2
+      vertex -27.3964 -15.3427 0.799999
+      vertex -27.3964 -15.3427 57.2
+    endloop
+  endfacet
+  facet normal 0.984435 -0.175751 0
+    outer loop
+      vertex 30.7967 -6.12584 57.2
+      vertex 31.0134 -4.91204 0.799999
+      vertex 31.0134 -4.91204 57.2
+    endloop
+  endfacet
+  facet normal 0.984435 -0.175751 0
+    outer loop
+      vertex 31.0134 -4.91204 0.799999
+      vertex 30.7967 -6.12584 57.2
+      vertex 30.7967 -6.12584 0.799999
+    endloop
+  endfacet
+  facet normal 0.664273 -0.74749 0
+    outer loop
+      vertex 20.3927 -23.8767 0.799999
+      vertex 21.3143 -23.0577 57.2
+      vertex 20.3927 -23.8767 57.2
+    endloop
+  endfacet
+  facet normal 0.664273 -0.74749 0
+    outer loop
+      vertex 21.3143 -23.0577 57.2
+      vertex 20.3927 -23.8767 0.799999
+      vertex 21.3143 -23.0577 0.799999
+    endloop
+  endfacet
+  facet normal -0.990562 -0.137063 0
+    outer loop
+      vertex -31.0134 -4.91204 0.799999
+      vertex -31.1824 -3.69067 57.2
+      vertex -31.1824 -3.69067 0.799999
+    endloop
+  endfacet
+  facet normal -0.990562 -0.137063 0
+    outer loop
+      vertex -31.1824 -3.69067 57.2
+      vertex -31.0134 -4.91204 0.799999
+      vertex -31.0134 -4.91204 57.2
+    endloop
+  endfacet
+  facet normal 0.916187 0.400751 0
+    outer loop
+      vertex 29.0098 12.0163 57.2
+      vertex 28.5157 13.1459 0.799999
+      vertex 28.5157 13.1459 57.2
+    endloop
+  endfacet
+  facet normal 0.916187 0.400751 0
+    outer loop
+      vertex 28.5157 13.1459 0.799999
+      vertex 29.0098 12.0163 57.2
+      vertex 29.0098 12.0163 0.799999
+    endloop
+  endfacet
+  facet normal -0.364473 0.931214 0
+    outer loop
+      vertex -10.8681 29.4592 0.799999
+      vertex -12.0163 29.0098 57.2
+      vertex -10.8681 29.4592 57.2
+    endloop
+  endfacet
+  facet normal -0.364473 0.931214 0
+    outer loop
+      vertex -12.0163 29.0098 57.2
+      vertex -10.8681 29.4592 0.799999
+      vertex -12.0163 29.0098 0.799999
+    endloop
+  endfacet
+  facet normal 0.69302 0.720919 -0
+    outer loop
+      vertex 22.2032 22.2032 0.799999
+      vertex 21.3143 23.0577 57.2
+      vertex 22.2032 22.2032 57.2
+    endloop
+  endfacet
+  facet normal 0.69302 0.720919 0
+    outer loop
+      vertex 21.3143 23.0577 57.2
+      vertex 22.2032 22.2032 0.799999
+      vertex 21.3143 23.0577 0.799999
+    endloop
+  endfacet
+  facet normal -0.820419 0.571763 0
+    outer loop
+      vertex -26.1081 17.4449 0.799999
+      vertex -25.4031 18.4565 57.2
+      vertex -25.4031 18.4565 0.799999
+    endloop
+  endfacet
+  facet normal -0.820419 0.571763 0
+    outer loop
+      vertex -25.4031 18.4565 57.2
+      vertex -26.1081 17.4449 0.799999
+      vertex -26.1081 17.4449 57.2
+    endloop
+  endfacet
+  facet normal -0.60355 0.797325 0
+    outer loop
+      vertex -18.4565 25.4031 0.799999
+      vertex -19.4395 24.659 57.2
+      vertex -18.4565 25.4031 57.2
+    endloop
+  endfacet
+  facet normal -0.60355 0.797325 0
+    outer loop
+      vertex -19.4395 24.659 57.2
+      vertex -18.4565 25.4031 0.799999
+      vertex -19.4395 24.659 0.799999
+    endloop
+  endfacet
+  facet normal 0.0979739 0.995189 -0
+    outer loop
+      vertex 3.69067 31.1824 0.799999
+      vertex 2.46362 31.3032 57.2
+      vertex 3.69067 31.1824 57.2
+    endloop
+  endfacet
+  facet normal 0.0979739 0.995189 0
+    outer loop
+      vertex 2.46362 31.3032 57.2
+      vertex 3.69067 31.1824 0.799999
+      vertex 2.46362 31.3032 0.799999
+    endloop
+  endfacet
+  facet normal 0.364473 0.931214 -0
+    outer loop
+      vertex 12.0163 29.0098 0.799999
+      vertex 10.8681 29.4592 57.2
+      vertex 12.0163 29.0098 57.2
+    endloop
+  endfacet
+  facet normal 0.364473 0.931214 0
+    outer loop
+      vertex 10.8681 29.4592 57.2
+      vertex 12.0163 29.0098 0.799999
+      vertex 10.8681 29.4592 0.799999
+    endloop
+  endfacet
+  facet normal -0.797325 -0.60355 0
+    outer loop
+      vertex -24.659 -19.4395 0.799999
+      vertex -25.4031 -18.4565 57.2
+      vertex -25.4031 -18.4565 0.799999
+    endloop
+  endfacet
+  facet normal -0.797325 -0.60355 0
+    outer loop
+      vertex -25.4031 -18.4565 57.2
+      vertex -24.659 -19.4395 0.799999
+      vertex -24.659 -19.4395 57.2
+    endloop
+  endfacet
+  facet normal -0.999807 0.019627 0
+    outer loop
+      vertex -31.4 0 0.799999
+      vertex -31.3758 1.23276 57.2
+      vertex -31.3758 1.23276 0.799999
+    endloop
+  endfacet
+  facet normal -0.999807 0.019627 0
+    outer loop
+      vertex -31.3758 1.23276 57.2
+      vertex -31.4 0 0.799999
+      vertex -31.4 0 57.2
+    endloop
+  endfacet
+  facet normal -0.0979739 -0.995189 0
+    outer loop
+      vertex -3.69067 -31.1824 0.799999
+      vertex -2.46362 -31.3032 57.2
+      vertex -3.69067 -31.1824 57.2
+    endloop
+  endfacet
+  facet normal -0.0979739 -0.995189 -0
+    outer loop
+      vertex -2.46362 -31.3032 57.2
+      vertex -3.69067 -31.1824 0.799999
+      vertex -2.46362 -31.3032 0.799999
+    endloop
+  endfacet
+  facet normal 0.842189 0.539183 0
+    outer loop
+      vertex 26.7729 16.4065 57.2
+      vertex 26.1081 17.4449 0.799999
+      vertex 26.1081 17.4449 57.2
+    endloop
+  endfacet
+  facet normal 0.842189 0.539183 0
+    outer loop
+      vertex 26.1081 17.4449 0.799999
+      vertex 26.7729 16.4065 57.2
+      vertex 26.7729 16.4065 0.799999
+    endloop
+  endfacet
+  facet normal -0.999807 -0.019627 0
+    outer loop
+      vertex -31.3758 -1.23276 0.799999
+      vertex -31.4 0 57.2
+      vertex -31.4 0 0.799999
+    endloop
+  endfacet
+  facet normal -0.999807 -0.019627 0
+    outer loop
+      vertex -31.4 0 57.2
+      vertex -31.3758 -1.23276 0.799999
+      vertex -31.3758 -1.23276 57.2
+    endloop
+  endfacet
+  facet normal -0.0588808 -0.998265 0
+    outer loop
+      vertex -2.46362 -31.3032 0.799999
+      vertex -1.23276 -31.3758 57.2
+      vertex -2.46362 -31.3032 57.2
+    endloop
+  endfacet
+  facet normal -0.0588808 -0.998265 -0
+    outer loop
+      vertex -1.23276 -31.3758 57.2
+      vertex -2.46362 -31.3032 0.799999
+      vertex -1.23276 -31.3758 0.799999
+    endloop
+  endfacet
+  facet normal 0.327647 0.9448 -0
+    outer loop
+      vertex 10.8681 29.4592 0.799999
+      vertex 9.70313 29.8632 57.2
+      vertex 10.8681 29.4592 57.2
+    endloop
+  endfacet
+  facet normal 0.327647 0.9448 0
+    outer loop
+      vertex 9.70313 29.8632 57.2
+      vertex 10.8681 29.4592 0.799999
+      vertex 9.70313 29.8632 0.799999
+    endloop
+  endfacet
+  facet normal 0.797325 -0.60355 0
+    outer loop
+      vertex 24.659 -19.4395 57.2
+      vertex 25.4031 -18.4565 0.799999
+      vertex 25.4031 -18.4565 57.2
+    endloop
+  endfacet
+  facet normal 0.797325 -0.60355 0
+    outer loop
+      vertex 25.4031 -18.4565 0.799999
+      vertex 24.659 -19.4395 57.2
+      vertex 24.659 -19.4395 0.799999
+    endloop
+  endfacet
+  facet normal -0.019627 0.999807 0
+    outer loop
+      vertex 0 31.4 0.799999
+      vertex -1.23276 31.3758 57.2
+      vertex 0 31.4 57.2
+    endloop
+  endfacet
+  facet normal -0.019627 0.999807 0
+    outer loop
+      vertex -1.23276 31.3758 57.2
+      vertex 0 31.4 0.799999
+      vertex -1.23276 31.3758 0.799999
+    endloop
+  endfacet
+  facet normal 0.019627 -0.999807 0
+    outer loop
+      vertex 0 -31.4 0.799999
+      vertex 1.23276 -31.3758 57.2
+      vertex 0 -31.4 57.2
+    endloop
+  endfacet
+  facet normal 0.019627 -0.999807 0
+    outer loop
+      vertex 1.23276 -31.3758 57.2
+      vertex 0 -31.4 0.799999
+      vertex 1.23276 -31.3758 0.799999
+    endloop
+  endfacet
+  facet normal -0.137063 -0.990562 0
+    outer loop
+      vertex -4.91204 -31.0134 0.799999
+      vertex -3.69067 -31.1824 57.2
+      vertex -4.91204 -31.0134 57.2
+    endloop
+  endfacet
+  facet normal -0.137063 -0.990562 -0
+    outer loop
+      vertex -3.69067 -31.1824 57.2
+      vertex -4.91204 -31.0134 0.799999
+      vertex -3.69067 -31.1824 0.799999
+    endloop
+  endfacet
+  facet normal 0.400751 -0.916187 0
+    outer loop
+      vertex 12.0163 -29.0098 0.799999
+      vertex 13.1459 -28.5157 57.2
+      vertex 12.0163 -29.0098 57.2
+    endloop
+  endfacet
+  facet normal 0.400751 -0.916187 0
+    outer loop
+      vertex 13.1459 -28.5157 57.2
+      vertex 12.0163 -29.0098 0.799999
+      vertex 13.1459 -28.5157 0.799999
+    endloop
+  endfacet
+  facet normal 0.0588808 -0.998265 0
+    outer loop
+      vertex 1.23276 -31.3758 0.799999
+      vertex 2.46362 -31.3032 57.2
+      vertex 1.23276 -31.3758 57.2
+    endloop
+  endfacet
+  facet normal 0.0588808 -0.998265 0
+    outer loop
+      vertex 2.46362 -31.3032 57.2
+      vertex 1.23276 -31.3758 0.799999
+      vertex 2.46362 -31.3032 0.799999
+    endloop
+  endfacet
+  facet normal 0.290271 -0.956945 0
+    outer loop
+      vertex 8.52323 -30.2211 0.799999
+      vertex 9.70313 -29.8632 57.2
+      vertex 8.52323 -30.2211 57.2
+    endloop
+  endfacet
+  facet normal 0.290271 -0.956945 0
+    outer loop
+      vertex 9.70313 -29.8632 57.2
+      vertex 8.52323 -30.2211 0.799999
+      vertex 9.70313 -29.8632 0.799999
+    endloop
+  endfacet
+  facet normal 0.899748 0.436411 0
+    outer loop
+      vertex 28.5157 13.1459 57.2
+      vertex 27.9776 14.2553 0.799999
+      vertex 27.9776 14.2553 57.2
+    endloop
+  endfacet
+  facet normal 0.899748 0.436411 0
+    outer loop
+      vertex 27.9776 14.2553 0.799999
+      vertex 28.5157 13.1459 57.2
+      vertex 28.5157 13.1459 0.799999
+    endloop
+  endfacet
+  facet normal -0.9448 0.327647 0
+    outer loop
+      vertex -29.8632 9.70313 0.799999
+      vertex -29.4592 10.8681 57.2
+      vertex -29.4592 10.8681 0.799999
+    endloop
+  endfacet
+  facet normal -0.9448 0.327647 0
+    outer loop
+      vertex -29.4592 10.8681 57.2
+      vertex -29.8632 9.70313 0.799999
+      vertex -29.8632 9.70313 57.2
+    endloop
+  endfacet
+  facet normal -0.364473 -0.931214 0
+    outer loop
+      vertex -12.0163 -29.0098 0.799999
+      vertex -10.8681 -29.4592 57.2
+      vertex -12.0163 -29.0098 57.2
+    endloop
+  endfacet
+  facet normal -0.364473 -0.931214 -0
+    outer loop
+      vertex -10.8681 -29.4592 57.2
+      vertex -12.0163 -29.0098 0.799999
+      vertex -10.8681 -29.4592 0.799999
+    endloop
+  endfacet
+  facet normal 0.634407 0.772999 -0
+    outer loop
+      vertex 20.3927 23.8767 0.799999
+      vertex 19.4395 24.659 57.2
+      vertex 20.3927 23.8767 57.2
+    endloop
+  endfacet
+  facet normal 0.634407 0.772999 0
+    outer loop
+      vertex 19.4395 24.659 57.2
+      vertex 20.3927 23.8767 0.799999
+      vertex 19.4395 24.659 0.799999
+    endloop
+  endfacet
+  facet normal -0.998265 0.0588808 0
+    outer loop
+      vertex -31.3758 1.23276 0.799999
+      vertex -31.3032 2.46362 57.2
+      vertex -31.3032 2.46362 0.799999
+    endloop
+  endfacet
+  facet normal -0.998265 0.0588808 0
+    outer loop
+      vertex -31.3032 2.46362 57.2
+      vertex -31.3758 1.23276 0.799999
+      vertex -31.3758 1.23276 57.2
+    endloop
+  endfacet
+  facet normal 0.505655 -0.862736 0
+    outer loop
+      vertex 15.3427 -27.3964 0.799999
+      vertex 16.4065 -26.7729 57.2
+      vertex 15.3427 -27.3964 57.2
+    endloop
+  endfacet
+  facet normal 0.505655 -0.862736 0
+    outer loop
+      vertex 16.4065 -26.7729 57.2
+      vertex 15.3427 -27.3964 0.799999
+      vertex 16.4065 -26.7729 0.799999
+    endloop
+  endfacet
+  facet normal -0.571763 0.820419 0
+    outer loop
+      vertex -17.4449 26.1081 0.799999
+      vertex -18.4565 25.4031 57.2
+      vertex -17.4449 26.1081 57.2
+    endloop
+  endfacet
+  facet normal -0.571763 0.820419 0
+    outer loop
+      vertex -18.4565 25.4031 57.2
+      vertex -17.4449 26.1081 0.799999
+      vertex -18.4565 25.4031 0.799999
+    endloop
+  endfacet
+  facet normal -0.634407 -0.772999 0
+    outer loop
+      vertex -20.3927 -23.8767 0.799999
+      vertex -19.4395 -24.659 57.2
+      vertex -20.3927 -23.8767 57.2
+    endloop
+  endfacet
+  facet normal -0.634407 -0.772999 -0
+    outer loop
+      vertex -19.4395 -24.659 57.2
+      vertex -20.3927 -23.8767 0.799999
+      vertex -19.4395 -24.659 0.799999
+    endloop
+  endfacet
+  facet normal 0.976756 -0.214355 0
+    outer loop
+      vertex 30.5324 -7.33018 57.2
+      vertex 30.7967 -6.12584 0.799999
+      vertex 30.7967 -6.12584 57.2
+    endloop
+  endfacet
+  facet normal 0.976756 -0.214355 0
+    outer loop
+      vertex 30.7967 -6.12584 0.799999
+      vertex 30.5324 -7.33018 57.2
+      vertex 30.5324 -7.33018 0.799999
+    endloop
+  endfacet
+  facet normal -0.899748 0.436411 0
+    outer loop
+      vertex -28.5157 13.1459 0.799999
+      vertex -27.9776 14.2553 57.2
+      vertex -27.9776 14.2553 0.799999
+    endloop
+  endfacet
+  facet normal -0.899748 0.436411 0
+    outer loop
+      vertex -27.9776 14.2553 57.2
+      vertex -28.5157 13.1459 0.799999
+      vertex -28.5157 13.1459 57.2
+    endloop
+  endfacet
+  facet normal 0.364473 -0.931214 0
+    outer loop
+      vertex 10.8681 -29.4592 0.799999
+      vertex 12.0163 -29.0098 57.2
+      vertex 10.8681 -29.4592 57.2
+    endloop
+  endfacet
+  facet normal 0.364473 -0.931214 0
+    outer loop
+      vertex 12.0163 -29.0098 57.2
+      vertex 10.8681 -29.4592 0.799999
+      vertex 12.0163 -29.0098 0.799999
+    endloop
+  endfacet
+  facet normal -0.290271 -0.956945 0
+    outer loop
+      vertex -9.70313 -29.8632 0.799999
+      vertex -8.52323 -30.2211 57.2
+      vertex -9.70313 -29.8632 57.2
+    endloop
+  endfacet
+  facet normal -0.290271 -0.956945 -0
+    outer loop
+      vertex -8.52323 -30.2211 57.2
+      vertex -9.70313 -29.8632 0.799999
+      vertex -8.52323 -30.2211 0.799999
+    endloop
+  endfacet
+  facet normal 0.999807 -0.019627 0
+    outer loop
+      vertex 31.3758 -1.23276 57.2
+      vertex 31.4 0 0.799999
+      vertex 31.4 0 57.2
+    endloop
+  endfacet
+  facet normal 0.999807 -0.019627 0
+    outer loop
+      vertex 31.4 0 0.799999
+      vertex 31.3758 -1.23276 57.2
+      vertex 31.3758 -1.23276 0.799999
+    endloop
+  endfacet
+  facet normal -0.931214 0.364473 0
+    outer loop
+      vertex -29.4592 10.8681 0.799999
+      vertex -29.0098 12.0163 57.2
+      vertex -29.0098 12.0163 0.799999
+    endloop
+  endfacet
+  facet normal -0.931214 0.364473 0
+    outer loop
+      vertex -29.0098 12.0163 57.2
+      vertex -29.4592 10.8681 0.799999
+      vertex -29.4592 10.8681 57.2
+    endloop
+  endfacet
+  facet normal 0.990562 -0.137063 0
+    outer loop
+      vertex 31.0134 -4.91204 57.2
+      vertex 31.1824 -3.69067 0.799999
+      vertex 31.1824 -3.69067 57.2
+    endloop
+  endfacet
+  facet normal 0.990562 -0.137063 0
+    outer loop
+      vertex 31.1824 -3.69067 0.799999
+      vertex 31.0134 -4.91204 57.2
+      vertex 31.0134 -4.91204 0.799999
+    endloop
+  endfacet
+  facet normal -0.797325 0.60355 0
+    outer loop
+      vertex -25.4031 18.4565 0.799999
+      vertex -24.659 19.4395 57.2
+      vertex -24.659 19.4395 0.799999
+    endloop
+  endfacet
+  facet normal -0.797325 0.60355 0
+    outer loop
+      vertex -24.659 19.4395 57.2
+      vertex -25.4031 18.4565 0.799999
+      vertex -25.4031 18.4565 57.2
+    endloop
+  endfacet
+  facet normal -0.436411 0.899748 0
+    outer loop
+      vertex -13.1459 28.5157 0.799999
+      vertex -14.2553 27.9776 57.2
+      vertex -13.1459 28.5157 57.2
+    endloop
+  endfacet
+  facet normal -0.436411 0.899748 0
+    outer loop
+      vertex -14.2553 27.9776 57.2
+      vertex -13.1459 28.5157 0.799999
+      vertex -14.2553 27.9776 0.799999
+    endloop
+  endfacet
+  facet normal -0.984435 -0.175751 0
+    outer loop
+      vertex -30.7967 -6.12584 0.799999
+      vertex -31.0134 -4.91204 57.2
+      vertex -31.0134 -4.91204 0.799999
+    endloop
+  endfacet
+  facet normal -0.984435 -0.175751 0
+    outer loop
+      vertex -31.0134 -4.91204 57.2
+      vertex -30.7967 -6.12584 0.799999
+      vertex -30.7967 -6.12584 57.2
+    endloop
+  endfacet
+  facet normal 0.931214 0.364473 0
+    outer loop
+      vertex 29.4592 10.8681 57.2
+      vertex 29.0098 12.0163 0.799999
+      vertex 29.0098 12.0163 57.2
+    endloop
+  endfacet
+  facet normal 0.931214 0.364473 0
+    outer loop
+      vertex 29.0098 12.0163 0.799999
+      vertex 29.4592 10.8681 57.2
+      vertex 29.4592 10.8681 0.799999
+    endloop
+  endfacet
+  facet normal -0.916187 -0.400751 0
+    outer loop
+      vertex -28.5157 -13.1459 0.799999
+      vertex -29.0098 -12.0163 57.2
+      vertex -29.0098 -12.0163 0.799999
+    endloop
+  endfacet
+  facet normal -0.916187 -0.400751 0
+    outer loop
+      vertex -29.0098 -12.0163 57.2
+      vertex -28.5157 -13.1459 0.799999
+      vertex -28.5157 -13.1459 57.2
+    endloop
+  endfacet
+  facet normal 0.9448 -0.327647 0
+    outer loop
+      vertex 29.4592 -10.8681 57.2
+      vertex 29.8632 -9.70313 0.799999
+      vertex 29.8632 -9.70313 57.2
+    endloop
+  endfacet
+  facet normal 0.9448 -0.327647 0
+    outer loop
+      vertex 29.8632 -9.70313 0.799999
+      vertex 29.4592 -10.8681 57.2
+      vertex 29.4592 -10.8681 0.799999
+    endloop
+  endfacet
+  facet normal -0.664273 -0.74749 0
+    outer loop
+      vertex -21.3143 -23.0577 0.799999
+      vertex -20.3927 -23.8767 57.2
+      vertex -21.3143 -23.0577 57.2
+    endloop
+  endfacet
+  facet normal -0.664273 -0.74749 -0
+    outer loop
+      vertex -20.3927 -23.8767 57.2
+      vertex -21.3143 -23.0577 0.799999
+      vertex -20.3927 -23.8767 0.799999
+    endloop
+  endfacet
+  facet normal 0.984435 0.175751 0
+    outer loop
+      vertex 31.0134 4.91204 57.2
+      vertex 30.7967 6.12584 0.799999
+      vertex 30.7967 6.12584 57.2
+    endloop
+  endfacet
+  facet normal 0.984435 0.175751 0
+    outer loop
+      vertex 30.7967 6.12584 0.799999
+      vertex 31.0134 4.91204 57.2
+      vertex 31.0134 4.91204 0.799999
+    endloop
+  endfacet
+  facet normal -0.842189 -0.539183 0
+    outer loop
+      vertex -26.1081 -17.4449 0.799999
+      vertex -26.7729 -16.4065 57.2
+      vertex -26.7729 -16.4065 0.799999
+    endloop
+  endfacet
+  facet normal -0.842189 -0.539183 0
+    outer loop
+      vertex -26.7729 -16.4065 57.2
+      vertex -26.1081 -17.4449 0.799999
+      vertex -26.1081 -17.4449 57.2
+    endloop
+  endfacet
+  facet normal 0.60355 -0.797325 0
+    outer loop
+      vertex 18.4565 -25.4031 0.799999
+      vertex 19.4395 -24.659 57.2
+      vertex 18.4565 -25.4031 57.2
+    endloop
+  endfacet
+  facet normal 0.60355 -0.797325 0
+    outer loop
+      vertex 19.4395 -24.659 57.2
+      vertex 18.4565 -25.4031 0.799999
+      vertex 19.4395 -24.659 0.799999
+    endloop
+  endfacet
+  facet normal -0.899748 -0.436411 0
+    outer loop
+      vertex -27.9776 -14.2553 0.799999
+      vertex -28.5157 -13.1459 57.2
+      vertex -28.5157 -13.1459 0.799999
+    endloop
+  endfacet
+  facet normal -0.899748 -0.436411 0
+    outer loop
+      vertex -28.5157 -13.1459 57.2
+      vertex -27.9776 -14.2553 0.799999
+      vertex -27.9776 -14.2553 57.2
+    endloop
+  endfacet
+  facet normal 0.990562 0.137063 0
+    outer loop
+      vertex 31.1824 3.69067 57.2
+      vertex 31.0134 4.91204 0.799999
+      vertex 31.0134 4.91204 57.2
+    endloop
+  endfacet
+  facet normal 0.990562 0.137063 0
+    outer loop
+      vertex 31.0134 4.91204 0.799999
+      vertex 31.1824 3.69067 57.2
+      vertex 31.1824 3.69067 0.799999
+    endloop
+  endfacet
+  facet normal 0.400751 0.916187 -0
+    outer loop
+      vertex 13.1459 28.5157 0.799999
+      vertex 12.0163 29.0098 57.2
+      vertex 13.1459 28.5157 57.2
+    endloop
+  endfacet
+  facet normal 0.400751 0.916187 0
+    outer loop
+      vertex 12.0163 29.0098 57.2
+      vertex 13.1459 28.5157 0.799999
+      vertex 12.0163 29.0098 0.799999
+    endloop
+  endfacet
+  facet normal -0.175751 -0.984435 0
+    outer loop
+      vertex -6.12584 -30.7967 0.799999
+      vertex -4.91204 -31.0134 57.2
+      vertex -6.12584 -30.7967 57.2
+    endloop
+  endfacet
+  facet normal -0.175751 -0.984435 -0
+    outer loop
+      vertex -4.91204 -31.0134 57.2
+      vertex -6.12584 -30.7967 0.799999
+      vertex -4.91204 -31.0134 0.799999
+    endloop
+  endfacet
+  facet normal -0.175751 0.984435 0
+    outer loop
+      vertex -4.91204 31.0134 0.799999
+      vertex -6.12584 30.7967 57.2
+      vertex -4.91204 31.0134 57.2
+    endloop
+  endfacet
+  facet normal -0.175751 0.984435 0
+    outer loop
+      vertex -6.12584 30.7967 57.2
+      vertex -4.91204 31.0134 0.799999
+      vertex -6.12584 30.7967 0.799999
+    endloop
+  endfacet
+  facet normal 0.862736 0.505655 0
+    outer loop
+      vertex 27.3964 15.3427 57.2
+      vertex 26.7729 16.4065 0.799999
+      vertex 26.7729 16.4065 57.2
+    endloop
+  endfacet
+  facet normal 0.862736 0.505655 0
+    outer loop
+      vertex 26.7729 16.4065 0.799999
+      vertex 27.3964 15.3427 57.2
+      vertex 27.3964 15.3427 0.799999
+    endloop
+  endfacet
+  facet normal 0.976756 0.214355 0
+    outer loop
+      vertex 30.7967 6.12584 57.2
+      vertex 30.5324 7.33018 0.799999
+      vertex 30.5324 7.33018 57.2
+    endloop
+  endfacet
+  facet normal 0.976756 0.214355 0
+    outer loop
+      vertex 30.5324 7.33018 0.799999
+      vertex 30.7967 6.12584 57.2
+      vertex 30.7967 6.12584 0.799999
+    endloop
+  endfacet
+  facet normal 0.967603 0.252475 0
+    outer loop
+      vertex 30.5324 7.33018 57.2
+      vertex 30.2211 8.52323 0.799999
+      vertex 30.2211 8.52323 57.2
+    endloop
+  endfacet
+  facet normal 0.967603 0.252475 0
+    outer loop
+      vertex 30.2211 8.52323 0.799999
+      vertex 30.5324 7.33018 57.2
+      vertex 30.5324 7.33018 0.799999
+    endloop
+  endfacet
+  facet normal -0.820419 -0.571763 0
+    outer loop
+      vertex -25.4031 -18.4565 0.799999
+      vertex -26.1081 -17.4449 57.2
+      vertex -26.1081 -17.4449 0.799999
+    endloop
+  endfacet
+  facet normal -0.820419 -0.571763 0
+    outer loop
+      vertex -26.1081 -17.4449 57.2
+      vertex -25.4031 -18.4565 0.799999
+      vertex -25.4031 -18.4565 57.2
+    endloop
+  endfacet
+  facet normal 0.571763 0.820419 -0
+    outer loop
+      vertex 18.4565 25.4031 0.799999
+      vertex 17.4449 26.1081 57.2
+      vertex 18.4565 25.4031 57.2
+    endloop
+  endfacet
+  facet normal 0.571763 0.820419 0
+    outer loop
+      vertex 17.4449 26.1081 57.2
+      vertex 18.4565 25.4031 0.799999
+      vertex 17.4449 26.1081 0.799999
+    endloop
+  endfacet
+  facet normal 0.019627 0.999807 -0
+    outer loop
+      vertex 1.23276 31.3758 0.799999
+      vertex 0 31.4 57.2
+      vertex 1.23276 31.3758 57.2
+    endloop
+  endfacet
+  facet normal 0.019627 0.999807 0
+    outer loop
+      vertex 0 31.4 57.2
+      vertex 1.23276 31.3758 0.799999
+      vertex 0 31.4 0.799999
+    endloop
+  endfacet
+  facet normal 0.862736 -0.505655 0
+    outer loop
+      vertex 26.7729 -16.4065 57.2
+      vertex 27.3964 -15.3427 0.799999
+      vertex 27.3964 -15.3427 57.2
+    endloop
+  endfacet
+  facet normal 0.862736 -0.505655 0
+    outer loop
+      vertex 27.3964 -15.3427 0.799999
+      vertex 26.7729 -16.4065 57.2
+      vertex 26.7729 -16.4065 0.799999
+    endloop
+  endfacet
+  facet normal 0.539183 0.842189 -0
+    outer loop
+      vertex 17.4449 26.1081 0.799999
+      vertex 16.4065 26.7729 57.2
+      vertex 17.4449 26.1081 57.2
+    endloop
+  endfacet
+  facet normal 0.539183 0.842189 0
+    outer loop
+      vertex 16.4065 26.7729 57.2
+      vertex 17.4449 26.1081 0.799999
+      vertex 16.4065 26.7729 0.799999
+    endloop
+  endfacet
+  facet normal 0.634407 -0.772999 0
+    outer loop
+      vertex 19.4395 -24.659 0.799999
+      vertex 20.3927 -23.8767 57.2
+      vertex 19.4395 -24.659 57.2
+    endloop
+  endfacet
+  facet normal 0.634407 -0.772999 0
+    outer loop
+      vertex 20.3927 -23.8767 57.2
+      vertex 19.4395 -24.659 0.799999
+      vertex 20.3927 -23.8767 0.799999
+    endloop
+  endfacet
+  facet normal -0.720919 -0.69302 0
+    outer loop
+      vertex -22.2032 -22.2032 0.799999
+      vertex -23.0577 -21.3143 57.2
+      vertex -23.0577 -21.3143 0.799999
+    endloop
+  endfacet
+  facet normal -0.720919 -0.69302 0
+    outer loop
+      vertex -23.0577 -21.3143 57.2
+      vertex -22.2032 -22.2032 0.799999
+      vertex -22.2032 -22.2032 57.2
+    endloop
+  endfacet
+  facet normal -0.976756 -0.214355 0
+    outer loop
+      vertex -30.5324 -7.33018 0.799999
+      vertex -30.7967 -6.12584 57.2
+      vertex -30.7967 -6.12584 0.799999
+    endloop
+  endfacet
+  facet normal -0.976756 -0.214355 0
+    outer loop
+      vertex -30.7967 -6.12584 57.2
+      vertex -30.5324 -7.33018 0.799999
+      vertex -30.5324 -7.33018 57.2
+    endloop
+  endfacet
+  facet normal -0.0979739 0.995189 0
+    outer loop
+      vertex -2.46362 31.3032 0.799999
+      vertex -3.69067 31.1824 57.2
+      vertex -2.46362 31.3032 57.2
+    endloop
+  endfacet
+  facet normal -0.0979739 0.995189 0
+    outer loop
+      vertex -3.69067 31.1824 57.2
+      vertex -2.46362 31.3032 0.799999
+      vertex -3.69067 31.1824 0.799999
+    endloop
+  endfacet
+  facet normal 0.797325 0.60355 0
+    outer loop
+      vertex 25.4031 18.4565 57.2
+      vertex 24.659 19.4395 0.799999
+      vertex 24.659 19.4395 57.2
+    endloop
+  endfacet
+  facet normal 0.797325 0.60355 0
+    outer loop
+      vertex 24.659 19.4395 0.799999
+      vertex 25.4031 18.4565 57.2
+      vertex 25.4031 18.4565 0.799999
+    endloop
+  endfacet
+  facet normal 0.720919 0.69302 0
+    outer loop
+      vertex 23.0577 21.3143 57.2
+      vertex 22.2032 22.2032 0.799999
+      vertex 22.2032 22.2032 57.2
+    endloop
+  endfacet
+  facet normal 0.720919 0.69302 0
+    outer loop
+      vertex 22.2032 22.2032 0.799999
+      vertex 23.0577 21.3143 57.2
+      vertex 23.0577 21.3143 0.799999
+    endloop
+  endfacet
+  facet normal -0.956945 0.290271 0
+    outer loop
+      vertex -30.2211 8.52323 0.799999
+      vertex -29.8632 9.70313 57.2
+      vertex -29.8632 9.70313 0.799999
+    endloop
+  endfacet
+  facet normal -0.956945 0.290271 0
+    outer loop
+      vertex -29.8632 9.70313 57.2
+      vertex -30.2211 8.52323 0.799999
+      vertex -30.2211 8.52323 57.2
+    endloop
+  endfacet
+  facet normal -0.998265 -0.0588808 0
+    outer loop
+      vertex -31.3032 -2.46362 0.799999
+      vertex -31.3758 -1.23276 57.2
+      vertex -31.3758 -1.23276 0.799999
+    endloop
+  endfacet
+  facet normal -0.998265 -0.0588808 0
+    outer loop
+      vertex -31.3758 -1.23276 57.2
+      vertex -31.3032 -2.46362 0.799999
+      vertex -31.3032 -2.46362 57.2
+    endloop
+  endfacet
+  facet normal 0.664273 0.74749 -0
+    outer loop
+      vertex 21.3143 23.0577 0.799999
+      vertex 20.3927 23.8767 57.2
+      vertex 21.3143 23.0577 57.2
+    endloop
+  endfacet
+  facet normal 0.664273 0.74749 0
+    outer loop
+      vertex 20.3927 23.8767 57.2
+      vertex 21.3143 23.0577 0.799999
+      vertex 20.3927 23.8767 0.799999
+    endloop
+  endfacet
+  facet normal -0.74749 0.664273 0
+    outer loop
+      vertex -23.8767 20.3927 0.799999
+      vertex -23.0577 21.3143 57.2
+      vertex -23.0577 21.3143 0.799999
+    endloop
+  endfacet
+  facet normal -0.74749 0.664273 0
+    outer loop
+      vertex -23.0577 21.3143 57.2
+      vertex -23.8767 20.3927 0.799999
+      vertex -23.8767 20.3927 57.2
+    endloop
+  endfacet
+  facet normal -0.69302 -0.720919 0
+    outer loop
+      vertex -22.2032 -22.2032 0.799999
+      vertex -21.3143 -23.0577 57.2
+      vertex -22.2032 -22.2032 57.2
+    endloop
+  endfacet
+  facet normal -0.69302 -0.720919 -0
+    outer loop
+      vertex -21.3143 -23.0577 57.2
+      vertex -22.2032 -22.2032 0.799999
+      vertex -21.3143 -23.0577 0.799999
+    endloop
+  endfacet
+  facet normal -0.214355 0.976756 0
+    outer loop
+      vertex -6.12584 30.7967 0.799999
+      vertex -7.33018 30.5324 57.2
+      vertex -6.12584 30.7967 57.2
+    endloop
+  endfacet
+  facet normal -0.214355 0.976756 0
+    outer loop
+      vertex -7.33018 30.5324 57.2
+      vertex -6.12584 30.7967 0.799999
+      vertex -7.33018 30.5324 0.799999
+    endloop
+  endfacet
+  facet normal -0.720919 0.69302 0
+    outer loop
+      vertex -23.0577 21.3143 0.799999
+      vertex -22.2032 22.2032 57.2
+      vertex -22.2032 22.2032 0.799999
+    endloop
+  endfacet
+  facet normal -0.720919 0.69302 0
+    outer loop
+      vertex -22.2032 22.2032 57.2
+      vertex -23.0577 21.3143 0.799999
+      vertex -23.0577 21.3143 57.2
+    endloop
+  endfacet
+  facet normal 0.74749 -0.664273 0
+    outer loop
+      vertex 23.0577 -21.3143 57.2
+      vertex 23.8767 -20.3927 0.799999
+      vertex 23.8767 -20.3927 57.2
+    endloop
+  endfacet
+  facet normal 0.74749 -0.664273 0
+    outer loop
+      vertex 23.8767 -20.3927 0.799999
+      vertex 23.0577 -21.3143 57.2
+      vertex 23.0577 -21.3143 0.799999
+    endloop
+  endfacet
+  facet normal -0.252475 0.967603 0
+    outer loop
+      vertex -7.33018 30.5324 0.799999
+      vertex -8.52323 30.2211 57.2
+      vertex -7.33018 30.5324 57.2
+    endloop
+  endfacet
+  facet normal -0.252475 0.967603 0
+    outer loop
+      vertex -8.52323 30.2211 57.2
+      vertex -7.33018 30.5324 0.799999
+      vertex -8.52323 30.2211 0.799999
+    endloop
+  endfacet
+  facet normal -0.990562 0.137063 0
+    outer loop
+      vertex -31.1824 3.69067 0.799999
+      vertex -31.0134 4.91204 57.2
+      vertex -31.0134 4.91204 0.799999
+    endloop
+  endfacet
+  facet normal -0.990562 0.137063 0
+    outer loop
+      vertex -31.0134 4.91204 57.2
+      vertex -31.1824 3.69067 0.799999
+      vertex -31.1824 3.69067 57.2
+    endloop
+  endfacet
+  facet normal -0.69302 0.720919 0
+    outer loop
+      vertex -21.3143 23.0577 0.799999
+      vertex -22.2032 22.2032 57.2
+      vertex -21.3143 23.0577 57.2
+    endloop
+  endfacet
+  facet normal -0.69302 0.720919 0
+    outer loop
+      vertex -22.2032 22.2032 57.2
+      vertex -21.3143 23.0577 0.799999
+      vertex -22.2032 22.2032 0.799999
+    endloop
+  endfacet
+  facet normal -0.0588808 0.998265 0
+    outer loop
+      vertex -1.23276 31.3758 0.799999
+      vertex -2.46362 31.3032 57.2
+      vertex -1.23276 31.3758 57.2
+    endloop
+  endfacet
+  facet normal -0.0588808 0.998265 0
+    outer loop
+      vertex -2.46362 31.3032 57.2
+      vertex -1.23276 31.3758 0.799999
+      vertex -2.46362 31.3032 0.799999
+    endloop
+  endfacet
+  facet normal -0.664273 0.74749 0
+    outer loop
+      vertex -20.3927 23.8767 0.799999
+      vertex -21.3143 23.0577 57.2
+      vertex -20.3927 23.8767 57.2
+    endloop
+  endfacet
+  facet normal -0.664273 0.74749 0
+    outer loop
+      vertex -21.3143 23.0577 57.2
+      vertex -20.3927 23.8767 0.799999
+      vertex -21.3143 23.0577 0.799999
+    endloop
+  endfacet
+  facet normal -0.74749 -0.664273 0
+    outer loop
+      vertex -23.0577 -21.3143 0.799999
+      vertex -23.8767 -20.3927 57.2
+      vertex -23.8767 -20.3927 0.799999
+    endloop
+  endfacet
+  facet normal -0.74749 -0.664273 0
+    outer loop
+      vertex -23.8767 -20.3927 57.2
+      vertex -23.0577 -21.3143 0.799999
+      vertex -23.0577 -21.3143 57.2
+    endloop
+  endfacet
+  facet normal 0.931214 -0.364473 0
+    outer loop
+      vertex 29.0098 -12.0163 57.2
+      vertex 29.4592 -10.8681 0.799999
+      vertex 29.4592 -10.8681 57.2
+    endloop
+  endfacet
+  facet normal 0.931214 -0.364473 0
+    outer loop
+      vertex 29.4592 -10.8681 0.799999
+      vertex 29.0098 -12.0163 57.2
+      vertex 29.0098 -12.0163 0.799999
+    endloop
+  endfacet
+  facet normal 0.995189 -0.0979739 0
+    outer loop
+      vertex 31.1824 -3.69067 57.2
+      vertex 31.3032 -2.46362 0.799999
+      vertex 31.3032 -2.46362 57.2
+    endloop
+  endfacet
+  facet normal 0.995189 -0.0979739 0
+    outer loop
+      vertex 31.3032 -2.46362 0.799999
+      vertex 31.1824 -3.69067 57.2
+      vertex 31.1824 -3.69067 0.799999
+    endloop
+  endfacet
+  facet normal -0.9448 -0.327647 0
+    outer loop
+      vertex -29.4592 -10.8681 0.799999
+      vertex -29.8632 -9.70313 57.2
+      vertex -29.8632 -9.70313 0.799999
+    endloop
+  endfacet
+  facet normal -0.9448 -0.327647 0
+    outer loop
+      vertex -29.8632 -9.70313 57.2
+      vertex -29.4592 -10.8681 0.799999
+      vertex -29.4592 -10.8681 57.2
+    endloop
+  endfacet
+  facet normal -0.436411 -0.899748 0
+    outer loop
+      vertex -14.2553 -27.9776 0.799999
+      vertex -13.1459 -28.5157 57.2
+      vertex -14.2553 -27.9776 57.2
+    endloop
+  endfacet
+  facet normal -0.436411 -0.899748 -0
+    outer loop
+      vertex -13.1459 -28.5157 57.2
+      vertex -14.2553 -27.9776 0.799999
+      vertex -13.1459 -28.5157 0.799999
+    endloop
+  endfacet
+  facet normal -0.881931 0.471379 0
+    outer loop
+      vertex -27.9776 14.2553 0.799999
+      vertex -27.3964 15.3427 57.2
+      vertex -27.3964 15.3427 0.799999
+    endloop
+  endfacet
+  facet normal -0.881931 0.471379 0
+    outer loop
+      vertex -27.3964 15.3427 57.2
+      vertex -27.9776 14.2553 0.799999
+      vertex -27.9776 14.2553 57.2
+    endloop
+  endfacet
+  facet normal -0.471379 0.881931 0
+    outer loop
+      vertex -14.2553 27.9776 0.799999
+      vertex -15.3427 27.3964 57.2
+      vertex -14.2553 27.9776 57.2
+    endloop
+  endfacet
+  facet normal -0.471379 0.881931 0
+    outer loop
+      vertex -15.3427 27.3964 57.2
+      vertex -14.2553 27.9776 0.799999
+      vertex -15.3427 27.3964 0.799999
+    endloop
+  endfacet
+  facet normal 0.436411 -0.899748 0
+    outer loop
+      vertex 13.1459 -28.5157 0.799999
+      vertex 14.2553 -27.9776 57.2
+      vertex 13.1459 -28.5157 57.2
+    endloop
+  endfacet
+  facet normal 0.436411 -0.899748 0
+    outer loop
+      vertex 14.2553 -27.9776 57.2
+      vertex 13.1459 -28.5157 0.799999
+      vertex 14.2553 -27.9776 0.799999
+    endloop
+  endfacet
+  facet normal -0.539183 0.842189 0
+    outer loop
+      vertex -16.4065 26.7729 0.799999
+      vertex -17.4449 26.1081 57.2
+      vertex -16.4065 26.7729 57.2
+    endloop
+  endfacet
+  facet normal -0.539183 0.842189 0
+    outer loop
+      vertex -17.4449 26.1081 57.2
+      vertex -16.4065 26.7729 0.799999
+      vertex -17.4449 26.1081 0.799999
+    endloop
+  endfacet
+  facet normal -0.931214 -0.364473 0
+    outer loop
+      vertex -29.0098 -12.0163 0.799999
+      vertex -29.4592 -10.8681 57.2
+      vertex -29.4592 -10.8681 0.799999
+    endloop
+  endfacet
+  facet normal -0.931214 -0.364473 0
+    outer loop
+      vertex -29.4592 -10.8681 57.2
+      vertex -29.0098 -12.0163 0.799999
+      vertex -29.0098 -12.0163 57.2
+    endloop
+  endfacet
+  facet normal 0.539183 -0.842189 0
+    outer loop
+      vertex 16.4065 -26.7729 0.799999
+      vertex 17.4449 -26.1081 57.2
+      vertex 16.4065 -26.7729 57.2
+    endloop
+  endfacet
+  facet normal 0.539183 -0.842189 0
+    outer loop
+      vertex 17.4449 -26.1081 57.2
+      vertex 16.4065 -26.7729 0.799999
+      vertex 17.4449 -26.1081 0.799999
+    endloop
+  endfacet
+  facet normal -0.956945 -0.290271 0
+    outer loop
+      vertex -29.8632 -9.70313 0.799999
+      vertex -30.2211 -8.52323 57.2
+      vertex -30.2211 -8.52323 0.799999
+    endloop
+  endfacet
+  facet normal -0.956945 -0.290271 0
+    outer loop
+      vertex -30.2211 -8.52323 57.2
+      vertex -29.8632 -9.70313 0.799999
+      vertex -29.8632 -9.70313 57.2
+    endloop
+  endfacet
+  facet normal 0.881931 0.471379 0
+    outer loop
+      vertex 27.9776 14.2553 57.2
+      vertex 27.3964 15.3427 0.799999
+      vertex 27.3964 15.3427 57.2
+    endloop
+  endfacet
+  facet normal 0.881931 0.471379 0
+    outer loop
+      vertex 27.3964 15.3427 0.799999
+      vertex 27.9776 14.2553 57.2
+      vertex 27.9776 14.2553 0.799999
+    endloop
+  endfacet
+  facet normal 0.505655 0.862736 -0
+    outer loop
+      vertex 16.4065 26.7729 0.799999
+      vertex 15.3427 27.3964 57.2
+      vertex 16.4065 26.7729 57.2
+    endloop
+  endfacet
+  facet normal 0.505655 0.862736 0
+    outer loop
+      vertex 15.3427 27.3964 57.2
+      vertex 16.4065 26.7729 0.799999
+      vertex 15.3427 27.3964 0.799999
+    endloop
+  endfacet
+  facet normal 0.0588808 0.998265 -0
+    outer loop
+      vertex 2.46362 31.3032 0.799999
+      vertex 1.23276 31.3758 57.2
+      vertex 2.46362 31.3032 57.2
+    endloop
+  endfacet
+  facet normal 0.0588808 0.998265 0
+    outer loop
+      vertex 1.23276 31.3758 57.2
+      vertex 2.46362 31.3032 0.799999
+      vertex 1.23276 31.3758 0.799999
+    endloop
+  endfacet
+  facet normal 0.60355 0.797325 -0
+    outer loop
+      vertex 19.4395 24.659 0.799999
+      vertex 18.4565 25.4031 57.2
+      vertex 19.4395 24.659 57.2
+    endloop
+  endfacet
+  facet normal 0.60355 0.797325 0
+    outer loop
+      vertex 18.4565 25.4031 57.2
+      vertex 19.4395 24.659 0.799999
+      vertex 18.4565 25.4031 0.799999
+    endloop
+  endfacet
+  facet normal -0.862736 -0.505655 0
+    outer loop
+      vertex -26.7729 -16.4065 0.799999
+      vertex -27.3964 -15.3427 57.2
+      vertex -27.3964 -15.3427 0.799999
+    endloop
+  endfacet
+  facet normal -0.862736 -0.505655 0
+    outer loop
+      vertex -27.3964 -15.3427 57.2
+      vertex -26.7729 -16.4065 0.799999
+      vertex -26.7729 -16.4065 57.2
+    endloop
+  endfacet
+  facet normal -0.137063 0.990562 0
+    outer loop
+      vertex -3.69067 31.1824 0.799999
+      vertex -4.91204 31.0134 57.2
+      vertex -3.69067 31.1824 57.2
+    endloop
+  endfacet
+  facet normal -0.137063 0.990562 0
+    outer loop
+      vertex -4.91204 31.0134 57.2
+      vertex -3.69067 31.1824 0.799999
+      vertex -4.91204 31.0134 0.799999
+    endloop
+  endfacet
+  facet normal 0.899748 -0.436411 0
+    outer loop
+      vertex 27.9776 -14.2553 57.2
+      vertex 28.5157 -13.1459 0.799999
+      vertex 28.5157 -13.1459 57.2
+    endloop
+  endfacet
+  facet normal 0.899748 -0.436411 0
+    outer loop
+      vertex 28.5157 -13.1459 0.799999
+      vertex 27.9776 -14.2553 57.2
+      vertex 27.9776 -14.2553 0.799999
+    endloop
+  endfacet
+  facet normal -0.327647 -0.9448 0
+    outer loop
+      vertex -10.8681 -29.4592 0.799999
+      vertex -9.70313 -29.8632 57.2
+      vertex -10.8681 -29.4592 57.2
+    endloop
+  endfacet
+  facet normal -0.327647 -0.9448 -0
+    outer loop
+      vertex -9.70313 -29.8632 57.2
+      vertex -10.8681 -29.4592 0.799999
+      vertex -9.70313 -29.8632 0.799999
+    endloop
+  endfacet
+  facet normal -0.976756 0.214355 0
+    outer loop
+      vertex -30.7967 6.12584 0.799999
+      vertex -30.5324 7.33018 57.2
+      vertex -30.5324 7.33018 0.799999
+    endloop
+  endfacet
+  facet normal -0.976756 0.214355 0
+    outer loop
+      vertex -30.5324 7.33018 57.2
+      vertex -30.7967 6.12584 0.799999
+      vertex -30.7967 6.12584 57.2
+    endloop
+  endfacet
+  facet normal 0.471379 -0.881931 0
+    outer loop
+      vertex 14.2553 -27.9776 0.799999
+      vertex 15.3427 -27.3964 57.2
+      vertex 14.2553 -27.9776 57.2
+    endloop
+  endfacet
+  facet normal 0.471379 -0.881931 0
+    outer loop
+      vertex 15.3427 -27.3964 57.2
+      vertex 14.2553 -27.9776 0.799999
+      vertex 15.3427 -27.3964 0.799999
+    endloop
+  endfacet
+  facet normal -0.505655 0.862736 0
+    outer loop
+      vertex -15.3427 27.3964 0.799999
+      vertex -16.4065 26.7729 57.2
+      vertex -15.3427 27.3964 57.2
+    endloop
+  endfacet
+  facet normal -0.505655 0.862736 0
+    outer loop
+      vertex -16.4065 26.7729 57.2
+      vertex -15.3427 27.3964 0.799999
+      vertex -16.4065 26.7729 0.799999
+    endloop
+  endfacet
+  facet normal -0.634407 0.772999 0
+    outer loop
+      vertex -19.4395 24.659 0.799999
+      vertex -20.3927 23.8767 57.2
+      vertex -19.4395 24.659 57.2
+    endloop
+  endfacet
+  facet normal -0.634407 0.772999 0
+    outer loop
+      vertex -20.3927 23.8767 57.2
+      vertex -19.4395 24.659 0.799999
+      vertex -20.3927 23.8767 0.799999
+    endloop
+  endfacet
+  facet normal 0.916187 -0.400751 0
+    outer loop
+      vertex 28.5157 -13.1459 57.2
+      vertex 29.0098 -12.0163 0.799999
+      vertex 29.0098 -12.0163 57.2
+    endloop
+  endfacet
+  facet normal 0.916187 -0.400751 0
+    outer loop
+      vertex 29.0098 -12.0163 0.799999
+      vertex 28.5157 -13.1459 57.2
+      vertex 28.5157 -13.1459 0.799999
+    endloop
+  endfacet
+  facet normal 0.74749 0.664273 0
+    outer loop
+      vertex 23.8767 20.3927 57.2
+      vertex 23.0577 21.3143 0.799999
+      vertex 23.0577 21.3143 57.2
+    endloop
+  endfacet
+  facet normal 0.74749 0.664273 0
+    outer loop
+      vertex 23.0577 21.3143 0.799999
+      vertex 23.8767 20.3927 57.2
+      vertex 23.8767 20.3927 0.799999
+    endloop
+  endfacet
+  facet normal -0.984435 0.175751 0
+    outer loop
+      vertex -31.0134 4.91204 0.799999
+      vertex -30.7967 6.12584 57.2
+      vertex -30.7967 6.12584 0.799999
+    endloop
+  endfacet
+  facet normal -0.984435 0.175751 0
+    outer loop
+      vertex -30.7967 6.12584 57.2
+      vertex -31.0134 4.91204 0.799999
+      vertex -31.0134 4.91204 57.2
+    endloop
+  endfacet
+  facet normal -0.252475 -0.967603 0
+    outer loop
+      vertex -8.52323 -30.2211 0.799999
+      vertex -7.33018 -30.5324 57.2
+      vertex -8.52323 -30.2211 57.2
+    endloop
+  endfacet
+  facet normal -0.252475 -0.967603 -0
+    outer loop
+      vertex -7.33018 -30.5324 57.2
+      vertex -8.52323 -30.2211 0.799999
+      vertex -7.33018 -30.5324 0.799999
+    endloop
+  endfacet
+  facet normal -0.019627 -0.999807 0
+    outer loop
+      vertex -1.23276 -31.3758 0.799999
+      vertex 0 -31.4 57.2
+      vertex -1.23276 -31.3758 57.2
+    endloop
+  endfacet
+  facet normal -0.019627 -0.999807 -0
+    outer loop
+      vertex 0 -31.4 57.2
+      vertex -1.23276 -31.3758 0.799999
+      vertex 0 -31.4 0.799999
+    endloop
+  endfacet
+  facet normal -0.842189 0.539183 0
+    outer loop
+      vertex -26.7729 16.4065 0.799999
+      vertex -26.1081 17.4449 57.2
+      vertex -26.1081 17.4449 0.799999
+    endloop
+  endfacet
+  facet normal -0.842189 0.539183 0
+    outer loop
+      vertex -26.1081 17.4449 57.2
+      vertex -26.7729 16.4065 0.799999
+      vertex -26.7729 16.4065 57.2
+    endloop
+  endfacet
+  facet normal -0.290271 0.956945 0
+    outer loop
+      vertex -8.52323 30.2211 0.799999
+      vertex -9.70313 29.8632 57.2
+      vertex -8.52323 30.2211 57.2
+    endloop
+  endfacet
+  facet normal -0.290271 0.956945 0
+    outer loop
+      vertex -9.70313 29.8632 57.2
+      vertex -8.52323 30.2211 0.799999
+      vertex -9.70313 29.8632 0.799999
+    endloop
+  endfacet
+  facet normal 0.471379 0.881931 -0
+    outer loop
+      vertex 15.3427 27.3964 0.799999
+      vertex 14.2553 27.9776 57.2
+      vertex 15.3427 27.3964 57.2
+    endloop
+  endfacet
+  facet normal 0.471379 0.881931 0
+    outer loop
+      vertex 14.2553 27.9776 57.2
+      vertex 15.3427 27.3964 0.799999
+      vertex 14.2553 27.9776 0.799999
+    endloop
+  endfacet
+  facet normal 0.720919 -0.69302 0
+    outer loop
+      vertex 22.2032 -22.2032 57.2
+      vertex 23.0577 -21.3143 0.799999
+      vertex 23.0577 -21.3143 57.2
+    endloop
+  endfacet
+  facet normal 0.720919 -0.69302 0
+    outer loop
+      vertex 23.0577 -21.3143 0.799999
+      vertex 22.2032 -22.2032 57.2
+      vertex 22.2032 -22.2032 0.799999
+    endloop
+  endfacet
+  facet normal -0.400751 -0.916187 0
+    outer loop
+      vertex -13.1459 -28.5157 0.799999
+      vertex -12.0163 -29.0098 57.2
+      vertex -13.1459 -28.5157 57.2
+    endloop
+  endfacet
+  facet normal -0.400751 -0.916187 -0
+    outer loop
+      vertex -12.0163 -29.0098 57.2
+      vertex -13.1459 -28.5157 0.799999
+      vertex -12.0163 -29.0098 0.799999
+    endloop
+  endfacet
+  facet normal 0.772999 0.634407 0
+    outer loop
+      vertex 24.659 19.4395 57.2
+      vertex 23.8767 20.3927 0.799999
+      vertex 23.8767 20.3927 57.2
+    endloop
+  endfacet
+  facet normal 0.772999 0.634407 0
+    outer loop
+      vertex 23.8767 20.3927 0.799999
+      vertex 24.659 19.4395 57.2
+      vertex 24.659 19.4395 0.799999
+    endloop
+  endfacet
+  facet normal -0.995189 -0.0979739 0
+    outer loop
+      vertex -31.1824 -3.69067 0.799999
+      vertex -31.3032 -2.46362 57.2
+      vertex -31.3032 -2.46362 0.799999
+    endloop
+  endfacet
+  facet normal -0.995189 -0.0979739 0
+    outer loop
+      vertex -31.3032 -2.46362 57.2
+      vertex -31.1824 -3.69067 0.799999
+      vertex -31.1824 -3.69067 57.2
+    endloop
+  endfacet
+  facet normal -0.967603 0.252475 0
+    outer loop
+      vertex -30.5324 7.33018 0.799999
+      vertex -30.2211 8.52323 57.2
+      vertex -30.2211 8.52323 0.799999
+    endloop
+  endfacet
+  facet normal -0.967603 0.252475 0
+    outer loop
+      vertex -30.2211 8.52323 57.2
+      vertex -30.5324 7.33018 0.799999
+      vertex -30.5324 7.33018 57.2
+    endloop
+  endfacet
+  facet normal 0.820419 -0.571763 0
+    outer loop
+      vertex 25.4031 -18.4565 57.2
+      vertex 26.1081 -17.4449 0.799999
+      vertex 26.1081 -17.4449 57.2
+    endloop
+  endfacet
+  facet normal 0.820419 -0.571763 0
+    outer loop
+      vertex 26.1081 -17.4449 0.799999
+      vertex 25.4031 -18.4565 57.2
+      vertex 25.4031 -18.4565 0.799999
+    endloop
+  endfacet
+  facet normal 0.252475 -0.967603 0
+    outer loop
+      vertex 7.33018 -30.5324 0.799999
+      vertex 8.52323 -30.2211 57.2
+      vertex 7.33018 -30.5324 57.2
+    endloop
+  endfacet
+  facet normal 0.252475 -0.967603 0
+    outer loop
+      vertex 8.52323 -30.2211 57.2
+      vertex 7.33018 -30.5324 0.799999
+      vertex 8.52323 -30.2211 0.799999
+    endloop
+  endfacet
+  facet normal -0.471379 -0.881931 0
+    outer loop
+      vertex -15.3427 -27.3964 0.799999
+      vertex -14.2553 -27.9776 57.2
+      vertex -15.3427 -27.3964 57.2
+    endloop
+  endfacet
+  facet normal -0.471379 -0.881931 -0
+    outer loop
+      vertex -14.2553 -27.9776 57.2
+      vertex -15.3427 -27.3964 0.799999
+      vertex -14.2553 -27.9776 0.799999
+    endloop
+  endfacet
+  facet normal -0.327647 0.9448 0
+    outer loop
+      vertex -9.70313 29.8632 0.799999
+      vertex -10.8681 29.4592 57.2
+      vertex -9.70313 29.8632 57.2
+    endloop
+  endfacet
+  facet normal -0.327647 0.9448 0
+    outer loop
+      vertex -10.8681 29.4592 57.2
+      vertex -9.70313 29.8632 0.799999
+      vertex -10.8681 29.4592 0.799999
+    endloop
+  endfacet
+  facet normal -0.995189 0.0979739 0
+    outer loop
+      vertex -31.3032 2.46362 0.799999
+      vertex -31.1824 3.69067 57.2
+      vertex -31.1824 3.69067 0.799999
+    endloop
+  endfacet
+  facet normal -0.995189 0.0979739 0
+    outer loop
+      vertex -31.1824 3.69067 57.2
+      vertex -31.3032 2.46362 0.799999
+      vertex -31.3032 2.46362 57.2
+    endloop
+  endfacet
+  facet normal 0.175751 0.984435 -0
+    outer loop
+      vertex 6.12584 30.7967 0.799999
+      vertex 4.91204 31.0134 57.2
+      vertex 6.12584 30.7967 57.2
+    endloop
+  endfacet
+  facet normal 0.175751 0.984435 0
+    outer loop
+      vertex 4.91204 31.0134 57.2
+      vertex 6.12584 30.7967 0.799999
+      vertex 4.91204 31.0134 0.799999
+    endloop
+  endfacet
+  facet normal 0.9448 0.327647 0
+    outer loop
+      vertex 29.8632 9.70313 57.2
+      vertex 29.4592 10.8681 0.799999
+      vertex 29.4592 10.8681 57.2
+    endloop
+  endfacet
+  facet normal 0.9448 0.327647 0
+    outer loop
+      vertex 29.4592 10.8681 0.799999
+      vertex 29.8632 9.70313 57.2
+      vertex 29.8632 9.70313 0.799999
+    endloop
+  endfacet
+  facet normal -0.214355 -0.976756 0
+    outer loop
+      vertex -7.33018 -30.5324 0.799999
+      vertex -6.12584 -30.7967 57.2
+      vertex -7.33018 -30.5324 57.2
+    endloop
+  endfacet
+  facet normal -0.214355 -0.976756 -0
+    outer loop
+      vertex -6.12584 -30.7967 57.2
+      vertex -7.33018 -30.5324 0.799999
+      vertex -6.12584 -30.7967 0.799999
+    endloop
+  endfacet
+  facet normal 0.956945 -0.290271 0
+    outer loop
+      vertex 29.8632 -9.70313 57.2
+      vertex 30.2211 -8.52323 0.799999
+      vertex 30.2211 -8.52323 57.2
+    endloop
+  endfacet
+  facet normal 0.956945 -0.290271 0
+    outer loop
+      vertex 30.2211 -8.52323 0.799999
+      vertex 29.8632 -9.70313 57.2
+      vertex 29.8632 -9.70313 0.799999
+    endloop
+  endfacet
+  facet normal 0.881931 -0.471379 0
+    outer loop
+      vertex 27.3964 -15.3427 57.2
+      vertex 27.9776 -14.2553 0.799999
+      vertex 27.9776 -14.2553 57.2
+    endloop
+  endfacet
+  facet normal 0.881931 -0.471379 0
+    outer loop
+      vertex 27.9776 -14.2553 0.799999
+      vertex 27.3964 -15.3427 57.2
+      vertex 27.3964 -15.3427 0.799999
+    endloop
+  endfacet
+  facet normal 0.772999 -0.634407 0
+    outer loop
+      vertex 23.8767 -20.3927 57.2
+      vertex 24.659 -19.4395 0.799999
+      vertex 24.659 -19.4395 57.2
+    endloop
+  endfacet
+  facet normal 0.772999 -0.634407 0
+    outer loop
+      vertex 24.659 -19.4395 0.799999
+      vertex 23.8767 -20.3927 57.2
+      vertex 23.8767 -20.3927 0.799999
+    endloop
+  endfacet
+  facet normal 0.252475 0.967603 -0
+    outer loop
+      vertex 8.52323 30.2211 0.799999
+      vertex 7.33018 30.5324 57.2
+      vertex 8.52323 30.2211 57.2
+    endloop
+  endfacet
+  facet normal 0.252475 0.967603 0
+    outer loop
+      vertex 7.33018 30.5324 57.2
+      vertex 8.52323 30.2211 0.799999
+      vertex 7.33018 30.5324 0.799999
+    endloop
+  endfacet
+  facet normal -0.505655 -0.862736 0
+    outer loop
+      vertex -16.4065 -26.7729 0.799999
+      vertex -15.3427 -27.3964 57.2
+      vertex -16.4065 -26.7729 57.2
+    endloop
+  endfacet
+  facet normal -0.505655 -0.862736 -0
+    outer loop
+      vertex -15.3427 -27.3964 57.2
+      vertex -16.4065 -26.7729 0.799999
+      vertex -15.3427 -27.3964 0.799999
+    endloop
+  endfacet
+  facet normal 0.69302 -0.720919 0
+    outer loop
+      vertex 21.3143 -23.0577 0.799999
+      vertex 22.2032 -22.2032 57.2
+      vertex 21.3143 -23.0577 57.2
+    endloop
+  endfacet
+  facet normal 0.69302 -0.720919 0
+    outer loop
+      vertex 22.2032 -22.2032 57.2
+      vertex 21.3143 -23.0577 0.799999
+      vertex 22.2032 -22.2032 0.799999
+    endloop
+  endfacet
+  facet normal -0.539183 -0.842189 0
+    outer loop
+      vertex -17.4449 -26.1081 0.799999
+      vertex -16.4065 -26.7729 57.2
+      vertex -17.4449 -26.1081 57.2
+    endloop
+  endfacet
+  facet normal -0.539183 -0.842189 -0
+    outer loop
+      vertex -16.4065 -26.7729 57.2
+      vertex -17.4449 -26.1081 0.799999
+      vertex -16.4065 -26.7729 0.799999
+    endloop
+  endfacet
+  facet normal 0.707038 0.0138895 -0.707039
+    outer loop
+      vertex 30.6 0 0
+      vertex 30.5764 1.20135 0
+      vertex 31.4 0 0.799999
+    endloop
+  endfacet
+  facet normal -0.490117 -0.509773 -0.707048
+    outer loop
+      vertex -20.7713 -22.4703 0
+      vertex -22.2032 -22.2032 0.799999
+      vertex -21.6375 -21.6375 0
+    endloop
+  endfacet
+  facet normal -0.563851 0.426787 -0.707054
+    outer loop
+      vertex -24.7559 17.9862 0
+      vertex -25.4031 18.4565 0.799999
+      vertex -24.0307 18.9443 0
+    endloop
+  endfacet
+  facet normal 0.469778 -0.528629 -0.707008
+    outer loop
+      vertex 21.3143 -23.0577 0.799999
+      vertex 20.3927 -23.8767 0.799999
+      vertex 20.7713 -22.4703 0
+    endloop
+  endfacet
+  facet normal -0.696188 -0.124291 -0.707018
+    outer loop
+      vertex -30.7967 -6.12584 0.799999
+      vertex -31.0134 -4.91204 0.799999
+      vertex -30.2233 -4.78689 0
+    endloop
+  endfacet
+  facet normal -0.546649 -0.44864 -0.707034
+    outer loop
+      vertex -23.8767 -20.3927 0.799999
+      vertex -24.659 -19.4395 0.799999
+      vertex -24.0307 -18.9443 0
+    endloop
+  endfacet
+  facet normal -0.70594 -0.0416386 -0.707046
+    outer loop
+      vertex -31.3032 -2.46362 0.799999
+      vertex -31.3758 -1.23276 0.799999
+      vertex -30.5764 -1.20135 0
+    endloop
+  endfacet
+  facet normal 0.205268 -0.676712 -0.707054
+    outer loop
+      vertex 8.52323 -30.2211 0.799999
+      vertex 8.30608 -29.4511 0
+      vertex 9.70313 -29.8632 0.799999
+    endloop
+  endfacet
+  facet normal 0.528633 -0.46972 -0.707043
+    outer loop
+      vertex 23.8767 -20.3927 0.799999
+      vertex 22.4703 -20.7713 0
+      vertex 23.2684 -19.8731 0
+    endloop
+  endfacet
+  facet normal 0.690714 -0.151541 -0.707071
+    outer loop
+      vertex 30.7967 -6.12584 0.799999
+      vertex 29.7545 -7.14343 0
+      vertex 30.012 -5.96976 0
+    endloop
+  endfacet
+  facet normal 0.595578 0.381299 -0.707034
+    outer loop
+      vertex 26.7729 16.4065 0.799999
+      vertex 26.0908 15.9885 0
+      vertex 26.1081 17.4449 0.799999
+    endloop
+  endfacet
+  facet normal -0.0692827 0.703753 -0.707059
+    outer loop
+      vertex -3.59664 30.3879 0
+      vertex -3.69067 31.1824 0.799999
+      vertex -2.46362 31.3032 0.799999
+    endloop
+  endfacet
+  facet normal 0.700481 -0.096925 -0.707059
+    outer loop
+      vertex 31.0134 -4.91204 0.799999
+      vertex 30.3879 -3.59664 0
+      vertex 31.1824 -3.69067 0.799999
+    endloop
+  endfacet
+  facet normal 0.448643 -0.546635 -0.707042
+    outer loop
+      vertex 20.3927 -23.8767 0.799999
+      vertex 18.9443 -24.0307 0
+      vertex 19.8731 -23.2684 0
+    endloop
+  endfacet
+  facet normal 0.696123 0.124351 -0.707071
+    outer loop
+      vertex 30.2233 4.78689 0
+      vertex 30.012 5.96976 0
+      vertex 30.7967 6.12584 0.799999
+    endloop
+  endfacet
+  facet normal -0.580171 0.404377 -0.707023
+    outer loop
+      vertex -25.443 17.0004 0
+      vertex -26.1081 17.4449 0.799999
+      vertex -24.7559 17.9862 0
+    endloop
+  endfacet
+  facet normal 0.426787 -0.563851 -0.707054
+    outer loop
+      vertex 18.4565 -25.4031 0.799999
+      vertex 17.9862 -24.7559 0
+      vertex 18.9443 -24.0307 0
+    endloop
+  endfacet
+  facet normal 0.205275 -0.676702 -0.707062
+    outer loop
+      vertex 9.70313 -29.8632 0.799999
+      vertex 8.30608 -29.4511 0
+      vertex 9.45592 -29.1023 0
+    endloop
+  endfacet
+  facet normal 0.65851 0.257778 -0.707047
+    outer loop
+      vertex 28.7087 10.5912 0
+      vertex 28.2707 11.7101 0
+      vertex 29.0098 12.0163 0.799999
+    endloop
+  endfacet
+  facet normal 0.563851 -0.426817 -0.707035
+    outer loop
+      vertex 24.659 -19.4395 0.799999
+      vertex 24.0307 -18.9443 0
+      vertex 25.4031 -18.4565 0.799999
+    endloop
+  endfacet
+  facet normal 0.647907 0.283375 -0.707047
+    outer loop
+      vertex 28.2707 11.7101 0
+      vertex 27.7892 12.811 0
+      vertex 29.0098 12.0163 0.799999
+    endloop
+  endfacet
+  facet normal 0.595598 -0.381291 -0.707022
+    outer loop
+      vertex 26.1081 -17.4449 0.799999
+      vertex 25.443 -17.0004 0
+      vertex 26.0908 -15.9885 0
+    endloop
+  endfacet
+  facet normal -0.357585 0.610103 -0.707041
+    outer loop
+      vertex -14.9518 26.6984 0
+      vertex -16.4065 26.7729 0.799999
+      vertex -15.3427 27.3964 0.799999
+    endloop
+  endfacet
+  facet normal 0.700481 0.096925 -0.707059
+    outer loop
+      vertex 31.1824 3.69067 0.799999
+      vertex 30.3879 3.59664 0
+      vertex 31.0134 4.91204 0.799999
+    endloop
+  endfacet
+  facet normal -0.580169 -0.404329 -0.707052
+    outer loop
+      vertex -25.4031 -18.4565 0.799999
+      vertex -26.1081 -17.4449 0.799999
+      vertex -24.7559 -17.9862 0
+    endloop
+  endfacet
+  facet normal -0.684245 -0.178558 -0.707054
+    outer loop
+      vertex -29.4511 -8.30608 0
+      vertex -30.2211 -8.52323 0.799999
+      vertex -29.7545 -7.14343 0
+    endloop
+  endfacet
+  facet normal -0.381291 -0.595598 -0.707022
+    outer loop
+      vertex -15.9885 -26.0908 0
+      vertex -17.4449 -26.1081 0.799999
+      vertex -17.0004 -25.443 0
+    endloop
+  endfacet
+  facet normal -0.707031 0.0138795 -0.707046
+    outer loop
+      vertex -30.5764 1.20135 0
+      vertex -31.4 0 0.799999
+      vertex -31.3758 1.23276 0.799999
+    endloop
+  endfacet
+  facet normal -0.676702 0.205275 -0.707062
+    outer loop
+      vertex -29.4511 8.30608 0
+      vertex -29.8632 9.70313 0.799999
+      vertex -29.1023 9.45592 0
+    endloop
+  endfacet
+  facet normal -0.65855 -0.257753 -0.707018
+    outer loop
+      vertex -29.0098 -12.0163 0.799999
+      vertex -29.4592 -10.8681 0.799999
+      vertex -28.7087 -10.5912 0
+    endloop
+  endfacet
+  facet normal -0.0138795 -0.707031 -0.707046
+    outer loop
+      vertex 0 -31.4 0.799999
+      vertex -1.23276 -31.3758 0.799999
+      vertex -1.20135 -30.5764 0
+    endloop
+  endfacet
+  facet normal -0.404377 -0.580171 -0.707023
+    outer loop
+      vertex -17.4449 -26.1081 0.799999
+      vertex -17.9862 -24.7559 0
+      vertex -17.0004 -25.443 0
+    endloop
+  endfacet
+  facet normal 0.257753 -0.65855 -0.707018
+    outer loop
+      vertex 10.8681 -29.4592 0.799999
+      vertex 10.5912 -28.7087 0
+      vertex 12.0163 -29.0098 0.799999
+    endloop
+  endfacet
+  facet normal 0.0692827 0.703753 -0.707059
+    outer loop
+      vertex 3.59664 30.3879 0
+      vertex 2.46362 31.3032 0.799999
+      vertex 3.69067 31.1824 0.799999
+    endloop
+  endfacet
+  facet normal -0.623677 -0.333347 -0.707041
+    outer loop
+      vertex -27.3964 -15.3427 0.799999
+      vertex -27.9776 -14.2553 0.799999
+      vertex -26.6984 -14.9518 0
+    endloop
+  endfacet
+  facet normal 0.580169 -0.404329 -0.707052
+    outer loop
+      vertex 25.4031 -18.4565 0.799999
+      vertex 24.7559 -17.9862 0
+      vertex 26.1081 -17.4449 0.799999
+    endloop
+  endfacet
+  facet normal -0.528633 0.46972 -0.707043
+    outer loop
+      vertex -23.2684 19.8731 0
+      vertex -23.8767 20.3927 0.799999
+      vertex -22.4703 20.7713 0
+    endloop
+  endfacet
+  facet normal -0.595578 0.381299 -0.707034
+    outer loop
+      vertex -26.0908 15.9885 0
+      vertex -26.7729 16.4065 0.799999
+      vertex -26.1081 17.4449 0.799999
+    endloop
+  endfacet
+  facet normal 0.490107 -0.509837 -0.707009
+    outer loop
+      vertex 21.3143 -23.0577 0.799999
+      vertex 20.7713 -22.4703 0
+      vertex 22.2032 -22.2032 0.799999
+    endloop
+  endfacet
+  facet normal 0.705964 -0.0416104 -0.707024
+    outer loop
+      vertex 31.3032 -2.46362 0.799999
+      vertex 30.5057 -2.40085 0
+      vertex 30.5764 -1.20135 0
+    endloop
+  endfacet
+  facet normal 0.690714 0.151541 -0.707071
+    outer loop
+      vertex 30.012 5.96976 0
+      vertex 29.7545 7.14343 0
+      vertex 30.7967 6.12584 0.799999
+    endloop
+  endfacet
+  facet normal 0.595578 -0.381299 -0.707034
+    outer loop
+      vertex 26.1081 -17.4449 0.799999
+      vertex 26.0908 -15.9885 0
+      vertex 26.7729 -16.4065 0.799999
+    endloop
+  endfacet
+  facet normal -0.647907 0.283375 -0.707047
+    outer loop
+      vertex -28.2707 11.7101 0
+      vertex -29.0098 12.0163 0.799999
+      vertex -27.7892 12.811 0
+    endloop
+  endfacet
+  facet normal 0.0416386 -0.70594 -0.707046
+    outer loop
+      vertex 1.23276 -31.3758 0.799999
+      vertex 1.20135 -30.5764 0
+      vertex 2.46362 -31.3032 0.799999
+    endloop
+  endfacet
+  facet normal -0.707031 -0.0138795 -0.707046
+    outer loop
+      vertex -31.3758 -1.23276 0.799999
+      vertex -31.4 0 0.799999
+      vertex -30.5764 -1.20135 0
+    endloop
+  endfacet
+  facet normal 0.696188 0.124291 -0.707018
+    outer loop
+      vertex 31.0134 4.91204 0.799999
+      vertex 30.2233 4.78689 0
+      vertex 30.7967 6.12584 0.799999
+    endloop
+  endfacet
+  facet normal 0.490117 -0.509773 -0.707048
+    outer loop
+      vertex 22.2032 -22.2032 0.799999
+      vertex 20.7713 -22.4703 0
+      vertex 21.6375 -21.6375 0
+    endloop
+  endfacet
+  facet normal -0.636283 0.308636 -0.707028
+    outer loop
+      vertex -27.7892 12.811 0
+      vertex -28.5157 13.1459 0.799999
+      vertex -27.2648 13.8921 0
+    endloop
+  endfacet
+  facet normal 0.684245 -0.178558 -0.707054
+    outer loop
+      vertex 30.2211 -8.52323 0.799999
+      vertex 29.4511 -8.30608 0
+      vertex 29.7545 -7.14343 0
+    endloop
+  endfacet
+  facet normal 0.096925 0.700481 -0.707059
+    outer loop
+      vertex 4.91204 31.0134 0.799999
+      vertex 3.59664 30.3879 0
+      vertex 3.69067 31.1824 0.799999
+    endloop
+  endfacet
+  facet normal 0.151586 0.690735 -0.707041
+    outer loop
+      vertex 7.14343 29.7545 0
+      vertex 6.12584 30.7967 0.799999
+      vertex 7.33018 30.5324 0.799999
+    endloop
+  endfacet
+  facet normal -0.690735 -0.151586 -0.707041
+    outer loop
+      vertex -30.5324 -7.33018 0.799999
+      vertex -30.7967 -6.12584 0.799999
+      vertex -29.7545 -7.14343 0
+    endloop
+  endfacet
+  facet normal 0.124291 -0.696188 -0.707018
+    outer loop
+      vertex 4.91204 -31.0134 0.799999
+      vertex 4.78689 -30.2233 0
+      vertex 6.12584 -30.7967 0.799999
+    endloop
+  endfacet
+  facet normal -0.70053 0.0968765 -0.707017
+    outer loop
+      vertex -30.3879 3.59664 0
+      vertex -31.0134 4.91204 0.799999
+      vertex -30.2233 4.78689 0
+    endloop
+  endfacet
+  facet normal 0.684263 -0.178543 -0.70704
+    outer loop
+      vertex 30.2211 -8.52323 0.799999
+      vertex 29.7545 -7.14343 0
+      vertex 30.5324 -7.33018 0.799999
+    endloop
+  endfacet
+  facet normal -0.70053 -0.0968765 -0.707017
+    outer loop
+      vertex -30.2233 -4.78689 0
+      vertex -31.0134 -4.91204 0.799999
+      vertex -30.3879 -3.59664 0
+    endloop
+  endfacet
+  facet normal 0.623677 -0.333347 -0.707041
+    outer loop
+      vertex 27.3964 -15.3427 0.799999
+      vertex 26.6984 -14.9518 0
+      vertex 27.9776 -14.2553 0.799999
+    endloop
+  endfacet
+  facet normal -0.700481 0.096925 -0.707059
+    outer loop
+      vertex -30.3879 3.59664 0
+      vertex -31.1824 3.69067 0.799999
+      vertex -31.0134 4.91204 0.799999
+    endloop
+  endfacet
+  facet normal 0.0138795 -0.707031 -0.707046
+    outer loop
+      vertex 1.23276 -31.3758 0.799999
+      vertex 0 -31.4 0.799999
+      vertex 1.20135 -30.5764 0
+    endloop
+  endfacet
+  facet normal -0.647907 -0.283375 -0.707047
+    outer loop
+      vertex -27.7892 -12.811 0
+      vertex -29.0098 -12.0163 0.799999
+      vertex -28.2707 -11.7101 0
+    endloop
+  endfacet
+  facet normal 0.610103 0.357585 -0.707041
+    outer loop
+      vertex 27.3964 15.3427 0.799999
+      vertex 26.6984 14.9518 0
+      vertex 26.7729 16.4065 0.799999
+    endloop
+  endfacet
+  facet normal -0.283405 0.647914 -0.707028
+    outer loop
+      vertex -12.811 27.7892 0
+      vertex -13.1459 28.5157 0.799999
+      vertex -12.0163 29.0098 0.799999
+    endloop
+  endfacet
+  facet normal -0.705964 0.0416104 -0.707024
+    outer loop
+      vertex -30.5764 1.20135 0
+      vertex -31.3032 2.46362 0.799999
+      vertex -30.5057 2.40085 0
+    endloop
+  endfacet
+  facet normal -0.151541 -0.690714 -0.707071
+    outer loop
+      vertex -6.12584 -30.7967 0.799999
+      vertex -7.14343 -29.7545 0
+      vertex -5.96976 -30.012 0
+    endloop
+  endfacet
+  facet normal 0.676712 -0.205268 -0.707054
+    outer loop
+      vertex 29.8632 -9.70313 0.799999
+      vertex 29.4511 -8.30608 0
+      vertex 30.2211 -8.52323 0.799999
+    endloop
+  endfacet
+  facet normal -0.70594 0.0416386 -0.707046
+    outer loop
+      vertex -30.5764 1.20135 0
+      vertex -31.3758 1.23276 0.799999
+      vertex -31.3032 2.46362 0.799999
+    endloop
+  endfacet
+  facet normal -0.283375 0.647907 -0.707047
+    outer loop
+      vertex -11.7101 28.2707 0
+      vertex -12.811 27.7892 0
+      vertex -12.0163 29.0098 0.799999
+    endloop
+  endfacet
+  facet normal 0.647914 -0.283405 -0.707028
+    outer loop
+      vertex 28.5157 -13.1459 0.799999
+      vertex 27.7892 -12.811 0
+      vertex 29.0098 -12.0163 0.799999
+    endloop
+  endfacet
+  facet normal 0.707031 0.0138795 -0.707046
+    outer loop
+      vertex 31.4 0 0.799999
+      vertex 30.5764 1.20135 0
+      vertex 31.3758 1.23276 0.799999
+    endloop
+  endfacet
+  facet normal -0.668158 0.231711 -0.707018
+    outer loop
+      vertex -28.7087 10.5912 0
+      vertex -29.8632 9.70313 0.799999
+      vertex -29.4592 10.8681 0.799999
+    endloop
+  endfacet
+  facet normal 0.696188 -0.124291 -0.707018
+    outer loop
+      vertex 30.7967 -6.12584 0.799999
+      vertex 30.2233 -4.78689 0
+      vertex 31.0134 -4.91204 0.799999
+    endloop
+  endfacet
+  facet normal 0.490107 0.509837 -0.707009
+    outer loop
+      vertex 22.2032 22.2032 0.799999
+      vertex 20.7713 22.4703 0
+      vertex 21.3143 23.0577 0.799999
+    endloop
+  endfacet
+  facet normal 0.610113 -0.357581 -0.707035
+    outer loop
+      vertex 26.7729 -16.4065 0.799999
+      vertex 26.0908 -15.9885 0
+      vertex 26.6984 -14.9518 0
+    endloop
+  endfacet
+  facet normal -0.684245 0.178558 -0.707054
+    outer loop
+      vertex -29.7545 7.14343 0
+      vertex -30.2211 8.52323 0.799999
+      vertex -29.4511 8.30608 0
+    endloop
+  endfacet
+  facet normal 0.707038 -0.0138895 -0.707039
+    outer loop
+      vertex 31.4 0 0.799999
+      vertex 30.5764 -1.20135 0
+      vertex 30.6 0 0
+    endloop
+  endfacet
+  facet normal 0.690735 0.151586 -0.707041
+    outer loop
+      vertex 30.7967 6.12584 0.799999
+      vertex 29.7545 7.14343 0
+      vertex 30.5324 7.33018 0.799999
+    endloop
+  endfacet
+  facet normal 0.46972 0.528633 -0.707043
+    outer loop
+      vertex 20.7713 22.4703 0
+      vertex 19.8731 23.2684 0
+      vertex 20.3927 23.8767 0.799999
+    endloop
+  endfacet
+  facet normal 0.528629 0.469778 -0.707008
+    outer loop
+      vertex 23.8767 20.3927 0.799999
+      vertex 22.4703 20.7713 0
+      vertex 23.0577 21.3143 0.799999
+    endloop
+  endfacet
+  facet normal -0.124291 0.696188 -0.707018
+    outer loop
+      vertex -4.78689 30.2233 0
+      vertex -6.12584 30.7967 0.799999
+      vertex -4.91204 31.0134 0.799999
+    endloop
+  endfacet
+  facet normal 0.70053 0.0968765 -0.707017
+    outer loop
+      vertex 30.3879 3.59664 0
+      vertex 30.2233 4.78689 0
+      vertex 31.0134 4.91204 0.799999
+    endloop
+  endfacet
+  facet normal 0.509837 0.490107 -0.707009
+    outer loop
+      vertex 22.4703 20.7713 0
+      vertex 22.2032 22.2032 0.799999
+      vertex 23.0577 21.3143 0.799999
+    endloop
+  endfacet
+  facet normal 0.610103 -0.357585 -0.707041
+    outer loop
+      vertex 26.7729 -16.4065 0.799999
+      vertex 26.6984 -14.9518 0
+      vertex 27.3964 -15.3427 0.799999
+    endloop
+  endfacet
+  facet normal -0.595598 0.381291 -0.707022
+    outer loop
+      vertex -26.0908 15.9885 0
+      vertex -26.1081 17.4449 0.799999
+      vertex -25.443 17.0004 0
+    endloop
+  endfacet
+  facet normal 0.703783 -0.0693312 -0.707024
+    outer loop
+      vertex 31.3032 -2.46362 0.799999
+      vertex 30.3879 -3.59664 0
+      vertex 30.5057 -2.40085 0
+    endloop
+  endfacet
+  facet normal -0.096925 -0.700481 -0.707059
+    outer loop
+      vertex -3.69067 -31.1824 0.799999
+      vertex -4.91204 -31.0134 0.799999
+      vertex -3.59664 -30.3879 0
+    endloop
+  endfacet
+  facet normal -0.647914 -0.283405 -0.707028
+    outer loop
+      vertex -28.5157 -13.1459 0.799999
+      vertex -29.0098 -12.0163 0.799999
+      vertex -27.7892 -12.811 0
+    endloop
+  endfacet
+  facet normal -0.381299 0.595578 -0.707034
+    outer loop
+      vertex -15.9885 26.0908 0
+      vertex -17.4449 26.1081 0.799999
+      vertex -16.4065 26.7729 0.799999
+    endloop
+  endfacet
+  facet normal 0.0138895 0.707038 -0.707039
+    outer loop
+      vertex 1.20135 30.5764 0
+      vertex 0 30.6 0
+      vertex 0 31.4 0.799999
+    endloop
+  endfacet
+  facet normal 0.684263 0.178543 -0.70704
+    outer loop
+      vertex 30.5324 7.33018 0.799999
+      vertex 29.7545 7.14343 0
+      vertex 30.2211 8.52323 0.799999
+    endloop
+  endfacet
+  facet normal -0.563851 0.426817 -0.707035
+    outer loop
+      vertex -24.0307 18.9443 0
+      vertex -25.4031 18.4565 0.799999
+      vertex -24.659 19.4395 0.799999
+    endloop
+  endfacet
+  facet normal 0.636279 0.308619 -0.707038
+    outer loop
+      vertex 28.5157 13.1459 0.799999
+      vertex 27.2648 13.8921 0
+      vertex 27.9776 14.2553 0.799999
+    endloop
+  endfacet
+  facet normal 0.70594 0.0416386 -0.707046
+    outer loop
+      vertex 31.3758 1.23276 0.799999
+      vertex 30.5764 1.20135 0
+      vertex 31.3032 2.46362 0.799999
+    endloop
+  endfacet
+  facet normal -0.636279 -0.308619 -0.707038
+    outer loop
+      vertex -27.9776 -14.2553 0.799999
+      vertex -28.5157 -13.1459 0.799999
+      vertex -27.2648 -13.8921 0
+    endloop
+  endfacet
+  facet normal 0.381291 0.595598 -0.707022
+    outer loop
+      vertex 17.0004 25.443 0
+      vertex 15.9885 26.0908 0
+      vertex 17.4449 26.1081 0.799999
+    endloop
+  endfacet
+  facet normal -0.647914 0.283405 -0.707028
+    outer loop
+      vertex -27.7892 12.811 0
+      vertex -29.0098 12.0163 0.799999
+      vertex -28.5157 13.1459 0.799999
+    endloop
+  endfacet
+  facet normal 0.70053 -0.0968765 -0.707017
+    outer loop
+      vertex 31.0134 -4.91204 0.799999
+      vertex 30.2233 -4.78689 0
+      vertex 30.3879 -3.59664 0
+    endloop
+  endfacet
+  facet normal 0.0692827 -0.703753 -0.707059
+    outer loop
+      vertex 3.69067 -31.1824 0.799999
+      vertex 2.46362 -31.3032 0.799999
+      vertex 3.59664 -30.3879 0
+    endloop
+  endfacet
+  facet normal -0.707038 -0.0138895 -0.707039
+    outer loop
+      vertex -30.5764 -1.20135 0
+      vertex -31.4 0 0.799999
+      vertex -30.6 0 0
+    endloop
+  endfacet
+  facet normal 0.0138795 0.707031 -0.707046
+    outer loop
+      vertex 1.20135 30.5764 0
+      vertex 0 31.4 0.799999
+      vertex 1.23276 31.3758 0.799999
+    endloop
+  endfacet
+  facet normal -0.65855 0.257753 -0.707018
+    outer loop
+      vertex -28.7087 10.5912 0
+      vertex -29.4592 10.8681 0.799999
+      vertex -29.0098 12.0163 0.799999
+    endloop
+  endfacet
+  facet normal -0.563851 -0.426787 -0.707054
+    outer loop
+      vertex -24.0307 -18.9443 0
+      vertex -25.4031 -18.4565 0.799999
+      vertex -24.7559 -17.9862 0
+    endloop
+  endfacet
+  facet normal 0.509837 -0.490107 -0.707009
+    outer loop
+      vertex 23.0577 -21.3143 0.799999
+      vertex 22.2032 -22.2032 0.799999
+      vertex 22.4703 -20.7713 0
+    endloop
+  endfacet
+  facet normal 0.595598 0.381291 -0.707022
+    outer loop
+      vertex 26.0908 15.9885 0
+      vertex 25.443 17.0004 0
+      vertex 26.1081 17.4449 0.799999
+    endloop
+  endfacet
+  facet normal -0.0138895 0.707038 -0.707039
+    outer loop
+      vertex 0 30.6 0
+      vertex -1.20135 30.5764 0
+      vertex 0 31.4 0.799999
+    endloop
+  endfacet
+  facet normal -0.469778 -0.528629 -0.707008
+    outer loop
+      vertex -20.3927 -23.8767 0.799999
+      vertex -21.3143 -23.0577 0.799999
+      vertex -20.7713 -22.4703 0
+    endloop
+  endfacet
+  facet normal 0.528629 -0.469778 -0.707008
+    outer loop
+      vertex 23.0577 -21.3143 0.799999
+      vertex 22.4703 -20.7713 0
+      vertex 23.8767 -20.3927 0.799999
+    endloop
+  endfacet
+  facet normal 0.707031 -0.0138795 -0.707046
+    outer loop
+      vertex 31.3758 -1.23276 0.799999
+      vertex 30.5764 -1.20135 0
+      vertex 31.4 0 0.799999
+    endloop
+  endfacet
+  facet normal 0.357581 -0.610113 -0.707035
+    outer loop
+      vertex 16.4065 -26.7729 0.799999
+      vertex 14.9518 -26.6984 0
+      vertex 15.9885 -26.0908 0
+    endloop
+  endfacet
+  facet normal 0.381299 -0.595578 -0.707034
+    outer loop
+      vertex 16.4065 -26.7729 0.799999
+      vertex 15.9885 -26.0908 0
+      vertex 17.4449 -26.1081 0.799999
+    endloop
+  endfacet
+  facet normal 0.0416104 -0.705964 -0.707024
+    outer loop
+      vertex 2.46362 -31.3032 0.799999
+      vertex 1.20135 -30.5764 0
+      vertex 2.40085 -30.5057 0
+    endloop
+  endfacet
+  facet normal -0.546635 -0.448643 -0.707042
+    outer loop
+      vertex -23.8767 -20.3927 0.799999
+      vertex -24.0307 -18.9443 0
+      vertex -23.2684 -19.8731 0
+    endloop
+  endfacet
+  facet normal -0.257753 -0.65855 -0.707018
+    outer loop
+      vertex -10.8681 -29.4592 0.799999
+      vertex -12.0163 -29.0098 0.799999
+      vertex -10.5912 -28.7087 0
+    endloop
+  endfacet
+  facet normal -0.696188 0.124291 -0.707018
+    outer loop
+      vertex -30.2233 4.78689 0
+      vertex -31.0134 4.91204 0.799999
+      vertex -30.7967 6.12584 0.799999
+    endloop
+  endfacet
+  facet normal 0.668158 -0.231711 -0.707018
+    outer loop
+      vertex 29.4592 -10.8681 0.799999
+      vertex 28.7087 -10.5912 0
+      vertex 29.8632 -9.70313 0.799999
+    endloop
+  endfacet
+  facet normal -0.231642 0.668136 -0.707062
+    outer loop
+      vertex -9.45592 29.1023 0
+      vertex -10.5912 28.7087 0
+      vertex -9.70313 29.8632 0.799999
+    endloop
+  endfacet
+  facet normal -0.703783 -0.0693312 -0.707024
+    outer loop
+      vertex -30.3879 -3.59664 0
+      vertex -31.3032 -2.46362 0.799999
+      vertex -30.5057 -2.40085 0
+    endloop
+  endfacet
+  facet normal 0.703753 0.0692827 -0.707059
+    outer loop
+      vertex 31.3032 2.46362 0.799999
+      vertex 30.3879 3.59664 0
+      vertex 31.1824 3.69067 0.799999
+    endloop
+  endfacet
+  facet normal 0.703753 -0.0692827 -0.707059
+    outer loop
+      vertex 31.1824 -3.69067 0.799999
+      vertex 30.3879 -3.59664 0
+      vertex 31.3032 -2.46362 0.799999
+    endloop
+  endfacet
+  facet normal -0.528629 0.469778 -0.707008
+    outer loop
+      vertex -22.4703 20.7713 0
+      vertex -23.8767 20.3927 0.799999
+      vertex -23.0577 21.3143 0.799999
+    endloop
+  endfacet
+  facet normal 0.70594 -0.0416386 -0.707046
+    outer loop
+      vertex 31.3032 -2.46362 0.799999
+      vertex 30.5764 -1.20135 0
+      vertex 31.3758 -1.23276 0.799999
+    endloop
+  endfacet
+  facet normal 0.647914 0.283405 -0.707028
+    outer loop
+      vertex 29.0098 12.0163 0.799999
+      vertex 27.7892 12.811 0
+      vertex 28.5157 13.1459 0.799999
+    endloop
+  endfacet
+  facet normal -0.684263 -0.178543 -0.70704
+    outer loop
+      vertex -30.2211 -8.52323 0.799999
+      vertex -30.5324 -7.33018 0.799999
+      vertex -29.7545 -7.14343 0
+    endloop
+  endfacet
+  facet normal -0.231711 -0.668158 -0.707018
+    outer loop
+      vertex -9.70313 -29.8632 0.799999
+      vertex -10.8681 -29.4592 0.799999
+      vertex -10.5912 -28.7087 0
+    endloop
+  endfacet
+  facet normal 0.676712 0.205268 -0.707054
+    outer loop
+      vertex 30.2211 8.52323 0.799999
+      vertex 29.4511 8.30608 0
+      vertex 29.8632 9.70313 0.799999
+    endloop
+  endfacet
+  facet normal 0.426817 0.563851 -0.707035
+    outer loop
+      vertex 18.9443 24.0307 0
+      vertex 18.4565 25.4031 0.799999
+      vertex 19.4395 24.659 0.799999
+    endloop
+  endfacet
+  facet normal -0.668158 -0.231711 -0.707018
+    outer loop
+      vertex -29.4592 -10.8681 0.799999
+      vertex -29.8632 -9.70313 0.799999
+      vertex -28.7087 -10.5912 0
+    endloop
+  endfacet
+  facet normal 0.636283 -0.308636 -0.707028
+    outer loop
+      vertex 28.5157 -13.1459 0.799999
+      vertex 27.2648 -13.8921 0
+      vertex 27.7892 -12.811 0
+    endloop
+  endfacet
+  facet normal 0.509773 0.490117 -0.707048
+    outer loop
+      vertex 22.4703 20.7713 0
+      vertex 21.6375 21.6375 0
+      vertex 22.2032 22.2032 0.799999
+    endloop
+  endfacet
+  facet normal 0.668158 0.231711 -0.707018
+    outer loop
+      vertex 29.8632 9.70313 0.799999
+      vertex 28.7087 10.5912 0
+      vertex 29.4592 10.8681 0.799999
+    endloop
+  endfacet
+  facet normal -0.308619 -0.636279 -0.707038
+    outer loop
+      vertex -13.1459 -28.5157 0.799999
+      vertex -14.2553 -27.9776 0.799999
+      vertex -13.8921 -27.2648 0
+    endloop
+  endfacet
+  facet normal 0.610113 0.357581 -0.707035
+    outer loop
+      vertex 26.6984 14.9518 0
+      vertex 26.0908 15.9885 0
+      vertex 26.7729 16.4065 0.799999
+    endloop
+  endfacet
+  facet normal 0.333347 -0.623677 -0.707041
+    outer loop
+      vertex 15.3427 -27.3964 0.799999
+      vertex 14.2553 -27.9776 0.799999
+      vertex 14.9518 -26.6984 0
+    endloop
+  endfacet
+  facet normal -0.308636 -0.636283 -0.707028
+    outer loop
+      vertex -13.1459 -28.5157 0.799999
+      vertex -13.8921 -27.2648 0
+      vertex -12.811 -27.7892 0
+    endloop
+  endfacet
+  facet normal 0.308619 0.636279 -0.707038
+    outer loop
+      vertex 13.8921 27.2648 0
+      vertex 13.1459 28.5157 0.799999
+      vertex 14.2553 27.9776 0.799999
+    endloop
+  endfacet
+  facet normal -0.151586 -0.690735 -0.707041
+    outer loop
+      vertex -6.12584 -30.7967 0.799999
+      vertex -7.33018 -30.5324 0.799999
+      vertex -7.14343 -29.7545 0
+    endloop
+  endfacet
+  facet normal -0.0416386 0.70594 -0.707046
+    outer loop
+      vertex -1.20135 30.5764 0
+      vertex -2.46362 31.3032 0.799999
+      vertex -1.23276 31.3758 0.799999
+    endloop
+  endfacet
+  facet normal 0.283375 -0.647907 -0.707047
+    outer loop
+      vertex 12.0163 -29.0098 0.799999
+      vertex 11.7101 -28.2707 0
+      vertex 12.811 -27.7892 0
+    endloop
+  endfacet
+  facet normal 0.283405 -0.647914 -0.707028
+    outer loop
+      vertex 13.1459 -28.5157 0.799999
+      vertex 12.0163 -29.0098 0.799999
+      vertex 12.811 -27.7892 0
+    endloop
+  endfacet
+  facet normal 0.546635 -0.448643 -0.707042
+    outer loop
+      vertex 23.8767 -20.3927 0.799999
+      vertex 23.2684 -19.8731 0
+      vertex 24.0307 -18.9443 0
+    endloop
+  endfacet
+  facet normal 0.703783 0.0693312 -0.707024
+    outer loop
+      vertex 30.5057 2.40085 0
+      vertex 30.3879 3.59664 0
+      vertex 31.3032 2.46362 0.799999
+    endloop
+  endfacet
+  facet normal -0.668136 -0.231642 -0.707062
+    outer loop
+      vertex -28.7087 -10.5912 0
+      vertex -29.8632 -9.70313 0.799999
+      vertex -29.1023 -9.45592 0
+    endloop
+  endfacet
+  facet normal -0.178543 -0.684263 -0.70704
+    outer loop
+      vertex -7.33018 -30.5324 0.799999
+      vertex -8.52323 -30.2211 0.799999
+      vertex -7.14343 -29.7545 0
+    endloop
+  endfacet
+  facet normal 0.636279 -0.308619 -0.707038
+    outer loop
+      vertex 27.9776 -14.2553 0.799999
+      vertex 27.2648 -13.8921 0
+      vertex 28.5157 -13.1459 0.799999
+    endloop
+  endfacet
+  facet normal -0.623678 0.33335 -0.707039
+    outer loop
+      vertex -27.2648 13.8921 0
+      vertex -27.9776 14.2553 0.799999
+      vertex -26.6984 14.9518 0
+    endloop
+  endfacet
+  facet normal -0.46972 -0.528633 -0.707043
+    outer loop
+      vertex -20.3927 -23.8767 0.799999
+      vertex -20.7713 -22.4703 0
+      vertex -19.8731 -23.2684 0
+    endloop
+  endfacet
+  facet normal -0.509837 0.490107 -0.707009
+    outer loop
+      vertex -22.4703 20.7713 0
+      vertex -23.0577 21.3143 0.799999
+      vertex -22.2032 22.2032 0.799999
+    endloop
+  endfacet
+  facet normal 0.46972 -0.528633 -0.707043
+    outer loop
+      vertex 20.3927 -23.8767 0.799999
+      vertex 19.8731 -23.2684 0
+      vertex 20.7713 -22.4703 0
+    endloop
+  endfacet
+  facet normal 0.257778 -0.65851 -0.707047
+    outer loop
+      vertex 12.0163 -29.0098 0.799999
+      vertex 10.5912 -28.7087 0
+      vertex 11.7101 -28.2707 0
+    endloop
+  endfacet
+  facet normal 0.636283 0.308636 -0.707028
+    outer loop
+      vertex 27.7892 12.811 0
+      vertex 27.2648 13.8921 0
+      vertex 28.5157 13.1459 0.799999
+    endloop
+  endfacet
+  facet normal 0.283405 0.647914 -0.707028
+    outer loop
+      vertex 12.811 27.7892 0
+      vertex 12.0163 29.0098 0.799999
+      vertex 13.1459 28.5157 0.799999
+    endloop
+  endfacet
+  facet normal -0.546649 0.44864 -0.707034
+    outer loop
+      vertex -24.0307 18.9443 0
+      vertex -24.659 19.4395 0.799999
+      vertex -23.8767 20.3927 0.799999
+    endloop
+  endfacet
+  facet normal 0.151541 0.690714 -0.707071
+    outer loop
+      vertex 7.14343 29.7545 0
+      vertex 5.96976 30.012 0
+      vertex 6.12584 30.7967 0.799999
+    endloop
+  endfacet
+  facet normal -0.703783 0.0693312 -0.707024
+    outer loop
+      vertex -30.5057 2.40085 0
+      vertex -31.3032 2.46362 0.799999
+      vertex -30.3879 3.59664 0
+    endloop
+  endfacet
+  facet normal 0.668136 -0.231642 -0.707062
+    outer loop
+      vertex 29.8632 -9.70313 0.799999
+      vertex 28.7087 -10.5912 0
+      vertex 29.1023 -9.45592 0
+    endloop
+  endfacet
+  facet normal -0.426817 0.563851 -0.707035
+    outer loop
+      vertex -18.9443 24.0307 0
+      vertex -19.4395 24.659 0.799999
+      vertex -18.4565 25.4031 0.799999
+    endloop
+  endfacet
+  facet normal -0.707038 0.0138895 -0.707039
+    outer loop
+      vertex -30.6 0 0
+      vertex -31.4 0 0.799999
+      vertex -30.5764 1.20135 0
+    endloop
+  endfacet
+  facet normal 0.404329 0.580169 -0.707052
+    outer loop
+      vertex 17.9862 24.7559 0
+      vertex 17.4449 26.1081 0.799999
+      vertex 18.4565 25.4031 0.799999
+    endloop
+  endfacet
+  facet normal -0.490107 -0.509837 -0.707009
+    outer loop
+      vertex -21.3143 -23.0577 0.799999
+      vertex -22.2032 -22.2032 0.799999
+      vertex -20.7713 -22.4703 0
+    endloop
+  endfacet
+  facet normal 0.231711 0.668158 -0.707018
+    outer loop
+      vertex 10.5912 28.7087 0
+      vertex 9.70313 29.8632 0.799999
+      vertex 10.8681 29.4592 0.799999
+    endloop
+  endfacet
+  facet normal -0.703753 0.0692827 -0.707059
+    outer loop
+      vertex -30.3879 3.59664 0
+      vertex -31.3032 2.46362 0.799999
+      vertex -31.1824 3.69067 0.799999
+    endloop
+  endfacet
+  facet normal 0.65855 0.257753 -0.707018
+    outer loop
+      vertex 29.4592 10.8681 0.799999
+      vertex 28.7087 10.5912 0
+      vertex 29.0098 12.0163 0.799999
+    endloop
+  endfacet
+  facet normal -0.124291 -0.696188 -0.707018
+    outer loop
+      vertex -4.91204 -31.0134 0.799999
+      vertex -6.12584 -30.7967 0.799999
+      vertex -4.78689 -30.2233 0
+    endloop
+  endfacet
+  facet normal 0.205268 0.676712 -0.707054
+    outer loop
+      vertex 9.70313 29.8632 0.799999
+      vertex 8.30608 29.4511 0
+      vertex 8.52323 30.2211 0.799999
+    endloop
+  endfacet
+  facet normal 0.178558 -0.684245 -0.707054
+    outer loop
+      vertex 8.52323 -30.2211 0.799999
+      vertex 7.14343 -29.7545 0
+      vertex 8.30608 -29.4511 0
+    endloop
+  endfacet
+  facet normal 0.124351 0.696123 -0.707071
+    outer loop
+      vertex 5.96976 30.012 0
+      vertex 4.78689 30.2233 0
+      vertex 6.12584 30.7967 0.799999
+    endloop
+  endfacet
+  facet normal 0.151541 -0.690714 -0.707071
+    outer loop
+      vertex 6.12584 -30.7967 0.799999
+      vertex 5.96976 -30.012 0
+      vertex 7.14343 -29.7545 0
+    endloop
+  endfacet
+  facet normal -0.0416386 -0.70594 -0.707046
+    outer loop
+      vertex -1.23276 -31.3758 0.799999
+      vertex -2.46362 -31.3032 0.799999
+      vertex -1.20135 -30.5764 0
+    endloop
+  endfacet
+  facet normal 0.696123 -0.124351 -0.707071
+    outer loop
+      vertex 30.7967 -6.12584 0.799999
+      vertex 30.012 -5.96976 0
+      vertex 30.2233 -4.78689 0
+    endloop
+  endfacet
+  facet normal 0.580171 0.404377 -0.707023
+    outer loop
+      vertex 25.443 17.0004 0
+      vertex 24.7559 17.9862 0
+      vertex 26.1081 17.4449 0.799999
+    endloop
+  endfacet
+  facet normal -0.257778 -0.65851 -0.707047
+    outer loop
+      vertex -10.5912 -28.7087 0
+      vertex -12.0163 -29.0098 0.799999
+      vertex -11.7101 -28.2707 0
+    endloop
+  endfacet
+  facet normal -0.703753 -0.0692827 -0.707059
+    outer loop
+      vertex -31.1824 -3.69067 0.799999
+      vertex -31.3032 -2.46362 0.799999
+      vertex -30.3879 -3.59664 0
+    endloop
+  endfacet
+  facet normal 0.0416386 0.70594 -0.707046
+    outer loop
+      vertex 2.46362 31.3032 0.799999
+      vertex 1.20135 30.5764 0
+      vertex 1.23276 31.3758 0.799999
+    endloop
+  endfacet
+  facet normal -0.0138895 -0.707038 -0.707039
+    outer loop
+      vertex 0 -31.4 0.799999
+      vertex -1.20135 -30.5764 0
+      vertex 0 -30.6 0
+    endloop
+  endfacet
+  facet normal -0.636279 0.308619 -0.707038
+    outer loop
+      vertex -27.2648 13.8921 0
+      vertex -28.5157 13.1459 0.799999
+      vertex -27.9776 14.2553 0.799999
+    endloop
+  endfacet
+  facet normal -0.509773 0.490117 -0.707048
+    outer loop
+      vertex -21.6375 21.6375 0
+      vertex -22.4703 20.7713 0
+      vertex -22.2032 22.2032 0.799999
+    endloop
+  endfacet
+  facet normal -0.178558 0.684245 -0.707054
+    outer loop
+      vertex -8.30608 29.4511 0
+      vertex -8.52323 30.2211 0.799999
+      vertex -7.14343 29.7545 0
+    endloop
+  endfacet
+  facet normal -0.668136 0.231642 -0.707062
+    outer loop
+      vertex -29.1023 9.45592 0
+      vertex -29.8632 9.70313 0.799999
+      vertex -28.7087 10.5912 0
+    endloop
+  endfacet
+  facet normal -0.0416104 -0.705964 -0.707024
+    outer loop
+      vertex -1.20135 -30.5764 0
+      vertex -2.46362 -31.3032 0.799999
+      vertex -2.40085 -30.5057 0
+    endloop
+  endfacet
+  facet normal -0.205275 0.676702 -0.707062
+    outer loop
+      vertex -9.45592 29.1023 0
+      vertex -9.70313 29.8632 0.799999
+      vertex -8.30608 29.4511 0
+    endloop
+  endfacet
+  facet normal 0.490117 0.509773 -0.707048
+    outer loop
+      vertex 21.6375 21.6375 0
+      vertex 20.7713 22.4703 0
+      vertex 22.2032 22.2032 0.799999
+    endloop
+  endfacet
+  facet normal -0.231711 0.668158 -0.707018
+    outer loop
+      vertex -10.5912 28.7087 0
+      vertex -10.8681 29.4592 0.799999
+      vertex -9.70313 29.8632 0.799999
+    endloop
+  endfacet
+  facet normal -0.308619 0.636279 -0.707038
+    outer loop
+      vertex -13.8921 27.2648 0
+      vertex -14.2553 27.9776 0.799999
+      vertex -13.1459 28.5157 0.799999
+    endloop
+  endfacet
+  facet normal -0.490117 0.509773 -0.707048
+    outer loop
+      vertex -21.6375 21.6375 0
+      vertex -22.2032 22.2032 0.799999
+      vertex -20.7713 22.4703 0
+    endloop
+  endfacet
+  facet normal -0.333347 0.623677 -0.707041
+    outer loop
+      vertex -14.9518 26.6984 0
+      vertex -15.3427 27.3964 0.799999
+      vertex -14.2553 27.9776 0.799999
+    endloop
+  endfacet
+  facet normal -0.381291 0.595598 -0.707022
+    outer loop
+      vertex -17.0004 25.443 0
+      vertex -17.4449 26.1081 0.799999
+      vertex -15.9885 26.0908 0
+    endloop
+  endfacet
+  facet normal -0.65851 0.257778 -0.707047
+    outer loop
+      vertex -28.7087 10.5912 0
+      vertex -29.0098 12.0163 0.799999
+      vertex -28.2707 11.7101 0
+    endloop
+  endfacet
+  facet normal 0.563851 -0.426787 -0.707054
+    outer loop
+      vertex 25.4031 -18.4565 0.799999
+      vertex 24.0307 -18.9443 0
+      vertex 24.7559 -17.9862 0
+    endloop
+  endfacet
+  facet normal 0.381299 0.595578 -0.707034
+    outer loop
+      vertex 17.4449 26.1081 0.799999
+      vertex 15.9885 26.0908 0
+      vertex 16.4065 26.7729 0.799999
+    endloop
+  endfacet
+  facet normal 0.546649 -0.44864 -0.707034
+    outer loop
+      vertex 24.659 -19.4395 0.799999
+      vertex 23.8767 -20.3927 0.799999
+      vertex 24.0307 -18.9443 0
+    endloop
+  endfacet
+  facet normal 0.580169 0.404329 -0.707052
+    outer loop
+      vertex 26.1081 17.4449 0.799999
+      vertex 24.7559 17.9862 0
+      vertex 25.4031 18.4565 0.799999
+    endloop
+  endfacet
+  facet normal -0.283375 -0.647907 -0.707047
+    outer loop
+      vertex -12.0163 -29.0098 0.799999
+      vertex -12.811 -27.7892 0
+      vertex -11.7101 -28.2707 0
+    endloop
+  endfacet
+  facet normal 0.257753 0.65855 -0.707018
+    outer loop
+      vertex 12.0163 29.0098 0.799999
+      vertex 10.5912 28.7087 0
+      vertex 10.8681 29.4592 0.799999
+    endloop
+  endfacet
+  facet normal -0.580169 0.404329 -0.707052
+    outer loop
+      vertex -24.7559 17.9862 0
+      vertex -26.1081 17.4449 0.799999
+      vertex -25.4031 18.4565 0.799999
+    endloop
+  endfacet
+  facet normal -0.333347 -0.623677 -0.707041
+    outer loop
+      vertex -14.2553 -27.9776 0.799999
+      vertex -15.3427 -27.3964 0.799999
+      vertex -14.9518 -26.6984 0
+    endloop
+  endfacet
+  facet normal -0.426787 -0.563851 -0.707054
+    outer loop
+      vertex -18.4565 -25.4031 0.799999
+      vertex -18.9443 -24.0307 0
+      vertex -17.9862 -24.7559 0
+    endloop
+  endfacet
+  facet normal -0.546635 0.448643 -0.707042
+    outer loop
+      vertex -23.2684 19.8731 0
+      vertex -24.0307 18.9443 0
+      vertex -23.8767 20.3927 0.799999
+    endloop
+  endfacet
+  facet normal 0.684245 0.178558 -0.707054
+    outer loop
+      vertex 29.7545 7.14343 0
+      vertex 29.4511 8.30608 0
+      vertex 30.2211 8.52323 0.799999
+    endloop
+  endfacet
+  facet normal 0.205275 0.676702 -0.707062
+    outer loop
+      vertex 9.45592 29.1023 0
+      vertex 8.30608 29.4511 0
+      vertex 9.70313 29.8632 0.799999
+    endloop
+  endfacet
+  facet normal 0.528633 0.46972 -0.707043
+    outer loop
+      vertex 23.2684 19.8731 0
+      vertex 22.4703 20.7713 0
+      vertex 23.8767 20.3927 0.799999
+    endloop
+  endfacet
+  facet normal 0.124291 0.696188 -0.707018
+    outer loop
+      vertex 6.12584 30.7967 0.799999
+      vertex 4.78689 30.2233 0
+      vertex 4.91204 31.0134 0.799999
+    endloop
+  endfacet
+  facet normal 0.65855 -0.257753 -0.707018
+    outer loop
+      vertex 29.0098 -12.0163 0.799999
+      vertex 28.7087 -10.5912 0
+      vertex 29.4592 -10.8681 0.799999
+    endloop
+  endfacet
+  facet normal 0.65851 -0.257778 -0.707047
+    outer loop
+      vertex 29.0098 -12.0163 0.799999
+      vertex 28.2707 -11.7101 0
+      vertex 28.7087 -10.5912 0
+    endloop
+  endfacet
+  facet normal -0.580171 -0.404377 -0.707023
+    outer loop
+      vertex -24.7559 -17.9862 0
+      vertex -26.1081 -17.4449 0.799999
+      vertex -25.443 -17.0004 0
+    endloop
+  endfacet
+  facet normal 0.509773 -0.490117 -0.707048
+    outer loop
+      vertex 22.2032 -22.2032 0.799999
+      vertex 21.6375 -21.6375 0
+      vertex 22.4703 -20.7713 0
+    endloop
+  endfacet
+  facet normal 0.178543 0.684263 -0.70704
+    outer loop
+      vertex 8.52323 30.2211 0.799999
+      vertex 7.14343 29.7545 0
+      vertex 7.33018 30.5324 0.799999
+    endloop
+  endfacet
+  facet normal 0.333347 0.623677 -0.707041
+    outer loop
+      vertex 14.9518 26.6984 0
+      vertex 14.2553 27.9776 0.799999
+      vertex 15.3427 27.3964 0.799999
+    endloop
+  endfacet
+  facet normal 0.0968765 0.70053 -0.707017
+    outer loop
+      vertex 4.78689 30.2233 0
+      vertex 3.59664 30.3879 0
+      vertex 4.91204 31.0134 0.799999
+    endloop
+  endfacet
+  facet normal 0.647907 -0.283375 -0.707047
+    outer loop
+      vertex 29.0098 -12.0163 0.799999
+      vertex 27.7892 -12.811 0
+      vertex 28.2707 -11.7101 0
+    endloop
+  endfacet
+  facet normal 0.33335 -0.623678 -0.707039
+    outer loop
+      vertex 14.2553 -27.9776 0.799999
+      vertex 13.8921 -27.2648 0
+      vertex 14.9518 -26.6984 0
+    endloop
+  endfacet
+  facet normal -0.610113 0.357581 -0.707035
+    outer loop
+      vertex -26.6984 14.9518 0
+      vertex -26.7729 16.4065 0.799999
+      vertex -26.0908 15.9885 0
+    endloop
+  endfacet
+  facet normal 0.580171 -0.404377 -0.707023
+    outer loop
+      vertex 26.1081 -17.4449 0.799999
+      vertex 24.7559 -17.9862 0
+      vertex 25.443 -17.0004 0
+    endloop
+  endfacet
+  facet normal -0.595578 -0.381299 -0.707034
+    outer loop
+      vertex -26.1081 -17.4449 0.799999
+      vertex -26.7729 -16.4065 0.799999
+      vertex -26.0908 -15.9885 0
+    endloop
+  endfacet
+  facet normal 0.357585 -0.610103 -0.707041
+    outer loop
+      vertex 15.3427 -27.3964 0.799999
+      vertex 14.9518 -26.6984 0
+      vertex 16.4065 -26.7729 0.799999
+    endloop
+  endfacet
+  facet normal 0.623678 -0.33335 -0.707039
+    outer loop
+      vertex 27.9776 -14.2553 0.799999
+      vertex 26.6984 -14.9518 0
+      vertex 27.2648 -13.8921 0
+    endloop
+  endfacet
+  facet normal 0.0138895 -0.707038 -0.707039
+    outer loop
+      vertex 1.20135 -30.5764 0
+      vertex 0 -31.4 0.799999
+      vertex 0 -30.6 0
+    endloop
+  endfacet
+  facet normal -0.705964 -0.0416104 -0.707024
+    outer loop
+      vertex -30.5057 -2.40085 0
+      vertex -31.3032 -2.46362 0.799999
+      vertex -30.5764 -1.20135 0
+    endloop
+  endfacet
+  facet normal -0.676712 0.205268 -0.707054
+    outer loop
+      vertex -29.4511 8.30608 0
+      vertex -30.2211 8.52323 0.799999
+      vertex -29.8632 9.70313 0.799999
+    endloop
+  endfacet
+  facet normal -0.509773 -0.490117 -0.707048
+    outer loop
+      vertex -22.2032 -22.2032 0.799999
+      vertex -22.4703 -20.7713 0
+      vertex -21.6375 -21.6375 0
+    endloop
+  endfacet
+  facet normal -0.257778 0.65851 -0.707047
+    outer loop
+      vertex -11.7101 28.2707 0
+      vertex -12.0163 29.0098 0.799999
+      vertex -10.5912 28.7087 0
+    endloop
+  endfacet
+  facet normal -0.44864 -0.546649 -0.707034
+    outer loop
+      vertex -19.4395 -24.659 0.799999
+      vertex -20.3927 -23.8767 0.799999
+      vertex -18.9443 -24.0307 0
+    endloop
+  endfacet
+  facet normal -0.623677 0.333347 -0.707041
+    outer loop
+      vertex -26.6984 14.9518 0
+      vertex -27.9776 14.2553 0.799999
+      vertex -27.3964 15.3427 0.799999
+    endloop
+  endfacet
+  facet normal -0.096925 0.700481 -0.707059
+    outer loop
+      vertex -3.59664 30.3879 0
+      vertex -4.91204 31.0134 0.799999
+      vertex -3.69067 31.1824 0.799999
+    endloop
+  endfacet
+  facet normal 0.0416104 0.705964 -0.707024
+    outer loop
+      vertex 2.40085 30.5057 0
+      vertex 1.20135 30.5764 0
+      vertex 2.46362 31.3032 0.799999
+    endloop
+  endfacet
+  facet normal -0.528633 -0.46972 -0.707043
+    outer loop
+      vertex -22.4703 -20.7713 0
+      vertex -23.8767 -20.3927 0.799999
+      vertex -23.2684 -19.8731 0
+    endloop
+  endfacet
+  facet normal 0.308636 -0.636283 -0.707028
+    outer loop
+      vertex 13.1459 -28.5157 0.799999
+      vertex 12.811 -27.7892 0
+      vertex 13.8921 -27.2648 0
+    endloop
+  endfacet
+  facet normal -0.610103 0.357585 -0.707041
+    outer loop
+      vertex -26.6984 14.9518 0
+      vertex -27.3964 15.3427 0.799999
+      vertex -26.7729 16.4065 0.799999
+    endloop
+  endfacet
+  facet normal -0.426817 -0.563851 -0.707035
+    outer loop
+      vertex -18.4565 -25.4031 0.799999
+      vertex -19.4395 -24.659 0.799999
+      vertex -18.9443 -24.0307 0
+    endloop
+  endfacet
+  facet normal 0.33335 0.623678 -0.707039
+    outer loop
+      vertex 14.9518 26.6984 0
+      vertex 13.8921 27.2648 0
+      vertex 14.2553 27.9776 0.799999
+    endloop
+  endfacet
+  facet normal -0.636283 -0.308636 -0.707028
+    outer loop
+      vertex -27.2648 -13.8921 0
+      vertex -28.5157 -13.1459 0.799999
+      vertex -27.7892 -12.811 0
+    endloop
+  endfacet
+  facet normal 0.283375 0.647907 -0.707047
+    outer loop
+      vertex 12.811 27.7892 0
+      vertex 11.7101 28.2707 0
+      vertex 12.0163 29.0098 0.799999
+    endloop
+  endfacet
+  facet normal -0.283405 -0.647914 -0.707028
+    outer loop
+      vertex -12.0163 -29.0098 0.799999
+      vertex -13.1459 -28.5157 0.799999
+      vertex -12.811 -27.7892 0
+    endloop
+  endfacet
+  facet normal -0.696123 0.124351 -0.707071
+    outer loop
+      vertex -30.2233 4.78689 0
+      vertex -30.7967 6.12584 0.799999
+      vertex -30.012 5.96976 0
+    endloop
+  endfacet
+  facet normal 0.231642 0.668136 -0.707062
+    outer loop
+      vertex 10.5912 28.7087 0
+      vertex 9.45592 29.1023 0
+      vertex 9.70313 29.8632 0.799999
+    endloop
+  endfacet
+  facet normal -0.700481 -0.096925 -0.707059
+    outer loop
+      vertex -31.0134 -4.91204 0.799999
+      vertex -31.1824 -3.69067 0.799999
+      vertex -30.3879 -3.59664 0
+    endloop
+  endfacet
+  facet normal -0.0138795 0.707031 -0.707046
+    outer loop
+      vertex -1.20135 30.5764 0
+      vertex -1.23276 31.3758 0.799999
+      vertex 0 31.4 0.799999
+    endloop
+  endfacet
+  facet normal -0.469778 0.528629 -0.707008
+    outer loop
+      vertex -20.7713 22.4703 0
+      vertex -21.3143 23.0577 0.799999
+      vertex -20.3927 23.8767 0.799999
+    endloop
+  endfacet
+  facet normal -0.490107 0.509837 -0.707009
+    outer loop
+      vertex -20.7713 22.4703 0
+      vertex -22.2032 22.2032 0.799999
+      vertex -21.3143 23.0577 0.799999
+    endloop
+  endfacet
+  facet normal 0.308619 -0.636279 -0.707038
+    outer loop
+      vertex 14.2553 -27.9776 0.799999
+      vertex 13.1459 -28.5157 0.799999
+      vertex 13.8921 -27.2648 0
+    endloop
+  endfacet
+  facet normal -0.690735 0.151586 -0.707041
+    outer loop
+      vertex -29.7545 7.14343 0
+      vertex -30.7967 6.12584 0.799999
+      vertex -30.5324 7.33018 0.799999
+    endloop
+  endfacet
+  facet normal -0.690714 0.151541 -0.707071
+    outer loop
+      vertex -30.012 5.96976 0
+      vertex -30.7967 6.12584 0.799999
+      vertex -29.7545 7.14343 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.85 0 0
+      vertex 30.6 0 0
+      vertex 30.5764 -1.20135 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.8285 -1.09339 0
+      vertex 30.5764 -1.20135 0
+      vertex 30.5057 -2.40085 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.6 0 0
+      vertex 27.85 0 0
+      vertex 30.5764 1.20135 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.7641 -2.18509 0
+      vertex 30.5057 -2.40085 0
+      vertex 30.3879 -3.59664 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.8285 1.09339 0
+      vertex 30.5764 1.20135 0
+      vertex 27.85 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.657 -3.27342 0
+      vertex 30.3879 -3.59664 0
+      vertex 30.2233 -4.78689 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 30.5764 1.20135 0
+      vertex 27.8285 1.09339 0
+      vertex 30.5057 2.40085 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.5071 -4.3567 0
+      vertex 30.2233 -4.78689 0
+      vertex 30.012 -5.96976 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.7641 2.18509 0
+      vertex 30.5057 2.40085 0
+      vertex 27.8285 1.09339 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3149 -5.43326 0
+      vertex 30.012 -5.96976 0
+      vertex 29.7545 -7.14343 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 30.5057 2.40085 0
+      vertex 27.7641 2.18509 0
+      vertex 30.3879 3.59664 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0805 -6.50145 0
+      vertex 29.7545 -7.14343 0
+      vertex 29.4511 -8.30608 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.657 3.27342 0
+      vertex 30.3879 3.59664 0
+      vertex 27.7641 2.18509 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8044 -7.55962 0
+      vertex 29.4511 -8.30608 0
+      vertex 29.1023 -9.45592 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 30.3879 3.59664 0
+      vertex 27.657 3.27342 0
+      vertex 30.2233 4.78689 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.4869 -8.60612 0
+      vertex 29.1023 -9.45592 0
+      vertex 28.7087 -10.5912 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.5071 4.3567 0
+      vertex 30.2233 4.78689 0
+      vertex 27.657 3.27342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1286 -9.63936 0
+      vertex 28.7087 -10.5912 0
+      vertex 28.2707 -11.7101 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 30.2233 4.78689 0
+      vertex 27.5071 4.3567 0
+      vertex 30.012 5.96976 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3149 5.43326 0
+      vertex 30.012 5.96976 0
+      vertex 27.5071 4.3567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.5764 -1.20135 0
+      vertex 27.8285 -1.09339 0
+      vertex 27.85 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.73 -10.6577 0
+      vertex 28.2707 -11.7101 0
+      vertex 27.7892 -12.811 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.5057 -2.40085 0
+      vertex 27.7641 -2.18509 0
+      vertex 27.8285 -1.09339 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.3879 -3.59664 0
+      vertex 27.657 -3.27342 0
+      vertex 27.7641 -2.18509 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.2233 -4.78689 0
+      vertex 27.5071 -4.3567 0
+      vertex 27.657 -3.27342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.012 -5.96976 0
+      vertex 27.3149 -5.43326 0
+      vertex 27.5071 -4.3567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.2918 -11.6597 0
+      vertex 27.7892 -12.811 0
+      vertex 27.2648 -13.8921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 29.7545 -7.14343 0
+      vertex 27.0805 -6.50145 0
+      vertex 27.3149 -5.43326 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 29.4511 -8.30608 0
+      vertex 26.8044 -7.55962 0
+      vertex 27.0805 -6.50145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8145 -12.6436 0
+      vertex 27.2648 -13.8921 0
+      vertex 26.6984 -14.9518 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 29.1023 -9.45592 0
+      vertex 26.4869 -8.60612 0
+      vertex 26.8044 -7.55962 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.7087 -10.5912 0
+      vertex 26.1286 -9.63936 0
+      vertex 26.4869 -8.60612 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.299 -13.6081 0
+      vertex 26.6984 -14.9518 0
+      vertex 26.0908 -15.9885 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.2707 -11.7101 0
+      vertex 25.73 -10.6577 0
+      vertex 26.1286 -9.63936 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.746 -14.5516 0
+      vertex 26.0908 -15.9885 0
+      vertex 25.443 -17.0004 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.7892 -12.811 0
+      vertex 25.2918 -11.6597 0
+      vertex 25.73 -10.6577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.2648 -13.8921 0
+      vertex 24.8145 -12.6436 0
+      vertex 25.2918 -11.6597 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.1564 -15.4726 0
+      vertex 25.443 -17.0004 0
+      vertex 24.7559 -17.9862 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6984 -14.9518 0
+      vertex 24.299 -13.6081 0
+      vertex 24.8145 -12.6436 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.5311 -16.3698 0
+      vertex 24.7559 -17.9862 0
+      vertex 24.0307 -18.9443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.0908 -15.9885 0
+      vertex 23.746 -14.5516 0
+      vertex 24.299 -13.6081 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.8711 -17.2418 0
+      vertex 24.0307 -18.9443 0
+      vertex 23.2684 -19.8731 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.443 -17.0004 0
+      vertex 23.1564 -15.4726 0
+      vertex 23.746 -14.5516 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.7559 -17.9862 0
+      vertex 22.5311 -16.3698 0
+      vertex 23.1564 -15.4726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.1773 -18.0871 0
+      vertex 23.2684 -19.8731 0
+      vertex 22.4703 -20.7713 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.0307 -18.9443 0
+      vertex 21.8711 -17.2418 0
+      vertex 22.5311 -16.3698 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.4509 -18.9046 0
+      vertex 22.4703 -20.7713 0
+      vertex 21.6375 -21.6375 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.2684 -19.8731 0
+      vertex 21.1773 -18.0871 0
+      vertex 21.8711 -17.2418 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.6929 -19.6929 0
+      vertex 21.6375 -21.6375 0
+      vertex 20.7713 -22.4703 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.4703 -20.7713 0
+      vertex 20.4509 -18.9046 0
+      vertex 21.1773 -18.0871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9046 -20.4509 0
+      vertex 20.7713 -22.4703 0
+      vertex 19.8731 -23.2684 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.6375 -21.6375 0
+      vertex 19.6929 -19.6929 0
+      vertex 20.4509 -18.9046 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.0871 -21.1773 0
+      vertex 19.8731 -23.2684 0
+      vertex 18.9443 -24.0307 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.7713 -22.4703 0
+      vertex 18.9046 -20.4509 0
+      vertex 19.6929 -19.6929 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.8731 -23.2684 0
+      vertex 18.0871 -21.1773 0
+      vertex 18.9046 -20.4509 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.2418 -21.8711 0
+      vertex 18.9443 -24.0307 0
+      vertex 17.9862 -24.7559 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9443 -24.0307 0
+      vertex 17.2418 -21.8711 0
+      vertex 18.0871 -21.1773 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.3698 -22.5311 0
+      vertex 17.9862 -24.7559 0
+      vertex 17.0004 -25.443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.9862 -24.7559 0
+      vertex 16.3698 -22.5311 0
+      vertex 17.2418 -21.8711 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4726 -23.1564 0
+      vertex 17.0004 -25.443 0
+      vertex 15.9885 -26.0908 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.0004 -25.443 0
+      vertex 15.4726 -23.1564 0
+      vertex 16.3698 -22.5311 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.5516 -23.746 0
+      vertex 15.9885 -26.0908 0
+      vertex 14.9518 -26.6984 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9885 -26.0908 0
+      vertex 14.5516 -23.746 0
+      vertex 15.4726 -23.1564 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6081 -24.299 0
+      vertex 14.9518 -26.6984 0
+      vertex 13.8921 -27.2648 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.9518 -26.6984 0
+      vertex 13.6081 -24.299 0
+      vertex 14.5516 -23.746 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6436 -24.8145 0
+      vertex 13.8921 -27.2648 0
+      vertex 12.811 -27.7892 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.8921 -27.2648 0
+      vertex 12.6436 -24.8145 0
+      vertex 13.6081 -24.299 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.6597 -25.2918 0
+      vertex 12.811 -27.7892 0
+      vertex 11.7101 -28.2707 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.811 -27.7892 0
+      vertex 11.6597 -25.2918 0
+      vertex 12.6436 -24.8145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.7101 -28.2707 0
+      vertex 10.6577 -25.73 0
+      vertex 11.6597 -25.2918 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.5912 -28.7087 0
+      vertex 10.6577 -25.73 0
+      vertex 11.7101 -28.2707 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.5912 -28.7087 0
+      vertex 9.63936 -26.1286 0
+      vertex 10.6577 -25.73 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.45592 -29.1023 0
+      vertex 9.63936 -26.1286 0
+      vertex 10.5912 -28.7087 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.45592 -29.1023 0
+      vertex 8.60612 -26.4869 0
+      vertex 9.63936 -26.1286 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.30608 -29.4511 0
+      vertex 8.60612 -26.4869 0
+      vertex 9.45592 -29.1023 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.30608 -29.4511 0
+      vertex 7.55962 -26.8044 0
+      vertex 8.60612 -26.4869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.14343 -29.7545 0
+      vertex 7.55962 -26.8044 0
+      vertex 8.30608 -29.4511 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.14343 -29.7545 0
+      vertex 6.50145 -27.0805 0
+      vertex 7.55962 -26.8044 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.96976 -30.012 0
+      vertex 6.50145 -27.0805 0
+      vertex 7.14343 -29.7545 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.96976 -30.012 0
+      vertex 5.43326 -27.3149 0
+      vertex 6.50145 -27.0805 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.78689 -30.2233 0
+      vertex 5.43326 -27.3149 0
+      vertex 5.96976 -30.012 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.78689 -30.2233 0
+      vertex 4.3567 -27.5071 0
+      vertex 5.43326 -27.3149 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.59664 -30.3879 0
+      vertex 4.3567 -27.5071 0
+      vertex 4.78689 -30.2233 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.59664 -30.3879 0
+      vertex 3.27342 -27.657 0
+      vertex 4.3567 -27.5071 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.40085 -30.5057 0
+      vertex 3.27342 -27.657 0
+      vertex 3.59664 -30.3879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.40085 -30.5057 0
+      vertex 2.18509 -27.7641 0
+      vertex 3.27342 -27.657 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.20135 -30.5764 0
+      vertex 2.18509 -27.7641 0
+      vertex 2.40085 -30.5057 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.20135 -30.5764 0
+      vertex 1.09339 -27.8285 0
+      vertex 2.18509 -27.7641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -30.6 0
+      vertex 1.09339 -27.8285 0
+      vertex 1.20135 -30.5764 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -30.6 0
+      vertex 0 -27.85 0
+      vertex 1.09339 -27.8285 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -30.6 0
+      vertex -1.09339 -27.8285 0
+      vertex 0 -27.85 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.20135 -30.5764 0
+      vertex -1.09339 -27.8285 0
+      vertex 0 -30.6 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.20135 -30.5764 0
+      vertex -2.18509 -27.7641 0
+      vertex -1.09339 -27.8285 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.40085 -30.5057 0
+      vertex -2.18509 -27.7641 0
+      vertex -1.20135 -30.5764 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.40085 -30.5057 0
+      vertex -3.27342 -27.657 0
+      vertex -2.18509 -27.7641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.59664 -30.3879 0
+      vertex -3.27342 -27.657 0
+      vertex -2.40085 -30.5057 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.59664 -30.3879 0
+      vertex -4.3567 -27.5071 0
+      vertex -3.27342 -27.657 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.78689 -30.2233 0
+      vertex -4.3567 -27.5071 0
+      vertex -3.59664 -30.3879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.78689 -30.2233 0
+      vertex -5.43326 -27.3149 0
+      vertex -4.3567 -27.5071 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.96976 -30.012 0
+      vertex -5.43326 -27.3149 0
+      vertex -4.78689 -30.2233 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.96976 -30.012 0
+      vertex -6.50145 -27.0805 0
+      vertex -5.43326 -27.3149 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.14343 -29.7545 0
+      vertex -6.50145 -27.0805 0
+      vertex -5.96976 -30.012 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.14343 -29.7545 0
+      vertex -7.55962 -26.8044 0
+      vertex -6.50145 -27.0805 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.30608 -29.4511 0
+      vertex -7.55962 -26.8044 0
+      vertex -7.14343 -29.7545 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.30608 -29.4511 0
+      vertex -8.60612 -26.4869 0
+      vertex -7.55962 -26.8044 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.45592 -29.1023 0
+      vertex -8.60612 -26.4869 0
+      vertex -8.30608 -29.4511 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.45592 -29.1023 0
+      vertex -9.63936 -26.1286 0
+      vertex -8.60612 -26.4869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.5912 -28.7087 0
+      vertex -9.63936 -26.1286 0
+      vertex -9.45592 -29.1023 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.5912 -28.7087 0
+      vertex -10.6577 -25.73 0
+      vertex -9.63936 -26.1286 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7101 -28.2707 0
+      vertex -10.6577 -25.73 0
+      vertex -10.5912 -28.7087 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -10.6577 -25.73 0
+      vertex -11.7101 -28.2707 0
+      vertex -11.6597 -25.2918 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.811 -27.7892 0
+      vertex -11.6597 -25.2918 0
+      vertex -11.7101 -28.2707 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -11.6597 -25.2918 0
+      vertex -12.811 -27.7892 0
+      vertex -12.6436 -24.8145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8921 -27.2648 0
+      vertex -12.6436 -24.8145 0
+      vertex -12.811 -27.7892 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -12.6436 -24.8145 0
+      vertex -13.8921 -27.2648 0
+      vertex -13.6081 -24.299 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.9518 -26.6984 0
+      vertex -13.6081 -24.299 0
+      vertex -13.8921 -27.2648 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.6081 -24.299 0
+      vertex -14.9518 -26.6984 0
+      vertex -14.5516 -23.746 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9885 -26.0908 0
+      vertex -14.5516 -23.746 0
+      vertex -14.9518 -26.6984 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.5516 -23.746 0
+      vertex -15.9885 -26.0908 0
+      vertex -15.4726 -23.1564 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0004 -25.443 0
+      vertex -15.4726 -23.1564 0
+      vertex -15.9885 -26.0908 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.4726 -23.1564 0
+      vertex -17.0004 -25.443 0
+      vertex -16.3698 -22.5311 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.9862 -24.7559 0
+      vertex -16.3698 -22.5311 0
+      vertex -17.0004 -25.443 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.3698 -22.5311 0
+      vertex -17.9862 -24.7559 0
+      vertex -17.2418 -21.8711 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9443 -24.0307 0
+      vertex -17.2418 -21.8711 0
+      vertex -17.9862 -24.7559 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -17.2418 -21.8711 0
+      vertex -18.9443 -24.0307 0
+      vertex -18.0871 -21.1773 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.8731 -23.2684 0
+      vertex -18.0871 -21.1773 0
+      vertex -18.9443 -24.0307 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.0871 -21.1773 0
+      vertex -19.8731 -23.2684 0
+      vertex -18.9046 -20.4509 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.7713 -22.4703 0
+      vertex -18.9046 -20.4509 0
+      vertex -19.8731 -23.2684 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.9046 -20.4509 0
+      vertex -20.7713 -22.4703 0
+      vertex -19.6929 -19.6929 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.6375 -21.6375 0
+      vertex -19.6929 -19.6929 0
+      vertex -20.7713 -22.4703 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.6929 -19.6929 0
+      vertex -21.6375 -21.6375 0
+      vertex -20.4509 -18.9046 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.4703 -20.7713 0
+      vertex -20.4509 -18.9046 0
+      vertex -21.6375 -21.6375 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -20.4509 -18.9046 0
+      vertex -22.4703 -20.7713 0
+      vertex -21.1773 -18.0871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.2684 -19.8731 0
+      vertex -21.1773 -18.0871 0
+      vertex -22.4703 -20.7713 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -21.1773 -18.0871 0
+      vertex -23.2684 -19.8731 0
+      vertex -21.8711 -17.2418 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.0307 -18.9443 0
+      vertex -21.8711 -17.2418 0
+      vertex -23.2684 -19.8731 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -21.8711 -17.2418 0
+      vertex -24.0307 -18.9443 0
+      vertex -22.5311 -16.3698 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.7559 -17.9862 0
+      vertex -22.5311 -16.3698 0
+      vertex -24.0307 -18.9443 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -22.5311 -16.3698 0
+      vertex -24.7559 -17.9862 0
+      vertex -23.1564 -15.4726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.443 -17.0004 0
+      vertex -23.1564 -15.4726 0
+      vertex -24.7559 -17.9862 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.1564 -15.4726 0
+      vertex -25.443 -17.0004 0
+      vertex -23.746 -14.5516 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.0908 -15.9885 0
+      vertex -23.746 -14.5516 0
+      vertex -25.443 -17.0004 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.746 -14.5516 0
+      vertex -26.0908 -15.9885 0
+      vertex -24.299 -13.6081 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.6984 -14.9518 0
+      vertex -24.299 -13.6081 0
+      vertex -26.0908 -15.9885 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.299 -13.6081 0
+      vertex -26.6984 -14.9518 0
+      vertex -24.8145 -12.6436 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.2648 -13.8921 0
+      vertex -24.8145 -12.6436 0
+      vertex -26.6984 -14.9518 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.8145 -12.6436 0
+      vertex -27.2648 -13.8921 0
+      vertex -25.2918 -11.6597 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.7892 -12.811 0
+      vertex -25.2918 -11.6597 0
+      vertex -27.2648 -13.8921 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.2918 -11.6597 0
+      vertex -27.7892 -12.811 0
+      vertex -25.73 -10.6577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.2707 -11.7101 0
+      vertex -25.73 -10.6577 0
+      vertex -27.7892 -12.811 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.73 -10.6577 0
+      vertex -28.2707 -11.7101 0
+      vertex -26.1286 -9.63936 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.7087 -10.5912 0
+      vertex -26.1286 -9.63936 0
+      vertex -28.2707 -11.7101 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.1286 -9.63936 0
+      vertex -28.7087 -10.5912 0
+      vertex -26.4869 -8.60612 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.1023 -9.45592 0
+      vertex -26.4869 -8.60612 0
+      vertex -28.7087 -10.5912 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.4869 -8.60612 0
+      vertex -29.1023 -9.45592 0
+      vertex -26.8044 -7.55962 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.4511 -8.30608 0
+      vertex -26.8044 -7.55962 0
+      vertex -29.1023 -9.45592 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.8044 -7.55962 0
+      vertex -29.4511 -8.30608 0
+      vertex -27.0805 -6.50145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.7545 -7.14343 0
+      vertex -27.0805 -6.50145 0
+      vertex -29.4511 -8.30608 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.0805 -6.50145 0
+      vertex -29.7545 -7.14343 0
+      vertex -27.3149 -5.43326 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.012 -5.96976 0
+      vertex -27.3149 -5.43326 0
+      vertex -29.7545 -7.14343 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 30.012 5.96976 0
+      vertex 27.3149 5.43326 0
+      vertex 29.7545 7.14343 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0805 6.50145 0
+      vertex 29.7545 7.14343 0
+      vertex 27.3149 5.43326 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 29.7545 7.14343 0
+      vertex 27.0805 6.50145 0
+      vertex 29.4511 8.30608 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8044 7.55962 0
+      vertex 29.4511 8.30608 0
+      vertex 27.0805 6.50145 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 29.4511 8.30608 0
+      vertex 26.8044 7.55962 0
+      vertex 29.1023 9.45592 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.4869 8.60612 0
+      vertex 29.1023 9.45592 0
+      vertex 26.8044 7.55962 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 29.1023 9.45592 0
+      vertex 26.4869 8.60612 0
+      vertex 28.7087 10.5912 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1286 9.63936 0
+      vertex 28.7087 10.5912 0
+      vertex 26.4869 8.60612 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.7087 10.5912 0
+      vertex 26.1286 9.63936 0
+      vertex 28.2707 11.7101 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.73 10.6577 0
+      vertex 28.2707 11.7101 0
+      vertex 26.1286 9.63936 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.2707 11.7101 0
+      vertex 25.73 10.6577 0
+      vertex 27.7892 12.811 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.2918 11.6597 0
+      vertex 27.7892 12.811 0
+      vertex 25.73 10.6577 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 27.7892 12.811 0
+      vertex 25.2918 11.6597 0
+      vertex 27.2648 13.8921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8145 12.6436 0
+      vertex 27.2648 13.8921 0
+      vertex 25.2918 11.6597 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 27.2648 13.8921 0
+      vertex 24.8145 12.6436 0
+      vertex 26.6984 14.9518 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.299 13.6081 0
+      vertex 26.6984 14.9518 0
+      vertex 24.8145 12.6436 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 26.6984 14.9518 0
+      vertex 24.299 13.6081 0
+      vertex 26.0908 15.9885 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.746 14.5516 0
+      vertex 26.0908 15.9885 0
+      vertex 24.299 13.6081 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 26.0908 15.9885 0
+      vertex 23.746 14.5516 0
+      vertex 25.443 17.0004 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.1564 15.4726 0
+      vertex 25.443 17.0004 0
+      vertex 23.746 14.5516 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 25.443 17.0004 0
+      vertex 23.1564 15.4726 0
+      vertex 24.7559 17.9862 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.5311 16.3698 0
+      vertex 24.7559 17.9862 0
+      vertex 23.1564 15.4726 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 24.7559 17.9862 0
+      vertex 22.5311 16.3698 0
+      vertex 24.0307 18.9443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.8711 17.2418 0
+      vertex 24.0307 18.9443 0
+      vertex 22.5311 16.3698 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 24.0307 18.9443 0
+      vertex 21.8711 17.2418 0
+      vertex 23.2684 19.8731 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.1773 18.0871 0
+      vertex 23.2684 19.8731 0
+      vertex 21.8711 17.2418 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 23.2684 19.8731 0
+      vertex 21.1773 18.0871 0
+      vertex 22.4703 20.7713 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.4509 18.9046 0
+      vertex 22.4703 20.7713 0
+      vertex 21.1773 18.0871 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 22.4703 20.7713 0
+      vertex 20.4509 18.9046 0
+      vertex 21.6375 21.6375 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.6929 19.6929 0
+      vertex 21.6375 21.6375 0
+      vertex 20.4509 18.9046 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 21.6375 21.6375 0
+      vertex 19.6929 19.6929 0
+      vertex 20.7713 22.4703 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9046 20.4509 0
+      vertex 20.7713 22.4703 0
+      vertex 19.6929 19.6929 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.7713 22.4703 0
+      vertex 18.9046 20.4509 0
+      vertex 19.8731 23.2684 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.0871 21.1773 0
+      vertex 19.8731 23.2684 0
+      vertex 18.9046 20.4509 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.8731 23.2684 0
+      vertex 18.0871 21.1773 0
+      vertex 18.9443 24.0307 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.2418 21.8711 0
+      vertex 18.9443 24.0307 0
+      vertex 18.0871 21.1773 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 18.9443 24.0307 0
+      vertex 17.2418 21.8711 0
+      vertex 17.9862 24.7559 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.3698 22.5311 0
+      vertex 17.9862 24.7559 0
+      vertex 17.2418 21.8711 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.9862 24.7559 0
+      vertex 16.3698 22.5311 0
+      vertex 17.0004 25.443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4726 23.1564 0
+      vertex 17.0004 25.443 0
+      vertex 16.3698 22.5311 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.0004 25.443 0
+      vertex 15.4726 23.1564 0
+      vertex 15.9885 26.0908 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.5516 23.746 0
+      vertex 15.9885 26.0908 0
+      vertex 15.4726 23.1564 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.9885 26.0908 0
+      vertex 14.5516 23.746 0
+      vertex 14.9518 26.6984 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6081 24.299 0
+      vertex 14.9518 26.6984 0
+      vertex 14.5516 23.746 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14.9518 26.6984 0
+      vertex 13.6081 24.299 0
+      vertex 13.8921 27.2648 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6436 24.8145 0
+      vertex 13.8921 27.2648 0
+      vertex 13.6081 24.299 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 13.8921 27.2648 0
+      vertex 12.6436 24.8145 0
+      vertex 12.811 27.7892 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.6597 25.2918 0
+      vertex 12.811 27.7892 0
+      vertex 12.6436 24.8145 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 12.811 27.7892 0
+      vertex 11.6597 25.2918 0
+      vertex 11.7101 28.2707 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6577 25.73 0
+      vertex 11.7101 28.2707 0
+      vertex 11.6597 25.2918 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6577 25.73 0
+      vertex 10.5912 28.7087 0
+      vertex 11.7101 28.2707 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.63936 26.1286 0
+      vertex 10.5912 28.7087 0
+      vertex 10.6577 25.73 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.63936 26.1286 0
+      vertex 9.45592 29.1023 0
+      vertex 10.5912 28.7087 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.60612 26.4869 0
+      vertex 9.45592 29.1023 0
+      vertex 9.63936 26.1286 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.60612 26.4869 0
+      vertex 8.30608 29.4511 0
+      vertex 9.45592 29.1023 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.55962 26.8044 0
+      vertex 8.30608 29.4511 0
+      vertex 8.60612 26.4869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.55962 26.8044 0
+      vertex 7.14343 29.7545 0
+      vertex 8.30608 29.4511 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.50145 27.0805 0
+      vertex 7.14343 29.7545 0
+      vertex 7.55962 26.8044 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.50145 27.0805 0
+      vertex 5.96976 30.012 0
+      vertex 7.14343 29.7545 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.43326 27.3149 0
+      vertex 5.96976 30.012 0
+      vertex 6.50145 27.0805 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.43326 27.3149 0
+      vertex 4.78689 30.2233 0
+      vertex 5.96976 30.012 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.3567 27.5071 0
+      vertex 4.78689 30.2233 0
+      vertex 5.43326 27.3149 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.3567 27.5071 0
+      vertex 3.59664 30.3879 0
+      vertex 4.78689 30.2233 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.27342 27.657 0
+      vertex 3.59664 30.3879 0
+      vertex 4.3567 27.5071 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.27342 27.657 0
+      vertex 2.40085 30.5057 0
+      vertex 3.59664 30.3879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.18509 27.7641 0
+      vertex 2.40085 30.5057 0
+      vertex 3.27342 27.657 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.18509 27.7641 0
+      vertex 1.20135 30.5764 0
+      vertex 2.40085 30.5057 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.09339 27.8285 0
+      vertex 1.20135 30.5764 0
+      vertex 2.18509 27.7641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 27.85 0
+      vertex 1.20135 30.5764 0
+      vertex 1.09339 27.8285 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 27.85 0
+      vertex 0 30.6 0
+      vertex 1.20135 30.5764 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.09339 27.8285 0
+      vertex 0 30.6 0
+      vertex 0 27.85 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.09339 27.8285 0
+      vertex -1.20135 30.5764 0
+      vertex 0 30.6 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.18509 27.7641 0
+      vertex -1.20135 30.5764 0
+      vertex -1.09339 27.8285 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.18509 27.7641 0
+      vertex -2.40085 30.5057 0
+      vertex -1.20135 30.5764 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.27342 27.657 0
+      vertex -2.40085 30.5057 0
+      vertex -2.18509 27.7641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.27342 27.657 0
+      vertex -3.59664 30.3879 0
+      vertex -2.40085 30.5057 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.3567 27.5071 0
+      vertex -3.59664 30.3879 0
+      vertex -3.27342 27.657 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.3567 27.5071 0
+      vertex -4.78689 30.2233 0
+      vertex -3.59664 30.3879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.43326 27.3149 0
+      vertex -4.78689 30.2233 0
+      vertex -4.3567 27.5071 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.43326 27.3149 0
+      vertex -5.96976 30.012 0
+      vertex -4.78689 30.2233 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.50145 27.0805 0
+      vertex -5.96976 30.012 0
+      vertex -5.43326 27.3149 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.50145 27.0805 0
+      vertex -7.14343 29.7545 0
+      vertex -5.96976 30.012 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.55962 26.8044 0
+      vertex -7.14343 29.7545 0
+      vertex -6.50145 27.0805 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.55962 26.8044 0
+      vertex -8.30608 29.4511 0
+      vertex -7.14343 29.7545 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.60612 26.4869 0
+      vertex -8.30608 29.4511 0
+      vertex -7.55962 26.8044 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.60612 26.4869 0
+      vertex -9.45592 29.1023 0
+      vertex -8.30608 29.4511 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.63936 26.1286 0
+      vertex -9.45592 29.1023 0
+      vertex -8.60612 26.4869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.63936 26.1286 0
+      vertex -10.5912 28.7087 0
+      vertex -9.45592 29.1023 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6577 25.73 0
+      vertex -10.5912 28.7087 0
+      vertex -9.63936 26.1286 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7101 28.2707 0
+      vertex -10.6577 25.73 0
+      vertex -11.6597 25.2918 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6577 25.73 0
+      vertex -11.7101 28.2707 0
+      vertex -10.5912 28.7087 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.811 27.7892 0
+      vertex -11.6597 25.2918 0
+      vertex -12.6436 24.8145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.6597 25.2918 0
+      vertex -12.811 27.7892 0
+      vertex -11.7101 28.2707 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8921 27.2648 0
+      vertex -12.6436 24.8145 0
+      vertex -13.6081 24.299 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.6436 24.8145 0
+      vertex -13.8921 27.2648 0
+      vertex -12.811 27.7892 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.9518 26.6984 0
+      vertex -13.6081 24.299 0
+      vertex -14.5516 23.746 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.6081 24.299 0
+      vertex -14.9518 26.6984 0
+      vertex -13.8921 27.2648 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9885 26.0908 0
+      vertex -14.5516 23.746 0
+      vertex -15.4726 23.1564 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.5516 23.746 0
+      vertex -15.9885 26.0908 0
+      vertex -14.9518 26.6984 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0004 25.443 0
+      vertex -15.4726 23.1564 0
+      vertex -16.3698 22.5311 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.4726 23.1564 0
+      vertex -17.0004 25.443 0
+      vertex -15.9885 26.0908 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.9862 24.7559 0
+      vertex -16.3698 22.5311 0
+      vertex -17.2418 21.8711 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.3698 22.5311 0
+      vertex -17.9862 24.7559 0
+      vertex -17.0004 25.443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9443 24.0307 0
+      vertex -17.2418 21.8711 0
+      vertex -18.0871 21.1773 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.8731 23.2684 0
+      vertex -18.0871 21.1773 0
+      vertex -18.9046 20.4509 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.2418 21.8711 0
+      vertex -18.9443 24.0307 0
+      vertex -17.9862 24.7559 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.7713 22.4703 0
+      vertex -18.9046 20.4509 0
+      vertex -19.6929 19.6929 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.0871 21.1773 0
+      vertex -19.8731 23.2684 0
+      vertex -18.9443 24.0307 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.6375 21.6375 0
+      vertex -19.6929 19.6929 0
+      vertex -20.4509 18.9046 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9046 20.4509 0
+      vertex -20.7713 22.4703 0
+      vertex -19.8731 23.2684 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.4703 20.7713 0
+      vertex -20.4509 18.9046 0
+      vertex -21.1773 18.0871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.6929 19.6929 0
+      vertex -21.6375 21.6375 0
+      vertex -20.7713 22.4703 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.2684 19.8731 0
+      vertex -21.1773 18.0871 0
+      vertex -21.8711 17.2418 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.4509 18.9046 0
+      vertex -22.4703 20.7713 0
+      vertex -21.6375 21.6375 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.0307 18.9443 0
+      vertex -21.8711 17.2418 0
+      vertex -22.5311 16.3698 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.7559 17.9862 0
+      vertex -22.5311 16.3698 0
+      vertex -23.1564 15.4726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.1773 18.0871 0
+      vertex -23.2684 19.8731 0
+      vertex -22.4703 20.7713 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.443 17.0004 0
+      vertex -23.1564 15.4726 0
+      vertex -23.746 14.5516 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.8711 17.2418 0
+      vertex -24.0307 18.9443 0
+      vertex -23.2684 19.8731 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.0908 15.9885 0
+      vertex -23.746 14.5516 0
+      vertex -24.299 13.6081 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5311 16.3698 0
+      vertex -24.7559 17.9862 0
+      vertex -24.0307 18.9443 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.6984 14.9518 0
+      vertex -24.299 13.6081 0
+      vertex -24.8145 12.6436 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.2648 13.8921 0
+      vertex -24.8145 12.6436 0
+      vertex -25.2918 11.6597 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.1564 15.4726 0
+      vertex -25.443 17.0004 0
+      vertex -24.7559 17.9862 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.7892 12.811 0
+      vertex -25.2918 11.6597 0
+      vertex -25.73 10.6577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.746 14.5516 0
+      vertex -26.0908 15.9885 0
+      vertex -25.443 17.0004 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.2707 11.7101 0
+      vertex -25.73 10.6577 0
+      vertex -26.1286 9.63936 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.7087 10.5912 0
+      vertex -26.1286 9.63936 0
+      vertex -26.4869 8.60612 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.299 13.6081 0
+      vertex -26.6984 14.9518 0
+      vertex -26.0908 15.9885 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.1023 9.45592 0
+      vertex -26.4869 8.60612 0
+      vertex -26.8044 7.55962 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.4511 8.30608 0
+      vertex -26.8044 7.55962 0
+      vertex -27.0805 6.50145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.8145 12.6436 0
+      vertex -27.2648 13.8921 0
+      vertex -26.6984 14.9518 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.7545 7.14343 0
+      vertex -27.0805 6.50145 0
+      vertex -27.3149 5.43326 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.012 5.96976 0
+      vertex -27.3149 5.43326 0
+      vertex -27.5071 4.3567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.2233 4.78689 0
+      vertex -27.5071 4.3567 0
+      vertex -27.657 3.27342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.3879 3.59664 0
+      vertex -27.657 3.27342 0
+      vertex -27.7641 2.18509 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.2918 11.6597 0
+      vertex -27.7892 12.811 0
+      vertex -27.2648 13.8921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.5057 2.40085 0
+      vertex -27.7641 2.18509 0
+      vertex -27.8285 1.09339 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.5764 1.20135 0
+      vertex -27.8285 1.09339 0
+      vertex -27.85 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.3149 -5.43326 0
+      vertex -30.012 -5.96976 0
+      vertex -27.5071 -4.3567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.73 10.6577 0
+      vertex -28.2707 11.7101 0
+      vertex -27.7892 12.811 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.2233 -4.78689 0
+      vertex -27.5071 -4.3567 0
+      vertex -30.012 -5.96976 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.1286 9.63936 0
+      vertex -28.7087 10.5912 0
+      vertex -28.2707 11.7101 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.5071 -4.3567 0
+      vertex -30.2233 -4.78689 0
+      vertex -27.657 -3.27342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.4869 8.60612 0
+      vertex -29.1023 9.45592 0
+      vertex -28.7087 10.5912 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.3879 -3.59664 0
+      vertex -27.657 -3.27342 0
+      vertex -30.2233 -4.78689 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.8044 7.55962 0
+      vertex -29.4511 8.30608 0
+      vertex -29.1023 9.45592 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.657 -3.27342 0
+      vertex -30.3879 -3.59664 0
+      vertex -27.7641 -2.18509 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0805 6.50145 0
+      vertex -29.7545 7.14343 0
+      vertex -29.4511 8.30608 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.5057 -2.40085 0
+      vertex -27.7641 -2.18509 0
+      vertex -30.3879 -3.59664 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.3149 5.43326 0
+      vertex -30.012 5.96976 0
+      vertex -29.7545 7.14343 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.7641 -2.18509 0
+      vertex -30.5057 -2.40085 0
+      vertex -27.8285 -1.09339 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.5071 4.3567 0
+      vertex -30.2233 4.78689 0
+      vertex -30.012 5.96976 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.5764 -1.20135 0
+      vertex -27.8285 -1.09339 0
+      vertex -30.5057 -2.40085 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.657 3.27342 0
+      vertex -30.3879 3.59664 0
+      vertex -30.2233 4.78689 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.8285 -1.09339 0
+      vertex -30.5764 -1.20135 0
+      vertex -27.85 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.7641 2.18509 0
+      vertex -30.5057 2.40085 0
+      vertex -30.3879 3.59664 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.6 0 0
+      vertex -27.85 0 0
+      vertex -30.5764 -1.20135 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.8285 1.09339 0
+      vertex -30.5764 1.20135 0
+      vertex -30.5057 2.40085 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.85 0 0
+      vertex -30.6 0 0
+      vertex -30.5764 1.20135 0
+    endloop
+  endfacet
+  facet normal 0.257778 0.65851 -0.707047
+    outer loop
+      vertex 11.7101 28.2707 0
+      vertex 10.5912 28.7087 0
+      vertex 12.0163 29.0098 0.799999
+    endloop
+  endfacet
+  facet normal 0.096925 -0.700481 -0.707059
+    outer loop
+      vertex 3.69067 -31.1824 0.799999
+      vertex 3.59664 -30.3879 0
+      vertex 4.91204 -31.0134 0.799999
+    endloop
+  endfacet
+  facet normal -0.65851 -0.257778 -0.707047
+    outer loop
+      vertex -28.2707 -11.7101 0
+      vertex -29.0098 -12.0163 0.799999
+      vertex -28.7087 -10.5912 0
+    endloop
+  endfacet
+  facet normal 0.705964 0.0416104 -0.707024
+    outer loop
+      vertex 30.5764 1.20135 0
+      vertex 30.5057 2.40085 0
+      vertex 31.3032 2.46362 0.799999
+    endloop
+  endfacet
+  facet normal 0.404377 0.580171 -0.707023
+    outer loop
+      vertex 17.9862 24.7559 0
+      vertex 17.0004 25.443 0
+      vertex 17.4449 26.1081 0.799999
+    endloop
+  endfacet
+  facet normal -0.124351 0.696123 -0.707071
+    outer loop
+      vertex -5.96976 30.012 0
+      vertex -6.12584 30.7967 0.799999
+      vertex -4.78689 30.2233 0
+    endloop
+  endfacet
+  facet normal -0.690714 -0.151541 -0.707071
+    outer loop
+      vertex -29.7545 -7.14343 0
+      vertex -30.7967 -6.12584 0.799999
+      vertex -30.012 -5.96976 0
+    endloop
+  endfacet
+  facet normal 0.448643 0.546635 -0.707042
+    outer loop
+      vertex 19.8731 23.2684 0
+      vertex 18.9443 24.0307 0
+      vertex 20.3927 23.8767 0.799999
+    endloop
+  endfacet
+  facet normal 0.690735 -0.151586 -0.707041
+    outer loop
+      vertex 30.5324 -7.33018 0.799999
+      vertex 29.7545 -7.14343 0
+      vertex 30.7967 -6.12584 0.799999
+    endloop
+  endfacet
+  facet normal -0.151541 0.690714 -0.707071
+    outer loop
+      vertex -5.96976 30.012 0
+      vertex -7.14343 29.7545 0
+      vertex -6.12584 30.7967 0.799999
+    endloop
+  endfacet
+  facet normal -0.595598 -0.381291 -0.707022
+    outer loop
+      vertex -25.443 -17.0004 0
+      vertex -26.1081 -17.4449 0.799999
+      vertex -26.0908 -15.9885 0
+    endloop
+  endfacet
+  facet normal 0.668136 0.231642 -0.707062
+    outer loop
+      vertex 29.1023 9.45592 0
+      vertex 28.7087 10.5912 0
+      vertex 29.8632 9.70313 0.799999
+    endloop
+  endfacet
+  facet normal 0.231711 -0.668158 -0.707018
+    outer loop
+      vertex 10.8681 -29.4592 0.799999
+      vertex 9.70313 -29.8632 0.799999
+      vertex 10.5912 -28.7087 0
+    endloop
+  endfacet
+  facet normal 0.0693312 0.703783 -0.707024
+    outer loop
+      vertex 3.59664 30.3879 0
+      vertex 2.40085 30.5057 0
+      vertex 2.46362 31.3032 0.799999
+    endloop
+  endfacet
+  facet normal -0.308636 0.636283 -0.707028
+    outer loop
+      vertex -12.811 27.7892 0
+      vertex -13.8921 27.2648 0
+      vertex -13.1459 28.5157 0.799999
+    endloop
+  endfacet
+  facet normal -0.404329 0.580169 -0.707052
+    outer loop
+      vertex -17.9862 24.7559 0
+      vertex -18.4565 25.4031 0.799999
+      vertex -17.4449 26.1081 0.799999
+    endloop
+  endfacet
+  facet normal -0.404377 0.580171 -0.707023
+    outer loop
+      vertex -17.0004 25.443 0
+      vertex -17.9862 24.7559 0
+      vertex -17.4449 26.1081 0.799999
+    endloop
+  endfacet
+  facet normal 0.178543 -0.684263 -0.70704
+    outer loop
+      vertex 7.33018 -30.5324 0.799999
+      vertex 7.14343 -29.7545 0
+      vertex 8.52323 -30.2211 0.799999
+    endloop
+  endfacet
+  facet normal 0.676702 0.205275 -0.707062
+    outer loop
+      vertex 29.4511 8.30608 0
+      vertex 29.1023 9.45592 0
+      vertex 29.8632 9.70313 0.799999
+    endloop
+  endfacet
+  facet normal 0.676702 -0.205275 -0.707062
+    outer loop
+      vertex 29.8632 -9.70313 0.799999
+      vertex 29.1023 -9.45592 0
+      vertex 29.4511 -8.30608 0
+    endloop
+  endfacet
+  facet normal -0.684263 0.178543 -0.70704
+    outer loop
+      vertex -29.7545 7.14343 0
+      vertex -30.5324 7.33018 0.799999
+      vertex -30.2211 8.52323 0.799999
+    endloop
+  endfacet
+  facet normal 0.357585 0.610103 -0.707041
+    outer loop
+      vertex 16.4065 26.7729 0.799999
+      vertex 14.9518 26.6984 0
+      vertex 15.3427 27.3964 0.799999
+    endloop
+  endfacet
+  facet normal 0.404377 -0.580171 -0.707023
+    outer loop
+      vertex 17.4449 -26.1081 0.799999
+      vertex 17.0004 -25.443 0
+      vertex 17.9862 -24.7559 0
+    endloop
+  endfacet
+  facet normal 0.404329 -0.580169 -0.707052
+    outer loop
+      vertex 18.4565 -25.4031 0.799999
+      vertex 17.4449 -26.1081 0.799999
+      vertex 17.9862 -24.7559 0
+    endloop
+  endfacet
+  facet normal 0.381291 -0.595598 -0.707022
+    outer loop
+      vertex 17.4449 -26.1081 0.799999
+      vertex 15.9885 -26.0908 0
+      vertex 17.0004 -25.443 0
+    endloop
+  endfacet
+  facet normal -0.448643 -0.546635 -0.707042
+    outer loop
+      vertex -18.9443 -24.0307 0
+      vertex -20.3927 -23.8767 0.799999
+      vertex -19.8731 -23.2684 0
+    endloop
+  endfacet
+  facet normal -0.205268 0.676712 -0.707054
+    outer loop
+      vertex -8.30608 29.4511 0
+      vertex -9.70313 29.8632 0.799999
+      vertex -8.52323 30.2211 0.799999
+    endloop
+  endfacet
+  facet normal 0.0968765 -0.70053 -0.707017
+    outer loop
+      vertex 4.91204 -31.0134 0.799999
+      vertex 3.59664 -30.3879 0
+      vertex 4.78689 -30.2233 0
+    endloop
+  endfacet
+  facet normal 0.426817 -0.563851 -0.707035
+    outer loop
+      vertex 19.4395 -24.659 0.799999
+      vertex 18.4565 -25.4031 0.799999
+      vertex 18.9443 -24.0307 0
+    endloop
+  endfacet
+  facet normal 0.44864 -0.546649 -0.707034
+    outer loop
+      vertex 19.4395 -24.659 0.799999
+      vertex 18.9443 -24.0307 0
+      vertex 20.3927 -23.8767 0.799999
+    endloop
+  endfacet
+  facet normal -0.205268 -0.676712 -0.707054
+    outer loop
+      vertex -8.52323 -30.2211 0.799999
+      vertex -9.70313 -29.8632 0.799999
+      vertex -8.30608 -29.4511 0
+    endloop
+  endfacet
+  facet normal 0.623677 0.333347 -0.707041
+    outer loop
+      vertex 27.9776 14.2553 0.799999
+      vertex 26.6984 14.9518 0
+      vertex 27.3964 15.3427 0.799999
+    endloop
+  endfacet
+  facet normal -0.231642 -0.668136 -0.707062
+    outer loop
+      vertex -9.70313 -29.8632 0.799999
+      vertex -10.5912 -28.7087 0
+      vertex -9.45592 -29.1023 0
+    endloop
+  endfacet
+  facet normal -0.0416104 0.705964 -0.707024
+    outer loop
+      vertex -2.40085 30.5057 0
+      vertex -2.46362 31.3032 0.799999
+      vertex -1.20135 30.5764 0
+    endloop
+  endfacet
+  facet normal -0.610113 -0.357581 -0.707035
+    outer loop
+      vertex -26.0908 -15.9885 0
+      vertex -26.7729 -16.4065 0.799999
+      vertex -26.6984 -14.9518 0
+    endloop
+  endfacet
+  facet normal -0.563851 -0.426817 -0.707035
+    outer loop
+      vertex -24.659 -19.4395 0.799999
+      vertex -25.4031 -18.4565 0.799999
+      vertex -24.0307 -18.9443 0
+    endloop
+  endfacet
+  facet normal 0.124351 -0.696123 -0.707071
+    outer loop
+      vertex 6.12584 -30.7967 0.799999
+      vertex 4.78689 -30.2233 0
+      vertex 5.96976 -30.012 0
+    endloop
+  endfacet
+  facet normal 0.308636 0.636283 -0.707028
+    outer loop
+      vertex 13.8921 27.2648 0
+      vertex 12.811 27.7892 0
+      vertex 13.1459 28.5157 0.799999
+    endloop
+  endfacet
+  facet normal -0.0968765 -0.70053 -0.707017
+    outer loop
+      vertex -3.59664 -30.3879 0
+      vertex -4.91204 -31.0134 0.799999
+      vertex -4.78689 -30.2233 0
+    endloop
+  endfacet
+  facet normal -0.404329 -0.580169 -0.707052
+    outer loop
+      vertex -17.4449 -26.1081 0.799999
+      vertex -18.4565 -25.4031 0.799999
+      vertex -17.9862 -24.7559 0
+    endloop
+  endfacet
+  facet normal 0.546649 0.44864 -0.707034
+    outer loop
+      vertex 24.0307 18.9443 0
+      vertex 23.8767 20.3927 0.799999
+      vertex 24.659 19.4395 0.799999
+    endloop
+  endfacet
+  facet normal -0.124351 -0.696123 -0.707071
+    outer loop
+      vertex -4.78689 -30.2233 0
+      vertex -6.12584 -30.7967 0.799999
+      vertex -5.96976 -30.012 0
+    endloop
+  endfacet
+  facet normal -0.623678 -0.33335 -0.707039
+    outer loop
+      vertex -26.6984 -14.9518 0
+      vertex -27.9776 -14.2553 0.799999
+      vertex -27.2648 -13.8921 0
+    endloop
+  endfacet
+  facet normal 0.178558 0.684245 -0.707054
+    outer loop
+      vertex 8.30608 29.4511 0
+      vertex 7.14343 29.7545 0
+      vertex 8.52323 30.2211 0.799999
+    endloop
+  endfacet
+  facet normal -0.381299 -0.595578 -0.707034
+    outer loop
+      vertex -16.4065 -26.7729 0.799999
+      vertex -17.4449 -26.1081 0.799999
+      vertex -15.9885 -26.0908 0
+    endloop
+  endfacet
+  facet normal -0.528629 -0.469778 -0.707008
+    outer loop
+      vertex -23.0577 -21.3143 0.799999
+      vertex -23.8767 -20.3927 0.799999
+      vertex -22.4703 -20.7713 0
+    endloop
+  endfacet
+  facet normal -0.509837 -0.490107 -0.707009
+    outer loop
+      vertex -22.2032 -22.2032 0.799999
+      vertex -23.0577 -21.3143 0.799999
+      vertex -22.4703 -20.7713 0
+    endloop
+  endfacet
+  facet normal -0.33335 -0.623678 -0.707039
+    outer loop
+      vertex -14.2553 -27.9776 0.799999
+      vertex -14.9518 -26.6984 0
+      vertex -13.8921 -27.2648 0
+    endloop
+  endfacet
+  facet normal 0.469778 0.528629 -0.707008
+    outer loop
+      vertex 20.7713 22.4703 0
+      vertex 20.3927 23.8767 0.799999
+      vertex 21.3143 23.0577 0.799999
+    endloop
+  endfacet
+  facet normal -0.676712 -0.205268 -0.707054
+    outer loop
+      vertex -29.8632 -9.70313 0.799999
+      vertex -30.2211 -8.52323 0.799999
+      vertex -29.4511 -8.30608 0
+    endloop
+  endfacet
+  facet normal 0.563851 0.426817 -0.707035
+    outer loop
+      vertex 25.4031 18.4565 0.799999
+      vertex 24.0307 18.9443 0
+      vertex 24.659 19.4395 0.799999
+    endloop
+  endfacet
+  facet normal 0.231642 -0.668136 -0.707062
+    outer loop
+      vertex 9.70313 -29.8632 0.799999
+      vertex 9.45592 -29.1023 0
+      vertex 10.5912 -28.7087 0
+    endloop
+  endfacet
+  facet normal 0.0693312 -0.703783 -0.707024
+    outer loop
+      vertex 2.46362 -31.3032 0.799999
+      vertex 2.40085 -30.5057 0
+      vertex 3.59664 -30.3879 0
+    endloop
+  endfacet
+  facet normal -0.178558 -0.684245 -0.707054
+    outer loop
+      vertex -7.14343 -29.7545 0
+      vertex -8.52323 -30.2211 0.799999
+      vertex -8.30608 -29.4511 0
+    endloop
+  endfacet
+  facet normal -0.205275 -0.676702 -0.707062
+    outer loop
+      vertex -8.30608 -29.4511 0
+      vertex -9.70313 -29.8632 0.799999
+      vertex -9.45592 -29.1023 0
+    endloop
+  endfacet
+  facet normal -0.0968765 0.70053 -0.707017
+    outer loop
+      vertex -4.78689 30.2233 0
+      vertex -4.91204 31.0134 0.799999
+      vertex -3.59664 30.3879 0
+    endloop
+  endfacet
+  facet normal -0.257753 0.65855 -0.707018
+    outer loop
+      vertex -10.5912 28.7087 0
+      vertex -12.0163 29.0098 0.799999
+      vertex -10.8681 29.4592 0.799999
+    endloop
+  endfacet
+  facet normal -0.46972 0.528633 -0.707043
+    outer loop
+      vertex -19.8731 23.2684 0
+      vertex -20.7713 22.4703 0
+      vertex -20.3927 23.8767 0.799999
+    endloop
+  endfacet
+  facet normal -0.676702 -0.205275 -0.707062
+    outer loop
+      vertex -29.1023 -9.45592 0
+      vertex -29.8632 -9.70313 0.799999
+      vertex -29.4511 -8.30608 0
+    endloop
+  endfacet
+  facet normal -0.357581 0.610113 -0.707035
+    outer loop
+      vertex -15.9885 26.0908 0
+      vertex -16.4065 26.7729 0.799999
+      vertex -14.9518 26.6984 0
+    endloop
+  endfacet
+  facet normal -0.33335 0.623678 -0.707039
+    outer loop
+      vertex -13.8921 27.2648 0
+      vertex -14.9518 26.6984 0
+      vertex -14.2553 27.9776 0.799999
+    endloop
+  endfacet
+  facet normal -0.610103 -0.357585 -0.707041
+    outer loop
+      vertex -26.7729 -16.4065 0.799999
+      vertex -27.3964 -15.3427 0.799999
+      vertex -26.6984 -14.9518 0
+    endloop
+  endfacet
+  facet normal 0.546635 0.448643 -0.707042
+    outer loop
+      vertex 24.0307 18.9443 0
+      vertex 23.2684 19.8731 0
+      vertex 23.8767 20.3927 0.799999
+    endloop
+  endfacet
+  facet normal 0.623678 0.33335 -0.707039
+    outer loop
+      vertex 27.2648 13.8921 0
+      vertex 26.6984 14.9518 0
+      vertex 27.9776 14.2553 0.799999
+    endloop
+  endfacet
+  facet normal 0.151586 -0.690735 -0.707041
+    outer loop
+      vertex 7.33018 -30.5324 0.799999
+      vertex 6.12584 -30.7967 0.799999
+      vertex 7.14343 -29.7545 0
+    endloop
+  endfacet
+  facet normal -0.696123 -0.124351 -0.707071
+    outer loop
+      vertex -30.012 -5.96976 0
+      vertex -30.7967 -6.12584 0.799999
+      vertex -30.2233 -4.78689 0
+    endloop
+  endfacet
+  facet normal -0.357581 -0.610113 -0.707035
+    outer loop
+      vertex -14.9518 -26.6984 0
+      vertex -16.4065 -26.7729 0.799999
+      vertex -15.9885 -26.0908 0
+    endloop
+  endfacet
+  facet normal 0.563851 0.426787 -0.707054
+    outer loop
+      vertex 24.7559 17.9862 0
+      vertex 24.0307 18.9443 0
+      vertex 25.4031 18.4565 0.799999
+    endloop
+  endfacet
+  facet normal -0.0692827 -0.703753 -0.707059
+    outer loop
+      vertex -2.46362 -31.3032 0.799999
+      vertex -3.69067 -31.1824 0.799999
+      vertex -3.59664 -30.3879 0
+    endloop
+  endfacet
+  facet normal -0.0693312 -0.703783 -0.707024
+    outer loop
+      vertex -2.46362 -31.3032 0.799999
+      vertex -3.59664 -30.3879 0
+      vertex -2.40085 -30.5057 0
+    endloop
+  endfacet
+  facet normal -0.178543 0.684263 -0.70704
+    outer loop
+      vertex -7.14343 29.7545 0
+      vertex -8.52323 30.2211 0.799999
+      vertex -7.33018 30.5324 0.799999
+    endloop
+  endfacet
+  facet normal 0.426787 0.563851 -0.707054
+    outer loop
+      vertex 18.9443 24.0307 0
+      vertex 17.9862 24.7559 0
+      vertex 18.4565 25.4031 0.799999
+    endloop
+  endfacet
+  facet normal -0.151586 0.690735 -0.707041
+    outer loop
+      vertex -7.14343 29.7545 0
+      vertex -7.33018 30.5324 0.799999
+      vertex -6.12584 30.7967 0.799999
+    endloop
+  endfacet
+  facet normal 0.357581 0.610113 -0.707035
+    outer loop
+      vertex 15.9885 26.0908 0
+      vertex 14.9518 26.6984 0
+      vertex 16.4065 26.7729 0.799999
+    endloop
+  endfacet
+  facet normal -0.0693312 0.703783 -0.707024
+    outer loop
+      vertex -2.40085 30.5057 0
+      vertex -3.59664 30.3879 0
+      vertex -2.46362 31.3032 0.799999
+    endloop
+  endfacet
+  facet normal 0.44864 0.546649 -0.707034
+    outer loop
+      vertex 20.3927 23.8767 0.799999
+      vertex 18.9443 24.0307 0
+      vertex 19.4395 24.659 0.799999
+    endloop
+  endfacet
+  facet normal -0.357585 -0.610103 -0.707041
+    outer loop
+      vertex -15.3427 -27.3964 0.799999
+      vertex -16.4065 -26.7729 0.799999
+      vertex -14.9518 -26.6984 0
+    endloop
+  endfacet
+  facet normal -0.448643 0.546635 -0.707042
+    outer loop
+      vertex -19.8731 23.2684 0
+      vertex -20.3927 23.8767 0.799999
+      vertex -18.9443 24.0307 0
+    endloop
+  endfacet
+  facet normal -0.44864 0.546649 -0.707034
+    outer loop
+      vertex -18.9443 24.0307 0
+      vertex -20.3927 23.8767 0.799999
+      vertex -19.4395 24.659 0.799999
+    endloop
+  endfacet
+  facet normal -0.426787 0.563851 -0.707054
+    outer loop
+      vertex -17.9862 24.7559 0
+      vertex -18.9443 24.0307 0
+      vertex -18.4565 25.4031 0.799999
+    endloop
+  endfacet
+  facet normal 0.580169 -0.404329 0.707052
+    outer loop
+      vertex 26.1081 -17.4449 57.2
+      vertex 24.7559 -17.9862 58
+      vertex 25.4031 -18.4565 57.2
+    endloop
+  endfacet
+  facet normal 0.707039 0.0138895 0.707039
+    outer loop
+      vertex 31.4 0 57.2
+      vertex 30.5764 1.20135 58
+      vertex 30.6 0 58
+    endloop
+  endfacet
+  facet normal 0.707031 0.0138796 0.707046
+    outer loop
+      vertex 31.3758 1.23276 57.2
+      vertex 30.5764 1.20135 58
+      vertex 31.4 0 57.2
+    endloop
+  endfacet
+  facet normal 0.357582 0.610113 0.707034
+    outer loop
+      vertex 16.4065 26.7729 57.2
+      vertex 14.9518 26.6984 58
+      vertex 15.9885 26.0908 58
+    endloop
+  endfacet
+  facet normal -0.257778 -0.658511 0.707046
+    outer loop
+      vertex -11.7101 -28.2707 58
+      vertex -12.0163 -29.0098 57.2
+      vertex -10.5912 -28.7087 58
+    endloop
+  endfacet
+  facet normal -0.333347 -0.623678 0.70704
+    outer loop
+      vertex -14.9518 -26.6984 58
+      vertex -15.3427 -27.3964 57.2
+      vertex -14.2553 -27.9776 57.2
+    endloop
+  endfacet
+  facet normal 0.0416386 -0.705941 0.707046
+    outer loop
+      vertex 2.46362 -31.3032 57.2
+      vertex 1.20135 -30.5764 58
+      vertex 1.23276 -31.3758 57.2
+    endloop
+  endfacet
+  facet normal 0.676713 0.205268 0.707054
+    outer loop
+      vertex 29.8632 9.70313 57.2
+      vertex 29.4511 8.30608 58
+      vertex 30.2211 8.52323 57.2
+    endloop
+  endfacet
+  facet normal 0.623678 -0.333347 0.70704
+    outer loop
+      vertex 27.9776 -14.2553 57.2
+      vertex 26.6984 -14.9518 58
+      vertex 27.3964 -15.3427 57.2
+    endloop
+  endfacet
+  facet normal 0.426818 0.563851 0.707035
+    outer loop
+      vertex 19.4395 24.659 57.2
+      vertex 18.4565 25.4031 57.2
+      vertex 18.9443 24.0307 58
+    endloop
+  endfacet
+  facet normal 0.595579 0.381299 0.707034
+    outer loop
+      vertex 26.1081 17.4449 57.2
+      vertex 26.0908 15.9885 58
+      vertex 26.7729 16.4065 57.2
+    endloop
+  endfacet
+  facet normal 0.490107 0.509838 0.707008
+    outer loop
+      vertex 21.3143 23.0577 57.2
+      vertex 20.7713 22.4703 58
+      vertex 22.2032 22.2032 57.2
+    endloop
+  endfacet
+  facet normal 0.381292 0.595599 0.707021
+    outer loop
+      vertex 17.4449 26.1081 57.2
+      vertex 15.9885 26.0908 58
+      vertex 17.0004 25.443 58
+    endloop
+  endfacet
+  facet normal 0.231711 -0.668159 0.707018
+    outer loop
+      vertex 10.5912 -28.7087 58
+      vertex 9.70313 -29.8632 57.2
+      vertex 10.8681 -29.4592 57.2
+    endloop
+  endfacet
+  facet normal 0.696189 0.124291 0.707017
+    outer loop
+      vertex 30.7967 6.12584 57.2
+      vertex 30.2233 4.78689 58
+      vertex 31.0134 4.91204 57.2
+    endloop
+  endfacet
+  facet normal 0.404329 0.580169 0.707052
+    outer loop
+      vertex 18.4565 25.4031 57.2
+      vertex 17.4449 26.1081 57.2
+      vertex 17.9862 24.7559 58
+    endloop
+  endfacet
+  facet normal -0.610113 0.357582 0.707034
+    outer loop
+      vertex -26.0908 15.9885 58
+      vertex -26.7729 16.4065 57.2
+      vertex -26.6984 14.9518 58
+    endloop
+  endfacet
+  facet normal -0.0968765 -0.70053 0.707016
+    outer loop
+      vertex -4.78689 -30.2233 58
+      vertex -4.91204 -31.0134 57.2
+      vertex -3.59664 -30.3879 58
+    endloop
+  endfacet
+  facet normal 0.528629 0.469778 0.707008
+    outer loop
+      vertex 23.0577 21.3143 57.2
+      vertex 22.4703 20.7713 58
+      vertex 23.8767 20.3927 57.2
+    endloop
+  endfacet
+  facet normal -0.580171 -0.404378 0.707022
+    outer loop
+      vertex -25.443 -17.0004 58
+      vertex -26.1081 -17.4449 57.2
+      vertex -24.7559 -17.9862 58
+    endloop
+  endfacet
+  facet normal 0.0416104 -0.705965 0.707024
+    outer loop
+      vertex 2.40085 -30.5057 58
+      vertex 1.20135 -30.5764 58
+      vertex 2.46362 -31.3032 57.2
+    endloop
+  endfacet
+  facet normal -0.676713 -0.205268 0.707054
+    outer loop
+      vertex -29.4511 -8.30608 58
+      vertex -30.2211 -8.52323 57.2
+      vertex -29.8632 -9.70313 57.2
+    endloop
+  endfacet
+  facet normal 0.707031 -0.0138796 0.707046
+    outer loop
+      vertex 31.4 0 57.2
+      vertex 30.5764 -1.20135 58
+      vertex 31.3758 -1.23276 57.2
+    endloop
+  endfacet
+  facet normal 0.509773 0.490117 0.707048
+    outer loop
+      vertex 22.2032 22.2032 57.2
+      vertex 21.6375 21.6375 58
+      vertex 22.4703 20.7713 58
+    endloop
+  endfacet
+  facet normal 0.705941 0.0416386 0.707046
+    outer loop
+      vertex 31.3032 2.46362 57.2
+      vertex 30.5764 1.20135 58
+      vertex 31.3758 1.23276 57.2
+    endloop
+  endfacet
+  facet normal 0.690715 -0.151541 0.70707
+    outer loop
+      vertex 30.012 -5.96976 58
+      vertex 29.7545 -7.14343 58
+      vertex 30.7967 -6.12584 57.2
+    endloop
+  endfacet
+  facet normal 0.0693313 0.703783 0.707024
+    outer loop
+      vertex 2.46362 31.3032 57.2
+      vertex 2.40085 30.5057 58
+      vertex 3.59664 30.3879 58
+    endloop
+  endfacet
+  facet normal 0.357586 0.610103 0.707041
+    outer loop
+      vertex 15.3427 27.3964 57.2
+      vertex 14.9518 26.6984 58
+      vertex 16.4065 26.7729 57.2
+    endloop
+  endfacet
+  facet normal 0.580169 0.404329 0.707052
+    outer loop
+      vertex 25.4031 18.4565 57.2
+      vertex 24.7559 17.9862 58
+      vertex 26.1081 17.4449 57.2
+    endloop
+  endfacet
+  facet normal -0.178558 -0.684246 0.707054
+    outer loop
+      vertex -8.30608 -29.4511 58
+      vertex -8.52323 -30.2211 57.2
+      vertex -7.14343 -29.7545 58
+    endloop
+  endfacet
+  facet normal 0.595579 -0.381299 0.707034
+    outer loop
+      vertex 26.7729 -16.4065 57.2
+      vertex 26.0908 -15.9885 58
+      vertex 26.1081 -17.4449 57.2
+    endloop
+  endfacet
+  facet normal 0.333347 -0.623678 0.70704
+    outer loop
+      vertex 14.9518 -26.6984 58
+      vertex 14.2553 -27.9776 57.2
+      vertex 15.3427 -27.3964 57.2
+    endloop
+  endfacet
+  facet normal 0.54665 0.44864 0.707033
+    outer loop
+      vertex 24.659 19.4395 57.2
+      vertex 23.8767 20.3927 57.2
+      vertex 24.0307 18.9443 58
+    endloop
+  endfacet
+  facet normal -0.124351 0.696123 0.707071
+    outer loop
+      vertex -4.78689 30.2233 58
+      vertex -6.12584 30.7967 57.2
+      vertex -5.96976 30.012 58
+    endloop
+  endfacet
+  facet normal -0.636279 -0.308619 0.707038
+    outer loop
+      vertex -27.2648 -13.8921 58
+      vertex -28.5157 -13.1459 57.2
+      vertex -27.9776 -14.2553 57.2
+    endloop
+  endfacet
+  facet normal 0.283405 -0.647914 0.707028
+    outer loop
+      vertex 12.811 -27.7892 58
+      vertex 12.0163 -29.0098 57.2
+      vertex 13.1459 -28.5157 57.2
+    endloop
+  endfacet
+  facet normal 0.404378 0.580171 0.707022
+    outer loop
+      vertex 17.4449 26.1081 57.2
+      vertex 17.0004 25.443 58
+      vertex 17.9862 24.7559 58
+    endloop
+  endfacet
+  facet normal 0.684264 0.178544 0.70704
+    outer loop
+      vertex 30.2211 8.52323 57.2
+      vertex 29.7545 7.14343 58
+      vertex 30.5324 7.33018 57.2
+    endloop
+  endfacet
+  facet normal 0.308619 0.636279 0.707038
+    outer loop
+      vertex 14.2553 27.9776 57.2
+      vertex 13.1459 28.5157 57.2
+      vertex 13.8921 27.2648 58
+    endloop
+  endfacet
+  facet normal -0.308619 -0.636279 0.707038
+    outer loop
+      vertex -13.8921 -27.2648 58
+      vertex -14.2553 -27.9776 57.2
+      vertex -13.1459 -28.5157 57.2
+    endloop
+  endfacet
+  facet normal -0.404329 -0.580169 0.707052
+    outer loop
+      vertex -17.9862 -24.7559 58
+      vertex -18.4565 -25.4031 57.2
+      vertex -17.4449 -26.1081 57.2
+    endloop
+  endfacet
+  facet normal -0.0692827 0.703753 0.707058
+    outer loop
+      vertex -2.46362 31.3032 57.2
+      vertex -3.69067 31.1824 57.2
+      vertex -3.59664 30.3879 58
+    endloop
+  endfacet
+  facet normal -0.381299 0.595579 0.707034
+    outer loop
+      vertex -16.4065 26.7729 57.2
+      vertex -17.4449 26.1081 57.2
+      vertex -15.9885 26.0908 58
+    endloop
+  endfacet
+  facet normal 0.610113 0.357582 0.707034
+    outer loop
+      vertex 26.7729 16.4065 57.2
+      vertex 26.0908 15.9885 58
+      vertex 26.6984 14.9518 58
+    endloop
+  endfacet
+  facet normal -0.205268 0.676713 0.707054
+    outer loop
+      vertex -8.52323 30.2211 57.2
+      vertex -9.70313 29.8632 57.2
+      vertex -8.30608 29.4511 58
+    endloop
+  endfacet
+  facet normal 0.0969251 -0.700482 0.707058
+    outer loop
+      vertex 4.91204 -31.0134 57.2
+      vertex 3.59664 -30.3879 58
+      vertex 3.69067 -31.1824 57.2
+    endloop
+  endfacet
+  facet normal -0.178544 0.684264 0.70704
+    outer loop
+      vertex -7.33018 30.5324 57.2
+      vertex -8.52323 30.2211 57.2
+      vertex -7.14343 29.7545 58
+    endloop
+  endfacet
+  facet normal -0.668136 -0.231642 0.707061
+    outer loop
+      vertex -29.1023 -9.45592 58
+      vertex -29.8632 -9.70313 57.2
+      vertex -28.7087 -10.5912 58
+    endloop
+  endfacet
+  facet normal -0.490117 0.509773 0.707048
+    outer loop
+      vertex -20.7713 22.4703 58
+      vertex -22.2032 22.2032 57.2
+      vertex -21.6375 21.6375 58
+    endloop
+  endfacet
+  facet normal -0.658551 -0.257754 0.707018
+    outer loop
+      vertex -28.7087 -10.5912 58
+      vertex -29.4592 -10.8681 57.2
+      vertex -29.0098 -12.0163 57.2
+    endloop
+  endfacet
+  facet normal -0.703783 -0.0693313 0.707024
+    outer loop
+      vertex -30.5057 -2.40085 58
+      vertex -31.3032 -2.46362 57.2
+      vertex -30.3879 -3.59664 58
+    endloop
+  endfacet
+  facet normal -0.231642 0.668136 0.707061
+    outer loop
+      vertex -9.70313 29.8632 57.2
+      vertex -10.5912 28.7087 58
+      vertex -9.45592 29.1023 58
+    endloop
+  endfacet
+  facet normal 0.0138895 -0.707039 0.707039
+    outer loop
+      vertex 0 -30.6 58
+      vertex 0 -31.4 57.2
+      vertex 1.20135 -30.5764 58
+    endloop
+  endfacet
+  facet normal 0.563851 0.426787 0.707053
+    outer loop
+      vertex 25.4031 18.4565 57.2
+      vertex 24.0307 18.9443 58
+      vertex 24.7559 17.9862 58
+    endloop
+  endfacet
+  facet normal -0.509838 -0.490107 0.707008
+    outer loop
+      vertex -22.4703 -20.7713 58
+      vertex -23.0577 -21.3143 57.2
+      vertex -22.2032 -22.2032 57.2
+    endloop
+  endfacet
+  facet normal 0.610103 -0.357586 0.707041
+    outer loop
+      vertex 27.3964 -15.3427 57.2
+      vertex 26.6984 -14.9518 58
+      vertex 26.7729 -16.4065 57.2
+    endloop
+  endfacet
+  facet normal -0.658551 0.257754 0.707018
+    outer loop
+      vertex -29.0098 12.0163 57.2
+      vertex -29.4592 10.8681 57.2
+      vertex -28.7087 10.5912 58
+    endloop
+  endfacet
+  facet normal -0.684264 0.178544 0.70704
+    outer loop
+      vertex -30.2211 8.52323 57.2
+      vertex -30.5324 7.33018 57.2
+      vertex -29.7545 7.14343 58
+    endloop
+  endfacet
+  facet normal 0.257778 -0.658511 0.707046
+    outer loop
+      vertex 11.7101 -28.2707 58
+      vertex 10.5912 -28.7087 58
+      vertex 12.0163 -29.0098 57.2
+    endloop
+  endfacet
+  facet normal -0.623678 -0.333347 0.70704
+    outer loop
+      vertex -26.6984 -14.9518 58
+      vertex -27.9776 -14.2553 57.2
+      vertex -27.3964 -15.3427 57.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.85 0 58
+      vertex 30.6 0 58
+      vertex 30.5764 1.20135 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.8285 1.09339 58
+      vertex 30.5764 1.20135 58
+      vertex 30.5057 2.40085 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.6 0 58
+      vertex 27.85 0 58
+      vertex 30.5764 -1.20135 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.7641 2.18509 58
+      vertex 30.5057 2.40085 58
+      vertex 30.3879 3.59664 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.8285 -1.09339 58
+      vertex 30.5764 -1.20135 58
+      vertex 27.85 0 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.657 3.27342 58
+      vertex 30.3879 3.59664 58
+      vertex 30.2233 4.78689 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.5764 -1.20135 58
+      vertex 27.8285 -1.09339 58
+      vertex 30.5057 -2.40085 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.5071 4.3567 58
+      vertex 30.2233 4.78689 58
+      vertex 30.012 5.96976 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.7641 -2.18509 58
+      vertex 30.5057 -2.40085 58
+      vertex 27.8285 -1.09339 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.3149 5.43326 58
+      vertex 30.012 5.96976 58
+      vertex 29.7545 7.14343 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.5057 -2.40085 58
+      vertex 27.7641 -2.18509 58
+      vertex 30.3879 -3.59664 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.0805 6.50145 58
+      vertex 29.7545 7.14343 58
+      vertex 29.4511 8.30608 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.657 -3.27342 58
+      vertex 30.3879 -3.59664 58
+      vertex 27.7641 -2.18509 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.8044 7.55962 58
+      vertex 29.4511 8.30608 58
+      vertex 29.1023 9.45592 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.3879 -3.59664 58
+      vertex 27.657 -3.27342 58
+      vertex 30.2233 -4.78689 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.4869 8.60612 58
+      vertex 29.1023 9.45592 58
+      vertex 28.7087 10.5912 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.5071 -4.3567 58
+      vertex 30.2233 -4.78689 58
+      vertex 27.657 -3.27342 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.1286 9.63936 58
+      vertex 28.7087 10.5912 58
+      vertex 28.2707 11.7101 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.2233 -4.78689 58
+      vertex 27.5071 -4.3567 58
+      vertex 30.012 -5.96976 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.3149 -5.43326 58
+      vertex 30.012 -5.96976 58
+      vertex 27.5071 -4.3567 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.5764 1.20135 58
+      vertex 27.8285 1.09339 58
+      vertex 27.85 0 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.73 10.6577 58
+      vertex 28.2707 11.7101 58
+      vertex 27.7892 12.811 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.5057 2.40085 58
+      vertex 27.7641 2.18509 58
+      vertex 27.8285 1.09339 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.3879 3.59664 58
+      vertex 27.657 3.27342 58
+      vertex 27.7641 2.18509 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.2233 4.78689 58
+      vertex 27.5071 4.3567 58
+      vertex 27.657 3.27342 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.012 5.96976 58
+      vertex 27.3149 5.43326 58
+      vertex 27.5071 4.3567 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.2918 11.6597 58
+      vertex 27.7892 12.811 58
+      vertex 27.2648 13.8921 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.7545 7.14343 58
+      vertex 27.0805 6.50145 58
+      vertex 27.3149 5.43326 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.4511 8.30608 58
+      vertex 26.8044 7.55962 58
+      vertex 27.0805 6.50145 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8145 12.6436 58
+      vertex 27.2648 13.8921 58
+      vertex 26.6984 14.9518 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.1023 9.45592 58
+      vertex 26.4869 8.60612 58
+      vertex 26.8044 7.55962 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.7087 10.5912 58
+      vertex 26.1286 9.63936 58
+      vertex 26.4869 8.60612 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.299 13.6081 58
+      vertex 26.6984 14.9518 58
+      vertex 26.0908 15.9885 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.2707 11.7101 58
+      vertex 25.73 10.6577 58
+      vertex 26.1286 9.63936 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.746 14.5516 58
+      vertex 26.0908 15.9885 58
+      vertex 25.443 17.0004 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.7892 12.811 58
+      vertex 25.2918 11.6597 58
+      vertex 25.73 10.6577 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.2648 13.8921 58
+      vertex 24.8145 12.6436 58
+      vertex 25.2918 11.6597 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.1564 15.4726 58
+      vertex 25.443 17.0004 58
+      vertex 24.7559 17.9862 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6984 14.9518 58
+      vertex 24.299 13.6081 58
+      vertex 24.8145 12.6436 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.5311 16.3698 58
+      vertex 24.7559 17.9862 58
+      vertex 24.0307 18.9443 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.0908 15.9885 58
+      vertex 23.746 14.5516 58
+      vertex 24.299 13.6081 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.8711 17.2418 58
+      vertex 24.0307 18.9443 58
+      vertex 23.2684 19.8731 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.443 17.0004 58
+      vertex 23.1564 15.4726 58
+      vertex 23.746 14.5516 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.7559 17.9862 58
+      vertex 22.5311 16.3698 58
+      vertex 23.1564 15.4726 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.1773 18.0871 58
+      vertex 23.2684 19.8731 58
+      vertex 22.4703 20.7713 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.0307 18.9443 58
+      vertex 21.8711 17.2418 58
+      vertex 22.5311 16.3698 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.4509 18.9046 58
+      vertex 22.4703 20.7713 58
+      vertex 21.6375 21.6375 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.2684 19.8731 58
+      vertex 21.1773 18.0871 58
+      vertex 21.8711 17.2418 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.6929 19.6929 58
+      vertex 21.6375 21.6375 58
+      vertex 20.7713 22.4703 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.4703 20.7713 58
+      vertex 20.4509 18.9046 58
+      vertex 21.1773 18.0871 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.9046 20.4509 58
+      vertex 20.7713 22.4703 58
+      vertex 19.8731 23.2684 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.6375 21.6375 58
+      vertex 19.6929 19.6929 58
+      vertex 20.4509 18.9046 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0871 21.1773 58
+      vertex 19.8731 23.2684 58
+      vertex 18.9443 24.0307 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.7713 22.4703 58
+      vertex 18.9046 20.4509 58
+      vertex 19.6929 19.6929 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.8731 23.2684 58
+      vertex 18.0871 21.1773 58
+      vertex 18.9046 20.4509 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.2418 21.8711 58
+      vertex 18.9443 24.0307 58
+      vertex 17.9862 24.7559 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.9443 24.0307 58
+      vertex 17.2418 21.8711 58
+      vertex 18.0871 21.1773 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.3698 22.5311 58
+      vertex 17.9862 24.7559 58
+      vertex 17.0004 25.443 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.9862 24.7559 58
+      vertex 16.3698 22.5311 58
+      vertex 17.2418 21.8711 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4726 23.1564 58
+      vertex 17.0004 25.443 58
+      vertex 15.9885 26.0908 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.0004 25.443 58
+      vertex 15.4726 23.1564 58
+      vertex 16.3698 22.5311 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.5516 23.746 58
+      vertex 15.9885 26.0908 58
+      vertex 14.9518 26.6984 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.9885 26.0908 58
+      vertex 14.5516 23.746 58
+      vertex 15.4726 23.1564 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6081 24.299 58
+      vertex 14.9518 26.6984 58
+      vertex 13.8921 27.2648 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.9518 26.6984 58
+      vertex 13.6081 24.299 58
+      vertex 14.5516 23.746 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.6436 24.8145 58
+      vertex 13.8921 27.2648 58
+      vertex 12.811 27.7892 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.8921 27.2648 58
+      vertex 12.6436 24.8145 58
+      vertex 13.6081 24.299 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.6597 25.2918 58
+      vertex 12.811 27.7892 58
+      vertex 11.7101 28.2707 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.811 27.7892 58
+      vertex 11.6597 25.2918 58
+      vertex 12.6436 24.8145 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7101 28.2707 58
+      vertex 10.6577 25.73 58
+      vertex 11.6597 25.2918 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5912 28.7087 58
+      vertex 10.6577 25.73 58
+      vertex 11.7101 28.2707 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5912 28.7087 58
+      vertex 9.63936 26.1286 58
+      vertex 10.6577 25.73 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.45592 29.1023 58
+      vertex 9.63936 26.1286 58
+      vertex 10.5912 28.7087 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.45592 29.1023 58
+      vertex 8.60612 26.4869 58
+      vertex 9.63936 26.1286 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.30608 29.4511 58
+      vertex 8.60612 26.4869 58
+      vertex 9.45592 29.1023 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.30608 29.4511 58
+      vertex 7.55962 26.8044 58
+      vertex 8.60612 26.4869 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.14343 29.7545 58
+      vertex 7.55962 26.8044 58
+      vertex 8.30608 29.4511 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.14343 29.7545 58
+      vertex 6.50145 27.0805 58
+      vertex 7.55962 26.8044 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.96976 30.012 58
+      vertex 6.50145 27.0805 58
+      vertex 7.14343 29.7545 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.96976 30.012 58
+      vertex 5.43326 27.3149 58
+      vertex 6.50145 27.0805 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.78689 30.2233 58
+      vertex 5.43326 27.3149 58
+      vertex 5.96976 30.012 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.78689 30.2233 58
+      vertex 4.3567 27.5071 58
+      vertex 5.43326 27.3149 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.59664 30.3879 58
+      vertex 4.3567 27.5071 58
+      vertex 4.78689 30.2233 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.59664 30.3879 58
+      vertex 3.27342 27.657 58
+      vertex 4.3567 27.5071 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.40085 30.5057 58
+      vertex 3.27342 27.657 58
+      vertex 3.59664 30.3879 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.40085 30.5057 58
+      vertex 2.18509 27.7641 58
+      vertex 3.27342 27.657 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.20135 30.5764 58
+      vertex 2.18509 27.7641 58
+      vertex 2.40085 30.5057 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.20135 30.5764 58
+      vertex 1.09339 27.8285 58
+      vertex 2.18509 27.7641 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 30.6 58
+      vertex 1.09339 27.8285 58
+      vertex 1.20135 30.5764 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 30.6 58
+      vertex 0 27.85 58
+      vertex 1.09339 27.8285 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 30.6 58
+      vertex -1.09339 27.8285 58
+      vertex 0 27.85 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.20135 30.5764 58
+      vertex -1.09339 27.8285 58
+      vertex 0 30.6 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.20135 30.5764 58
+      vertex -2.18509 27.7641 58
+      vertex -1.09339 27.8285 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.40085 30.5057 58
+      vertex -2.18509 27.7641 58
+      vertex -1.20135 30.5764 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.40085 30.5057 58
+      vertex -3.27342 27.657 58
+      vertex -2.18509 27.7641 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3.59664 30.3879 58
+      vertex -3.27342 27.657 58
+      vertex -2.40085 30.5057 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.59664 30.3879 58
+      vertex -4.3567 27.5071 58
+      vertex -3.27342 27.657 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -4.78689 30.2233 58
+      vertex -4.3567 27.5071 58
+      vertex -3.59664 30.3879 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.78689 30.2233 58
+      vertex -5.43326 27.3149 58
+      vertex -4.3567 27.5071 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.96976 30.012 58
+      vertex -5.43326 27.3149 58
+      vertex -4.78689 30.2233 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.96976 30.012 58
+      vertex -6.50145 27.0805 58
+      vertex -5.43326 27.3149 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -7.14343 29.7545 58
+      vertex -6.50145 27.0805 58
+      vertex -5.96976 30.012 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.14343 29.7545 58
+      vertex -7.55962 26.8044 58
+      vertex -6.50145 27.0805 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -8.30608 29.4511 58
+      vertex -7.55962 26.8044 58
+      vertex -7.14343 29.7545 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.30608 29.4511 58
+      vertex -8.60612 26.4869 58
+      vertex -7.55962 26.8044 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.45592 29.1023 58
+      vertex -8.60612 26.4869 58
+      vertex -8.30608 29.4511 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.45592 29.1023 58
+      vertex -9.63936 26.1286 58
+      vertex -8.60612 26.4869 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.5912 28.7087 58
+      vertex -9.63936 26.1286 58
+      vertex -9.45592 29.1023 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5912 28.7087 58
+      vertex -10.6577 25.73 58
+      vertex -9.63936 26.1286 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.7101 28.2707 58
+      vertex -10.6577 25.73 58
+      vertex -10.5912 28.7087 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.6577 25.73 58
+      vertex -11.7101 28.2707 58
+      vertex -11.6597 25.2918 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.811 27.7892 58
+      vertex -11.6597 25.2918 58
+      vertex -11.7101 28.2707 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.6597 25.2918 58
+      vertex -12.811 27.7892 58
+      vertex -12.6436 24.8145 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.8921 27.2648 58
+      vertex -12.6436 24.8145 58
+      vertex -12.811 27.7892 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.6436 24.8145 58
+      vertex -13.8921 27.2648 58
+      vertex -13.6081 24.299 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.9518 26.6984 58
+      vertex -13.6081 24.299 58
+      vertex -13.8921 27.2648 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.6081 24.299 58
+      vertex -14.9518 26.6984 58
+      vertex -14.5516 23.746 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.9885 26.0908 58
+      vertex -14.5516 23.746 58
+      vertex -14.9518 26.6984 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.5516 23.746 58
+      vertex -15.9885 26.0908 58
+      vertex -15.4726 23.1564 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.0004 25.443 58
+      vertex -15.4726 23.1564 58
+      vertex -15.9885 26.0908 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.4726 23.1564 58
+      vertex -17.0004 25.443 58
+      vertex -16.3698 22.5311 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.9862 24.7559 58
+      vertex -16.3698 22.5311 58
+      vertex -17.0004 25.443 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.3698 22.5311 58
+      vertex -17.9862 24.7559 58
+      vertex -17.2418 21.8711 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.9443 24.0307 58
+      vertex -17.2418 21.8711 58
+      vertex -17.9862 24.7559 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.2418 21.8711 58
+      vertex -18.9443 24.0307 58
+      vertex -18.0871 21.1773 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.8731 23.2684 58
+      vertex -18.0871 21.1773 58
+      vertex -18.9443 24.0307 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0871 21.1773 58
+      vertex -19.8731 23.2684 58
+      vertex -18.9046 20.4509 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.7713 22.4703 58
+      vertex -18.9046 20.4509 58
+      vertex -19.8731 23.2684 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9046 20.4509 58
+      vertex -20.7713 22.4703 58
+      vertex -19.6929 19.6929 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.6375 21.6375 58
+      vertex -19.6929 19.6929 58
+      vertex -20.7713 22.4703 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.6929 19.6929 58
+      vertex -21.6375 21.6375 58
+      vertex -20.4509 18.9046 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.4703 20.7713 58
+      vertex -20.4509 18.9046 58
+      vertex -21.6375 21.6375 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.4509 18.9046 58
+      vertex -22.4703 20.7713 58
+      vertex -21.1773 18.0871 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.2684 19.8731 58
+      vertex -21.1773 18.0871 58
+      vertex -22.4703 20.7713 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.1773 18.0871 58
+      vertex -23.2684 19.8731 58
+      vertex -21.8711 17.2418 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.0307 18.9443 58
+      vertex -21.8711 17.2418 58
+      vertex -23.2684 19.8731 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.8711 17.2418 58
+      vertex -24.0307 18.9443 58
+      vertex -22.5311 16.3698 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.7559 17.9862 58
+      vertex -22.5311 16.3698 58
+      vertex -24.0307 18.9443 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5311 16.3698 58
+      vertex -24.7559 17.9862 58
+      vertex -23.1564 15.4726 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -25.443 17.0004 58
+      vertex -23.1564 15.4726 58
+      vertex -24.7559 17.9862 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1564 15.4726 58
+      vertex -25.443 17.0004 58
+      vertex -23.746 14.5516 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -26.0908 15.9885 58
+      vertex -23.746 14.5516 58
+      vertex -25.443 17.0004 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.746 14.5516 58
+      vertex -26.0908 15.9885 58
+      vertex -24.299 13.6081 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -26.6984 14.9518 58
+      vertex -24.299 13.6081 58
+      vertex -26.0908 15.9885 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.299 13.6081 58
+      vertex -26.6984 14.9518 58
+      vertex -24.8145 12.6436 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.2648 13.8921 58
+      vertex -24.8145 12.6436 58
+      vertex -26.6984 14.9518 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8145 12.6436 58
+      vertex -27.2648 13.8921 58
+      vertex -25.2918 11.6597 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.7892 12.811 58
+      vertex -25.2918 11.6597 58
+      vertex -27.2648 13.8921 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.2918 11.6597 58
+      vertex -27.7892 12.811 58
+      vertex -25.73 10.6577 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.2707 11.7101 58
+      vertex -25.73 10.6577 58
+      vertex -27.7892 12.811 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.73 10.6577 58
+      vertex -28.2707 11.7101 58
+      vertex -26.1286 9.63936 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.7087 10.5912 58
+      vertex -26.1286 9.63936 58
+      vertex -28.2707 11.7101 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1286 9.63936 58
+      vertex -28.7087 10.5912 58
+      vertex -26.4869 8.60612 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -29.1023 9.45592 58
+      vertex -26.4869 8.60612 58
+      vertex -28.7087 10.5912 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.4869 8.60612 58
+      vertex -29.1023 9.45592 58
+      vertex -26.8044 7.55962 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -29.4511 8.30608 58
+      vertex -26.8044 7.55962 58
+      vertex -29.1023 9.45592 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8044 7.55962 58
+      vertex -29.4511 8.30608 58
+      vertex -27.0805 6.50145 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -29.7545 7.14343 58
+      vertex -27.0805 6.50145 58
+      vertex -29.4511 8.30608 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0805 6.50145 58
+      vertex -29.7545 7.14343 58
+      vertex -27.3149 5.43326 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.012 5.96976 58
+      vertex -27.3149 5.43326 58
+      vertex -29.7545 7.14343 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.012 -5.96976 58
+      vertex 27.3149 -5.43326 58
+      vertex 29.7545 -7.14343 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.0805 -6.50145 58
+      vertex 29.7545 -7.14343 58
+      vertex 27.3149 -5.43326 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.7545 -7.14343 58
+      vertex 27.0805 -6.50145 58
+      vertex 29.4511 -8.30608 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.8044 -7.55962 58
+      vertex 29.4511 -8.30608 58
+      vertex 27.0805 -6.50145 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.4511 -8.30608 58
+      vertex 26.8044 -7.55962 58
+      vertex 29.1023 -9.45592 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.4869 -8.60612 58
+      vertex 29.1023 -9.45592 58
+      vertex 26.8044 -7.55962 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.1023 -9.45592 58
+      vertex 26.4869 -8.60612 58
+      vertex 28.7087 -10.5912 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.1286 -9.63936 58
+      vertex 28.7087 -10.5912 58
+      vertex 26.4869 -8.60612 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.7087 -10.5912 58
+      vertex 26.1286 -9.63936 58
+      vertex 28.2707 -11.7101 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.73 -10.6577 58
+      vertex 28.2707 -11.7101 58
+      vertex 26.1286 -9.63936 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.2707 -11.7101 58
+      vertex 25.73 -10.6577 58
+      vertex 27.7892 -12.811 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.2918 -11.6597 58
+      vertex 27.7892 -12.811 58
+      vertex 25.73 -10.6577 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.7892 -12.811 58
+      vertex 25.2918 -11.6597 58
+      vertex 27.2648 -13.8921 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.8145 -12.6436 58
+      vertex 27.2648 -13.8921 58
+      vertex 25.2918 -11.6597 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.2648 -13.8921 58
+      vertex 24.8145 -12.6436 58
+      vertex 26.6984 -14.9518 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.299 -13.6081 58
+      vertex 26.6984 -14.9518 58
+      vertex 24.8145 -12.6436 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6984 -14.9518 58
+      vertex 24.299 -13.6081 58
+      vertex 26.0908 -15.9885 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.746 -14.5516 58
+      vertex 26.0908 -15.9885 58
+      vertex 24.299 -13.6081 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.0908 -15.9885 58
+      vertex 23.746 -14.5516 58
+      vertex 25.443 -17.0004 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.1564 -15.4726 58
+      vertex 25.443 -17.0004 58
+      vertex 23.746 -14.5516 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.443 -17.0004 58
+      vertex 23.1564 -15.4726 58
+      vertex 24.7559 -17.9862 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.5311 -16.3698 58
+      vertex 24.7559 -17.9862 58
+      vertex 23.1564 -15.4726 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.7559 -17.9862 58
+      vertex 22.5311 -16.3698 58
+      vertex 24.0307 -18.9443 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.8711 -17.2418 58
+      vertex 24.0307 -18.9443 58
+      vertex 22.5311 -16.3698 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.0307 -18.9443 58
+      vertex 21.8711 -17.2418 58
+      vertex 23.2684 -19.8731 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.1773 -18.0871 58
+      vertex 23.2684 -19.8731 58
+      vertex 21.8711 -17.2418 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.2684 -19.8731 58
+      vertex 21.1773 -18.0871 58
+      vertex 22.4703 -20.7713 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.4509 -18.9046 58
+      vertex 22.4703 -20.7713 58
+      vertex 21.1773 -18.0871 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.4703 -20.7713 58
+      vertex 20.4509 -18.9046 58
+      vertex 21.6375 -21.6375 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.6929 -19.6929 58
+      vertex 21.6375 -21.6375 58
+      vertex 20.4509 -18.9046 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.6375 -21.6375 58
+      vertex 19.6929 -19.6929 58
+      vertex 20.7713 -22.4703 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.9046 -20.4509 58
+      vertex 20.7713 -22.4703 58
+      vertex 19.6929 -19.6929 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.7713 -22.4703 58
+      vertex 18.9046 -20.4509 58
+      vertex 19.8731 -23.2684 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.0871 -21.1773 58
+      vertex 19.8731 -23.2684 58
+      vertex 18.9046 -20.4509 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.8731 -23.2684 58
+      vertex 18.0871 -21.1773 58
+      vertex 18.9443 -24.0307 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.2418 -21.8711 58
+      vertex 18.9443 -24.0307 58
+      vertex 18.0871 -21.1773 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.9443 -24.0307 58
+      vertex 17.2418 -21.8711 58
+      vertex 17.9862 -24.7559 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.3698 -22.5311 58
+      vertex 17.9862 -24.7559 58
+      vertex 17.2418 -21.8711 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.9862 -24.7559 58
+      vertex 16.3698 -22.5311 58
+      vertex 17.0004 -25.443 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.4726 -23.1564 58
+      vertex 17.0004 -25.443 58
+      vertex 16.3698 -22.5311 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.0004 -25.443 58
+      vertex 15.4726 -23.1564 58
+      vertex 15.9885 -26.0908 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.5516 -23.746 58
+      vertex 15.9885 -26.0908 58
+      vertex 15.4726 -23.1564 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.9885 -26.0908 58
+      vertex 14.5516 -23.746 58
+      vertex 14.9518 -26.6984 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.6081 -24.299 58
+      vertex 14.9518 -26.6984 58
+      vertex 14.5516 -23.746 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.9518 -26.6984 58
+      vertex 13.6081 -24.299 58
+      vertex 13.8921 -27.2648 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.6436 -24.8145 58
+      vertex 13.8921 -27.2648 58
+      vertex 13.6081 -24.299 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.8921 -27.2648 58
+      vertex 12.6436 -24.8145 58
+      vertex 12.811 -27.7892 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.6597 -25.2918 58
+      vertex 12.811 -27.7892 58
+      vertex 12.6436 -24.8145 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.811 -27.7892 58
+      vertex 11.6597 -25.2918 58
+      vertex 11.7101 -28.2707 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.6577 -25.73 58
+      vertex 11.7101 -28.2707 58
+      vertex 11.6597 -25.2918 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.6577 -25.73 58
+      vertex 10.5912 -28.7087 58
+      vertex 11.7101 -28.2707 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.63936 -26.1286 58
+      vertex 10.5912 -28.7087 58
+      vertex 10.6577 -25.73 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.63936 -26.1286 58
+      vertex 9.45592 -29.1023 58
+      vertex 10.5912 -28.7087 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 8.60612 -26.4869 58
+      vertex 9.45592 -29.1023 58
+      vertex 9.63936 -26.1286 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.60612 -26.4869 58
+      vertex 8.30608 -29.4511 58
+      vertex 9.45592 -29.1023 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 7.55962 -26.8044 58
+      vertex 8.30608 -29.4511 58
+      vertex 8.60612 -26.4869 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.55962 -26.8044 58
+      vertex 7.14343 -29.7545 58
+      vertex 8.30608 -29.4511 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 6.50145 -27.0805 58
+      vertex 7.14343 -29.7545 58
+      vertex 7.55962 -26.8044 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.50145 -27.0805 58
+      vertex 5.96976 -30.012 58
+      vertex 7.14343 -29.7545 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.43326 -27.3149 58
+      vertex 5.96976 -30.012 58
+      vertex 6.50145 -27.0805 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.43326 -27.3149 58
+      vertex 4.78689 -30.2233 58
+      vertex 5.96976 -30.012 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.3567 -27.5071 58
+      vertex 4.78689 -30.2233 58
+      vertex 5.43326 -27.3149 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.3567 -27.5071 58
+      vertex 3.59664 -30.3879 58
+      vertex 4.78689 -30.2233 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.27342 -27.657 58
+      vertex 3.59664 -30.3879 58
+      vertex 4.3567 -27.5071 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.27342 -27.657 58
+      vertex 2.40085 -30.5057 58
+      vertex 3.59664 -30.3879 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.18509 -27.7641 58
+      vertex 2.40085 -30.5057 58
+      vertex 3.27342 -27.657 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.18509 -27.7641 58
+      vertex 1.20135 -30.5764 58
+      vertex 2.40085 -30.5057 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.09339 -27.8285 58
+      vertex 1.20135 -30.5764 58
+      vertex 2.18509 -27.7641 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 -27.85 58
+      vertex 1.20135 -30.5764 58
+      vertex 1.09339 -27.8285 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -27.85 58
+      vertex 0 -30.6 58
+      vertex 1.20135 -30.5764 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.09339 -27.8285 58
+      vertex 0 -30.6 58
+      vertex 0 -27.85 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.09339 -27.8285 58
+      vertex -1.20135 -30.5764 58
+      vertex 0 -30.6 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.18509 -27.7641 58
+      vertex -1.20135 -30.5764 58
+      vertex -1.09339 -27.8285 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.18509 -27.7641 58
+      vertex -2.40085 -30.5057 58
+      vertex -1.20135 -30.5764 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.27342 -27.657 58
+      vertex -2.40085 -30.5057 58
+      vertex -2.18509 -27.7641 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.27342 -27.657 58
+      vertex -3.59664 -30.3879 58
+      vertex -2.40085 -30.5057 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.3567 -27.5071 58
+      vertex -3.59664 -30.3879 58
+      vertex -3.27342 -27.657 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.3567 -27.5071 58
+      vertex -4.78689 -30.2233 58
+      vertex -3.59664 -30.3879 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.43326 -27.3149 58
+      vertex -4.78689 -30.2233 58
+      vertex -4.3567 -27.5071 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.43326 -27.3149 58
+      vertex -5.96976 -30.012 58
+      vertex -4.78689 -30.2233 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.50145 -27.0805 58
+      vertex -5.96976 -30.012 58
+      vertex -5.43326 -27.3149 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.50145 -27.0805 58
+      vertex -7.14343 -29.7545 58
+      vertex -5.96976 -30.012 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.55962 -26.8044 58
+      vertex -7.14343 -29.7545 58
+      vertex -6.50145 -27.0805 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.55962 -26.8044 58
+      vertex -8.30608 -29.4511 58
+      vertex -7.14343 -29.7545 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.60612 -26.4869 58
+      vertex -8.30608 -29.4511 58
+      vertex -7.55962 -26.8044 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.60612 -26.4869 58
+      vertex -9.45592 -29.1023 58
+      vertex -8.30608 -29.4511 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.63936 -26.1286 58
+      vertex -9.45592 -29.1023 58
+      vertex -8.60612 -26.4869 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.63936 -26.1286 58
+      vertex -10.5912 -28.7087 58
+      vertex -9.45592 -29.1023 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.6577 -25.73 58
+      vertex -10.5912 -28.7087 58
+      vertex -9.63936 -26.1286 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7101 -28.2707 58
+      vertex -10.6577 -25.73 58
+      vertex -11.6597 -25.2918 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.6577 -25.73 58
+      vertex -11.7101 -28.2707 58
+      vertex -10.5912 -28.7087 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.811 -27.7892 58
+      vertex -11.6597 -25.2918 58
+      vertex -12.6436 -24.8145 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.6597 -25.2918 58
+      vertex -12.811 -27.7892 58
+      vertex -11.7101 -28.2707 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.8921 -27.2648 58
+      vertex -12.6436 -24.8145 58
+      vertex -13.6081 -24.299 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.6436 -24.8145 58
+      vertex -13.8921 -27.2648 58
+      vertex -12.811 -27.7892 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.9518 -26.6984 58
+      vertex -13.6081 -24.299 58
+      vertex -14.5516 -23.746 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.6081 -24.299 58
+      vertex -14.9518 -26.6984 58
+      vertex -13.8921 -27.2648 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.9885 -26.0908 58
+      vertex -14.5516 -23.746 58
+      vertex -15.4726 -23.1564 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.5516 -23.746 58
+      vertex -15.9885 -26.0908 58
+      vertex -14.9518 -26.6984 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.0004 -25.443 58
+      vertex -15.4726 -23.1564 58
+      vertex -16.3698 -22.5311 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.4726 -23.1564 58
+      vertex -17.0004 -25.443 58
+      vertex -15.9885 -26.0908 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.9862 -24.7559 58
+      vertex -16.3698 -22.5311 58
+      vertex -17.2418 -21.8711 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.3698 -22.5311 58
+      vertex -17.9862 -24.7559 58
+      vertex -17.0004 -25.443 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9443 -24.0307 58
+      vertex -17.2418 -21.8711 58
+      vertex -18.0871 -21.1773 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.8731 -23.2684 58
+      vertex -18.0871 -21.1773 58
+      vertex -18.9046 -20.4509 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.2418 -21.8711 58
+      vertex -18.9443 -24.0307 58
+      vertex -17.9862 -24.7559 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.7713 -22.4703 58
+      vertex -18.9046 -20.4509 58
+      vertex -19.6929 -19.6929 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0871 -21.1773 58
+      vertex -19.8731 -23.2684 58
+      vertex -18.9443 -24.0307 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.6375 -21.6375 58
+      vertex -19.6929 -19.6929 58
+      vertex -20.4509 -18.9046 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9046 -20.4509 58
+      vertex -20.7713 -22.4703 58
+      vertex -19.8731 -23.2684 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.4703 -20.7713 58
+      vertex -20.4509 -18.9046 58
+      vertex -21.1773 -18.0871 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.6929 -19.6929 58
+      vertex -21.6375 -21.6375 58
+      vertex -20.7713 -22.4703 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.2684 -19.8731 58
+      vertex -21.1773 -18.0871 58
+      vertex -21.8711 -17.2418 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.4509 -18.9046 58
+      vertex -22.4703 -20.7713 58
+      vertex -21.6375 -21.6375 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.0307 -18.9443 58
+      vertex -21.8711 -17.2418 58
+      vertex -22.5311 -16.3698 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.7559 -17.9862 58
+      vertex -22.5311 -16.3698 58
+      vertex -23.1564 -15.4726 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.1773 -18.0871 58
+      vertex -23.2684 -19.8731 58
+      vertex -22.4703 -20.7713 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.443 -17.0004 58
+      vertex -23.1564 -15.4726 58
+      vertex -23.746 -14.5516 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.8711 -17.2418 58
+      vertex -24.0307 -18.9443 58
+      vertex -23.2684 -19.8731 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.0908 -15.9885 58
+      vertex -23.746 -14.5516 58
+      vertex -24.299 -13.6081 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5311 -16.3698 58
+      vertex -24.7559 -17.9862 58
+      vertex -24.0307 -18.9443 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.6984 -14.9518 58
+      vertex -24.299 -13.6081 58
+      vertex -24.8145 -12.6436 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.2648 -13.8921 58
+      vertex -24.8145 -12.6436 58
+      vertex -25.2918 -11.6597 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1564 -15.4726 58
+      vertex -25.443 -17.0004 58
+      vertex -24.7559 -17.9862 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.7892 -12.811 58
+      vertex -25.2918 -11.6597 58
+      vertex -25.73 -10.6577 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.746 -14.5516 58
+      vertex -26.0908 -15.9885 58
+      vertex -25.443 -17.0004 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.2707 -11.7101 58
+      vertex -25.73 -10.6577 58
+      vertex -26.1286 -9.63936 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.7087 -10.5912 58
+      vertex -26.1286 -9.63936 58
+      vertex -26.4869 -8.60612 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.299 -13.6081 58
+      vertex -26.6984 -14.9518 58
+      vertex -26.0908 -15.9885 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -29.1023 -9.45592 58
+      vertex -26.4869 -8.60612 58
+      vertex -26.8044 -7.55962 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -29.4511 -8.30608 58
+      vertex -26.8044 -7.55962 58
+      vertex -27.0805 -6.50145 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8145 -12.6436 58
+      vertex -27.2648 -13.8921 58
+      vertex -26.6984 -14.9518 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -29.7545 -7.14343 58
+      vertex -27.0805 -6.50145 58
+      vertex -27.3149 -5.43326 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.012 -5.96976 58
+      vertex -27.3149 -5.43326 58
+      vertex -27.5071 -4.3567 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.2233 -4.78689 58
+      vertex -27.5071 -4.3567 58
+      vertex -27.657 -3.27342 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.3879 -3.59664 58
+      vertex -27.657 -3.27342 58
+      vertex -27.7641 -2.18509 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.2918 -11.6597 58
+      vertex -27.7892 -12.811 58
+      vertex -27.2648 -13.8921 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.5057 -2.40085 58
+      vertex -27.7641 -2.18509 58
+      vertex -27.8285 -1.09339 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.5764 -1.20135 58
+      vertex -27.8285 -1.09339 58
+      vertex -27.85 0 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3149 5.43326 58
+      vertex -30.012 5.96976 58
+      vertex -27.5071 4.3567 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.73 -10.6577 58
+      vertex -28.2707 -11.7101 58
+      vertex -27.7892 -12.811 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.2233 4.78689 58
+      vertex -27.5071 4.3567 58
+      vertex -30.012 5.96976 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1286 -9.63936 58
+      vertex -28.7087 -10.5912 58
+      vertex -28.2707 -11.7101 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.5071 4.3567 58
+      vertex -30.2233 4.78689 58
+      vertex -27.657 3.27342 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.4869 -8.60612 58
+      vertex -29.1023 -9.45592 58
+      vertex -28.7087 -10.5912 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.3879 3.59664 58
+      vertex -27.657 3.27342 58
+      vertex -30.2233 4.78689 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8044 -7.55962 58
+      vertex -29.4511 -8.30608 58
+      vertex -29.1023 -9.45592 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.657 3.27342 58
+      vertex -30.3879 3.59664 58
+      vertex -27.7641 2.18509 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0805 -6.50145 58
+      vertex -29.7545 -7.14343 58
+      vertex -29.4511 -8.30608 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.5057 2.40085 58
+      vertex -27.7641 2.18509 58
+      vertex -30.3879 3.59664 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3149 -5.43326 58
+      vertex -30.012 -5.96976 58
+      vertex -29.7545 -7.14343 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.7641 2.18509 58
+      vertex -30.5057 2.40085 58
+      vertex -27.8285 1.09339 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.5071 -4.3567 58
+      vertex -30.2233 -4.78689 58
+      vertex -30.012 -5.96976 58
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.5764 1.20135 58
+      vertex -27.8285 1.09339 58
+      vertex -30.5057 2.40085 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.657 -3.27342 58
+      vertex -30.3879 -3.59664 58
+      vertex -30.2233 -4.78689 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.8285 1.09339 58
+      vertex -30.5764 1.20135 58
+      vertex -27.85 0 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.7641 -2.18509 58
+      vertex -30.5057 -2.40085 58
+      vertex -30.3879 -3.59664 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.6 0 58
+      vertex -27.85 0 58
+      vertex -30.5764 1.20135 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.8285 -1.09339 58
+      vertex -30.5764 -1.20135 58
+      vertex -30.5057 -2.40085 58
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.85 0 58
+      vertex -30.6 0 58
+      vertex -30.5764 -1.20135 58
+    endloop
+  endfacet
+  facet normal 0.658551 -0.257754 0.707018
+    outer loop
+      vertex 29.4592 -10.8681 57.2
+      vertex 28.7087 -10.5912 58
+      vertex 29.0098 -12.0163 57.2
+    endloop
+  endfacet
+  facet normal -0.490107 0.509838 0.707008
+    outer loop
+      vertex -21.3143 23.0577 57.2
+      vertex -22.2032 22.2032 57.2
+      vertex -20.7713 22.4703 58
+    endloop
+  endfacet
+  facet normal -0.381292 0.595599 0.707021
+    outer loop
+      vertex -15.9885 26.0908 58
+      vertex -17.4449 26.1081 57.2
+      vertex -17.0004 25.443 58
+    endloop
+  endfacet
+  facet normal -0.684246 -0.178558 0.707054
+    outer loop
+      vertex -29.7545 -7.14343 58
+      vertex -30.2211 -8.52323 57.2
+      vertex -29.4511 -8.30608 58
+    endloop
+  endfacet
+  facet normal -0.0693313 -0.703783 0.707024
+    outer loop
+      vertex -2.40085 -30.5057 58
+      vertex -3.59664 -30.3879 58
+      vertex -2.46362 -31.3032 57.2
+    endloop
+  endfacet
+  facet normal -0.647914 0.283405 0.707028
+    outer loop
+      vertex -28.5157 13.1459 57.2
+      vertex -29.0098 12.0163 57.2
+      vertex -27.7892 12.811 58
+    endloop
+  endfacet
+  facet normal 0.696189 -0.124291 0.707017
+    outer loop
+      vertex 31.0134 -4.91204 57.2
+      vertex 30.2233 -4.78689 58
+      vertex 30.7967 -6.12584 57.2
+    endloop
+  endfacet
+  facet normal -0.0138895 -0.707039 0.707039
+    outer loop
+      vertex 0 -30.6 58
+      vertex -1.20135 -30.5764 58
+      vertex 0 -31.4 57.2
+    endloop
+  endfacet
+  facet normal 0.668136 -0.231642 0.707061
+    outer loop
+      vertex 29.1023 -9.45592 58
+      vertex 28.7087 -10.5912 58
+      vertex 29.8632 -9.70313 57.2
+    endloop
+  endfacet
+  facet normal 0.0138796 0.707031 0.707046
+    outer loop
+      vertex 1.23276 31.3758 57.2
+      vertex 0 31.4 57.2
+      vertex 1.20135 30.5764 58
+    endloop
+  endfacet
+  facet normal -0.357582 -0.610113 0.707034
+    outer loop
+      vertex -15.9885 -26.0908 58
+      vertex -16.4065 -26.7729 57.2
+      vertex -14.9518 -26.6984 58
+    endloop
+  endfacet
+  facet normal -0.54665 0.44864 0.707033
+    outer loop
+      vertex -23.8767 20.3927 57.2
+      vertex -24.659 19.4395 57.2
+      vertex -24.0307 18.9443 58
+    endloop
+  endfacet
+  facet normal 0.676703 0.205275 0.707061
+    outer loop
+      vertex 29.8632 9.70313 57.2
+      vertex 29.1023 9.45592 58
+      vertex 29.4511 8.30608 58
+    endloop
+  endfacet
+  facet normal 0.0138796 -0.707031 0.707046
+    outer loop
+      vertex 1.20135 -30.5764 58
+      vertex 0 -31.4 57.2
+      vertex 1.23276 -31.3758 57.2
+    endloop
+  endfacet
+  facet normal -0.707039 -0.0138895 0.707039
+    outer loop
+      vertex -30.6 0 58
+      vertex -31.4 0 57.2
+      vertex -30.5764 -1.20135 58
+    endloop
+  endfacet
+  facet normal -0.231711 0.668159 0.707018
+    outer loop
+      vertex -9.70313 29.8632 57.2
+      vertex -10.8681 29.4592 57.2
+      vertex -10.5912 28.7087 58
+    endloop
+  endfacet
+  facet normal 0.703753 0.0692827 0.707058
+    outer loop
+      vertex 31.1824 3.69067 57.2
+      vertex 30.3879 3.59664 58
+      vertex 31.3032 2.46362 57.2
+    endloop
+  endfacet
+  facet normal 0.381292 -0.595599 0.707021
+    outer loop
+      vertex 17.0004 -25.443 58
+      vertex 15.9885 -26.0908 58
+      vertex 17.4449 -26.1081 57.2
+    endloop
+  endfacet
+  facet normal -0.469778 0.528629 0.707008
+    outer loop
+      vertex -20.3927 23.8767 57.2
+      vertex -21.3143 23.0577 57.2
+      vertex -20.7713 22.4703 58
+    endloop
+  endfacet
+  facet normal -0.684264 -0.178544 0.70704
+    outer loop
+      vertex -29.7545 -7.14343 58
+      vertex -30.5324 -7.33018 57.2
+      vertex -30.2211 -8.52323 57.2
+    endloop
+  endfacet
+  facet normal -0.124291 -0.696189 0.707017
+    outer loop
+      vertex -4.78689 -30.2233 58
+      vertex -6.12584 -30.7967 57.2
+      vertex -4.91204 -31.0134 57.2
+    endloop
+  endfacet
+  facet normal -0.668159 -0.231711 0.707018
+    outer loop
+      vertex -28.7087 -10.5912 58
+      vertex -29.8632 -9.70313 57.2
+      vertex -29.4592 -10.8681 57.2
+    endloop
+  endfacet
+  facet normal 0.647914 0.283405 0.707028
+    outer loop
+      vertex 28.5157 13.1459 57.2
+      vertex 27.7892 12.811 58
+      vertex 29.0098 12.0163 57.2
+    endloop
+  endfacet
+  facet normal 0.283405 0.647914 0.707028
+    outer loop
+      vertex 13.1459 28.5157 57.2
+      vertex 12.0163 29.0098 57.2
+      vertex 12.811 27.7892 58
+    endloop
+  endfacet
+  facet normal 0.151586 -0.690736 0.70704
+    outer loop
+      vertex 7.14343 -29.7545 58
+      vertex 6.12584 -30.7967 57.2
+      vertex 7.33018 -30.5324 57.2
+    endloop
+  endfacet
+  facet normal 0.703783 0.0693313 0.707024
+    outer loop
+      vertex 31.3032 2.46362 57.2
+      vertex 30.3879 3.59664 58
+      vertex 30.5057 2.40085 58
+    endloop
+  endfacet
+  facet normal 0.469778 0.528629 0.707008
+    outer loop
+      vertex 21.3143 23.0577 57.2
+      vertex 20.3927 23.8767 57.2
+      vertex 20.7713 22.4703 58
+    endloop
+  endfacet
+  facet normal 0.668159 -0.231711 0.707018
+    outer loop
+      vertex 29.8632 -9.70313 57.2
+      vertex 28.7087 -10.5912 58
+      vertex 29.4592 -10.8681 57.2
+    endloop
+  endfacet
+  facet normal -0.690736 -0.151586 0.70704
+    outer loop
+      vertex -29.7545 -7.14343 58
+      vertex -30.7967 -6.12584 57.2
+      vertex -30.5324 -7.33018 57.2
+    endloop
+  endfacet
+  facet normal 0.595599 0.381292 0.707021
+    outer loop
+      vertex 26.1081 17.4449 57.2
+      vertex 25.443 17.0004 58
+      vertex 26.0908 15.9885 58
+    endloop
+  endfacet
+  facet normal 0.610103 0.357586 0.707041
+    outer loop
+      vertex 26.7729 16.4065 57.2
+      vertex 26.6984 14.9518 58
+      vertex 27.3964 15.3427 57.2
+    endloop
+  endfacet
+  facet normal 0.70053 -0.0968765 0.707016
+    outer loop
+      vertex 30.3879 -3.59664 58
+      vertex 30.2233 -4.78689 58
+      vertex 31.0134 -4.91204 57.2
+    endloop
+  endfacet
+  facet normal -0.151541 0.690715 0.70707
+    outer loop
+      vertex -6.12584 30.7967 57.2
+      vertex -7.14343 29.7545 58
+      vertex -5.96976 30.012 58
+    endloop
+  endfacet
+  facet normal 0.700482 -0.0969251 0.707058
+    outer loop
+      vertex 31.1824 -3.69067 57.2
+      vertex 30.3879 -3.59664 58
+      vertex 31.0134 -4.91204 57.2
+    endloop
+  endfacet
+  facet normal 0.151541 -0.690715 0.70707
+    outer loop
+      vertex 7.14343 -29.7545 58
+      vertex 5.96976 -30.012 58
+      vertex 6.12584 -30.7967 57.2
+    endloop
+  endfacet
+  facet normal -0.636283 -0.308636 0.707027
+    outer loop
+      vertex -27.7892 -12.811 58
+      vertex -28.5157 -13.1459 57.2
+      vertex -27.2648 -13.8921 58
+    endloop
+  endfacet
+  facet normal 0.490117 -0.509773 0.707048
+    outer loop
+      vertex 21.6375 -21.6375 58
+      vertex 20.7713 -22.4703 58
+      vertex 22.2032 -22.2032 57.2
+    endloop
+  endfacet
+  facet normal 0.283375 0.647907 0.707047
+    outer loop
+      vertex 12.0163 29.0098 57.2
+      vertex 11.7101 28.2707 58
+      vertex 12.811 27.7892 58
+    endloop
+  endfacet
+  facet normal -0.700482 -0.0969251 0.707058
+    outer loop
+      vertex -30.3879 -3.59664 58
+      vertex -31.1824 -3.69067 57.2
+      vertex -31.0134 -4.91204 57.2
+    endloop
+  endfacet
+  facet normal -0.690715 -0.151541 0.70707
+    outer loop
+      vertex -30.012 -5.96976 58
+      vertex -30.7967 -6.12584 57.2
+      vertex -29.7545 -7.14343 58
+    endloop
+  endfacet
+  facet normal 0.690736 -0.151586 0.70704
+    outer loop
+      vertex 30.7967 -6.12584 57.2
+      vertex 29.7545 -7.14343 58
+      vertex 30.5324 -7.33018 57.2
+    endloop
+  endfacet
+  facet normal -0.33335 0.623678 0.707038
+    outer loop
+      vertex -14.2553 27.9776 57.2
+      vertex -14.9518 26.6984 58
+      vertex -13.8921 27.2648 58
+    endloop
+  endfacet
+  facet normal 0.381299 -0.595579 0.707034
+    outer loop
+      vertex 17.4449 -26.1081 57.2
+      vertex 15.9885 -26.0908 58
+      vertex 16.4065 -26.7729 57.2
+    endloop
+  endfacet
+  facet normal 0.595599 -0.381292 0.707021
+    outer loop
+      vertex 26.0908 -15.9885 58
+      vertex 25.443 -17.0004 58
+      vertex 26.1081 -17.4449 57.2
+    endloop
+  endfacet
+  facet normal -0.623678 0.333347 0.70704
+    outer loop
+      vertex -27.3964 15.3427 57.2
+      vertex -27.9776 14.2553 57.2
+      vertex -26.6984 14.9518 58
+    endloop
+  endfacet
+  facet normal 0.705965 -0.0416104 0.707024
+    outer loop
+      vertex 30.5764 -1.20135 58
+      vertex 30.5057 -2.40085 58
+      vertex 31.3032 -2.46362 57.2
+    endloop
+  endfacet
+  facet normal 0.151586 0.690736 0.70704
+    outer loop
+      vertex 7.33018 30.5324 57.2
+      vertex 6.12584 30.7967 57.2
+      vertex 7.14343 29.7545 58
+    endloop
+  endfacet
+  facet normal 0.707039 -0.0138895 0.707039
+    outer loop
+      vertex 30.6 0 58
+      vertex 30.5764 -1.20135 58
+      vertex 31.4 0 57.2
+    endloop
+  endfacet
+  facet normal -0.54665 -0.44864 0.707033
+    outer loop
+      vertex -24.0307 -18.9443 58
+      vertex -24.659 -19.4395 57.2
+      vertex -23.8767 -20.3927 57.2
+    endloop
+  endfacet
+  facet normal -0.0138796 0.707031 0.707046
+    outer loop
+      vertex 0 31.4 57.2
+      vertex -1.23276 31.3758 57.2
+      vertex -1.20135 30.5764 58
+    endloop
+  endfacet
+  facet normal 0.44864 0.54665 0.707033
+    outer loop
+      vertex 19.4395 24.659 57.2
+      vertex 18.9443 24.0307 58
+      vertex 20.3927 23.8767 57.2
+    endloop
+  endfacet
+  facet normal -0.509773 0.490117 0.707048
+    outer loop
+      vertex -22.2032 22.2032 57.2
+      vertex -22.4703 20.7713 58
+      vertex -21.6375 21.6375 58
+    endloop
+  endfacet
+  facet normal 0.509838 -0.490107 0.707008
+    outer loop
+      vertex 22.4703 -20.7713 58
+      vertex 22.2032 -22.2032 57.2
+      vertex 23.0577 -21.3143 57.2
+    endloop
+  endfacet
+  facet normal 0.647907 0.283375 0.707047
+    outer loop
+      vertex 29.0098 12.0163 57.2
+      vertex 27.7892 12.811 58
+      vertex 28.2707 11.7101 58
+    endloop
+  endfacet
+  facet normal -0.151586 0.690736 0.70704
+    outer loop
+      vertex -6.12584 30.7967 57.2
+      vertex -7.33018 30.5324 57.2
+      vertex -7.14343 29.7545 58
+    endloop
+  endfacet
+  facet normal -0.658511 -0.257778 0.707046
+    outer loop
+      vertex -28.7087 -10.5912 58
+      vertex -29.0098 -12.0163 57.2
+      vertex -28.2707 -11.7101 58
+    endloop
+  endfacet
+  facet normal 0.676713 -0.205268 0.707054
+    outer loop
+      vertex 30.2211 -8.52323 57.2
+      vertex 29.4511 -8.30608 58
+      vertex 29.8632 -9.70313 57.2
+    endloop
+  endfacet
+  facet normal 0.33335 -0.623678 0.707038
+    outer loop
+      vertex 14.9518 -26.6984 58
+      vertex 13.8921 -27.2648 58
+      vertex 14.2553 -27.9776 57.2
+    endloop
+  endfacet
+  facet normal -0.490117 -0.509773 0.707048
+    outer loop
+      vertex -21.6375 -21.6375 58
+      vertex -22.2032 -22.2032 57.2
+      vertex -20.7713 -22.4703 58
+    endloop
+  endfacet
+  facet normal -0.705941 -0.0416386 0.707046
+    outer loop
+      vertex -30.5764 -1.20135 58
+      vertex -31.3758 -1.23276 57.2
+      vertex -31.3032 -2.46362 57.2
+    endloop
+  endfacet
+  facet normal 0.0692827 0.703753 0.707058
+    outer loop
+      vertex 3.69067 31.1824 57.2
+      vertex 2.46362 31.3032 57.2
+      vertex 3.59664 30.3879 58
+    endloop
+  endfacet
+  facet normal -0.490107 -0.509838 0.707008
+    outer loop
+      vertex -20.7713 -22.4703 58
+      vertex -22.2032 -22.2032 57.2
+      vertex -21.3143 -23.0577 57.2
+    endloop
+  endfacet
+  facet normal -0.707031 0.0138796 0.707046
+    outer loop
+      vertex -31.3758 1.23276 57.2
+      vertex -31.4 0 57.2
+      vertex -30.5764 1.20135 58
+    endloop
+  endfacet
+  facet normal 0.509773 -0.490117 0.707048
+    outer loop
+      vertex 22.4703 -20.7713 58
+      vertex 21.6375 -21.6375 58
+      vertex 22.2032 -22.2032 57.2
+    endloop
+  endfacet
+  facet normal 0.546636 -0.448644 0.707042
+    outer loop
+      vertex 24.0307 -18.9443 58
+      vertex 23.2684 -19.8731 58
+      vertex 23.8767 -20.3927 57.2
+    endloop
+  endfacet
+  facet normal 0.257754 0.658551 0.707018
+    outer loop
+      vertex 10.8681 29.4592 57.2
+      vertex 10.5912 28.7087 58
+      vertex 12.0163 29.0098 57.2
+    endloop
+  endfacet
+  facet normal 0.178544 -0.684264 0.70704
+    outer loop
+      vertex 8.52323 -30.2211 57.2
+      vertex 7.14343 -29.7545 58
+      vertex 7.33018 -30.5324 57.2
+    endloop
+  endfacet
+  facet normal 0.658511 0.257778 0.707046
+    outer loop
+      vertex 29.0098 12.0163 57.2
+      vertex 28.2707 11.7101 58
+      vertex 28.7087 10.5912 58
+    endloop
+  endfacet
+  facet normal 0.0693313 -0.703783 0.707024
+    outer loop
+      vertex 3.59664 -30.3879 58
+      vertex 2.40085 -30.5057 58
+      vertex 2.46362 -31.3032 57.2
+    endloop
+  endfacet
+  facet normal 0.623678 -0.33335 0.707038
+    outer loop
+      vertex 27.2648 -13.8921 58
+      vertex 26.6984 -14.9518 58
+      vertex 27.9776 -14.2553 57.2
+    endloop
+  endfacet
+  facet normal -0.357586 0.610103 0.707041
+    outer loop
+      vertex -15.3427 27.3964 57.2
+      vertex -16.4065 26.7729 57.2
+      vertex -14.9518 26.6984 58
+    endloop
+  endfacet
+  facet normal -0.676713 0.205268 0.707054
+    outer loop
+      vertex -29.8632 9.70313 57.2
+      vertex -30.2211 8.52323 57.2
+      vertex -29.4511 8.30608 58
+    endloop
+  endfacet
+  facet normal -0.580169 -0.404329 0.707052
+    outer loop
+      vertex -24.7559 -17.9862 58
+      vertex -26.1081 -17.4449 57.2
+      vertex -25.4031 -18.4565 57.2
+    endloop
+  endfacet
+  facet normal -0.668136 0.231642 0.707061
+    outer loop
+      vertex -28.7087 10.5912 58
+      vertex -29.8632 9.70313 57.2
+      vertex -29.1023 9.45592 58
+    endloop
+  endfacet
+  facet normal 0.0692827 -0.703753 0.707058
+    outer loop
+      vertex 3.59664 -30.3879 58
+      vertex 2.46362 -31.3032 57.2
+      vertex 3.69067 -31.1824 57.2
+    endloop
+  endfacet
+  facet normal -0.696123 0.124351 0.707071
+    outer loop
+      vertex -30.012 5.96976 58
+      vertex -30.7967 6.12584 57.2
+      vertex -30.2233 4.78689 58
+    endloop
+  endfacet
+  facet normal 0.231711 0.668159 0.707018
+    outer loop
+      vertex 10.8681 29.4592 57.2
+      vertex 9.70313 29.8632 57.2
+      vertex 10.5912 28.7087 58
+    endloop
+  endfacet
+  facet normal -0.0969251 -0.700482 0.707058
+    outer loop
+      vertex -3.59664 -30.3879 58
+      vertex -4.91204 -31.0134 57.2
+      vertex -3.69067 -31.1824 57.2
+    endloop
+  endfacet
+  facet normal -0.469778 -0.528629 0.707008
+    outer loop
+      vertex -20.7713 -22.4703 58
+      vertex -21.3143 -23.0577 57.2
+      vertex -20.3927 -23.8767 57.2
+    endloop
+  endfacet
+  facet normal 0.257778 0.658511 0.707046
+    outer loop
+      vertex 12.0163 29.0098 57.2
+      vertex 10.5912 28.7087 58
+      vertex 11.7101 28.2707 58
+    endloop
+  endfacet
+  facet normal -0.595579 -0.381299 0.707034
+    outer loop
+      vertex -26.0908 -15.9885 58
+      vertex -26.7729 -16.4065 57.2
+      vertex -26.1081 -17.4449 57.2
+    endloop
+  endfacet
+  facet normal -0.0138895 0.707039 0.707039
+    outer loop
+      vertex 0 31.4 57.2
+      vertex -1.20135 30.5764 58
+      vertex 0 30.6 58
+    endloop
+  endfacet
+  facet normal 0.623678 0.333347 0.70704
+    outer loop
+      vertex 27.3964 15.3427 57.2
+      vertex 26.6984 14.9518 58
+      vertex 27.9776 14.2553 57.2
+    endloop
+  endfacet
+  facet normal 0.0969251 0.700482 0.707058
+    outer loop
+      vertex 3.69067 31.1824 57.2
+      vertex 3.59664 30.3879 58
+      vertex 4.91204 31.0134 57.2
+    endloop
+  endfacet
+  facet normal 0.178544 0.684264 0.70704
+    outer loop
+      vertex 7.33018 30.5324 57.2
+      vertex 7.14343 29.7545 58
+      vertex 8.52323 30.2211 57.2
+    endloop
+  endfacet
+  facet normal -0.703753 -0.0692827 0.707058
+    outer loop
+      vertex -30.3879 -3.59664 58
+      vertex -31.3032 -2.46362 57.2
+      vertex -31.1824 -3.69067 57.2
+    endloop
+  endfacet
+  facet normal 0.0416386 0.705941 0.707046
+    outer loop
+      vertex 1.23276 31.3758 57.2
+      vertex 1.20135 30.5764 58
+      vertex 2.46362 31.3032 57.2
+    endloop
+  endfacet
+  facet normal -0.696189 0.124291 0.707017
+    outer loop
+      vertex -30.7967 6.12584 57.2
+      vertex -31.0134 4.91204 57.2
+      vertex -30.2233 4.78689 58
+    endloop
+  endfacet
+  facet normal 0.563851 0.426818 0.707035
+    outer loop
+      vertex 24.659 19.4395 57.2
+      vertex 24.0307 18.9443 58
+      vertex 25.4031 18.4565 57.2
+    endloop
+  endfacet
+  facet normal -0.707031 -0.0138796 0.707046
+    outer loop
+      vertex -30.5764 -1.20135 58
+      vertex -31.4 0 57.2
+      vertex -31.3758 -1.23276 57.2
+    endloop
+  endfacet
+  facet normal 0.690736 0.151586 0.70704
+    outer loop
+      vertex 30.5324 7.33018 57.2
+      vertex 29.7545 7.14343 58
+      vertex 30.7967 6.12584 57.2
+    endloop
+  endfacet
+  facet normal 0.705965 0.0416104 0.707024
+    outer loop
+      vertex 31.3032 2.46362 57.2
+      vertex 30.5057 2.40085 58
+      vertex 30.5764 1.20135 58
+    endloop
+  endfacet
+  facet normal -0.700482 0.0969251 0.707058
+    outer loop
+      vertex -31.0134 4.91204 57.2
+      vertex -31.1824 3.69067 57.2
+      vertex -30.3879 3.59664 58
+    endloop
+  endfacet
+  facet normal 0.490107 -0.509838 0.707008
+    outer loop
+      vertex 22.2032 -22.2032 57.2
+      vertex 20.7713 -22.4703 58
+      vertex 21.3143 -23.0577 57.2
+    endloop
+  endfacet
+  facet normal -0.46972 -0.528634 0.707043
+    outer loop
+      vertex -19.8731 -23.2684 58
+      vertex -20.7713 -22.4703 58
+      vertex -20.3927 -23.8767 57.2
+    endloop
+  endfacet
+  facet normal 0.636279 0.308619 0.707038
+    outer loop
+      vertex 27.9776 14.2553 57.2
+      vertex 27.2648 13.8921 58
+      vertex 28.5157 13.1459 57.2
+    endloop
+  endfacet
+  facet normal -0.595579 0.381299 0.707034
+    outer loop
+      vertex -26.1081 17.4449 57.2
+      vertex -26.7729 16.4065 57.2
+      vertex -26.0908 15.9885 58
+    endloop
+  endfacet
+  facet normal 0.357582 -0.610113 0.707034
+    outer loop
+      vertex 15.9885 -26.0908 58
+      vertex 14.9518 -26.6984 58
+      vertex 16.4065 -26.7729 57.2
+    endloop
+  endfacet
+  facet normal -0.563851 -0.426818 0.707035
+    outer loop
+      vertex -24.0307 -18.9443 58
+      vertex -25.4031 -18.4565 57.2
+      vertex -24.659 -19.4395 57.2
+    endloop
+  endfacet
+  facet normal -0.595599 -0.381292 0.707021
+    outer loop
+      vertex -26.0908 -15.9885 58
+      vertex -26.1081 -17.4449 57.2
+      vertex -25.443 -17.0004 58
+    endloop
+  endfacet
+  facet normal -0.528629 -0.469778 0.707008
+    outer loop
+      vertex -22.4703 -20.7713 58
+      vertex -23.8767 -20.3927 57.2
+      vertex -23.0577 -21.3143 57.2
+    endloop
+  endfacet
+  facet normal -0.0416386 0.705941 0.707046
+    outer loop
+      vertex -1.23276 31.3758 57.2
+      vertex -2.46362 31.3032 57.2
+      vertex -1.20135 30.5764 58
+    endloop
+  endfacet
+  facet normal 0.490117 0.509773 0.707048
+    outer loop
+      vertex 22.2032 22.2032 57.2
+      vertex 20.7713 22.4703 58
+      vertex 21.6375 21.6375 58
+    endloop
+  endfacet
+  facet normal 0.178558 0.684246 0.707054
+    outer loop
+      vertex 8.52323 30.2211 57.2
+      vertex 7.14343 29.7545 58
+      vertex 8.30608 29.4511 58
+    endloop
+  endfacet
+  facet normal 0.658551 0.257754 0.707018
+    outer loop
+      vertex 29.0098 12.0163 57.2
+      vertex 28.7087 10.5912 58
+      vertex 29.4592 10.8681 57.2
+    endloop
+  endfacet
+  facet normal 0.647907 -0.283375 0.707047
+    outer loop
+      vertex 28.2707 -11.7101 58
+      vertex 27.7892 -12.811 58
+      vertex 29.0098 -12.0163 57.2
+    endloop
+  endfacet
+  facet normal 0.0968765 0.70053 0.707016
+    outer loop
+      vertex 4.91204 31.0134 57.2
+      vertex 3.59664 30.3879 58
+      vertex 4.78689 30.2233 58
+    endloop
+  endfacet
+  facet normal 0.696123 0.124351 0.707071
+    outer loop
+      vertex 30.7967 6.12584 57.2
+      vertex 30.012 5.96976 58
+      vertex 30.2233 4.78689 58
+    endloop
+  endfacet
+  facet normal 0.231642 -0.668136 0.707061
+    outer loop
+      vertex 10.5912 -28.7087 58
+      vertex 9.45592 -29.1023 58
+      vertex 9.70313 -29.8632 57.2
+    endloop
+  endfacet
+  facet normal -0.333347 0.623678 0.70704
+    outer loop
+      vertex -14.2553 27.9776 57.2
+      vertex -15.3427 27.3964 57.2
+      vertex -14.9518 26.6984 58
+    endloop
+  endfacet
+  facet normal -0.563851 0.426787 0.707053
+    outer loop
+      vertex -24.0307 18.9443 58
+      vertex -25.4031 18.4565 57.2
+      vertex -24.7559 17.9862 58
+    endloop
+  endfacet
+  facet normal 0.703753 -0.0692827 0.707058
+    outer loop
+      vertex 31.3032 -2.46362 57.2
+      vertex 30.3879 -3.59664 58
+      vertex 31.1824 -3.69067 57.2
+    endloop
+  endfacet
+  facet normal -0.528629 0.469778 0.707008
+    outer loop
+      vertex -23.0577 21.3143 57.2
+      vertex -23.8767 20.3927 57.2
+      vertex -22.4703 20.7713 58
+    endloop
+  endfacet
+  facet normal 0.381299 0.595579 0.707034
+    outer loop
+      vertex 16.4065 26.7729 57.2
+      vertex 15.9885 26.0908 58
+      vertex 17.4449 26.1081 57.2
+    endloop
+  endfacet
+  facet normal -0.46972 0.528634 0.707043
+    outer loop
+      vertex -20.3927 23.8767 57.2
+      vertex -20.7713 22.4703 58
+      vertex -19.8731 23.2684 58
+    endloop
+  endfacet
+  facet normal 0.333347 0.623678 0.70704
+    outer loop
+      vertex 15.3427 27.3964 57.2
+      vertex 14.2553 27.9776 57.2
+      vertex 14.9518 26.6984 58
+    endloop
+  endfacet
+  facet normal -0.528634 0.46972 0.707043
+    outer loop
+      vertex -22.4703 20.7713 58
+      vertex -23.8767 20.3927 57.2
+      vertex -23.2684 19.8731 58
+    endloop
+  endfacet
+  facet normal 0.46972 -0.528634 0.707043
+    outer loop
+      vertex 20.7713 -22.4703 58
+      vertex 19.8731 -23.2684 58
+      vertex 20.3927 -23.8767 57.2
+    endloop
+  endfacet
+  facet normal -0.580171 0.404378 0.707022
+    outer loop
+      vertex -24.7559 17.9862 58
+      vertex -26.1081 17.4449 57.2
+      vertex -25.443 17.0004 58
+    endloop
+  endfacet
+  facet normal -0.610103 -0.357586 0.707041
+    outer loop
+      vertex -26.6984 -14.9518 58
+      vertex -27.3964 -15.3427 57.2
+      vertex -26.7729 -16.4065 57.2
+    endloop
+  endfacet
+  facet normal 0.580171 -0.404378 0.707022
+    outer loop
+      vertex 25.443 -17.0004 58
+      vertex 24.7559 -17.9862 58
+      vertex 26.1081 -17.4449 57.2
+    endloop
+  endfacet
+  facet normal 0.0968765 -0.70053 0.707016
+    outer loop
+      vertex 4.78689 -30.2233 58
+      vertex 3.59664 -30.3879 58
+      vertex 4.91204 -31.0134 57.2
+    endloop
+  endfacet
+  facet normal -0.509773 -0.490117 0.707048
+    outer loop
+      vertex -21.6375 -21.6375 58
+      vertex -22.4703 -20.7713 58
+      vertex -22.2032 -22.2032 57.2
+    endloop
+  endfacet
+  facet normal -0.404378 -0.580171 0.707022
+    outer loop
+      vertex -17.0004 -25.443 58
+      vertex -17.9862 -24.7559 58
+      vertex -17.4449 -26.1081 57.2
+    endloop
+  endfacet
+  facet normal 0.684246 0.178558 0.707054
+    outer loop
+      vertex 30.2211 8.52323 57.2
+      vertex 29.4511 8.30608 58
+      vertex 29.7545 7.14343 58
+    endloop
+  endfacet
+  facet normal 0.647914 -0.283405 0.707028
+    outer loop
+      vertex 29.0098 -12.0163 57.2
+      vertex 27.7892 -12.811 58
+      vertex 28.5157 -13.1459 57.2
+    endloop
+  endfacet
+  facet normal -0.283375 -0.647907 0.707047
+    outer loop
+      vertex -11.7101 -28.2707 58
+      vertex -12.811 -27.7892 58
+      vertex -12.0163 -29.0098 57.2
+    endloop
+  endfacet
+  facet normal -0.308636 -0.636283 0.707027
+    outer loop
+      vertex -12.811 -27.7892 58
+      vertex -13.8921 -27.2648 58
+      vertex -13.1459 -28.5157 57.2
+    endloop
+  endfacet
+  facet normal -0.283405 -0.647914 0.707028
+    outer loop
+      vertex -12.811 -27.7892 58
+      vertex -13.1459 -28.5157 57.2
+      vertex -12.0163 -29.0098 57.2
+    endloop
+  endfacet
+  facet normal 0.404329 -0.580169 0.707052
+    outer loop
+      vertex 17.9862 -24.7559 58
+      vertex 17.4449 -26.1081 57.2
+      vertex 18.4565 -25.4031 57.2
+    endloop
+  endfacet
+  facet normal 0.257754 -0.658551 0.707018
+    outer loop
+      vertex 12.0163 -29.0098 57.2
+      vertex 10.5912 -28.7087 58
+      vertex 10.8681 -29.4592 57.2
+    endloop
+  endfacet
+  facet normal 0.469778 -0.528629 0.707008
+    outer loop
+      vertex 20.7713 -22.4703 58
+      vertex 20.3927 -23.8767 57.2
+      vertex 21.3143 -23.0577 57.2
+    endloop
+  endfacet
+  facet normal -0.357582 0.610113 0.707034
+    outer loop
+      vertex -14.9518 26.6984 58
+      vertex -16.4065 26.7729 57.2
+      vertex -15.9885 26.0908 58
+    endloop
+  endfacet
+  facet normal 0.509838 0.490107 0.707008
+    outer loop
+      vertex 23.0577 21.3143 57.2
+      vertex 22.2032 22.2032 57.2
+      vertex 22.4703 20.7713 58
+    endloop
+  endfacet
+  facet normal -0.426818 -0.563851 0.707035
+    outer loop
+      vertex -18.9443 -24.0307 58
+      vertex -19.4395 -24.659 57.2
+      vertex -18.4565 -25.4031 57.2
+    endloop
+  endfacet
+  facet normal 0.448644 0.546636 0.707042
+    outer loop
+      vertex 20.3927 23.8767 57.2
+      vertex 18.9443 24.0307 58
+      vertex 19.8731 23.2684 58
+    endloop
+  endfacet
+  facet normal 0.684264 -0.178544 0.70704
+    outer loop
+      vertex 30.5324 -7.33018 57.2
+      vertex 29.7545 -7.14343 58
+      vertex 30.2211 -8.52323 57.2
+    endloop
+  endfacet
+  facet normal 0.580171 0.404378 0.707022
+    outer loop
+      vertex 26.1081 17.4449 57.2
+      vertex 24.7559 17.9862 58
+      vertex 25.443 17.0004 58
+    endloop
+  endfacet
+  facet normal 0.658511 -0.257778 0.707046
+    outer loop
+      vertex 28.7087 -10.5912 58
+      vertex 28.2707 -11.7101 58
+      vertex 29.0098 -12.0163 57.2
+    endloop
+  endfacet
+  facet normal -0.684246 0.178558 0.707054
+    outer loop
+      vertex -29.4511 8.30608 58
+      vertex -30.2211 8.52323 57.2
+      vertex -29.7545 7.14343 58
+    endloop
+  endfacet
+  facet normal -0.707039 0.0138895 0.707039
+    outer loop
+      vertex -30.5764 1.20135 58
+      vertex -31.4 0 57.2
+      vertex -30.6 0 58
+    endloop
+  endfacet
+  facet normal 0.404378 -0.580171 0.707022
+    outer loop
+      vertex 17.9862 -24.7559 58
+      vertex 17.0004 -25.443 58
+      vertex 17.4449 -26.1081 57.2
+    endloop
+  endfacet
+  facet normal -0.658511 0.257778 0.707046
+    outer loop
+      vertex -28.2707 11.7101 58
+      vertex -29.0098 12.0163 57.2
+      vertex -28.7087 10.5912 58
+    endloop
+  endfacet
+  facet normal -0.705965 -0.0416104 0.707024
+    outer loop
+      vertex -30.5764 -1.20135 58
+      vertex -31.3032 -2.46362 57.2
+      vertex -30.5057 -2.40085 58
+    endloop
+  endfacet
+  facet normal 0.205275 -0.676703 0.707061
+    outer loop
+      vertex 9.45592 -29.1023 58
+      vertex 8.30608 -29.4511 58
+      vertex 9.70313 -29.8632 57.2
+    endloop
+  endfacet
+  facet normal 0.528629 -0.469778 0.707008
+    outer loop
+      vertex 23.8767 -20.3927 57.2
+      vertex 22.4703 -20.7713 58
+      vertex 23.0577 -21.3143 57.2
+    endloop
+  endfacet
+  facet normal -0.668159 0.231711 0.707018
+    outer loop
+      vertex -29.4592 10.8681 57.2
+      vertex -29.8632 9.70313 57.2
+      vertex -28.7087 10.5912 58
+    endloop
+  endfacet
+  facet normal 0.0138895 0.707039 0.707039
+    outer loop
+      vertex 0 31.4 57.2
+      vertex 0 30.6 58
+      vertex 1.20135 30.5764 58
+    endloop
+  endfacet
+  facet normal -0.563851 -0.426787 0.707053
+    outer loop
+      vertex -24.7559 -17.9862 58
+      vertex -25.4031 -18.4565 57.2
+      vertex -24.0307 -18.9443 58
+    endloop
+  endfacet
+  facet normal -0.257778 0.658511 0.707046
+    outer loop
+      vertex -10.5912 28.7087 58
+      vertex -12.0163 29.0098 57.2
+      vertex -11.7101 28.2707 58
+    endloop
+  endfacet
+  facet normal -0.623678 -0.33335 0.707038
+    outer loop
+      vertex -27.2648 -13.8921 58
+      vertex -27.9776 -14.2553 57.2
+      vertex -26.6984 -14.9518 58
+    endloop
+  endfacet
+  facet normal 0.124291 -0.696189 0.707017
+    outer loop
+      vertex 6.12584 -30.7967 57.2
+      vertex 4.78689 -30.2233 58
+      vertex 4.91204 -31.0134 57.2
+    endloop
+  endfacet
+  facet normal -0.647914 -0.283405 0.707028
+    outer loop
+      vertex -27.7892 -12.811 58
+      vertex -29.0098 -12.0163 57.2
+      vertex -28.5157 -13.1459 57.2
+    endloop
+  endfacet
+  facet normal -0.44864 -0.54665 0.707033
+    outer loop
+      vertex -18.9443 -24.0307 58
+      vertex -20.3927 -23.8767 57.2
+      vertex -19.4395 -24.659 57.2
+    endloop
+  endfacet
+  facet normal 0.308636 -0.636283 0.707027
+    outer loop
+      vertex 13.8921 -27.2648 58
+      vertex 12.811 -27.7892 58
+      vertex 13.1459 -28.5157 57.2
+    endloop
+  endfacet
+  facet normal -0.426787 -0.563851 0.707053
+    outer loop
+      vertex -17.9862 -24.7559 58
+      vertex -18.9443 -24.0307 58
+      vertex -18.4565 -25.4031 57.2
+    endloop
+  endfacet
+  facet normal 0.231642 0.668136 0.707061
+    outer loop
+      vertex 9.70313 29.8632 57.2
+      vertex 9.45592 29.1023 58
+      vertex 10.5912 28.7087 58
+    endloop
+  endfacet
+  facet normal -0.0692827 -0.703753 0.707058
+    outer loop
+      vertex -3.59664 -30.3879 58
+      vertex -3.69067 -31.1824 57.2
+      vertex -2.46362 -31.3032 57.2
+    endloop
+  endfacet
+  facet normal -0.205275 -0.676703 0.707061
+    outer loop
+      vertex -9.45592 -29.1023 58
+      vertex -9.70313 -29.8632 57.2
+      vertex -8.30608 -29.4511 58
+    endloop
+  endfacet
+  facet normal -0.580169 0.404329 0.707052
+    outer loop
+      vertex -25.4031 18.4565 57.2
+      vertex -26.1081 17.4449 57.2
+      vertex -24.7559 17.9862 58
+    endloop
+  endfacet
+  facet normal -0.308636 0.636283 0.707027
+    outer loop
+      vertex -13.1459 28.5157 57.2
+      vertex -13.8921 27.2648 58
+      vertex -12.811 27.7892 58
+    endloop
+  endfacet
+  facet normal 0.636283 0.308636 0.707027
+    outer loop
+      vertex 28.5157 13.1459 57.2
+      vertex 27.2648 13.8921 58
+      vertex 27.7892 12.811 58
+    endloop
+  endfacet
+  facet normal 0.623678 0.33335 0.707038
+    outer loop
+      vertex 27.9776 14.2553 57.2
+      vertex 26.6984 14.9518 58
+      vertex 27.2648 13.8921 58
+    endloop
+  endfacet
+  facet normal 0.44864 -0.54665 0.707033
+    outer loop
+      vertex 20.3927 -23.8767 57.2
+      vertex 18.9443 -24.0307 58
+      vertex 19.4395 -24.659 57.2
+    endloop
+  endfacet
+  facet normal -0.0968765 0.70053 0.707016
+    outer loop
+      vertex -3.59664 30.3879 58
+      vertex -4.91204 31.0134 57.2
+      vertex -4.78689 30.2233 58
+    endloop
+  endfacet
+  facet normal -0.178558 0.684246 0.707054
+    outer loop
+      vertex -7.14343 29.7545 58
+      vertex -8.52323 30.2211 57.2
+      vertex -8.30608 29.4511 58
+    endloop
+  endfacet
+  facet normal 0.528634 0.46972 0.707043
+    outer loop
+      vertex 23.8767 20.3927 57.2
+      vertex 22.4703 20.7713 58
+      vertex 23.2684 19.8731 58
+    endloop
+  endfacet
+  facet normal 0.546636 0.448644 0.707042
+    outer loop
+      vertex 23.8767 20.3927 57.2
+      vertex 23.2684 19.8731 58
+      vertex 24.0307 18.9443 58
+    endloop
+  endfacet
+  facet normal -0.610103 0.357586 0.707041
+    outer loop
+      vertex -26.7729 16.4065 57.2
+      vertex -27.3964 15.3427 57.2
+      vertex -26.6984 14.9518 58
+    endloop
+  endfacet
+  facet normal -0.283405 0.647914 0.707028
+    outer loop
+      vertex -12.0163 29.0098 57.2
+      vertex -13.1459 28.5157 57.2
+      vertex -12.811 27.7892 58
+    endloop
+  endfacet
+  facet normal -0.509838 0.490107 0.707008
+    outer loop
+      vertex -22.2032 22.2032 57.2
+      vertex -23.0577 21.3143 57.2
+      vertex -22.4703 20.7713 58
+    endloop
+  endfacet
+  facet normal -0.70053 -0.0968765 0.707016
+    outer loop
+      vertex -30.3879 -3.59664 58
+      vertex -31.0134 -4.91204 57.2
+      vertex -30.2233 -4.78689 58
+    endloop
+  endfacet
+  facet normal -0.696123 -0.124351 0.707071
+    outer loop
+      vertex -30.2233 -4.78689 58
+      vertex -30.7967 -6.12584 57.2
+      vertex -30.012 -5.96976 58
+    endloop
+  endfacet
+  facet normal -0.647907 -0.283375 0.707047
+    outer loop
+      vertex -28.2707 -11.7101 58
+      vertex -29.0098 -12.0163 57.2
+      vertex -27.7892 -12.811 58
+    endloop
+  endfacet
+  facet normal -0.124291 0.696189 0.707017
+    outer loop
+      vertex -4.91204 31.0134 57.2
+      vertex -6.12584 30.7967 57.2
+      vertex -4.78689 30.2233 58
+    endloop
+  endfacet
+  facet normal -0.636279 0.308619 0.707038
+    outer loop
+      vertex -27.9776 14.2553 57.2
+      vertex -28.5157 13.1459 57.2
+      vertex -27.2648 13.8921 58
+    endloop
+  endfacet
+  facet normal -0.33335 -0.623678 0.707038
+    outer loop
+      vertex -13.8921 -27.2648 58
+      vertex -14.9518 -26.6984 58
+      vertex -14.2553 -27.9776 57.2
+    endloop
+  endfacet
+  facet normal 0.124351 -0.696123 0.707071
+    outer loop
+      vertex 5.96976 -30.012 58
+      vertex 4.78689 -30.2233 58
+      vertex 6.12584 -30.7967 57.2
+    endloop
+  endfacet
+  facet normal -0.426818 0.563851 0.707035
+    outer loop
+      vertex -18.4565 25.4031 57.2
+      vertex -19.4395 24.659 57.2
+      vertex -18.9443 24.0307 58
+    endloop
+  endfacet
+  facet normal -0.0138796 -0.707031 0.707046
+    outer loop
+      vertex -1.20135 -30.5764 58
+      vertex -1.23276 -31.3758 57.2
+      vertex 0 -31.4 57.2
+    endloop
+  endfacet
+  facet normal -0.636283 0.308636 0.707027
+    outer loop
+      vertex -27.2648 13.8921 58
+      vertex -28.5157 13.1459 57.2
+      vertex -27.7892 12.811 58
+    endloop
+  endfacet
+  facet normal 0.703783 -0.0693313 0.707024
+    outer loop
+      vertex 30.5057 -2.40085 58
+      vertex 30.3879 -3.59664 58
+      vertex 31.3032 -2.46362 57.2
+    endloop
+  endfacet
+  facet normal 0.124351 0.696123 0.707071
+    outer loop
+      vertex 6.12584 30.7967 57.2
+      vertex 4.78689 30.2233 58
+      vertex 5.96976 30.012 58
+    endloop
+  endfacet
+  facet normal -0.705941 0.0416386 0.707046
+    outer loop
+      vertex -31.3032 2.46362 57.2
+      vertex -31.3758 1.23276 57.2
+      vertex -30.5764 1.20135 58
+    endloop
+  endfacet
+  facet normal -0.703783 0.0693313 0.707024
+    outer loop
+      vertex -30.3879 3.59664 58
+      vertex -31.3032 2.46362 57.2
+      vertex -30.5057 2.40085 58
+    endloop
+  endfacet
+  facet normal -0.696189 -0.124291 0.707017
+    outer loop
+      vertex -30.2233 -4.78689 58
+      vertex -31.0134 -4.91204 57.2
+      vertex -30.7967 -6.12584 57.2
+    endloop
+  endfacet
+  facet normal 0.610113 -0.357582 0.707034
+    outer loop
+      vertex 26.6984 -14.9518 58
+      vertex 26.0908 -15.9885 58
+      vertex 26.7729 -16.4065 57.2
+    endloop
+  endfacet
+  facet normal -0.257754 -0.658551 0.707018
+    outer loop
+      vertex -10.5912 -28.7087 58
+      vertex -12.0163 -29.0098 57.2
+      vertex -10.8681 -29.4592 57.2
+    endloop
+  endfacet
+  facet normal 0.357586 -0.610103 0.707041
+    outer loop
+      vertex 16.4065 -26.7729 57.2
+      vertex 14.9518 -26.6984 58
+      vertex 15.3427 -27.3964 57.2
+    endloop
+  endfacet
+  facet normal 0.308619 -0.636279 0.707038
+    outer loop
+      vertex 13.8921 -27.2648 58
+      vertex 13.1459 -28.5157 57.2
+      vertex 14.2553 -27.9776 57.2
+    endloop
+  endfacet
+  facet normal -0.595599 0.381292 0.707021
+    outer loop
+      vertex -25.443 17.0004 58
+      vertex -26.1081 17.4449 57.2
+      vertex -26.0908 15.9885 58
+    endloop
+  endfacet
+  facet normal -0.381299 -0.595579 0.707034
+    outer loop
+      vertex -15.9885 -26.0908 58
+      vertex -17.4449 -26.1081 57.2
+      vertex -16.4065 -26.7729 57.2
+    endloop
+  endfacet
+  facet normal 0.668136 0.231642 0.707061
+    outer loop
+      vertex 29.8632 9.70313 57.2
+      vertex 28.7087 10.5912 58
+      vertex 29.1023 9.45592 58
+    endloop
+  endfacet
+  facet normal -0.381292 -0.595599 0.707021
+    outer loop
+      vertex -17.0004 -25.443 58
+      vertex -17.4449 -26.1081 57.2
+      vertex -15.9885 -26.0908 58
+    endloop
+  endfacet
+  facet normal -0.0693313 0.703783 0.707024
+    outer loop
+      vertex -2.46362 31.3032 57.2
+      vertex -3.59664 30.3879 58
+      vertex -2.40085 30.5057 58
+    endloop
+  endfacet
+  facet normal -0.404329 0.580169 0.707052
+    outer loop
+      vertex -17.4449 26.1081 57.2
+      vertex -18.4565 25.4031 57.2
+      vertex -17.9862 24.7559 58
+    endloop
+  endfacet
+  facet normal 0.563851 -0.426818 0.707035
+    outer loop
+      vertex 25.4031 -18.4565 57.2
+      vertex 24.0307 -18.9443 58
+      vertex 24.659 -19.4395 57.2
+    endloop
+  endfacet
+  facet normal -0.610113 -0.357582 0.707034
+    outer loop
+      vertex -26.6984 -14.9518 58
+      vertex -26.7729 -16.4065 57.2
+      vertex -26.0908 -15.9885 58
+    endloop
+  endfacet
+  facet normal -0.448644 -0.546636 0.707042
+    outer loop
+      vertex -19.8731 -23.2684 58
+      vertex -20.3927 -23.8767 57.2
+      vertex -18.9443 -24.0307 58
+    endloop
+  endfacet
+  facet normal 0.205268 0.676713 0.707054
+    outer loop
+      vertex 8.52323 30.2211 57.2
+      vertex 8.30608 29.4511 58
+      vertex 9.70313 29.8632 57.2
+    endloop
+  endfacet
+  facet normal -0.690715 0.151541 0.70707
+    outer loop
+      vertex -29.7545 7.14343 58
+      vertex -30.7967 6.12584 57.2
+      vertex -30.012 5.96976 58
+    endloop
+  endfacet
+  facet normal 0.528634 -0.46972 0.707043
+    outer loop
+      vertex 23.2684 -19.8731 58
+      vertex 22.4703 -20.7713 58
+      vertex 23.8767 -20.3927 57.2
+    endloop
+  endfacet
+  facet normal 0.46972 0.528634 0.707043
+    outer loop
+      vertex 20.3927 23.8767 57.2
+      vertex 19.8731 23.2684 58
+      vertex 20.7713 22.4703 58
+    endloop
+  endfacet
+  facet normal -0.283375 0.647907 0.707047
+    outer loop
+      vertex -12.0163 29.0098 57.2
+      vertex -12.811 27.7892 58
+      vertex -11.7101 28.2707 58
+    endloop
+  endfacet
+  facet normal -0.257754 0.658551 0.707018
+    outer loop
+      vertex -10.8681 29.4592 57.2
+      vertex -12.0163 29.0098 57.2
+      vertex -10.5912 28.7087 58
+    endloop
+  endfacet
+  facet normal 0.283375 -0.647907 0.707047
+    outer loop
+      vertex 12.811 -27.7892 58
+      vertex 11.7101 -28.2707 58
+      vertex 12.0163 -29.0098 57.2
+    endloop
+  endfacet
+  facet normal -0.357586 -0.610103 0.707041
+    outer loop
+      vertex -14.9518 -26.6984 58
+      vertex -16.4065 -26.7729 57.2
+      vertex -15.3427 -27.3964 57.2
+    endloop
+  endfacet
+  facet normal 0.205268 -0.676713 0.707054
+    outer loop
+      vertex 9.70313 -29.8632 57.2
+      vertex 8.30608 -29.4511 58
+      vertex 8.52323 -30.2211 57.2
+    endloop
+  endfacet
+  facet normal 0.705941 -0.0416386 0.707046
+    outer loop
+      vertex 31.3758 -1.23276 57.2
+      vertex 30.5764 -1.20135 58
+      vertex 31.3032 -2.46362 57.2
+    endloop
+  endfacet
+  facet normal 0.448644 -0.546636 0.707042
+    outer loop
+      vertex 19.8731 -23.2684 58
+      vertex 18.9443 -24.0307 58
+      vertex 20.3927 -23.8767 57.2
+    endloop
+  endfacet
+  facet normal -0.426787 0.563851 0.707053
+    outer loop
+      vertex -18.4565 25.4031 57.2
+      vertex -18.9443 24.0307 58
+      vertex -17.9862 24.7559 58
+    endloop
+  endfacet
+  facet normal 0.636283 -0.308636 0.707027
+    outer loop
+      vertex 27.7892 -12.811 58
+      vertex 27.2648 -13.8921 58
+      vertex 28.5157 -13.1459 57.2
+    endloop
+  endfacet
+  facet normal 0.636279 -0.308619 0.707038
+    outer loop
+      vertex 28.5157 -13.1459 57.2
+      vertex 27.2648 -13.8921 58
+      vertex 27.9776 -14.2553 57.2
+    endloop
+  endfacet
+  facet normal 0.696123 -0.124351 0.707071
+    outer loop
+      vertex 30.2233 -4.78689 58
+      vertex 30.012 -5.96976 58
+      vertex 30.7967 -6.12584 57.2
+    endloop
+  endfacet
+  facet normal 0.690715 0.151541 0.70707
+    outer loop
+      vertex 30.7967 6.12584 57.2
+      vertex 29.7545 7.14343 58
+      vertex 30.012 5.96976 58
+    endloop
+  endfacet
+  facet normal -0.0416104 0.705965 0.707024
+    outer loop
+      vertex -1.20135 30.5764 58
+      vertex -2.46362 31.3032 57.2
+      vertex -2.40085 30.5057 58
+    endloop
+  endfacet
+  facet normal 0.668159 0.231711 0.707018
+    outer loop
+      vertex 29.4592 10.8681 57.2
+      vertex 28.7087 10.5912 58
+      vertex 29.8632 9.70313 57.2
+    endloop
+  endfacet
+  facet normal -0.690736 0.151586 0.70704
+    outer loop
+      vertex -30.5324 7.33018 57.2
+      vertex -30.7967 6.12584 57.2
+      vertex -29.7545 7.14343 58
+    endloop
+  endfacet
+  facet normal 0.700482 0.0969251 0.707058
+    outer loop
+      vertex 31.0134 4.91204 57.2
+      vertex 30.3879 3.59664 58
+      vertex 31.1824 3.69067 57.2
+    endloop
+  endfacet
+  facet normal 0.70053 0.0968765 0.707016
+    outer loop
+      vertex 31.0134 4.91204 57.2
+      vertex 30.2233 4.78689 58
+      vertex 30.3879 3.59664 58
+    endloop
+  endfacet
+  facet normal 0.426787 -0.563851 0.707053
+    outer loop
+      vertex 18.9443 -24.0307 58
+      vertex 17.9862 -24.7559 58
+      vertex 18.4565 -25.4031 57.2
+    endloop
+  endfacet
+  facet normal -0.231711 -0.668159 0.707018
+    outer loop
+      vertex -10.5912 -28.7087 58
+      vertex -10.8681 -29.4592 57.2
+      vertex -9.70313 -29.8632 57.2
+    endloop
+  endfacet
+  facet normal -0.647907 0.283375 0.707047
+    outer loop
+      vertex -27.7892 12.811 58
+      vertex -29.0098 12.0163 57.2
+      vertex -28.2707 11.7101 58
+    endloop
+  endfacet
+  facet normal -0.44864 0.54665 0.707033
+    outer loop
+      vertex -19.4395 24.659 57.2
+      vertex -20.3927 23.8767 57.2
+      vertex -18.9443 24.0307 58
+    endloop
+  endfacet
+  facet normal -0.70053 0.0968765 0.707016
+    outer loop
+      vertex -30.2233 4.78689 58
+      vertex -31.0134 4.91204 57.2
+      vertex -30.3879 3.59664 58
+    endloop
+  endfacet
+  facet normal -0.231642 -0.668136 0.707061
+    outer loop
+      vertex -9.45592 -29.1023 58
+      vertex -10.5912 -28.7087 58
+      vertex -9.70313 -29.8632 57.2
+    endloop
+  endfacet
+  facet normal -0.563851 0.426818 0.707035
+    outer loop
+      vertex -24.659 19.4395 57.2
+      vertex -25.4031 18.4565 57.2
+      vertex -24.0307 18.9443 58
+    endloop
+  endfacet
+  facet normal -0.0969251 0.700482 0.707058
+    outer loop
+      vertex -3.69067 31.1824 57.2
+      vertex -4.91204 31.0134 57.2
+      vertex -3.59664 30.3879 58
+    endloop
+  endfacet
+  facet normal -0.546636 0.448644 0.707042
+    outer loop
+      vertex -23.8767 20.3927 57.2
+      vertex -24.0307 18.9443 58
+      vertex -23.2684 19.8731 58
+    endloop
+  endfacet
+  facet normal 0.124291 0.696189 0.707017
+    outer loop
+      vertex 4.91204 31.0134 57.2
+      vertex 4.78689 30.2233 58
+      vertex 6.12584 30.7967 57.2
+    endloop
+  endfacet
+  facet normal 0.676703 -0.205275 0.707061
+    outer loop
+      vertex 29.4511 -8.30608 58
+      vertex 29.1023 -9.45592 58
+      vertex 29.8632 -9.70313 57.2
+    endloop
+  endfacet
+  facet normal 0.684246 -0.178558 0.707054
+    outer loop
+      vertex 29.7545 -7.14343 58
+      vertex 29.4511 -8.30608 58
+      vertex 30.2211 -8.52323 57.2
+    endloop
+  endfacet
+  facet normal 0.426818 -0.563851 0.707035
+    outer loop
+      vertex 18.9443 -24.0307 58
+      vertex 18.4565 -25.4031 57.2
+      vertex 19.4395 -24.659 57.2
+    endloop
+  endfacet
+  facet normal 0.33335 0.623678 0.707038
+    outer loop
+      vertex 14.2553 27.9776 57.2
+      vertex 13.8921 27.2648 58
+      vertex 14.9518 26.6984 58
+    endloop
+  endfacet
+  facet normal 0.308636 0.636283 0.707027
+    outer loop
+      vertex 13.1459 28.5157 57.2
+      vertex 12.811 27.7892 58
+      vertex 13.8921 27.2648 58
+    endloop
+  endfacet
+  facet normal -0.703753 0.0692827 0.707058
+    outer loop
+      vertex -31.1824 3.69067 57.2
+      vertex -31.3032 2.46362 57.2
+      vertex -30.3879 3.59664 58
+    endloop
+  endfacet
+  facet normal -0.676703 -0.205275 0.707061
+    outer loop
+      vertex -29.4511 -8.30608 58
+      vertex -29.8632 -9.70313 57.2
+      vertex -29.1023 -9.45592 58
+    endloop
+  endfacet
+  facet normal -0.623678 0.33335 0.707038
+    outer loop
+      vertex -26.6984 14.9518 58
+      vertex -27.9776 14.2553 57.2
+      vertex -27.2648 13.8921 58
+    endloop
+  endfacet
+  facet normal 0.563851 -0.426787 0.707053
+    outer loop
+      vertex 24.7559 -17.9862 58
+      vertex 24.0307 -18.9443 58
+      vertex 25.4031 -18.4565 57.2
+    endloop
+  endfacet
+  facet normal -0.151586 -0.690736 0.70704
+    outer loop
+      vertex -7.14343 -29.7545 58
+      vertex -7.33018 -30.5324 57.2
+      vertex -6.12584 -30.7967 57.2
+    endloop
+  endfacet
+  facet normal -0.528634 -0.46972 0.707043
+    outer loop
+      vertex -23.2684 -19.8731 58
+      vertex -23.8767 -20.3927 57.2
+      vertex -22.4703 -20.7713 58
+    endloop
+  endfacet
+  facet normal -0.546636 -0.448644 0.707042
+    outer loop
+      vertex -23.2684 -19.8731 58
+      vertex -24.0307 -18.9443 58
+      vertex -23.8767 -20.3927 57.2
+    endloop
+  endfacet
+  facet normal 0.205275 0.676703 0.707061
+    outer loop
+      vertex 9.70313 29.8632 57.2
+      vertex 8.30608 29.4511 58
+      vertex 9.45592 29.1023 58
+    endloop
+  endfacet
+  facet normal -0.448644 0.546636 0.707042
+    outer loop
+      vertex -18.9443 24.0307 58
+      vertex -20.3927 23.8767 57.2
+      vertex -19.8731 23.2684 58
+    endloop
+  endfacet
+  facet normal 0.0416104 0.705965 0.707024
+    outer loop
+      vertex 2.46362 31.3032 57.2
+      vertex 1.20135 30.5764 58
+      vertex 2.40085 30.5057 58
+    endloop
+  endfacet
+  facet normal 0.426787 0.563851 0.707053
+    outer loop
+      vertex 18.4565 25.4031 57.2
+      vertex 17.9862 24.7559 58
+      vertex 18.9443 24.0307 58
+    endloop
+  endfacet
+  facet normal -0.308619 0.636279 0.707038
+    outer loop
+      vertex -13.1459 28.5157 57.2
+      vertex -14.2553 27.9776 57.2
+      vertex -13.8921 27.2648 58
+    endloop
+  endfacet
+  facet normal -0.205275 0.676703 0.707061
+    outer loop
+      vertex -8.30608 29.4511 58
+      vertex -9.70313 29.8632 57.2
+      vertex -9.45592 29.1023 58
+    endloop
+  endfacet
+  facet normal -0.151541 -0.690715 0.70707
+    outer loop
+      vertex -5.96976 -30.012 58
+      vertex -7.14343 -29.7545 58
+      vertex -6.12584 -30.7967 57.2
+    endloop
+  endfacet
+  facet normal 0.178558 -0.684246 0.707054
+    outer loop
+      vertex 8.30608 -29.4511 58
+      vertex 7.14343 -29.7545 58
+      vertex 8.52323 -30.2211 57.2
+    endloop
+  endfacet
+  facet normal 0.54665 -0.44864 0.707033
+    outer loop
+      vertex 24.0307 -18.9443 58
+      vertex 23.8767 -20.3927 57.2
+      vertex 24.659 -19.4395 57.2
+    endloop
+  endfacet
+  facet normal -0.404378 0.580171 0.707022
+    outer loop
+      vertex -17.4449 26.1081 57.2
+      vertex -17.9862 24.7559 58
+      vertex -17.0004 25.443 58
+    endloop
+  endfacet
+  facet normal -0.124351 -0.696123 0.707071
+    outer loop
+      vertex -5.96976 -30.012 58
+      vertex -6.12584 -30.7967 57.2
+      vertex -4.78689 -30.2233 58
+    endloop
+  endfacet
+  facet normal -0.0416104 -0.705965 0.707024
+    outer loop
+      vertex -2.40085 -30.5057 58
+      vertex -2.46362 -31.3032 57.2
+      vertex -1.20135 -30.5764 58
+    endloop
+  endfacet
+  facet normal -0.0416386 -0.705941 0.707046
+    outer loop
+      vertex -1.20135 -30.5764 58
+      vertex -2.46362 -31.3032 57.2
+      vertex -1.23276 -31.3758 57.2
+    endloop
+  endfacet
+  facet normal 0.151541 0.690715 0.70707
+    outer loop
+      vertex 6.12584 30.7967 57.2
+      vertex 5.96976 30.012 58
+      vertex 7.14343 29.7545 58
+    endloop
+  endfacet
+  facet normal -0.705965 0.0416104 0.707024
+    outer loop
+      vertex -30.5057 2.40085 58
+      vertex -31.3032 2.46362 57.2
+      vertex -30.5764 1.20135 58
+    endloop
+  endfacet
+  facet normal -0.205268 -0.676713 0.707054
+    outer loop
+      vertex -8.30608 -29.4511 58
+      vertex -9.70313 -29.8632 57.2
+      vertex -8.52323 -30.2211 57.2
+    endloop
+  endfacet
+  facet normal -0.178544 -0.684264 0.70704
+    outer loop
+      vertex -7.14343 -29.7545 58
+      vertex -8.52323 -30.2211 57.2
+      vertex -7.33018 -30.5324 57.2
+    endloop
+  endfacet
+  facet normal -0.676703 0.205275 0.707061
+    outer loop
+      vertex -29.1023 9.45592 58
+      vertex -29.8632 9.70313 57.2
+      vertex -29.4511 8.30608 58
+    endloop
+  endfacet
+  facet normal -0.998265 -0.0588882 0
+    outer loop
+      vertex 27.8285 1.09339 0.599999
+      vertex 27.7641 2.18509 57.4
+      vertex 27.7641 2.18509 0.599999
+    endloop
+  endfacet
+  facet normal -0.998265 -0.0588882 0
+    outer loop
+      vertex 27.7641 2.18509 57.4
+      vertex 27.8285 1.09339 0.599999
+      vertex 27.8285 1.09339 57.4
+    endloop
+  endfacet
+  facet normal -0.999807 -0.0196598 0
+    outer loop
+      vertex 27.85 0 0.599999
+      vertex 27.8285 1.09339 57.4
+      vertex 27.8285 1.09339 0.599999
+    endloop
+  endfacet
+  facet normal -0.999807 -0.0196598 0
+    outer loop
+      vertex 27.8285 1.09339 57.4
+      vertex 27.85 0 0.599999
+      vertex 27.85 0 57.4
+    endloop
+  endfacet
+  facet normal -0.995193 -0.0979346 0
+    outer loop
+      vertex 27.7641 2.18509 0.599999
+      vertex 27.657 3.27342 57.4
+      vertex 27.657 3.27342 0.599999
+    endloop
+  endfacet
+  facet normal -0.995193 -0.0979346 0
+    outer loop
+      vertex 27.657 3.27342 57.4
+      vertex 27.7641 2.18509 0.599999
+      vertex 27.7641 2.18509 57.4
+    endloop
+  endfacet
+  facet normal -0.471371 0.881935 0
+    outer loop
+      vertex 13.6081 -24.299 0.599999
+      vertex 12.6436 -24.8145 57.4
+      vertex 13.6081 -24.299 57.4
+    endloop
+  endfacet
+  facet normal -0.471371 0.881935 0
+    outer loop
+      vertex 12.6436 -24.8145 57.4
+      vertex 13.6081 -24.299 0.599999
+      vertex 12.6436 -24.8145 0.599999
+    endloop
+  endfacet
+  facet normal -0.916216 0.400685 0
+    outer loop
+      vertex 25.2918 -11.6597 0.599999
+      vertex 25.73 -10.6577 57.4
+      vertex 25.73 -10.6577 0.599999
+    endloop
+  endfacet
+  facet normal -0.916216 0.400685 0
+    outer loop
+      vertex 25.73 -10.6577 57.4
+      vertex 25.2918 -11.6597 0.599999
+      vertex 25.2918 -11.6597 57.4
+    endloop
+  endfacet
+  facet normal 0.899722 -0.436464 0
+    outer loop
+      vertex -25.2918 11.6597 57.4
+      vertex -24.8145 12.6436 0.599999
+      vertex -24.8145 12.6436 57.4
+    endloop
+  endfacet
+  facet normal 0.899722 -0.436464 0
+    outer loop
+      vertex -24.8145 12.6436 0.599999
+      vertex -25.2918 11.6597 57.4
+      vertex -25.2918 11.6597 0.599999
+    endloop
+  endfacet
+  facet normal -0.990561 -0.13707 0
+    outer loop
+      vertex 27.657 3.27342 0.599999
+      vertex 27.5071 4.3567 57.4
+      vertex 27.5071 4.3567 0.599999
+    endloop
+  endfacet
+  facet normal -0.990561 -0.13707 0
+    outer loop
+      vertex 27.5071 4.3567 57.4
+      vertex 27.657 3.27342 0.599999
+      vertex 27.657 3.27342 57.4
+    endloop
+  endfacet
+  facet normal 0.74753 -0.664228 0
+    outer loop
+      vertex -21.1773 18.0871 57.4
+      vertex -20.4509 18.9046 0.599999
+      vertex -20.4509 18.9046 57.4
+    endloop
+  endfacet
+  facet normal 0.74753 -0.664228 0
+    outer loop
+      vertex -20.4509 18.9046 0.599999
+      vertex -21.1773 18.0871 57.4
+      vertex -21.1773 18.0871 0.599999
+    endloop
+  endfacet
+  facet normal 0.931206 0.364494 0
+    outer loop
+      vertex -25.73 -10.6577 57.4
+      vertex -26.1286 -9.63936 0.599999
+      vertex -26.1286 -9.63936 57.4
+    endloop
+  endfacet
+  facet normal 0.931206 0.364494 0
+    outer loop
+      vertex -26.1286 -9.63936 0.599999
+      vertex -25.73 -10.6577 57.4
+      vertex -25.73 -10.6577 0.599999
+    endloop
+  endfacet
+  facet normal -0.13707 0.990561 0
+    outer loop
+      vertex 4.3567 -27.5071 0.599999
+      vertex 3.27342 -27.657 57.4
+      vertex 4.3567 -27.5071 57.4
+    endloop
+  endfacet
+  facet normal -0.13707 0.990561 0
+    outer loop
+      vertex 3.27342 -27.657 57.4
+      vertex 4.3567 -27.5071 0.599999
+      vertex 3.27342 -27.657 0.599999
+    endloop
+  endfacet
+  facet normal -0.505661 0.862732 0
+    outer loop
+      vertex 14.5516 -23.746 0.599999
+      vertex 13.6081 -24.299 57.4
+      vertex 14.5516 -23.746 57.4
+    endloop
+  endfacet
+  facet normal -0.505661 0.862732 0
+    outer loop
+      vertex 13.6081 -24.299 57.4
+      vertex 14.5516 -23.746 0.599999
+      vertex 13.6081 -24.299 0.599999
+    endloop
+  endfacet
+  facet normal 0.820407 0.57178 0
+    outer loop
+      vertex -22.5311 -16.3698 57.4
+      vertex -23.1564 -15.4726 0.599999
+      vertex -23.1564 -15.4726 57.4
+    endloop
+  endfacet
+  facet normal 0.820407 0.57178 0
+    outer loop
+      vertex -23.1564 -15.4726 0.599999
+      vertex -22.5311 -16.3698 57.4
+      vertex -22.5311 -16.3698 0.599999
+    endloop
+  endfacet
+  facet normal -0.899722 -0.436464 0
+    outer loop
+      vertex 25.2918 11.6597 0.599999
+      vertex 24.8145 12.6436 57.4
+      vertex 24.8145 12.6436 0.599999
+    endloop
+  endfacet
+  facet normal -0.899722 -0.436464 0
+    outer loop
+      vertex 24.8145 12.6436 57.4
+      vertex 25.2918 11.6597 0.599999
+      vertex 25.2918 11.6597 57.4
+    endloop
+  endfacet
+  facet normal 0.998265 -0.0588882 0
+    outer loop
+      vertex -27.8285 1.09339 57.4
+      vertex -27.7641 2.18509 0.599999
+      vertex -27.7641 2.18509 57.4
+    endloop
+  endfacet
+  facet normal 0.998265 -0.0588882 0
+    outer loop
+      vertex -27.7641 2.18509 0.599999
+      vertex -27.8285 1.09339 57.4
+      vertex -27.8285 1.09339 0.599999
+    endloop
+  endfacet
+  facet normal -0.97676 0.214337 0
+    outer loop
+      vertex 27.0805 -6.50145 0.599999
+      vertex 27.3149 -5.43326 57.4
+      vertex 27.3149 -5.43326 0.599999
+    endloop
+  endfacet
+  facet normal -0.97676 0.214337 0
+    outer loop
+      vertex 27.3149 -5.43326 57.4
+      vertex 27.0805 -6.50145 0.599999
+      vertex 27.0805 -6.50145 57.4
+    endloop
+  endfacet
+  facet normal -0.881935 0.471371 0
+    outer loop
+      vertex 24.299 -13.6081 0.599999
+      vertex 24.8145 -12.6436 57.4
+      vertex 24.8145 -12.6436 0.599999
+    endloop
+  endfacet
+  facet normal -0.881935 0.471371 0
+    outer loop
+      vertex 24.8145 -12.6436 57.4
+      vertex 24.299 -13.6081 0.599999
+      vertex 24.299 -13.6081 57.4
+    endloop
+  endfacet
+  facet normal -0.797359 0.603506 0
+    outer loop
+      vertex 21.8711 -17.2418 0.599999
+      vertex 22.5311 -16.3698 57.4
+      vertex 22.5311 -16.3698 0.599999
+    endloop
+  endfacet
+  facet normal -0.797359 0.603506 0
+    outer loop
+      vertex 22.5311 -16.3698 57.4
+      vertex 21.8711 -17.2418 0.599999
+      vertex 21.8711 -17.2418 57.4
+    endloop
+  endfacet
+  facet normal -0.364494 0.931206 0
+    outer loop
+      vertex 10.6577 -25.73 0.599999
+      vertex 9.63936 -26.1286 57.4
+      vertex 10.6577 -25.73 57.4
+    endloop
+  endfacet
+  facet normal -0.364494 0.931206 0
+    outer loop
+      vertex 9.63936 -26.1286 57.4
+      vertex 10.6577 -25.73 0.599999
+      vertex 9.63936 -26.1286 0.599999
+    endloop
+  endfacet
+  facet normal -0.634437 -0.772974 0
+    outer loop
+      vertex 17.2418 21.8711 0.599999
+      vertex 18.0871 21.1773 57.4
+      vertex 17.2418 21.8711 57.4
+    endloop
+  endfacet
+  facet normal -0.634437 -0.772974 -0
+    outer loop
+      vertex 18.0871 21.1773 57.4
+      vertex 17.2418 21.8711 0.599999
+      vertex 18.0871 21.1773 0.599999
+    endloop
+  endfacet
+  facet normal -0.74753 0.664228 0
+    outer loop
+      vertex 20.4509 -18.9046 0.599999
+      vertex 21.1773 -18.0871 57.4
+      vertex 21.1773 -18.0871 0.599999
+    endloop
+  endfacet
+  facet normal -0.74753 0.664228 0
+    outer loop
+      vertex 21.1773 -18.0871 57.4
+      vertex 20.4509 -18.9046 0.599999
+      vertex 20.4509 -18.9046 57.4
+    endloop
+  endfacet
+  facet normal -0.364494 -0.931206 0
+    outer loop
+      vertex 9.63936 26.1286 0.599999
+      vertex 10.6577 25.73 57.4
+      vertex 9.63936 26.1286 57.4
+    endloop
+  endfacet
+  facet normal -0.364494 -0.931206 -0
+    outer loop
+      vertex 10.6577 25.73 57.4
+      vertex 9.63936 26.1286 0.599999
+      vertex 10.6577 25.73 0.599999
+    endloop
+  endfacet
+  facet normal -0.820407 -0.57178 0
+    outer loop
+      vertex 23.1564 15.4726 0.599999
+      vertex 22.5311 16.3698 57.4
+      vertex 22.5311 16.3698 0.599999
+    endloop
+  endfacet
+  facet normal -0.820407 -0.57178 0
+    outer loop
+      vertex 22.5311 16.3698 57.4
+      vertex 23.1564 15.4726 0.599999
+      vertex 23.1564 15.4726 57.4
+    endloop
+  endfacet
+  facet normal 0.881935 0.471371 0
+    outer loop
+      vertex -24.299 -13.6081 57.4
+      vertex -24.8145 -12.6436 0.599999
+      vertex -24.8145 -12.6436 57.4
+    endloop
+  endfacet
+  facet normal 0.881935 0.471371 0
+    outer loop
+      vertex -24.8145 -12.6436 0.599999
+      vertex -24.299 -13.6081 57.4
+      vertex -24.299 -13.6081 0.599999
+    endloop
+  endfacet
+  facet normal 0.603506 0.797359 -0
+    outer loop
+      vertex -16.3698 -22.5311 0.599999
+      vertex -17.2418 -21.8711 57.4
+      vertex -16.3698 -22.5311 57.4
+    endloop
+  endfacet
+  facet normal 0.603506 0.797359 0
+    outer loop
+      vertex -17.2418 -21.8711 57.4
+      vertex -16.3698 -22.5311 0.599999
+      vertex -17.2418 -21.8711 0.599999
+    endloop
+  endfacet
+  facet normal 0.999807 -0.0196598 0
+    outer loop
+      vertex -27.85 0 57.4
+      vertex -27.8285 1.09339 0.599999
+      vertex -27.8285 1.09339 57.4
+    endloop
+  endfacet
+  facet normal 0.999807 -0.0196598 0
+    outer loop
+      vertex -27.8285 1.09339 0.599999
+      vertex -27.85 0 57.4
+      vertex -27.85 0 0.599999
+    endloop
+  endfacet
+  facet normal 0.772974 -0.634437 0
+    outer loop
+      vertex -21.8711 17.2418 57.4
+      vertex -21.1773 18.0871 0.599999
+      vertex -21.1773 18.0871 57.4
+    endloop
+  endfacet
+  facet normal 0.772974 -0.634437 0
+    outer loop
+      vertex -21.1773 18.0871 0.599999
+      vertex -21.8711 17.2418 57.4
+      vertex -21.8711 17.2418 0.599999
+    endloop
+  endfacet
+  facet normal 0.400685 -0.916216 0
+    outer loop
+      vertex -11.6597 25.2918 0.599999
+      vertex -10.6577 25.73 57.4
+      vertex -11.6597 25.2918 57.4
+    endloop
+  endfacet
+  facet normal 0.400685 -0.916216 0
+    outer loop
+      vertex -10.6577 25.73 57.4
+      vertex -11.6597 25.2918 0.599999
+      vertex -10.6577 25.73 0.599999
+    endloop
+  endfacet
+  facet normal 0.25247 0.967605 -0
+    outer loop
+      vertex -6.50145 -27.0805 0.599999
+      vertex -7.55962 -26.8044 57.4
+      vertex -6.50145 -27.0805 57.4
+    endloop
+  endfacet
+  facet normal 0.25247 0.967605 0
+    outer loop
+      vertex -7.55962 -26.8044 57.4
+      vertex -6.50145 -27.0805 0.599999
+      vertex -7.55962 -26.8044 0.599999
+    endloop
+  endfacet
+  facet normal 0.772974 0.634437 0
+    outer loop
+      vertex -21.1773 -18.0871 57.4
+      vertex -21.8711 -17.2418 0.599999
+      vertex -21.8711 -17.2418 57.4
+    endloop
+  endfacet
+  facet normal 0.772974 0.634437 0
+    outer loop
+      vertex -21.8711 -17.2418 0.599999
+      vertex -21.1773 -18.0871 57.4
+      vertex -21.1773 -18.0871 0.599999
+    endloop
+  endfacet
+  facet normal -0.0979346 -0.995193 0
+    outer loop
+      vertex 2.18509 27.7641 0.599999
+      vertex 3.27342 27.657 57.4
+      vertex 2.18509 27.7641 57.4
+    endloop
+  endfacet
+  facet normal -0.0979346 -0.995193 -0
+    outer loop
+      vertex 3.27342 27.657 57.4
+      vertex 2.18509 27.7641 0.599999
+      vertex 3.27342 27.657 0.599999
+    endloop
+  endfacet
+  facet normal -0.664228 0.74753 0
+    outer loop
+      vertex 18.9046 -20.4509 0.599999
+      vertex 18.0871 -21.1773 57.4
+      vertex 18.9046 -20.4509 57.4
+    endloop
+  endfacet
+  facet normal -0.664228 0.74753 0
+    outer loop
+      vertex 18.0871 -21.1773 57.4
+      vertex 18.9046 -20.4509 0.599999
+      vertex 18.0871 -21.1773 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.85 0 0.599999
+      vertex 28.45 0 0.599999
+      vertex 28.4281 -1.11694 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.8285 -1.09339 0.599999
+      vertex 28.4281 -1.11694 0.599999
+      vertex 28.3623 -2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.45 0 0.599999
+      vertex 27.85 0 0.599999
+      vertex 28.4281 1.11694 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.7641 -2.18509 0.599999
+      vertex 28.3623 -2.23216 0.599999
+      vertex 28.2528 -3.34394 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.8285 1.09339 0.599999
+      vertex 28.4281 1.11694 0.599999
+      vertex 27.85 0 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.657 -3.27342 0.599999
+      vertex 28.2528 -3.34394 0.599999
+      vertex 28.0997 -4.45056 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.4281 1.11694 0.599999
+      vertex 27.8285 1.09339 0.599999
+      vertex 28.3623 2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.5071 -4.3567 0.599999
+      vertex 28.0997 -4.45056 0.599999
+      vertex 27.9033 -5.55032 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.7641 2.18509 0.599999
+      vertex 28.3623 2.23216 0.599999
+      vertex 27.8285 1.09339 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.3623 2.23216 0.599999
+      vertex 27.7641 2.18509 0.599999
+      vertex 28.2528 3.34394 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.4281 -1.11694 0.599999
+      vertex 27.8285 -1.09339 0.599999
+      vertex 27.85 0 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.3623 -2.23216 0.599999
+      vertex 27.7641 -2.18509 0.599999
+      vertex 27.8285 -1.09339 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3149 -5.43326 0.599999
+      vertex 27.9033 -5.55032 0.599999
+      vertex 27.6639 -6.64152 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.2528 -3.34394 0.599999
+      vertex 27.657 -3.27342 0.599999
+      vertex 27.7641 -2.18509 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.0997 -4.45056 0.599999
+      vertex 27.5071 -4.3567 0.599999
+      vertex 27.657 -3.27342 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0805 -6.50145 0.599999
+      vertex 27.6639 -6.64152 0.599999
+      vertex 27.3819 -7.72248 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.9033 -5.55032 0.599999
+      vertex 27.3149 -5.43326 0.599999
+      vertex 27.5071 -4.3567 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.6639 -6.64152 0.599999
+      vertex 27.0805 -6.50145 0.599999
+      vertex 27.3149 -5.43326 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8044 -7.55962 0.599999
+      vertex 27.3819 -7.72248 0.599999
+      vertex 27.0576 -8.79153 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3819 -7.72248 0.599999
+      vertex 26.8044 -7.55962 0.599999
+      vertex 27.0805 -6.50145 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.4869 -8.60612 0.599999
+      vertex 27.0576 -8.79153 0.599999
+      vertex 26.6915 -9.84703 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0576 -8.79153 0.599999
+      vertex 26.4869 -8.60612 0.599999
+      vertex 26.8044 -7.55962 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1286 -9.63936 0.599999
+      vertex 26.6915 -9.84703 0.599999
+      vertex 26.2844 -10.8873 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6915 -9.84703 0.599999
+      vertex 26.1286 -9.63936 0.599999
+      vertex 26.4869 -8.60612 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.73 -10.6577 0.599999
+      vertex 26.2844 -10.8873 0.599999
+      vertex 25.8367 -11.9109 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.2844 -10.8873 0.599999
+      vertex 25.73 -10.6577 0.599999
+      vertex 26.1286 -9.63936 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.2918 -11.6597 0.599999
+      vertex 25.8367 -11.9109 0.599999
+      vertex 25.3491 -12.916 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.8367 -11.9109 0.599999
+      vertex 25.2918 -11.6597 0.599999
+      vertex 25.73 -10.6577 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8145 -12.6436 0.599999
+      vertex 25.3491 -12.916 0.599999
+      vertex 24.8225 -13.9013 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.3491 -12.916 0.599999
+      vertex 24.8145 -12.6436 0.599999
+      vertex 25.2918 -11.6597 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8225 -13.9013 0.599999
+      vertex 24.299 -13.6081 0.599999
+      vertex 24.8145 -12.6436 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.2576 -14.8651 0.599999
+      vertex 24.299 -13.6081 0.599999
+      vertex 24.8225 -13.9013 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.2576 -14.8651 0.599999
+      vertex 23.746 -14.5516 0.599999
+      vertex 24.299 -13.6081 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.6553 -15.806 0.599999
+      vertex 23.746 -14.5516 0.599999
+      vertex 24.2576 -14.8651 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.6553 -15.806 0.599999
+      vertex 23.1564 -15.4726 0.599999
+      vertex 23.746 -14.5516 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.0165 -16.7225 0.599999
+      vertex 23.1564 -15.4726 0.599999
+      vertex 23.6553 -15.806 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.0165 -16.7225 0.599999
+      vertex 22.5311 -16.3698 0.599999
+      vertex 23.1564 -15.4726 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.3423 -17.6132 0.599999
+      vertex 22.5311 -16.3698 0.599999
+      vertex 23.0165 -16.7225 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.3423 -17.6132 0.599999
+      vertex 21.8711 -17.2418 0.599999
+      vertex 22.5311 -16.3698 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.6335 -18.4768 0.599999
+      vertex 21.8711 -17.2418 0.599999
+      vertex 22.3423 -17.6132 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.6335 -18.4768 0.599999
+      vertex 21.1773 -18.0871 0.599999
+      vertex 21.8711 -17.2418 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.8915 -19.3119 0.599999
+      vertex 21.1773 -18.0871 0.599999
+      vertex 21.6335 -18.4768 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.8915 -19.3119 0.599999
+      vertex 20.4509 -18.9046 0.599999
+      vertex 21.1773 -18.0871 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1172 -20.1172 0.599999
+      vertex 20.4509 -18.9046 0.599999
+      vertex 20.8915 -19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1172 -20.1172 0.599999
+      vertex 19.6929 -19.6929 0.599999
+      vertex 20.4509 -18.9046 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3119 -20.8915 0.599999
+      vertex 19.6929 -19.6929 0.599999
+      vertex 20.1172 -20.1172 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3119 -20.8915 0.599999
+      vertex 18.9046 -20.4509 0.599999
+      vertex 19.6929 -19.6929 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.4768 -21.6335 0.599999
+      vertex 18.9046 -20.4509 0.599999
+      vertex 19.3119 -20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.4768 -21.6335 0.599999
+      vertex 18.0871 -21.1773 0.599999
+      vertex 18.9046 -20.4509 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.6132 -22.3423 0.599999
+      vertex 18.0871 -21.1773 0.599999
+      vertex 18.4768 -21.6335 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.6132 -22.3423 0.599999
+      vertex 17.2418 -21.8711 0.599999
+      vertex 18.0871 -21.1773 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.7225 -23.0165 0.599999
+      vertex 17.2418 -21.8711 0.599999
+      vertex 17.6132 -22.3423 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.7225 -23.0165 0.599999
+      vertex 16.3698 -22.5311 0.599999
+      vertex 17.2418 -21.8711 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.806 -23.6553 0.599999
+      vertex 16.3698 -22.5311 0.599999
+      vertex 16.7225 -23.0165 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.806 -23.6553 0.599999
+      vertex 15.4726 -23.1564 0.599999
+      vertex 16.3698 -22.5311 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8651 -24.2576 0.599999
+      vertex 15.4726 -23.1564 0.599999
+      vertex 15.806 -23.6553 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8651 -24.2576 0.599999
+      vertex 14.5516 -23.746 0.599999
+      vertex 15.4726 -23.1564 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.9013 -24.8225 0.599999
+      vertex 14.5516 -23.746 0.599999
+      vertex 14.8651 -24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.9013 -24.8225 0.599999
+      vertex 13.6081 -24.299 0.599999
+      vertex 14.5516 -23.746 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.916 -25.3491 0.599999
+      vertex 13.6081 -24.299 0.599999
+      vertex 13.9013 -24.8225 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.916 -25.3491 0.599999
+      vertex 12.6436 -24.8145 0.599999
+      vertex 13.6081 -24.299 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.9109 -25.8367 0.599999
+      vertex 12.6436 -24.8145 0.599999
+      vertex 12.916 -25.3491 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.9109 -25.8367 0.599999
+      vertex 11.6597 -25.2918 0.599999
+      vertex 12.6436 -24.8145 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.8873 -26.2844 0.599999
+      vertex 11.6597 -25.2918 0.599999
+      vertex 11.9109 -25.8367 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.8873 -26.2844 0.599999
+      vertex 10.6577 -25.73 0.599999
+      vertex 11.6597 -25.2918 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.84703 -26.6915 0.599999
+      vertex 10.6577 -25.73 0.599999
+      vertex 10.8873 -26.2844 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.84703 -26.6915 0.599999
+      vertex 9.63936 -26.1286 0.599999
+      vertex 10.6577 -25.73 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.79153 -27.0576 0.599999
+      vertex 9.63936 -26.1286 0.599999
+      vertex 9.84703 -26.6915 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.79153 -27.0576 0.599999
+      vertex 8.60612 -26.4869 0.599999
+      vertex 9.63936 -26.1286 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.72248 -27.3819 0.599999
+      vertex 8.60612 -26.4869 0.599999
+      vertex 8.79153 -27.0576 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.72248 -27.3819 0.599999
+      vertex 7.55962 -26.8044 0.599999
+      vertex 8.60612 -26.4869 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.64152 -27.6639 0.599999
+      vertex 7.55962 -26.8044 0.599999
+      vertex 7.72248 -27.3819 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.64152 -27.6639 0.599999
+      vertex 6.50145 -27.0805 0.599999
+      vertex 7.55962 -26.8044 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.55032 -27.9033 0.599999
+      vertex 6.50145 -27.0805 0.599999
+      vertex 6.64152 -27.6639 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.55032 -27.9033 0.599999
+      vertex 5.43326 -27.3149 0.599999
+      vertex 6.50145 -27.0805 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.45056 -28.0997 0.599999
+      vertex 5.43326 -27.3149 0.599999
+      vertex 5.55032 -27.9033 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.45056 -28.0997 0.599999
+      vertex 4.3567 -27.5071 0.599999
+      vertex 5.43326 -27.3149 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.34394 -28.2528 0.599999
+      vertex 4.3567 -27.5071 0.599999
+      vertex 4.45056 -28.0997 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.34394 -28.2528 0.599999
+      vertex 3.27342 -27.657 0.599999
+      vertex 4.3567 -27.5071 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.23216 -28.3623 0.599999
+      vertex 3.27342 -27.657 0.599999
+      vertex 3.34394 -28.2528 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.23216 -28.3623 0.599999
+      vertex 2.18509 -27.7641 0.599999
+      vertex 3.27342 -27.657 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.11694 -28.4281 0.599999
+      vertex 2.18509 -27.7641 0.599999
+      vertex 2.23216 -28.3623 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.11694 -28.4281 0.599999
+      vertex 1.09339 -27.8285 0.599999
+      vertex 2.18509 -27.7641 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -28.45 0.599999
+      vertex 1.09339 -27.8285 0.599999
+      vertex 1.11694 -28.4281 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -28.45 0.599999
+      vertex 0 -27.85 0.599999
+      vertex 1.09339 -27.8285 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -28.45 0.599999
+      vertex -1.09339 -27.8285 0.599999
+      vertex 0 -27.85 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.11694 -28.4281 0.599999
+      vertex -1.09339 -27.8285 0.599999
+      vertex 0 -28.45 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.11694 -28.4281 0.599999
+      vertex -2.18509 -27.7641 0.599999
+      vertex -1.09339 -27.8285 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.23216 -28.3623 0.599999
+      vertex -2.18509 -27.7641 0.599999
+      vertex -1.11694 -28.4281 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.23216 -28.3623 0.599999
+      vertex -3.27342 -27.657 0.599999
+      vertex -2.18509 -27.7641 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.34394 -28.2528 0.599999
+      vertex -3.27342 -27.657 0.599999
+      vertex -2.23216 -28.3623 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.34394 -28.2528 0.599999
+      vertex -4.3567 -27.5071 0.599999
+      vertex -3.27342 -27.657 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.45056 -28.0997 0.599999
+      vertex -4.3567 -27.5071 0.599999
+      vertex -3.34394 -28.2528 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.45056 -28.0997 0.599999
+      vertex -5.43326 -27.3149 0.599999
+      vertex -4.3567 -27.5071 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.55032 -27.9033 0.599999
+      vertex -5.43326 -27.3149 0.599999
+      vertex -4.45056 -28.0997 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.55032 -27.9033 0.599999
+      vertex -6.50145 -27.0805 0.599999
+      vertex -5.43326 -27.3149 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.64152 -27.6639 0.599999
+      vertex -6.50145 -27.0805 0.599999
+      vertex -5.55032 -27.9033 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.64152 -27.6639 0.599999
+      vertex -7.55962 -26.8044 0.599999
+      vertex -6.50145 -27.0805 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.72248 -27.3819 0.599999
+      vertex -7.55962 -26.8044 0.599999
+      vertex -6.64152 -27.6639 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.72248 -27.3819 0.599999
+      vertex -8.60612 -26.4869 0.599999
+      vertex -7.55962 -26.8044 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.79153 -27.0576 0.599999
+      vertex -8.60612 -26.4869 0.599999
+      vertex -7.72248 -27.3819 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.79153 -27.0576 0.599999
+      vertex -9.63936 -26.1286 0.599999
+      vertex -8.60612 -26.4869 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.84703 -26.6915 0.599999
+      vertex -9.63936 -26.1286 0.599999
+      vertex -8.79153 -27.0576 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.84703 -26.6915 0.599999
+      vertex -10.6577 -25.73 0.599999
+      vertex -9.63936 -26.1286 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.8873 -26.2844 0.599999
+      vertex -10.6577 -25.73 0.599999
+      vertex -9.84703 -26.6915 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.8873 -26.2844 0.599999
+      vertex -11.6597 -25.2918 0.599999
+      vertex -10.6577 -25.73 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.9109 -25.8367 0.599999
+      vertex -11.6597 -25.2918 0.599999
+      vertex -10.8873 -26.2844 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.9109 -25.8367 0.599999
+      vertex -12.6436 -24.8145 0.599999
+      vertex -11.6597 -25.2918 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.916 -25.3491 0.599999
+      vertex -12.6436 -24.8145 0.599999
+      vertex -11.9109 -25.8367 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.916 -25.3491 0.599999
+      vertex -13.6081 -24.299 0.599999
+      vertex -12.6436 -24.8145 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.9013 -24.8225 0.599999
+      vertex -13.6081 -24.299 0.599999
+      vertex -12.916 -25.3491 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.9013 -24.8225 0.599999
+      vertex -14.5516 -23.746 0.599999
+      vertex -13.6081 -24.299 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8651 -24.2576 0.599999
+      vertex -14.5516 -23.746 0.599999
+      vertex -13.9013 -24.8225 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8651 -24.2576 0.599999
+      vertex -15.4726 -23.1564 0.599999
+      vertex -14.5516 -23.746 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.806 -23.6553 0.599999
+      vertex -15.4726 -23.1564 0.599999
+      vertex -14.8651 -24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.806 -23.6553 0.599999
+      vertex -16.3698 -22.5311 0.599999
+      vertex -15.4726 -23.1564 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.7225 -23.0165 0.599999
+      vertex -16.3698 -22.5311 0.599999
+      vertex -15.806 -23.6553 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.7225 -23.0165 0.599999
+      vertex -17.2418 -21.8711 0.599999
+      vertex -16.3698 -22.5311 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.6132 -22.3423 0.599999
+      vertex -17.2418 -21.8711 0.599999
+      vertex -16.7225 -23.0165 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.6132 -22.3423 0.599999
+      vertex -18.0871 -21.1773 0.599999
+      vertex -17.2418 -21.8711 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.4768 -21.6335 0.599999
+      vertex -18.0871 -21.1773 0.599999
+      vertex -17.6132 -22.3423 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.4768 -21.6335 0.599999
+      vertex -18.9046 -20.4509 0.599999
+      vertex -18.0871 -21.1773 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3119 -20.8915 0.599999
+      vertex -18.9046 -20.4509 0.599999
+      vertex -18.4768 -21.6335 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3119 -20.8915 0.599999
+      vertex -19.6929 -19.6929 0.599999
+      vertex -18.9046 -20.4509 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1172 -20.1172 0.599999
+      vertex -19.6929 -19.6929 0.599999
+      vertex -19.3119 -20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1172 -20.1172 0.599999
+      vertex -20.4509 -18.9046 0.599999
+      vertex -19.6929 -19.6929 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.8915 -19.3119 0.599999
+      vertex -20.4509 -18.9046 0.599999
+      vertex -20.1172 -20.1172 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.8915 -19.3119 0.599999
+      vertex -21.1773 -18.0871 0.599999
+      vertex -20.4509 -18.9046 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.6335 -18.4768 0.599999
+      vertex -21.1773 -18.0871 0.599999
+      vertex -20.8915 -19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.6335 -18.4768 0.599999
+      vertex -21.8711 -17.2418 0.599999
+      vertex -21.1773 -18.0871 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.3423 -17.6132 0.599999
+      vertex -21.8711 -17.2418 0.599999
+      vertex -21.6335 -18.4768 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.3423 -17.6132 0.599999
+      vertex -22.5311 -16.3698 0.599999
+      vertex -21.8711 -17.2418 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.0165 -16.7225 0.599999
+      vertex -22.5311 -16.3698 0.599999
+      vertex -22.3423 -17.6132 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.0165 -16.7225 0.599999
+      vertex -23.1564 -15.4726 0.599999
+      vertex -22.5311 -16.3698 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.6553 -15.806 0.599999
+      vertex -23.1564 -15.4726 0.599999
+      vertex -23.0165 -16.7225 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.6553 -15.806 0.599999
+      vertex -23.746 -14.5516 0.599999
+      vertex -23.1564 -15.4726 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.2576 -14.8651 0.599999
+      vertex -23.746 -14.5516 0.599999
+      vertex -23.6553 -15.806 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.2576 -14.8651 0.599999
+      vertex -24.299 -13.6081 0.599999
+      vertex -23.746 -14.5516 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.8225 -13.9013 0.599999
+      vertex -24.299 -13.6081 0.599999
+      vertex -24.2576 -14.8651 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.299 -13.6081 0.599999
+      vertex -24.8225 -13.9013 0.599999
+      vertex -24.8145 -12.6436 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.3491 -12.916 0.599999
+      vertex -24.8145 -12.6436 0.599999
+      vertex -24.8225 -13.9013 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.8145 -12.6436 0.599999
+      vertex -25.3491 -12.916 0.599999
+      vertex -25.2918 -11.6597 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.8367 -11.9109 0.599999
+      vertex -25.2918 -11.6597 0.599999
+      vertex -25.3491 -12.916 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.2918 -11.6597 0.599999
+      vertex -25.8367 -11.9109 0.599999
+      vertex -25.73 -10.6577 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.2844 -10.8873 0.599999
+      vertex -25.73 -10.6577 0.599999
+      vertex -25.8367 -11.9109 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.73 -10.6577 0.599999
+      vertex -26.2844 -10.8873 0.599999
+      vertex -26.1286 -9.63936 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.6915 -9.84703 0.599999
+      vertex -26.1286 -9.63936 0.599999
+      vertex -26.2844 -10.8873 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.1286 -9.63936 0.599999
+      vertex -26.6915 -9.84703 0.599999
+      vertex -26.4869 -8.60612 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0576 -8.79153 0.599999
+      vertex -26.4869 -8.60612 0.599999
+      vertex -26.6915 -9.84703 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.4869 -8.60612 0.599999
+      vertex -27.0576 -8.79153 0.599999
+      vertex -26.8044 -7.55962 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.3819 -7.72248 0.599999
+      vertex -26.8044 -7.55962 0.599999
+      vertex -27.0576 -8.79153 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.8044 -7.55962 0.599999
+      vertex -27.3819 -7.72248 0.599999
+      vertex -27.0805 -6.50145 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6639 -6.64152 0.599999
+      vertex -27.0805 -6.50145 0.599999
+      vertex -27.3819 -7.72248 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.0805 -6.50145 0.599999
+      vertex -27.6639 -6.64152 0.599999
+      vertex -27.3149 -5.43326 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.9033 -5.55032 0.599999
+      vertex -27.3149 -5.43326 0.599999
+      vertex -27.6639 -6.64152 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.3149 -5.43326 0.599999
+      vertex -27.9033 -5.55032 0.599999
+      vertex -27.5071 -4.3567 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.0997 -4.45056 0.599999
+      vertex -27.5071 -4.3567 0.599999
+      vertex -27.9033 -5.55032 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.5071 -4.3567 0.599999
+      vertex -28.0997 -4.45056 0.599999
+      vertex -27.657 -3.27342 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.657 -3.27342 0.599999
+      vertex -28.2528 -3.34394 0.599999
+      vertex -27.7641 -2.18509 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.2528 -3.34394 0.599999
+      vertex -27.657 -3.27342 0.599999
+      vertex -28.0997 -4.45056 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.657 3.27342 0.599999
+      vertex 28.2528 3.34394 0.599999
+      vertex 27.7641 2.18509 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.2528 3.34394 0.599999
+      vertex 27.657 3.27342 0.599999
+      vertex 28.0997 4.45056 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.5071 4.3567 0.599999
+      vertex 28.0997 4.45056 0.599999
+      vertex 27.657 3.27342 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.0997 4.45056 0.599999
+      vertex 27.5071 4.3567 0.599999
+      vertex 27.9033 5.55032 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3149 5.43326 0.599999
+      vertex 27.9033 5.55032 0.599999
+      vertex 27.5071 4.3567 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 27.9033 5.55032 0.599999
+      vertex 27.3149 5.43326 0.599999
+      vertex 27.6639 6.64152 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0805 6.50145 0.599999
+      vertex 27.6639 6.64152 0.599999
+      vertex 27.3149 5.43326 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 27.6639 6.64152 0.599999
+      vertex 27.0805 6.50145 0.599999
+      vertex 27.3819 7.72248 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8044 7.55962 0.599999
+      vertex 27.3819 7.72248 0.599999
+      vertex 27.0805 6.50145 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 27.3819 7.72248 0.599999
+      vertex 26.8044 7.55962 0.599999
+      vertex 27.0576 8.79153 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.4869 8.60612 0.599999
+      vertex 27.0576 8.79153 0.599999
+      vertex 26.8044 7.55962 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 27.0576 8.79153 0.599999
+      vertex 26.4869 8.60612 0.599999
+      vertex 26.6915 9.84703 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1286 9.63936 0.599999
+      vertex 26.6915 9.84703 0.599999
+      vertex 26.4869 8.60612 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 26.6915 9.84703 0.599999
+      vertex 26.1286 9.63936 0.599999
+      vertex 26.2844 10.8873 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.73 10.6577 0.599999
+      vertex 26.2844 10.8873 0.599999
+      vertex 26.1286 9.63936 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 26.2844 10.8873 0.599999
+      vertex 25.73 10.6577 0.599999
+      vertex 25.8367 11.9109 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.2918 11.6597 0.599999
+      vertex 25.8367 11.9109 0.599999
+      vertex 25.73 10.6577 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 25.8367 11.9109 0.599999
+      vertex 25.2918 11.6597 0.599999
+      vertex 25.3491 12.916 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8145 12.6436 0.599999
+      vertex 25.3491 12.916 0.599999
+      vertex 25.2918 11.6597 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 25.3491 12.916 0.599999
+      vertex 24.8145 12.6436 0.599999
+      vertex 24.8225 13.9013 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.299 13.6081 0.599999
+      vertex 24.8225 13.9013 0.599999
+      vertex 24.8145 12.6436 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.299 13.6081 0.599999
+      vertex 24.2576 14.8651 0.599999
+      vertex 24.8225 13.9013 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.746 14.5516 0.599999
+      vertex 24.2576 14.8651 0.599999
+      vertex 24.299 13.6081 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.746 14.5516 0.599999
+      vertex 23.6553 15.806 0.599999
+      vertex 24.2576 14.8651 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.1564 15.4726 0.599999
+      vertex 23.6553 15.806 0.599999
+      vertex 23.746 14.5516 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.1564 15.4726 0.599999
+      vertex 23.0165 16.7225 0.599999
+      vertex 23.6553 15.806 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.5311 16.3698 0.599999
+      vertex 23.0165 16.7225 0.599999
+      vertex 23.1564 15.4726 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.5311 16.3698 0.599999
+      vertex 22.3423 17.6132 0.599999
+      vertex 23.0165 16.7225 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.8711 17.2418 0.599999
+      vertex 22.3423 17.6132 0.599999
+      vertex 22.5311 16.3698 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.8711 17.2418 0.599999
+      vertex 21.6335 18.4768 0.599999
+      vertex 22.3423 17.6132 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.1773 18.0871 0.599999
+      vertex 21.6335 18.4768 0.599999
+      vertex 21.8711 17.2418 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.1773 18.0871 0.599999
+      vertex 20.8915 19.3119 0.599999
+      vertex 21.6335 18.4768 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.4509 18.9046 0.599999
+      vertex 20.8915 19.3119 0.599999
+      vertex 21.1773 18.0871 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.4509 18.9046 0.599999
+      vertex 20.1172 20.1172 0.599999
+      vertex 20.8915 19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.6929 19.6929 0.599999
+      vertex 20.1172 20.1172 0.599999
+      vertex 20.4509 18.9046 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.6929 19.6929 0.599999
+      vertex 19.3119 20.8915 0.599999
+      vertex 20.1172 20.1172 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9046 20.4509 0.599999
+      vertex 19.3119 20.8915 0.599999
+      vertex 19.6929 19.6929 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9046 20.4509 0.599999
+      vertex 18.4768 21.6335 0.599999
+      vertex 19.3119 20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.0871 21.1773 0.599999
+      vertex 18.4768 21.6335 0.599999
+      vertex 18.9046 20.4509 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.0871 21.1773 0.599999
+      vertex 17.6132 22.3423 0.599999
+      vertex 18.4768 21.6335 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.2418 21.8711 0.599999
+      vertex 17.6132 22.3423 0.599999
+      vertex 18.0871 21.1773 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.2418 21.8711 0.599999
+      vertex 16.7225 23.0165 0.599999
+      vertex 17.6132 22.3423 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.3698 22.5311 0.599999
+      vertex 16.7225 23.0165 0.599999
+      vertex 17.2418 21.8711 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.3698 22.5311 0.599999
+      vertex 15.806 23.6553 0.599999
+      vertex 16.7225 23.0165 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4726 23.1564 0.599999
+      vertex 15.806 23.6553 0.599999
+      vertex 16.3698 22.5311 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4726 23.1564 0.599999
+      vertex 14.8651 24.2576 0.599999
+      vertex 15.806 23.6553 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.5516 23.746 0.599999
+      vertex 14.8651 24.2576 0.599999
+      vertex 15.4726 23.1564 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.5516 23.746 0.599999
+      vertex 13.9013 24.8225 0.599999
+      vertex 14.8651 24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6081 24.299 0.599999
+      vertex 13.9013 24.8225 0.599999
+      vertex 14.5516 23.746 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6081 24.299 0.599999
+      vertex 12.916 25.3491 0.599999
+      vertex 13.9013 24.8225 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6436 24.8145 0.599999
+      vertex 12.916 25.3491 0.599999
+      vertex 13.6081 24.299 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6436 24.8145 0.599999
+      vertex 11.9109 25.8367 0.599999
+      vertex 12.916 25.3491 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.6597 25.2918 0.599999
+      vertex 11.9109 25.8367 0.599999
+      vertex 12.6436 24.8145 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.6597 25.2918 0.599999
+      vertex 10.8873 26.2844 0.599999
+      vertex 11.9109 25.8367 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6577 25.73 0.599999
+      vertex 10.8873 26.2844 0.599999
+      vertex 11.6597 25.2918 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6577 25.73 0.599999
+      vertex 9.84703 26.6915 0.599999
+      vertex 10.8873 26.2844 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.63936 26.1286 0.599999
+      vertex 9.84703 26.6915 0.599999
+      vertex 10.6577 25.73 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.63936 26.1286 0.599999
+      vertex 8.79153 27.0576 0.599999
+      vertex 9.84703 26.6915 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.60612 26.4869 0.599999
+      vertex 8.79153 27.0576 0.599999
+      vertex 9.63936 26.1286 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.60612 26.4869 0.599999
+      vertex 7.72248 27.3819 0.599999
+      vertex 8.79153 27.0576 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.55962 26.8044 0.599999
+      vertex 7.72248 27.3819 0.599999
+      vertex 8.60612 26.4869 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.55962 26.8044 0.599999
+      vertex 6.64152 27.6639 0.599999
+      vertex 7.72248 27.3819 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.50145 27.0805 0.599999
+      vertex 6.64152 27.6639 0.599999
+      vertex 7.55962 26.8044 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.50145 27.0805 0.599999
+      vertex 5.55032 27.9033 0.599999
+      vertex 6.64152 27.6639 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.43326 27.3149 0.599999
+      vertex 5.55032 27.9033 0.599999
+      vertex 6.50145 27.0805 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.43326 27.3149 0.599999
+      vertex 4.45056 28.0997 0.599999
+      vertex 5.55032 27.9033 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.3567 27.5071 0.599999
+      vertex 4.45056 28.0997 0.599999
+      vertex 5.43326 27.3149 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.3567 27.5071 0.599999
+      vertex 3.34394 28.2528 0.599999
+      vertex 4.45056 28.0997 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.27342 27.657 0.599999
+      vertex 3.34394 28.2528 0.599999
+      vertex 4.3567 27.5071 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.27342 27.657 0.599999
+      vertex 2.23216 28.3623 0.599999
+      vertex 3.34394 28.2528 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.18509 27.7641 0.599999
+      vertex 2.23216 28.3623 0.599999
+      vertex 3.27342 27.657 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.18509 27.7641 0.599999
+      vertex 1.11694 28.4281 0.599999
+      vertex 2.23216 28.3623 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.09339 27.8285 0.599999
+      vertex 1.11694 28.4281 0.599999
+      vertex 2.18509 27.7641 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 27.85 0.599999
+      vertex 1.11694 28.4281 0.599999
+      vertex 1.09339 27.8285 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 27.85 0.599999
+      vertex 0 28.45 0.599999
+      vertex 1.11694 28.4281 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.09339 27.8285 0.599999
+      vertex 0 28.45 0.599999
+      vertex 0 27.85 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.09339 27.8285 0.599999
+      vertex -1.11694 28.4281 0.599999
+      vertex 0 28.45 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.18509 27.7641 0.599999
+      vertex -1.11694 28.4281 0.599999
+      vertex -1.09339 27.8285 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.18509 27.7641 0.599999
+      vertex -2.23216 28.3623 0.599999
+      vertex -1.11694 28.4281 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.27342 27.657 0.599999
+      vertex -2.23216 28.3623 0.599999
+      vertex -2.18509 27.7641 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.27342 27.657 0.599999
+      vertex -3.34394 28.2528 0.599999
+      vertex -2.23216 28.3623 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.3567 27.5071 0.599999
+      vertex -3.34394 28.2528 0.599999
+      vertex -3.27342 27.657 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.3567 27.5071 0.599999
+      vertex -4.45056 28.0997 0.599999
+      vertex -3.34394 28.2528 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.43326 27.3149 0.599999
+      vertex -4.45056 28.0997 0.599999
+      vertex -4.3567 27.5071 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.43326 27.3149 0.599999
+      vertex -5.55032 27.9033 0.599999
+      vertex -4.45056 28.0997 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.50145 27.0805 0.599999
+      vertex -5.55032 27.9033 0.599999
+      vertex -5.43326 27.3149 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.50145 27.0805 0.599999
+      vertex -6.64152 27.6639 0.599999
+      vertex -5.55032 27.9033 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.55962 26.8044 0.599999
+      vertex -6.64152 27.6639 0.599999
+      vertex -6.50145 27.0805 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.55962 26.8044 0.599999
+      vertex -7.72248 27.3819 0.599999
+      vertex -6.64152 27.6639 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.60612 26.4869 0.599999
+      vertex -7.72248 27.3819 0.599999
+      vertex -7.55962 26.8044 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.60612 26.4869 0.599999
+      vertex -8.79153 27.0576 0.599999
+      vertex -7.72248 27.3819 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.63936 26.1286 0.599999
+      vertex -8.79153 27.0576 0.599999
+      vertex -8.60612 26.4869 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.63936 26.1286 0.599999
+      vertex -9.84703 26.6915 0.599999
+      vertex -8.79153 27.0576 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6577 25.73 0.599999
+      vertex -9.84703 26.6915 0.599999
+      vertex -9.63936 26.1286 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6577 25.73 0.599999
+      vertex -10.8873 26.2844 0.599999
+      vertex -9.84703 26.6915 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.6597 25.2918 0.599999
+      vertex -10.8873 26.2844 0.599999
+      vertex -10.6577 25.73 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.6597 25.2918 0.599999
+      vertex -11.9109 25.8367 0.599999
+      vertex -10.8873 26.2844 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.6436 24.8145 0.599999
+      vertex -11.9109 25.8367 0.599999
+      vertex -11.6597 25.2918 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.6436 24.8145 0.599999
+      vertex -12.916 25.3491 0.599999
+      vertex -11.9109 25.8367 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.6081 24.299 0.599999
+      vertex -12.916 25.3491 0.599999
+      vertex -12.6436 24.8145 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.6081 24.299 0.599999
+      vertex -13.9013 24.8225 0.599999
+      vertex -12.916 25.3491 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.5516 23.746 0.599999
+      vertex -13.9013 24.8225 0.599999
+      vertex -13.6081 24.299 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.5516 23.746 0.599999
+      vertex -14.8651 24.2576 0.599999
+      vertex -13.9013 24.8225 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.4726 23.1564 0.599999
+      vertex -14.8651 24.2576 0.599999
+      vertex -14.5516 23.746 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.4726 23.1564 0.599999
+      vertex -15.806 23.6553 0.599999
+      vertex -14.8651 24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.3698 22.5311 0.599999
+      vertex -15.806 23.6553 0.599999
+      vertex -15.4726 23.1564 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.3698 22.5311 0.599999
+      vertex -16.7225 23.0165 0.599999
+      vertex -15.806 23.6553 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.2418 21.8711 0.599999
+      vertex -16.7225 23.0165 0.599999
+      vertex -16.3698 22.5311 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.2418 21.8711 0.599999
+      vertex -17.6132 22.3423 0.599999
+      vertex -16.7225 23.0165 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.0871 21.1773 0.599999
+      vertex -17.6132 22.3423 0.599999
+      vertex -17.2418 21.8711 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.0871 21.1773 0.599999
+      vertex -18.4768 21.6335 0.599999
+      vertex -17.6132 22.3423 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9046 20.4509 0.599999
+      vertex -18.4768 21.6335 0.599999
+      vertex -18.0871 21.1773 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9046 20.4509 0.599999
+      vertex -19.3119 20.8915 0.599999
+      vertex -18.4768 21.6335 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.6929 19.6929 0.599999
+      vertex -19.3119 20.8915 0.599999
+      vertex -18.9046 20.4509 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.6929 19.6929 0.599999
+      vertex -20.1172 20.1172 0.599999
+      vertex -19.3119 20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.4509 18.9046 0.599999
+      vertex -20.1172 20.1172 0.599999
+      vertex -19.6929 19.6929 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.4509 18.9046 0.599999
+      vertex -20.8915 19.3119 0.599999
+      vertex -20.1172 20.1172 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.1773 18.0871 0.599999
+      vertex -20.8915 19.3119 0.599999
+      vertex -20.4509 18.9046 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.1773 18.0871 0.599999
+      vertex -21.6335 18.4768 0.599999
+      vertex -20.8915 19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.8711 17.2418 0.599999
+      vertex -21.6335 18.4768 0.599999
+      vertex -21.1773 18.0871 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.8711 17.2418 0.599999
+      vertex -22.3423 17.6132 0.599999
+      vertex -21.6335 18.4768 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5311 16.3698 0.599999
+      vertex -22.3423 17.6132 0.599999
+      vertex -21.8711 17.2418 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5311 16.3698 0.599999
+      vertex -23.0165 16.7225 0.599999
+      vertex -22.3423 17.6132 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.1564 15.4726 0.599999
+      vertex -23.0165 16.7225 0.599999
+      vertex -22.5311 16.3698 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.1564 15.4726 0.599999
+      vertex -23.6553 15.806 0.599999
+      vertex -23.0165 16.7225 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.746 14.5516 0.599999
+      vertex -23.6553 15.806 0.599999
+      vertex -23.1564 15.4726 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.746 14.5516 0.599999
+      vertex -24.2576 14.8651 0.599999
+      vertex -23.6553 15.806 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.299 13.6081 0.599999
+      vertex -24.2576 14.8651 0.599999
+      vertex -23.746 14.5516 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.8225 13.9013 0.599999
+      vertex -24.299 13.6081 0.599999
+      vertex -24.8145 12.6436 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.299 13.6081 0.599999
+      vertex -24.8225 13.9013 0.599999
+      vertex -24.2576 14.8651 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.3491 12.916 0.599999
+      vertex -24.8145 12.6436 0.599999
+      vertex -25.2918 11.6597 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.8145 12.6436 0.599999
+      vertex -25.3491 12.916 0.599999
+      vertex -24.8225 13.9013 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.8367 11.9109 0.599999
+      vertex -25.2918 11.6597 0.599999
+      vertex -25.73 10.6577 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.2918 11.6597 0.599999
+      vertex -25.8367 11.9109 0.599999
+      vertex -25.3491 12.916 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.2844 10.8873 0.599999
+      vertex -25.73 10.6577 0.599999
+      vertex -26.1286 9.63936 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.73 10.6577 0.599999
+      vertex -26.2844 10.8873 0.599999
+      vertex -25.8367 11.9109 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.6915 9.84703 0.599999
+      vertex -26.1286 9.63936 0.599999
+      vertex -26.4869 8.60612 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.1286 9.63936 0.599999
+      vertex -26.6915 9.84703 0.599999
+      vertex -26.2844 10.8873 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0576 8.79153 0.599999
+      vertex -26.4869 8.60612 0.599999
+      vertex -26.8044 7.55962 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.4869 8.60612 0.599999
+      vertex -27.0576 8.79153 0.599999
+      vertex -26.6915 9.84703 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.3819 7.72248 0.599999
+      vertex -26.8044 7.55962 0.599999
+      vertex -27.0805 6.50145 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6639 6.64152 0.599999
+      vertex -27.0805 6.50145 0.599999
+      vertex -27.3149 5.43326 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.8044 7.55962 0.599999
+      vertex -27.3819 7.72248 0.599999
+      vertex -27.0576 8.79153 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.9033 5.55032 0.599999
+      vertex -27.3149 5.43326 0.599999
+      vertex -27.5071 4.3567 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.0997 4.45056 0.599999
+      vertex -27.5071 4.3567 0.599999
+      vertex -27.657 3.27342 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0805 6.50145 0.599999
+      vertex -27.6639 6.64152 0.599999
+      vertex -27.3819 7.72248 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.2528 3.34394 0.599999
+      vertex -27.657 3.27342 0.599999
+      vertex -27.7641 2.18509 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.3623 2.23216 0.599999
+      vertex -27.7641 2.18509 0.599999
+      vertex -27.8285 1.09339 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.3149 5.43326 0.599999
+      vertex -27.9033 5.55032 0.599999
+      vertex -27.6639 6.64152 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.4281 1.11694 0.599999
+      vertex -27.8285 1.09339 0.599999
+      vertex -27.85 0 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.3623 -2.23216 0.599999
+      vertex -27.7641 -2.18509 0.599999
+      vertex -28.2528 -3.34394 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.7641 -2.18509 0.599999
+      vertex -28.3623 -2.23216 0.599999
+      vertex -27.8285 -1.09339 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.5071 4.3567 0.599999
+      vertex -28.0997 4.45056 0.599999
+      vertex -27.9033 5.55032 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.4281 -1.11694 0.599999
+      vertex -27.8285 -1.09339 0.599999
+      vertex -28.3623 -2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.657 3.27342 0.599999
+      vertex -28.2528 3.34394 0.599999
+      vertex -28.0997 4.45056 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.8285 -1.09339 0.599999
+      vertex -28.4281 -1.11694 0.599999
+      vertex -27.85 0 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.7641 2.18509 0.599999
+      vertex -28.3623 2.23216 0.599999
+      vertex -28.2528 3.34394 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.45 0 0.599999
+      vertex -27.85 0 0.599999
+      vertex -28.4281 -1.11694 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.8285 1.09339 0.599999
+      vertex -28.4281 1.11694 0.599999
+      vertex -28.3623 2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.85 0 0.599999
+      vertex -28.45 0 0.599999
+      vertex -28.4281 1.11694 0.599999
+    endloop
+  endfacet
+  facet normal 0.603506 -0.797359 0
+    outer loop
+      vertex -17.2418 21.8711 0.599999
+      vertex -16.3698 22.5311 57.4
+      vertex -17.2418 21.8711 57.4
+    endloop
+  endfacet
+  facet normal 0.603506 -0.797359 0
+    outer loop
+      vertex -16.3698 22.5311 57.4
+      vertex -17.2418 21.8711 0.599999
+      vertex -16.3698 22.5311 0.599999
+    endloop
+  endfacet
+  facet normal 0.916216 -0.400685 0
+    outer loop
+      vertex -25.73 10.6577 57.4
+      vertex -25.2918 11.6597 0.599999
+      vertex -25.2918 11.6597 57.4
+    endloop
+  endfacet
+  facet normal 0.916216 -0.400685 0
+    outer loop
+      vertex -25.2918 11.6597 0.599999
+      vertex -25.73 10.6577 57.4
+      vertex -25.73 10.6577 0.599999
+    endloop
+  endfacet
+  facet normal 0.0196598 0.999807 -0
+    outer loop
+      vertex 0 -27.85 0.599999
+      vertex -1.09339 -27.8285 57.4
+      vertex 0 -27.85 57.4
+    endloop
+  endfacet
+  facet normal 0.0196598 0.999807 0
+    outer loop
+      vertex -1.09339 -27.8285 57.4
+      vertex 0 -27.85 0.599999
+      vertex -1.09339 -27.8285 0.599999
+    endloop
+  endfacet
+  facet normal -0.327633 0.944805 0
+    outer loop
+      vertex 9.63936 -26.1286 0.599999
+      vertex 8.60612 -26.4869 57.4
+      vertex 9.63936 -26.1286 57.4
+    endloop
+  endfacet
+  facet normal -0.327633 0.944805 0
+    outer loop
+      vertex 8.60612 -26.4869 57.4
+      vertex 9.63936 -26.1286 0.599999
+      vertex 8.60612 -26.4869 0.599999
+    endloop
+  endfacet
+  facet normal -0.400685 -0.916216 0
+    outer loop
+      vertex 10.6577 25.73 0.599999
+      vertex 11.6597 25.2918 57.4
+      vertex 10.6577 25.73 57.4
+    endloop
+  endfacet
+  facet normal -0.400685 -0.916216 -0
+    outer loop
+      vertex 11.6597 25.2918 57.4
+      vertex 10.6577 25.73 0.599999
+      vertex 11.6597 25.2918 0.599999
+    endloop
+  endfacet
+  facet normal -0.881935 -0.471371 0
+    outer loop
+      vertex 24.8145 12.6436 0.599999
+      vertex 24.299 13.6081 57.4
+      vertex 24.299 13.6081 0.599999
+    endloop
+  endfacet
+  facet normal -0.881935 -0.471371 0
+    outer loop
+      vertex 24.299 13.6081 57.4
+      vertex 24.8145 12.6436 0.599999
+      vertex 24.8145 12.6436 57.4
+    endloop
+  endfacet
+  facet normal -0.995193 0.0979346 0
+    outer loop
+      vertex 27.657 -3.27342 0.599999
+      vertex 27.7641 -2.18509 57.4
+      vertex 27.7641 -2.18509 0.599999
+    endloop
+  endfacet
+  facet normal -0.995193 0.0979346 0
+    outer loop
+      vertex 27.7641 -2.18509 57.4
+      vertex 27.657 -3.27342 0.599999
+      vertex 27.657 -3.27342 57.4
+    endloop
+  endfacet
+  facet normal -0.290325 -0.956928 0
+    outer loop
+      vertex 7.55962 26.8044 0.599999
+      vertex 8.60612 26.4869 57.4
+      vertex 7.55962 26.8044 57.4
+    endloop
+  endfacet
+  facet normal -0.290325 -0.956928 -0
+    outer loop
+      vertex 8.60612 26.4869 57.4
+      vertex 7.55962 26.8044 0.599999
+      vertex 8.60612 26.4869 0.599999
+    endloop
+  endfacet
+  facet normal 0.0979346 -0.995193 0
+    outer loop
+      vertex -3.27342 27.657 0.599999
+      vertex -2.18509 27.7641 57.4
+      vertex -3.27342 27.657 57.4
+    endloop
+  endfacet
+  facet normal 0.0979346 -0.995193 0
+    outer loop
+      vertex -2.18509 27.7641 57.4
+      vertex -3.27342 27.657 0.599999
+      vertex -2.18509 27.7641 0.599999
+    endloop
+  endfacet
+  facet normal -0.984434 0.175753 0
+    outer loop
+      vertex 27.3149 -5.43326 0.599999
+      vertex 27.5071 -4.3567 57.4
+      vertex 27.5071 -4.3567 0.599999
+    endloop
+  endfacet
+  facet normal -0.984434 0.175753 0
+    outer loop
+      vertex 27.5071 -4.3567 57.4
+      vertex 27.3149 -5.43326 0.599999
+      vertex 27.3149 -5.43326 57.4
+    endloop
+  endfacet
+  facet normal -0.400685 0.916216 0
+    outer loop
+      vertex 11.6597 -25.2918 0.599999
+      vertex 10.6577 -25.73 57.4
+      vertex 11.6597 -25.2918 57.4
+    endloop
+  endfacet
+  facet normal -0.400685 0.916216 0
+    outer loop
+      vertex 10.6577 -25.73 57.4
+      vertex 11.6597 -25.2918 0.599999
+      vertex 10.6577 -25.73 0.599999
+    endloop
+  endfacet
+  facet normal 0.327633 0.944805 -0
+    outer loop
+      vertex -8.60612 -26.4869 0.599999
+      vertex -9.63936 -26.1286 57.4
+      vertex -8.60612 -26.4869 57.4
+    endloop
+  endfacet
+  facet normal 0.327633 0.944805 0
+    outer loop
+      vertex -9.63936 -26.1286 57.4
+      vertex -8.60612 -26.4869 0.599999
+      vertex -9.63936 -26.1286 0.599999
+    endloop
+  endfacet
+  facet normal 0.944805 0.327633 0
+    outer loop
+      vertex -26.1286 -9.63936 57.4
+      vertex -26.4869 -8.60612 0.599999
+      vertex -26.4869 -8.60612 57.4
+    endloop
+  endfacet
+  facet normal 0.944805 0.327633 0
+    outer loop
+      vertex -26.4869 -8.60612 0.599999
+      vertex -26.1286 -9.63936 57.4
+      vertex -26.1286 -9.63936 0.599999
+    endloop
+  endfacet
+  facet normal -0.25247 0.967605 0
+    outer loop
+      vertex 7.55962 -26.8044 0.599999
+      vertex 6.50145 -27.0805 57.4
+      vertex 7.55962 -26.8044 57.4
+    endloop
+  endfacet
+  facet normal -0.25247 0.967605 0
+    outer loop
+      vertex 6.50145 -27.0805 57.4
+      vertex 7.55962 -26.8044 0.599999
+      vertex 6.50145 -27.0805 0.599999
+    endloop
+  endfacet
+  facet normal -0.984434 -0.175753 0
+    outer loop
+      vertex 27.5071 4.3567 0.599999
+      vertex 27.3149 5.43326 57.4
+      vertex 27.3149 5.43326 0.599999
+    endloop
+  endfacet
+  facet normal -0.984434 -0.175753 0
+    outer loop
+      vertex 27.3149 5.43326 57.4
+      vertex 27.5071 4.3567 0.599999
+      vertex 27.5071 4.3567 57.4
+    endloop
+  endfacet
+  facet normal -0.97676 -0.214337 0
+    outer loop
+      vertex 27.3149 5.43326 0.599999
+      vertex 27.0805 6.50145 57.4
+      vertex 27.0805 6.50145 0.599999
+    endloop
+  endfacet
+  facet normal -0.97676 -0.214337 0
+    outer loop
+      vertex 27.0805 6.50145 57.4
+      vertex 27.3149 5.43326 0.599999
+      vertex 27.3149 5.43326 57.4
+    endloop
+  endfacet
+  facet normal -0.693118 -0.720824 0
+    outer loop
+      vertex 18.9046 20.4509 0.599999
+      vertex 19.6929 19.6929 57.4
+      vertex 18.9046 20.4509 57.4
+    endloop
+  endfacet
+  facet normal -0.693118 -0.720824 -0
+    outer loop
+      vertex 19.6929 19.6929 57.4
+      vertex 18.9046 20.4509 0.599999
+      vertex 19.6929 19.6929 0.599999
+    endloop
+  endfacet
+  facet normal -0.956928 -0.290325 0
+    outer loop
+      vertex 26.8044 7.55962 0.599999
+      vertex 26.4869 8.60612 57.4
+      vertex 26.4869 8.60612 0.599999
+    endloop
+  endfacet
+  facet normal -0.956928 -0.290325 0
+    outer loop
+      vertex 26.4869 8.60612 57.4
+      vertex 26.8044 7.55962 0.599999
+      vertex 26.8044 7.55962 57.4
+    endloop
+  endfacet
+  facet normal 0.0588882 -0.998265 0
+    outer loop
+      vertex -2.18509 27.7641 0.599999
+      vertex -1.09339 27.8285 57.4
+      vertex -2.18509 27.7641 57.4
+    endloop
+  endfacet
+  facet normal 0.0588882 -0.998265 0
+    outer loop
+      vertex -1.09339 27.8285 57.4
+      vertex -2.18509 27.7641 0.599999
+      vertex -1.09339 27.8285 0.599999
+    endloop
+  endfacet
+  facet normal 0.214337 0.97676 -0
+    outer loop
+      vertex -5.43326 -27.3149 0.599999
+      vertex -6.50145 -27.0805 57.4
+      vertex -5.43326 -27.3149 57.4
+    endloop
+  endfacet
+  facet normal 0.214337 0.97676 0
+    outer loop
+      vertex -6.50145 -27.0805 57.4
+      vertex -5.43326 -27.3149 0.599999
+      vertex -6.50145 -27.0805 0.599999
+    endloop
+  endfacet
+  facet normal -0.0588882 0.998265 0
+    outer loop
+      vertex 2.18509 -27.7641 0.599999
+      vertex 1.09339 -27.8285 57.4
+      vertex 2.18509 -27.7641 57.4
+    endloop
+  endfacet
+  facet normal -0.0588882 0.998265 0
+    outer loop
+      vertex 1.09339 -27.8285 57.4
+      vertex 2.18509 -27.7641 0.599999
+      vertex 1.09339 -27.8285 0.599999
+    endloop
+  endfacet
+  facet normal -0.899722 0.436464 0
+    outer loop
+      vertex 24.8145 -12.6436 0.599999
+      vertex 25.2918 -11.6597 57.4
+      vertex 25.2918 -11.6597 0.599999
+    endloop
+  endfacet
+  facet normal -0.899722 0.436464 0
+    outer loop
+      vertex 25.2918 -11.6597 57.4
+      vertex 24.8145 -12.6436 0.599999
+      vertex 24.8145 -12.6436 57.4
+    endloop
+  endfacet
+  facet normal 0.995193 0.0979346 0
+    outer loop
+      vertex -27.657 -3.27342 57.4
+      vertex -27.7641 -2.18509 0.599999
+      vertex -27.7641 -2.18509 57.4
+    endloop
+  endfacet
+  facet normal 0.995193 0.0979346 0
+    outer loop
+      vertex -27.7641 -2.18509 0.599999
+      vertex -27.657 -3.27342 57.4
+      vertex -27.657 -3.27342 0.599999
+    endloop
+  endfacet
+  facet normal -0.436464 0.899722 0
+    outer loop
+      vertex 12.6436 -24.8145 0.599999
+      vertex 11.6597 -25.2918 57.4
+      vertex 12.6436 -24.8145 57.4
+    endloop
+  endfacet
+  facet normal -0.436464 0.899722 0
+    outer loop
+      vertex 11.6597 -25.2918 57.4
+      vertex 12.6436 -24.8145 0.599999
+      vertex 11.6597 -25.2918 0.599999
+    endloop
+  endfacet
+  facet normal 0.327633 -0.944805 0
+    outer loop
+      vertex -9.63936 26.1286 0.599999
+      vertex -8.60612 26.4869 57.4
+      vertex -9.63936 26.1286 57.4
+    endloop
+  endfacet
+  facet normal 0.327633 -0.944805 0
+    outer loop
+      vertex -8.60612 26.4869 57.4
+      vertex -9.63936 26.1286 0.599999
+      vertex -8.60612 26.4869 0.599999
+    endloop
+  endfacet
+  facet normal -0.820407 0.57178 0
+    outer loop
+      vertex 22.5311 -16.3698 0.599999
+      vertex 23.1564 -15.4726 57.4
+      vertex 23.1564 -15.4726 0.599999
+    endloop
+  endfacet
+  facet normal -0.820407 0.57178 0
+    outer loop
+      vertex 23.1564 -15.4726 57.4
+      vertex 22.5311 -16.3698 0.599999
+      vertex 22.5311 -16.3698 57.4
+    endloop
+  endfacet
+  facet normal -0.175753 0.984434 0
+    outer loop
+      vertex 5.43326 -27.3149 0.599999
+      vertex 4.3567 -27.5071 57.4
+      vertex 5.43326 -27.3149 57.4
+    endloop
+  endfacet
+  facet normal -0.175753 0.984434 0
+    outer loop
+      vertex 4.3567 -27.5071 57.4
+      vertex 5.43326 -27.3149 0.599999
+      vertex 4.3567 -27.5071 0.599999
+    endloop
+  endfacet
+  facet normal 0.175753 0.984434 -0
+    outer loop
+      vertex -4.3567 -27.5071 0.599999
+      vertex -5.43326 -27.3149 57.4
+      vertex -4.3567 -27.5071 57.4
+    endloop
+  endfacet
+  facet normal 0.175753 0.984434 0
+    outer loop
+      vertex -5.43326 -27.3149 57.4
+      vertex -4.3567 -27.5071 0.599999
+      vertex -5.43326 -27.3149 0.599999
+    endloop
+  endfacet
+  facet normal -0.57178 -0.820407 0
+    outer loop
+      vertex 15.4726 23.1564 0.599999
+      vertex 16.3698 22.5311 57.4
+      vertex 15.4726 23.1564 57.4
+    endloop
+  endfacet
+  facet normal -0.57178 -0.820407 -0
+    outer loop
+      vertex 16.3698 22.5311 57.4
+      vertex 15.4726 23.1564 0.599999
+      vertex 16.3698 22.5311 0.599999
+    endloop
+  endfacet
+  facet normal -0.25247 -0.967605 0
+    outer loop
+      vertex 6.50145 27.0805 0.599999
+      vertex 7.55962 26.8044 57.4
+      vertex 6.50145 27.0805 57.4
+    endloop
+  endfacet
+  facet normal -0.25247 -0.967605 -0
+    outer loop
+      vertex 7.55962 26.8044 57.4
+      vertex 6.50145 27.0805 0.599999
+      vertex 7.55962 26.8044 0.599999
+    endloop
+  endfacet
+  facet normal -0.13707 -0.990561 0
+    outer loop
+      vertex 3.27342 27.657 0.599999
+      vertex 4.3567 27.5071 57.4
+      vertex 3.27342 27.657 57.4
+    endloop
+  endfacet
+  facet normal -0.13707 -0.990561 -0
+    outer loop
+      vertex 4.3567 27.5071 57.4
+      vertex 3.27342 27.657 0.599999
+      vertex 4.3567 27.5071 0.599999
+    endloop
+  endfacet
+  facet normal 0.13707 -0.990561 0
+    outer loop
+      vertex -4.3567 27.5071 0.599999
+      vertex -3.27342 27.657 57.4
+      vertex -4.3567 27.5071 57.4
+    endloop
+  endfacet
+  facet normal 0.13707 -0.990561 0
+    outer loop
+      vertex -3.27342 27.657 57.4
+      vertex -4.3567 27.5071 0.599999
+      vertex -3.27342 27.657 0.599999
+    endloop
+  endfacet
+  facet normal -0.0979346 0.995193 0
+    outer loop
+      vertex 3.27342 -27.657 0.599999
+      vertex 2.18509 -27.7641 57.4
+      vertex 3.27342 -27.657 57.4
+    endloop
+  endfacet
+  facet normal -0.0979346 0.995193 0
+    outer loop
+      vertex 2.18509 -27.7641 57.4
+      vertex 3.27342 -27.657 0.599999
+      vertex 2.18509 -27.7641 0.599999
+    endloop
+  endfacet
+  facet normal -0.990561 0.13707 0
+    outer loop
+      vertex 27.5071 -4.3567 0.599999
+      vertex 27.657 -3.27342 57.4
+      vertex 27.657 -3.27342 0.599999
+    endloop
+  endfacet
+  facet normal -0.990561 0.13707 0
+    outer loop
+      vertex 27.657 -3.27342 57.4
+      vertex 27.5071 -4.3567 0.599999
+      vertex 27.5071 -4.3567 57.4
+    endloop
+  endfacet
+  facet normal -0.842205 0.539157 0
+    outer loop
+      vertex 23.1564 -15.4726 0.599999
+      vertex 23.746 -14.5516 57.4
+      vertex 23.746 -14.5516 0.599999
+    endloop
+  endfacet
+  facet normal -0.842205 0.539157 0
+    outer loop
+      vertex 23.746 -14.5516 57.4
+      vertex 23.1564 -15.4726 0.599999
+      vertex 23.1564 -15.4726 57.4
+    endloop
+  endfacet
+  facet normal -0.664228 -0.74753 0
+    outer loop
+      vertex 18.0871 21.1773 0.599999
+      vertex 18.9046 20.4509 57.4
+      vertex 18.0871 21.1773 57.4
+    endloop
+  endfacet
+  facet normal -0.664228 -0.74753 -0
+    outer loop
+      vertex 18.9046 20.4509 57.4
+      vertex 18.0871 21.1773 0.599999
+      vertex 18.9046 20.4509 0.599999
+    endloop
+  endfacet
+  facet normal 0.364494 0.931206 -0
+    outer loop
+      vertex -9.63936 -26.1286 0.599999
+      vertex -10.6577 -25.73 57.4
+      vertex -9.63936 -26.1286 57.4
+    endloop
+  endfacet
+  facet normal 0.364494 0.931206 0
+    outer loop
+      vertex -10.6577 -25.73 57.4
+      vertex -9.63936 -26.1286 0.599999
+      vertex -10.6577 -25.73 0.599999
+    endloop
+  endfacet
+  facet normal -0.998265 0.0588882 0
+    outer loop
+      vertex 27.7641 -2.18509 0.599999
+      vertex 27.8285 -1.09339 57.4
+      vertex 27.8285 -1.09339 0.599999
+    endloop
+  endfacet
+  facet normal -0.998265 0.0588882 0
+    outer loop
+      vertex 27.8285 -1.09339 57.4
+      vertex 27.7641 -2.18509 0.599999
+      vertex 27.7641 -2.18509 57.4
+    endloop
+  endfacet
+  facet normal -0.999807 0.0196598 0
+    outer loop
+      vertex 27.8285 -1.09339 0.599999
+      vertex 27.85 0 57.4
+      vertex 27.85 0 0.599999
+    endloop
+  endfacet
+  facet normal -0.999807 0.0196598 0
+    outer loop
+      vertex 27.85 0 57.4
+      vertex 27.8285 -1.09339 0.599999
+      vertex 27.8285 -1.09339 57.4
+    endloop
+  endfacet
+  facet normal -0.720824 0.693118 0
+    outer loop
+      vertex 19.6929 -19.6929 0.599999
+      vertex 20.4509 -18.9046 57.4
+      vertex 20.4509 -18.9046 0.599999
+    endloop
+  endfacet
+  facet normal -0.720824 0.693118 0
+    outer loop
+      vertex 20.4509 -18.9046 57.4
+      vertex 19.6929 -19.6929 0.599999
+      vertex 19.6929 -19.6929 57.4
+    endloop
+  endfacet
+  facet normal 0.436464 0.899722 -0
+    outer loop
+      vertex -11.6597 -25.2918 0.599999
+      vertex -12.6436 -24.8145 57.4
+      vertex -11.6597 -25.2918 57.4
+    endloop
+  endfacet
+  facet normal 0.436464 0.899722 0
+    outer loop
+      vertex -12.6436 -24.8145 57.4
+      vertex -11.6597 -25.2918 0.599999
+      vertex -12.6436 -24.8145 0.599999
+    endloop
+  endfacet
+  facet normal -0.967605 -0.25247 0
+    outer loop
+      vertex 27.0805 6.50145 0.599999
+      vertex 26.8044 7.55962 57.4
+      vertex 26.8044 7.55962 0.599999
+    endloop
+  endfacet
+  facet normal -0.967605 -0.25247 0
+    outer loop
+      vertex 26.8044 7.55962 57.4
+      vertex 27.0805 6.50145 0.599999
+      vertex 27.0805 6.50145 57.4
+    endloop
+  endfacet
+  facet normal 0.990561 0.13707 0
+    outer loop
+      vertex -27.5071 -4.3567 57.4
+      vertex -27.657 -3.27342 0.599999
+      vertex -27.657 -3.27342 57.4
+    endloop
+  endfacet
+  facet normal 0.990561 0.13707 0
+    outer loop
+      vertex -27.657 -3.27342 0.599999
+      vertex -27.5071 -4.3567 57.4
+      vertex -27.5071 -4.3567 0.599999
+    endloop
+  endfacet
+  facet normal 0.995193 -0.0979346 0
+    outer loop
+      vertex -27.7641 2.18509 57.4
+      vertex -27.657 3.27342 0.599999
+      vertex -27.657 3.27342 57.4
+    endloop
+  endfacet
+  facet normal 0.995193 -0.0979346 0
+    outer loop
+      vertex -27.657 3.27342 0.599999
+      vertex -27.7641 2.18509 57.4
+      vertex -27.7641 2.18509 0.599999
+    endloop
+  endfacet
+  facet normal -0.772974 0.634437 0
+    outer loop
+      vertex 21.1773 -18.0871 0.599999
+      vertex 21.8711 -17.2418 57.4
+      vertex 21.8711 -17.2418 0.599999
+    endloop
+  endfacet
+  facet normal -0.772974 0.634437 0
+    outer loop
+      vertex 21.8711 -17.2418 57.4
+      vertex 21.1773 -18.0871 0.599999
+      vertex 21.1773 -18.0871 57.4
+    endloop
+  endfacet
+  facet normal 0.634437 0.772974 -0
+    outer loop
+      vertex -17.2418 -21.8711 0.599999
+      vertex -18.0871 -21.1773 57.4
+      vertex -17.2418 -21.8711 57.4
+    endloop
+  endfacet
+  facet normal 0.634437 0.772974 0
+    outer loop
+      vertex -18.0871 -21.1773 57.4
+      vertex -17.2418 -21.8711 0.599999
+      vertex -18.0871 -21.1773 0.599999
+    endloop
+  endfacet
+  facet normal -0.57178 0.820407 0
+    outer loop
+      vertex 16.3698 -22.5311 0.599999
+      vertex 15.4726 -23.1564 57.4
+      vertex 16.3698 -22.5311 57.4
+    endloop
+  endfacet
+  facet normal -0.57178 0.820407 0
+    outer loop
+      vertex 15.4726 -23.1564 57.4
+      vertex 16.3698 -22.5311 0.599999
+      vertex 15.4726 -23.1564 0.599999
+    endloop
+  endfacet
+  facet normal 0.862732 0.505661 0
+    outer loop
+      vertex -23.746 -14.5516 57.4
+      vertex -24.299 -13.6081 0.599999
+      vertex -24.299 -13.6081 57.4
+    endloop
+  endfacet
+  facet normal 0.862732 0.505661 0
+    outer loop
+      vertex -24.299 -13.6081 0.599999
+      vertex -23.746 -14.5516 57.4
+      vertex -23.746 -14.5516 0.599999
+    endloop
+  endfacet
+  facet normal 0.944805 -0.327633 0
+    outer loop
+      vertex -26.4869 8.60612 57.4
+      vertex -26.1286 9.63936 0.599999
+      vertex -26.1286 9.63936 57.4
+    endloop
+  endfacet
+  facet normal 0.944805 -0.327633 0
+    outer loop
+      vertex -26.1286 9.63936 0.599999
+      vertex -26.4869 8.60612 57.4
+      vertex -26.4869 8.60612 0.599999
+    endloop
+  endfacet
+  facet normal 0.634437 -0.772974 0
+    outer loop
+      vertex -18.0871 21.1773 0.599999
+      vertex -17.2418 21.8711 57.4
+      vertex -18.0871 21.1773 57.4
+    endloop
+  endfacet
+  facet normal 0.634437 -0.772974 0
+    outer loop
+      vertex -17.2418 21.8711 57.4
+      vertex -18.0871 21.1773 0.599999
+      vertex -17.2418 21.8711 0.599999
+    endloop
+  endfacet
+  facet normal -0.603506 0.797359 0
+    outer loop
+      vertex 17.2418 -21.8711 0.599999
+      vertex 16.3698 -22.5311 57.4
+      vertex 17.2418 -21.8711 57.4
+    endloop
+  endfacet
+  facet normal -0.603506 0.797359 0
+    outer loop
+      vertex 16.3698 -22.5311 57.4
+      vertex 17.2418 -21.8711 0.599999
+      vertex 16.3698 -22.5311 0.599999
+    endloop
+  endfacet
+  facet normal -0.327633 -0.944805 0
+    outer loop
+      vertex 8.60612 26.4869 0.599999
+      vertex 9.63936 26.1286 57.4
+      vertex 8.60612 26.4869 57.4
+    endloop
+  endfacet
+  facet normal -0.327633 -0.944805 -0
+    outer loop
+      vertex 9.63936 26.1286 57.4
+      vertex 8.60612 26.4869 0.599999
+      vertex 9.63936 26.1286 0.599999
+    endloop
+  endfacet
+  facet normal 0.797359 0.603506 0
+    outer loop
+      vertex -21.8711 -17.2418 57.4
+      vertex -22.5311 -16.3698 0.599999
+      vertex -22.5311 -16.3698 57.4
+    endloop
+  endfacet
+  facet normal 0.797359 0.603506 0
+    outer loop
+      vertex -22.5311 -16.3698 0.599999
+      vertex -21.8711 -17.2418 57.4
+      vertex -21.8711 -17.2418 0.599999
+    endloop
+  endfacet
+  facet normal 0.471371 -0.881935 0
+    outer loop
+      vertex -13.6081 24.299 0.599999
+      vertex -12.6436 24.8145 57.4
+      vertex -13.6081 24.299 57.4
+    endloop
+  endfacet
+  facet normal 0.471371 -0.881935 0
+    outer loop
+      vertex -12.6436 24.8145 57.4
+      vertex -13.6081 24.299 0.599999
+      vertex -12.6436 24.8145 0.599999
+    endloop
+  endfacet
+  facet normal 0.505661 -0.862732 0
+    outer loop
+      vertex -14.5516 23.746 0.599999
+      vertex -13.6081 24.299 57.4
+      vertex -14.5516 23.746 57.4
+    endloop
+  endfacet
+  facet normal 0.505661 -0.862732 0
+    outer loop
+      vertex -13.6081 24.299 57.4
+      vertex -14.5516 23.746 0.599999
+      vertex -13.6081 24.299 0.599999
+    endloop
+  endfacet
+  facet normal -0.603506 -0.797359 0
+    outer loop
+      vertex 16.3698 22.5311 0.599999
+      vertex 17.2418 21.8711 57.4
+      vertex 16.3698 22.5311 57.4
+    endloop
+  endfacet
+  facet normal -0.603506 -0.797359 -0
+    outer loop
+      vertex 17.2418 21.8711 57.4
+      vertex 16.3698 22.5311 0.599999
+      vertex 17.2418 21.8711 0.599999
+    endloop
+  endfacet
+  facet normal -0.539157 -0.842205 0
+    outer loop
+      vertex 14.5516 23.746 0.599999
+      vertex 15.4726 23.1564 57.4
+      vertex 14.5516 23.746 57.4
+    endloop
+  endfacet
+  facet normal -0.539157 -0.842205 -0
+    outer loop
+      vertex 15.4726 23.1564 57.4
+      vertex 14.5516 23.746 0.599999
+      vertex 15.4726 23.1564 0.599999
+    endloop
+  endfacet
+  facet normal -0.0196598 0.999807 0
+    outer loop
+      vertex 1.09339 -27.8285 0.599999
+      vertex 0 -27.85 57.4
+      vertex 1.09339 -27.8285 57.4
+    endloop
+  endfacet
+  facet normal -0.0196598 0.999807 0
+    outer loop
+      vertex 0 -27.85 57.4
+      vertex 1.09339 -27.8285 0.599999
+      vertex 0 -27.85 0.599999
+    endloop
+  endfacet
+  facet normal 0.999807 0.0196598 0
+    outer loop
+      vertex -27.8285 -1.09339 57.4
+      vertex -27.85 0 0.599999
+      vertex -27.85 0 57.4
+    endloop
+  endfacet
+  facet normal 0.999807 0.0196598 0
+    outer loop
+      vertex -27.85 0 0.599999
+      vertex -27.8285 -1.09339 57.4
+      vertex -27.8285 -1.09339 0.599999
+    endloop
+  endfacet
+  facet normal 0.931206 -0.364494 0
+    outer loop
+      vertex -26.1286 9.63936 57.4
+      vertex -25.73 10.6577 0.599999
+      vertex -25.73 10.6577 57.4
+    endloop
+  endfacet
+  facet normal 0.931206 -0.364494 0
+    outer loop
+      vertex -25.73 10.6577 0.599999
+      vertex -26.1286 9.63936 57.4
+      vertex -26.1286 9.63936 0.599999
+    endloop
+  endfacet
+  facet normal 0.664228 0.74753 -0
+    outer loop
+      vertex -18.0871 -21.1773 0.599999
+      vertex -18.9046 -20.4509 57.4
+      vertex -18.0871 -21.1773 57.4
+    endloop
+  endfacet
+  facet normal 0.664228 0.74753 0
+    outer loop
+      vertex -18.9046 -20.4509 57.4
+      vertex -18.0871 -21.1773 0.599999
+      vertex -18.9046 -20.4509 0.599999
+    endloop
+  endfacet
+  facet normal 0.97676 0.214337 0
+    outer loop
+      vertex -27.0805 -6.50145 57.4
+      vertex -27.3149 -5.43326 0.599999
+      vertex -27.3149 -5.43326 57.4
+    endloop
+  endfacet
+  facet normal 0.97676 0.214337 0
+    outer loop
+      vertex -27.3149 -5.43326 0.599999
+      vertex -27.0805 -6.50145 57.4
+      vertex -27.0805 -6.50145 0.599999
+    endloop
+  endfacet
+  facet normal 0.720824 -0.693118 0
+    outer loop
+      vertex -20.4509 18.9046 57.4
+      vertex -19.6929 19.6929 0.599999
+      vertex -19.6929 19.6929 57.4
+    endloop
+  endfacet
+  facet normal 0.720824 -0.693118 0
+    outer loop
+      vertex -19.6929 19.6929 0.599999
+      vertex -20.4509 18.9046 57.4
+      vertex -20.4509 18.9046 0.599999
+    endloop
+  endfacet
+  facet normal 0.214337 -0.97676 0
+    outer loop
+      vertex -6.50145 27.0805 0.599999
+      vertex -5.43326 27.3149 57.4
+      vertex -6.50145 27.0805 57.4
+    endloop
+  endfacet
+  facet normal 0.214337 -0.97676 0
+    outer loop
+      vertex -5.43326 27.3149 57.4
+      vertex -6.50145 27.0805 0.599999
+      vertex -5.43326 27.3149 0.599999
+    endloop
+  endfacet
+  facet normal -0.956928 0.290325 0
+    outer loop
+      vertex 26.4869 -8.60612 0.599999
+      vertex 26.8044 -7.55962 57.4
+      vertex 26.8044 -7.55962 0.599999
+    endloop
+  endfacet
+  facet normal -0.956928 0.290325 0
+    outer loop
+      vertex 26.8044 -7.55962 57.4
+      vertex 26.4869 -8.60612 0.599999
+      vertex 26.4869 -8.60612 57.4
+    endloop
+  endfacet
+  facet normal -0.862732 -0.505661 0
+    outer loop
+      vertex 24.299 13.6081 0.599999
+      vertex 23.746 14.5516 57.4
+      vertex 23.746 14.5516 0.599999
+    endloop
+  endfacet
+  facet normal -0.862732 -0.505661 0
+    outer loop
+      vertex 23.746 14.5516 57.4
+      vertex 24.299 13.6081 0.599999
+      vertex 24.299 13.6081 57.4
+    endloop
+  endfacet
+  facet normal 0.720824 0.693118 0
+    outer loop
+      vertex -19.6929 -19.6929 57.4
+      vertex -20.4509 -18.9046 0.599999
+      vertex -20.4509 -18.9046 57.4
+    endloop
+  endfacet
+  facet normal 0.720824 0.693118 0
+    outer loop
+      vertex -20.4509 -18.9046 0.599999
+      vertex -19.6929 -19.6929 57.4
+      vertex -19.6929 -19.6929 0.599999
+    endloop
+  endfacet
+  facet normal 0.693118 -0.720824 0
+    outer loop
+      vertex -19.6929 19.6929 0.599999
+      vertex -18.9046 20.4509 57.4
+      vertex -19.6929 19.6929 57.4
+    endloop
+  endfacet
+  facet normal 0.693118 -0.720824 0
+    outer loop
+      vertex -18.9046 20.4509 57.4
+      vertex -19.6929 19.6929 0.599999
+      vertex -18.9046 20.4509 0.599999
+    endloop
+  endfacet
+  facet normal 0.664228 -0.74753 0
+    outer loop
+      vertex -18.9046 20.4509 0.599999
+      vertex -18.0871 21.1773 57.4
+      vertex -18.9046 20.4509 57.4
+    endloop
+  endfacet
+  facet normal 0.664228 -0.74753 0
+    outer loop
+      vertex -18.0871 21.1773 57.4
+      vertex -18.9046 20.4509 0.599999
+      vertex -18.0871 21.1773 0.599999
+    endloop
+  endfacet
+  facet normal 0.175753 -0.984434 0
+    outer loop
+      vertex -5.43326 27.3149 0.599999
+      vertex -4.3567 27.5071 57.4
+      vertex -5.43326 27.3149 57.4
+    endloop
+  endfacet
+  facet normal 0.175753 -0.984434 0
+    outer loop
+      vertex -4.3567 27.5071 57.4
+      vertex -5.43326 27.3149 0.599999
+      vertex -4.3567 27.5071 0.599999
+    endloop
+  endfacet
+  facet normal -0.471371 -0.881935 0
+    outer loop
+      vertex 12.6436 24.8145 0.599999
+      vertex 13.6081 24.299 57.4
+      vertex 12.6436 24.8145 57.4
+    endloop
+  endfacet
+  facet normal -0.471371 -0.881935 -0
+    outer loop
+      vertex 13.6081 24.299 57.4
+      vertex 12.6436 24.8145 0.599999
+      vertex 13.6081 24.299 0.599999
+    endloop
+  endfacet
+  facet normal -0.944805 0.327633 0
+    outer loop
+      vertex 26.1286 -9.63936 0.599999
+      vertex 26.4869 -8.60612 57.4
+      vertex 26.4869 -8.60612 0.599999
+    endloop
+  endfacet
+  facet normal -0.944805 0.327633 0
+    outer loop
+      vertex 26.4869 -8.60612 57.4
+      vertex 26.1286 -9.63936 0.599999
+      vertex 26.1286 -9.63936 57.4
+    endloop
+  endfacet
+  facet normal -0.931206 -0.364494 0
+    outer loop
+      vertex 26.1286 9.63936 0.599999
+      vertex 25.73 10.6577 57.4
+      vertex 25.73 10.6577 0.599999
+    endloop
+  endfacet
+  facet normal -0.931206 -0.364494 0
+    outer loop
+      vertex 25.73 10.6577 57.4
+      vertex 26.1286 9.63936 0.599999
+      vertex 26.1286 9.63936 57.4
+    endloop
+  endfacet
+  facet normal -0.931206 0.364494 0
+    outer loop
+      vertex 25.73 -10.6577 0.599999
+      vertex 26.1286 -9.63936 57.4
+      vertex 26.1286 -9.63936 0.599999
+    endloop
+  endfacet
+  facet normal -0.931206 0.364494 0
+    outer loop
+      vertex 26.1286 -9.63936 57.4
+      vertex 25.73 -10.6577 0.599999
+      vertex 25.73 -10.6577 57.4
+    endloop
+  endfacet
+  facet normal -0.539157 0.842205 0
+    outer loop
+      vertex 15.4726 -23.1564 0.599999
+      vertex 14.5516 -23.746 57.4
+      vertex 15.4726 -23.1564 57.4
+    endloop
+  endfacet
+  facet normal -0.539157 0.842205 0
+    outer loop
+      vertex 14.5516 -23.746 57.4
+      vertex 15.4726 -23.1564 0.599999
+      vertex 14.5516 -23.746 0.599999
+    endloop
+  endfacet
+  facet normal -0.720824 -0.693118 0
+    outer loop
+      vertex 20.4509 18.9046 0.599999
+      vertex 19.6929 19.6929 57.4
+      vertex 19.6929 19.6929 0.599999
+    endloop
+  endfacet
+  facet normal -0.720824 -0.693118 0
+    outer loop
+      vertex 19.6929 19.6929 57.4
+      vertex 20.4509 18.9046 0.599999
+      vertex 20.4509 18.9046 57.4
+    endloop
+  endfacet
+  facet normal -0.505661 -0.862732 0
+    outer loop
+      vertex 13.6081 24.299 0.599999
+      vertex 14.5516 23.746 57.4
+      vertex 13.6081 24.299 57.4
+    endloop
+  endfacet
+  facet normal -0.505661 -0.862732 -0
+    outer loop
+      vertex 14.5516 23.746 57.4
+      vertex 13.6081 24.299 0.599999
+      vertex 14.5516 23.746 0.599999
+    endloop
+  endfacet
+  facet normal -0.175753 -0.984434 0
+    outer loop
+      vertex 4.3567 27.5071 0.599999
+      vertex 5.43326 27.3149 57.4
+      vertex 4.3567 27.5071 57.4
+    endloop
+  endfacet
+  facet normal -0.175753 -0.984434 -0
+    outer loop
+      vertex 5.43326 27.3149 57.4
+      vertex 4.3567 27.5071 0.599999
+      vertex 5.43326 27.3149 0.599999
+    endloop
+  endfacet
+  facet normal 0.97676 -0.214337 0
+    outer loop
+      vertex -27.3149 5.43326 57.4
+      vertex -27.0805 6.50145 0.599999
+      vertex -27.0805 6.50145 57.4
+    endloop
+  endfacet
+  facet normal 0.97676 -0.214337 0
+    outer loop
+      vertex -27.0805 6.50145 0.599999
+      vertex -27.3149 5.43326 57.4
+      vertex -27.3149 5.43326 0.599999
+    endloop
+  endfacet
+  facet normal 0.984434 0.175753 0
+    outer loop
+      vertex -27.3149 -5.43326 57.4
+      vertex -27.5071 -4.3567 0.599999
+      vertex -27.5071 -4.3567 57.4
+    endloop
+  endfacet
+  facet normal 0.984434 0.175753 0
+    outer loop
+      vertex -27.5071 -4.3567 0.599999
+      vertex -27.3149 -5.43326 57.4
+      vertex -27.3149 -5.43326 0.599999
+    endloop
+  endfacet
+  facet normal -0.916216 -0.400685 0
+    outer loop
+      vertex 25.73 10.6577 0.599999
+      vertex 25.2918 11.6597 57.4
+      vertex 25.2918 11.6597 0.599999
+    endloop
+  endfacet
+  facet normal -0.916216 -0.400685 0
+    outer loop
+      vertex 25.2918 11.6597 57.4
+      vertex 25.73 10.6577 0.599999
+      vertex 25.73 10.6577 57.4
+    endloop
+  endfacet
+  facet normal -0.214337 0.97676 0
+    outer loop
+      vertex 6.50145 -27.0805 0.599999
+      vertex 5.43326 -27.3149 57.4
+      vertex 6.50145 -27.0805 57.4
+    endloop
+  endfacet
+  facet normal -0.214337 0.97676 0
+    outer loop
+      vertex 5.43326 -27.3149 57.4
+      vertex 6.50145 -27.0805 0.599999
+      vertex 5.43326 -27.3149 0.599999
+    endloop
+  endfacet
+  facet normal 0.916216 0.400685 0
+    outer loop
+      vertex -25.2918 -11.6597 57.4
+      vertex -25.73 -10.6577 0.599999
+      vertex -25.73 -10.6577 57.4
+    endloop
+  endfacet
+  facet normal 0.916216 0.400685 0
+    outer loop
+      vertex -25.73 -10.6577 0.599999
+      vertex -25.2918 -11.6597 57.4
+      vertex -25.2918 -11.6597 0.599999
+    endloop
+  endfacet
+  facet normal -0.862732 0.505661 0
+    outer loop
+      vertex 23.746 -14.5516 0.599999
+      vertex 24.299 -13.6081 57.4
+      vertex 24.299 -13.6081 0.599999
+    endloop
+  endfacet
+  facet normal -0.862732 0.505661 0
+    outer loop
+      vertex 24.299 -13.6081 57.4
+      vertex 23.746 -14.5516 0.599999
+      vertex 23.746 -14.5516 57.4
+    endloop
+  endfacet
+  facet normal 0.57178 -0.820407 0
+    outer loop
+      vertex -16.3698 22.5311 0.599999
+      vertex -15.4726 23.1564 57.4
+      vertex -16.3698 22.5311 57.4
+    endloop
+  endfacet
+  facet normal 0.57178 -0.820407 0
+    outer loop
+      vertex -15.4726 23.1564 57.4
+      vertex -16.3698 22.5311 0.599999
+      vertex -15.4726 23.1564 0.599999
+    endloop
+  endfacet
+  facet normal -0.944805 -0.327633 0
+    outer loop
+      vertex 26.4869 8.60612 0.599999
+      vertex 26.1286 9.63936 57.4
+      vertex 26.1286 9.63936 0.599999
+    endloop
+  endfacet
+  facet normal -0.944805 -0.327633 0
+    outer loop
+      vertex 26.1286 9.63936 57.4
+      vertex 26.4869 8.60612 0.599999
+      vertex 26.4869 8.60612 57.4
+    endloop
+  endfacet
+  facet normal -0.842205 -0.539157 0
+    outer loop
+      vertex 23.746 14.5516 0.599999
+      vertex 23.1564 15.4726 57.4
+      vertex 23.1564 15.4726 0.599999
+    endloop
+  endfacet
+  facet normal -0.842205 -0.539157 0
+    outer loop
+      vertex 23.1564 15.4726 57.4
+      vertex 23.746 14.5516 0.599999
+      vertex 23.746 14.5516 57.4
+    endloop
+  endfacet
+  facet normal 0.967605 -0.25247 0
+    outer loop
+      vertex -27.0805 6.50145 57.4
+      vertex -26.8044 7.55962 0.599999
+      vertex -26.8044 7.55962 57.4
+    endloop
+  endfacet
+  facet normal 0.967605 -0.25247 0
+    outer loop
+      vertex -26.8044 7.55962 0.599999
+      vertex -27.0805 6.50145 57.4
+      vertex -27.0805 6.50145 0.599999
+    endloop
+  endfacet
+  facet normal 0.13707 0.990561 -0
+    outer loop
+      vertex -3.27342 -27.657 0.599999
+      vertex -4.3567 -27.5071 57.4
+      vertex -3.27342 -27.657 57.4
+    endloop
+  endfacet
+  facet normal 0.13707 0.990561 0
+    outer loop
+      vertex -4.3567 -27.5071 57.4
+      vertex -3.27342 -27.657 0.599999
+      vertex -4.3567 -27.5071 0.599999
+    endloop
+  endfacet
+  facet normal -0.436464 -0.899722 0
+    outer loop
+      vertex 11.6597 25.2918 0.599999
+      vertex 12.6436 24.8145 57.4
+      vertex 11.6597 25.2918 57.4
+    endloop
+  endfacet
+  facet normal -0.436464 -0.899722 -0
+    outer loop
+      vertex 12.6436 24.8145 57.4
+      vertex 11.6597 25.2918 0.599999
+      vertex 12.6436 24.8145 0.599999
+    endloop
+  endfacet
+  facet normal -0.0196598 -0.999807 0
+    outer loop
+      vertex 0 27.85 0.599999
+      vertex 1.09339 27.8285 57.4
+      vertex 0 27.85 57.4
+    endloop
+  endfacet
+  facet normal -0.0196598 -0.999807 -0
+    outer loop
+      vertex 1.09339 27.8285 57.4
+      vertex 0 27.85 0.599999
+      vertex 1.09339 27.8285 0.599999
+    endloop
+  endfacet
+  facet normal 0.0196598 -0.999807 0
+    outer loop
+      vertex -1.09339 27.8285 0.599999
+      vertex 0 27.85 57.4
+      vertex -1.09339 27.8285 57.4
+    endloop
+  endfacet
+  facet normal 0.0196598 -0.999807 0
+    outer loop
+      vertex 0 27.85 57.4
+      vertex -1.09339 27.8285 0.599999
+      vertex 0 27.85 0.599999
+    endloop
+  endfacet
+  facet normal 0.842205 0.539157 0
+    outer loop
+      vertex -23.1564 -15.4726 57.4
+      vertex -23.746 -14.5516 0.599999
+      vertex -23.746 -14.5516 57.4
+    endloop
+  endfacet
+  facet normal 0.842205 0.539157 0
+    outer loop
+      vertex -23.746 -14.5516 0.599999
+      vertex -23.1564 -15.4726 57.4
+      vertex -23.1564 -15.4726 0.599999
+    endloop
+  endfacet
+  facet normal -0.634437 0.772974 0
+    outer loop
+      vertex 18.0871 -21.1773 0.599999
+      vertex 17.2418 -21.8711 57.4
+      vertex 18.0871 -21.1773 57.4
+    endloop
+  endfacet
+  facet normal -0.634437 0.772974 0
+    outer loop
+      vertex 17.2418 -21.8711 57.4
+      vertex 18.0871 -21.1773 0.599999
+      vertex 17.2418 -21.8711 0.599999
+    endloop
+  endfacet
+  facet normal 0.881935 -0.471371 0
+    outer loop
+      vertex -24.8145 12.6436 57.4
+      vertex -24.299 13.6081 0.599999
+      vertex -24.299 13.6081 57.4
+    endloop
+  endfacet
+  facet normal 0.881935 -0.471371 0
+    outer loop
+      vertex -24.299 13.6081 0.599999
+      vertex -24.8145 12.6436 57.4
+      vertex -24.8145 12.6436 0.599999
+    endloop
+  endfacet
+  facet normal 0.0588882 0.998265 -0
+    outer loop
+      vertex -1.09339 -27.8285 0.599999
+      vertex -2.18509 -27.7641 57.4
+      vertex -1.09339 -27.8285 57.4
+    endloop
+  endfacet
+  facet normal 0.0588882 0.998265 0
+    outer loop
+      vertex -2.18509 -27.7641 57.4
+      vertex -1.09339 -27.8285 0.599999
+      vertex -2.18509 -27.7641 0.599999
+    endloop
+  endfacet
+  facet normal 0.998265 0.0588882 0
+    outer loop
+      vertex -27.7641 -2.18509 57.4
+      vertex -27.8285 -1.09339 0.599999
+      vertex -27.8285 -1.09339 57.4
+    endloop
+  endfacet
+  facet normal 0.998265 0.0588882 0
+    outer loop
+      vertex -27.8285 -1.09339 0.599999
+      vertex -27.7641 -2.18509 57.4
+      vertex -27.7641 -2.18509 0.599999
+    endloop
+  endfacet
+  facet normal 0.25247 -0.967605 0
+    outer loop
+      vertex -7.55962 26.8044 0.599999
+      vertex -6.50145 27.0805 57.4
+      vertex -7.55962 26.8044 57.4
+    endloop
+  endfacet
+  facet normal 0.25247 -0.967605 0
+    outer loop
+      vertex -6.50145 27.0805 57.4
+      vertex -7.55962 26.8044 0.599999
+      vertex -6.50145 27.0805 0.599999
+    endloop
+  endfacet
+  facet normal 0.984434 -0.175753 0
+    outer loop
+      vertex -27.5071 4.3567 57.4
+      vertex -27.3149 5.43326 0.599999
+      vertex -27.3149 5.43326 57.4
+    endloop
+  endfacet
+  facet normal 0.984434 -0.175753 0
+    outer loop
+      vertex -27.3149 5.43326 0.599999
+      vertex -27.5071 4.3567 57.4
+      vertex -27.5071 4.3567 0.599999
+    endloop
+  endfacet
+  facet normal 0.990561 -0.13707 0
+    outer loop
+      vertex -27.657 3.27342 57.4
+      vertex -27.5071 4.3567 0.599999
+      vertex -27.5071 4.3567 57.4
+    endloop
+  endfacet
+  facet normal 0.990561 -0.13707 0
+    outer loop
+      vertex -27.5071 4.3567 0.599999
+      vertex -27.657 3.27342 57.4
+      vertex -27.657 3.27342 0.599999
+    endloop
+  endfacet
+  facet normal 0.74753 0.664228 0
+    outer loop
+      vertex -20.4509 -18.9046 57.4
+      vertex -21.1773 -18.0871 0.599999
+      vertex -21.1773 -18.0871 57.4
+    endloop
+  endfacet
+  facet normal 0.74753 0.664228 0
+    outer loop
+      vertex -21.1773 -18.0871 0.599999
+      vertex -20.4509 -18.9046 57.4
+      vertex -20.4509 -18.9046 0.599999
+    endloop
+  endfacet
+  facet normal 0.290325 -0.956928 0
+    outer loop
+      vertex -8.60612 26.4869 0.599999
+      vertex -7.55962 26.8044 57.4
+      vertex -8.60612 26.4869 57.4
+    endloop
+  endfacet
+  facet normal 0.290325 -0.956928 0
+    outer loop
+      vertex -7.55962 26.8044 57.4
+      vertex -8.60612 26.4869 0.599999
+      vertex -7.55962 26.8044 0.599999
+    endloop
+  endfacet
+  facet normal -0.290325 0.956928 0
+    outer loop
+      vertex 8.60612 -26.4869 0.599999
+      vertex 7.55962 -26.8044 57.4
+      vertex 8.60612 -26.4869 57.4
+    endloop
+  endfacet
+  facet normal -0.290325 0.956928 0
+    outer loop
+      vertex 7.55962 -26.8044 57.4
+      vertex 8.60612 -26.4869 0.599999
+      vertex 7.55962 -26.8044 0.599999
+    endloop
+  endfacet
+  facet normal 0.0979346 0.995193 -0
+    outer loop
+      vertex -2.18509 -27.7641 0.599999
+      vertex -3.27342 -27.657 57.4
+      vertex -2.18509 -27.7641 57.4
+    endloop
+  endfacet
+  facet normal 0.0979346 0.995193 0
+    outer loop
+      vertex -3.27342 -27.657 57.4
+      vertex -2.18509 -27.7641 0.599999
+      vertex -3.27342 -27.657 0.599999
+    endloop
+  endfacet
+  facet normal 0.539157 0.842205 -0
+    outer loop
+      vertex -14.5516 -23.746 0.599999
+      vertex -15.4726 -23.1564 57.4
+      vertex -14.5516 -23.746 57.4
+    endloop
+  endfacet
+  facet normal 0.539157 0.842205 0
+    outer loop
+      vertex -15.4726 -23.1564 57.4
+      vertex -14.5516 -23.746 0.599999
+      vertex -15.4726 -23.1564 0.599999
+    endloop
+  endfacet
+  facet normal -0.693118 0.720824 0
+    outer loop
+      vertex 19.6929 -19.6929 0.599999
+      vertex 18.9046 -20.4509 57.4
+      vertex 19.6929 -19.6929 57.4
+    endloop
+  endfacet
+  facet normal -0.693118 0.720824 0
+    outer loop
+      vertex 18.9046 -20.4509 57.4
+      vertex 19.6929 -19.6929 0.599999
+      vertex 18.9046 -20.4509 0.599999
+    endloop
+  endfacet
+  facet normal 0.471371 0.881935 -0
+    outer loop
+      vertex -12.6436 -24.8145 0.599999
+      vertex -13.6081 -24.299 57.4
+      vertex -12.6436 -24.8145 57.4
+    endloop
+  endfacet
+  facet normal 0.471371 0.881935 0
+    outer loop
+      vertex -13.6081 -24.299 57.4
+      vertex -12.6436 -24.8145 0.599999
+      vertex -13.6081 -24.299 0.599999
+    endloop
+  endfacet
+  facet normal -0.0588882 -0.998265 0
+    outer loop
+      vertex 1.09339 27.8285 0.599999
+      vertex 2.18509 27.7641 57.4
+      vertex 1.09339 27.8285 57.4
+    endloop
+  endfacet
+  facet normal -0.0588882 -0.998265 -0
+    outer loop
+      vertex 2.18509 27.7641 57.4
+      vertex 1.09339 27.8285 0.599999
+      vertex 2.18509 27.7641 0.599999
+    endloop
+  endfacet
+  facet normal 0.539157 -0.842205 0
+    outer loop
+      vertex -15.4726 23.1564 0.599999
+      vertex -14.5516 23.746 57.4
+      vertex -15.4726 23.1564 57.4
+    endloop
+  endfacet
+  facet normal 0.539157 -0.842205 0
+    outer loop
+      vertex -14.5516 23.746 57.4
+      vertex -15.4726 23.1564 0.599999
+      vertex -14.5516 23.746 0.599999
+    endloop
+  endfacet
+  facet normal 0.820407 -0.57178 0
+    outer loop
+      vertex -23.1564 15.4726 57.4
+      vertex -22.5311 16.3698 0.599999
+      vertex -22.5311 16.3698 57.4
+    endloop
+  endfacet
+  facet normal 0.820407 -0.57178 0
+    outer loop
+      vertex -22.5311 16.3698 0.599999
+      vertex -23.1564 15.4726 57.4
+      vertex -23.1564 15.4726 0.599999
+    endloop
+  endfacet
+  facet normal -0.967605 0.25247 0
+    outer loop
+      vertex 26.8044 -7.55962 0.599999
+      vertex 27.0805 -6.50145 57.4
+      vertex 27.0805 -6.50145 0.599999
+    endloop
+  endfacet
+  facet normal -0.967605 0.25247 0
+    outer loop
+      vertex 27.0805 -6.50145 57.4
+      vertex 26.8044 -7.55962 0.599999
+      vertex 26.8044 -7.55962 57.4
+    endloop
+  endfacet
+  facet normal -0.74753 -0.664228 0
+    outer loop
+      vertex 21.1773 18.0871 0.599999
+      vertex 20.4509 18.9046 57.4
+      vertex 20.4509 18.9046 0.599999
+    endloop
+  endfacet
+  facet normal -0.74753 -0.664228 0
+    outer loop
+      vertex 20.4509 18.9046 57.4
+      vertex 21.1773 18.0871 0.599999
+      vertex 21.1773 18.0871 57.4
+    endloop
+  endfacet
+  facet normal 0.862732 -0.505661 0
+    outer loop
+      vertex -24.299 13.6081 57.4
+      vertex -23.746 14.5516 0.599999
+      vertex -23.746 14.5516 57.4
+    endloop
+  endfacet
+  facet normal 0.862732 -0.505661 0
+    outer loop
+      vertex -23.746 14.5516 0.599999
+      vertex -24.299 13.6081 57.4
+      vertex -24.299 13.6081 0.599999
+    endloop
+  endfacet
+  facet normal 0.364494 -0.931206 0
+    outer loop
+      vertex -10.6577 25.73 0.599999
+      vertex -9.63936 26.1286 57.4
+      vertex -10.6577 25.73 57.4
+    endloop
+  endfacet
+  facet normal 0.364494 -0.931206 0
+    outer loop
+      vertex -9.63936 26.1286 57.4
+      vertex -10.6577 25.73 0.599999
+      vertex -9.63936 26.1286 0.599999
+    endloop
+  endfacet
+  facet normal 0.797359 -0.603506 0
+    outer loop
+      vertex -22.5311 16.3698 57.4
+      vertex -21.8711 17.2418 0.599999
+      vertex -21.8711 17.2418 57.4
+    endloop
+  endfacet
+  facet normal 0.797359 -0.603506 0
+    outer loop
+      vertex -21.8711 17.2418 0.599999
+      vertex -22.5311 16.3698 57.4
+      vertex -22.5311 16.3698 0.599999
+    endloop
+  endfacet
+  facet normal 0.956928 0.290325 0
+    outer loop
+      vertex -26.4869 -8.60612 57.4
+      vertex -26.8044 -7.55962 0.599999
+      vertex -26.8044 -7.55962 57.4
+    endloop
+  endfacet
+  facet normal 0.956928 0.290325 0
+    outer loop
+      vertex -26.8044 -7.55962 0.599999
+      vertex -26.4869 -8.60612 57.4
+      vertex -26.4869 -8.60612 0.599999
+    endloop
+  endfacet
+  facet normal 0.956928 -0.290325 0
+    outer loop
+      vertex -26.8044 7.55962 57.4
+      vertex -26.4869 8.60612 0.599999
+      vertex -26.4869 8.60612 57.4
+    endloop
+  endfacet
+  facet normal 0.956928 -0.290325 0
+    outer loop
+      vertex -26.4869 8.60612 0.599999
+      vertex -26.8044 7.55962 57.4
+      vertex -26.8044 7.55962 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.85 0 57.4
+      vertex 28.45 0 57.4
+      vertex 28.4281 1.11694 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.8285 1.09339 57.4
+      vertex 28.4281 1.11694 57.4
+      vertex 28.3623 2.23216 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.45 0 57.4
+      vertex 27.85 0 57.4
+      vertex 28.4281 -1.11694 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.7641 2.18509 57.4
+      vertex 28.3623 2.23216 57.4
+      vertex 28.2528 3.34394 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.8285 -1.09339 57.4
+      vertex 28.4281 -1.11694 57.4
+      vertex 27.85 0 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.657 3.27342 57.4
+      vertex 28.2528 3.34394 57.4
+      vertex 28.0997 4.45056 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.4281 -1.11694 57.4
+      vertex 27.8285 -1.09339 57.4
+      vertex 28.3623 -2.23216 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.5071 4.3567 57.4
+      vertex 28.0997 4.45056 57.4
+      vertex 27.9033 5.55032 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.7641 -2.18509 57.4
+      vertex 28.3623 -2.23216 57.4
+      vertex 27.8285 -1.09339 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.3623 -2.23216 57.4
+      vertex 27.7641 -2.18509 57.4
+      vertex 28.2528 -3.34394 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.4281 1.11694 57.4
+      vertex 27.8285 1.09339 57.4
+      vertex 27.85 0 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.3623 2.23216 57.4
+      vertex 27.7641 2.18509 57.4
+      vertex 27.8285 1.09339 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.3149 5.43326 57.4
+      vertex 27.9033 5.55032 57.4
+      vertex 27.6639 6.64152 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.2528 3.34394 57.4
+      vertex 27.657 3.27342 57.4
+      vertex 27.7641 2.18509 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.0997 4.45056 57.4
+      vertex 27.5071 4.3567 57.4
+      vertex 27.657 3.27342 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.0805 6.50145 57.4
+      vertex 27.6639 6.64152 57.4
+      vertex 27.3819 7.72248 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.9033 5.55032 57.4
+      vertex 27.3149 5.43326 57.4
+      vertex 27.5071 4.3567 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.6639 6.64152 57.4
+      vertex 27.0805 6.50145 57.4
+      vertex 27.3149 5.43326 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.8044 7.55962 57.4
+      vertex 27.3819 7.72248 57.4
+      vertex 27.0576 8.79153 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.3819 7.72248 57.4
+      vertex 26.8044 7.55962 57.4
+      vertex 27.0805 6.50145 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.4869 8.60612 57.4
+      vertex 27.0576 8.79153 57.4
+      vertex 26.6915 9.84703 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.0576 8.79153 57.4
+      vertex 26.4869 8.60612 57.4
+      vertex 26.8044 7.55962 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.1286 9.63936 57.4
+      vertex 26.6915 9.84703 57.4
+      vertex 26.2844 10.8873 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6915 9.84703 57.4
+      vertex 26.1286 9.63936 57.4
+      vertex 26.4869 8.60612 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.73 10.6577 57.4
+      vertex 26.2844 10.8873 57.4
+      vertex 25.8367 11.9109 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.2844 10.8873 57.4
+      vertex 25.73 10.6577 57.4
+      vertex 26.1286 9.63936 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.2918 11.6597 57.4
+      vertex 25.8367 11.9109 57.4
+      vertex 25.3491 12.916 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.8367 11.9109 57.4
+      vertex 25.2918 11.6597 57.4
+      vertex 25.73 10.6577 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8145 12.6436 57.4
+      vertex 25.3491 12.916 57.4
+      vertex 24.8225 13.9013 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.3491 12.916 57.4
+      vertex 24.8145 12.6436 57.4
+      vertex 25.2918 11.6597 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8225 13.9013 57.4
+      vertex 24.299 13.6081 57.4
+      vertex 24.8145 12.6436 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.2576 14.8651 57.4
+      vertex 24.299 13.6081 57.4
+      vertex 24.8225 13.9013 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.2576 14.8651 57.4
+      vertex 23.746 14.5516 57.4
+      vertex 24.299 13.6081 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.6553 15.806 57.4
+      vertex 23.746 14.5516 57.4
+      vertex 24.2576 14.8651 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.6553 15.806 57.4
+      vertex 23.1564 15.4726 57.4
+      vertex 23.746 14.5516 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.0165 16.7225 57.4
+      vertex 23.1564 15.4726 57.4
+      vertex 23.6553 15.806 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.0165 16.7225 57.4
+      vertex 22.5311 16.3698 57.4
+      vertex 23.1564 15.4726 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.3423 17.6132 57.4
+      vertex 22.5311 16.3698 57.4
+      vertex 23.0165 16.7225 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.3423 17.6132 57.4
+      vertex 21.8711 17.2418 57.4
+      vertex 22.5311 16.3698 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.6335 18.4768 57.4
+      vertex 21.8711 17.2418 57.4
+      vertex 22.3423 17.6132 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.6335 18.4768 57.4
+      vertex 21.1773 18.0871 57.4
+      vertex 21.8711 17.2418 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8915 19.3119 57.4
+      vertex 21.1773 18.0871 57.4
+      vertex 21.6335 18.4768 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8915 19.3119 57.4
+      vertex 20.4509 18.9046 57.4
+      vertex 21.1773 18.0871 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1172 20.1172 57.4
+      vertex 20.4509 18.9046 57.4
+      vertex 20.8915 19.3119 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1172 20.1172 57.4
+      vertex 19.6929 19.6929 57.4
+      vertex 20.4509 18.9046 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3119 20.8915 57.4
+      vertex 19.6929 19.6929 57.4
+      vertex 20.1172 20.1172 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3119 20.8915 57.4
+      vertex 18.9046 20.4509 57.4
+      vertex 19.6929 19.6929 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.4768 21.6335 57.4
+      vertex 18.9046 20.4509 57.4
+      vertex 19.3119 20.8915 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.4768 21.6335 57.4
+      vertex 18.0871 21.1773 57.4
+      vertex 18.9046 20.4509 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6132 22.3423 57.4
+      vertex 18.0871 21.1773 57.4
+      vertex 18.4768 21.6335 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6132 22.3423 57.4
+      vertex 17.2418 21.8711 57.4
+      vertex 18.0871 21.1773 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.7225 23.0165 57.4
+      vertex 17.2418 21.8711 57.4
+      vertex 17.6132 22.3423 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.7225 23.0165 57.4
+      vertex 16.3698 22.5311 57.4
+      vertex 17.2418 21.8711 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.806 23.6553 57.4
+      vertex 16.3698 22.5311 57.4
+      vertex 16.7225 23.0165 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.806 23.6553 57.4
+      vertex 15.4726 23.1564 57.4
+      vertex 16.3698 22.5311 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8651 24.2576 57.4
+      vertex 15.4726 23.1564 57.4
+      vertex 15.806 23.6553 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8651 24.2576 57.4
+      vertex 14.5516 23.746 57.4
+      vertex 15.4726 23.1564 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.9013 24.8225 57.4
+      vertex 14.5516 23.746 57.4
+      vertex 14.8651 24.2576 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.9013 24.8225 57.4
+      vertex 13.6081 24.299 57.4
+      vertex 14.5516 23.746 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.916 25.3491 57.4
+      vertex 13.6081 24.299 57.4
+      vertex 13.9013 24.8225 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.916 25.3491 57.4
+      vertex 12.6436 24.8145 57.4
+      vertex 13.6081 24.299 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.9109 25.8367 57.4
+      vertex 12.6436 24.8145 57.4
+      vertex 12.916 25.3491 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.9109 25.8367 57.4
+      vertex 11.6597 25.2918 57.4
+      vertex 12.6436 24.8145 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.8873 26.2844 57.4
+      vertex 11.6597 25.2918 57.4
+      vertex 11.9109 25.8367 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.8873 26.2844 57.4
+      vertex 10.6577 25.73 57.4
+      vertex 11.6597 25.2918 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.84703 26.6915 57.4
+      vertex 10.6577 25.73 57.4
+      vertex 10.8873 26.2844 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.84703 26.6915 57.4
+      vertex 9.63936 26.1286 57.4
+      vertex 10.6577 25.73 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.79153 27.0576 57.4
+      vertex 9.63936 26.1286 57.4
+      vertex 9.84703 26.6915 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.79153 27.0576 57.4
+      vertex 8.60612 26.4869 57.4
+      vertex 9.63936 26.1286 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.72248 27.3819 57.4
+      vertex 8.60612 26.4869 57.4
+      vertex 8.79153 27.0576 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.72248 27.3819 57.4
+      vertex 7.55962 26.8044 57.4
+      vertex 8.60612 26.4869 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.64152 27.6639 57.4
+      vertex 7.55962 26.8044 57.4
+      vertex 7.72248 27.3819 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.64152 27.6639 57.4
+      vertex 6.50145 27.0805 57.4
+      vertex 7.55962 26.8044 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.55032 27.9033 57.4
+      vertex 6.50145 27.0805 57.4
+      vertex 6.64152 27.6639 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.55032 27.9033 57.4
+      vertex 5.43326 27.3149 57.4
+      vertex 6.50145 27.0805 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.45056 28.0997 57.4
+      vertex 5.43326 27.3149 57.4
+      vertex 5.55032 27.9033 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.45056 28.0997 57.4
+      vertex 4.3567 27.5071 57.4
+      vertex 5.43326 27.3149 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.34394 28.2528 57.4
+      vertex 4.3567 27.5071 57.4
+      vertex 4.45056 28.0997 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.34394 28.2528 57.4
+      vertex 3.27342 27.657 57.4
+      vertex 4.3567 27.5071 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.23216 28.3623 57.4
+      vertex 3.27342 27.657 57.4
+      vertex 3.34394 28.2528 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.23216 28.3623 57.4
+      vertex 2.18509 27.7641 57.4
+      vertex 3.27342 27.657 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.11694 28.4281 57.4
+      vertex 2.18509 27.7641 57.4
+      vertex 2.23216 28.3623 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.11694 28.4281 57.4
+      vertex 1.09339 27.8285 57.4
+      vertex 2.18509 27.7641 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 28.45 57.4
+      vertex 1.09339 27.8285 57.4
+      vertex 1.11694 28.4281 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 28.45 57.4
+      vertex 0 27.85 57.4
+      vertex 1.09339 27.8285 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 28.45 57.4
+      vertex -1.09339 27.8285 57.4
+      vertex 0 27.85 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.11694 28.4281 57.4
+      vertex -1.09339 27.8285 57.4
+      vertex 0 28.45 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.11694 28.4281 57.4
+      vertex -2.18509 27.7641 57.4
+      vertex -1.09339 27.8285 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.23216 28.3623 57.4
+      vertex -2.18509 27.7641 57.4
+      vertex -1.11694 28.4281 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.23216 28.3623 57.4
+      vertex -3.27342 27.657 57.4
+      vertex -2.18509 27.7641 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3.34394 28.2528 57.4
+      vertex -3.27342 27.657 57.4
+      vertex -2.23216 28.3623 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.34394 28.2528 57.4
+      vertex -4.3567 27.5071 57.4
+      vertex -3.27342 27.657 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -4.45056 28.0997 57.4
+      vertex -4.3567 27.5071 57.4
+      vertex -3.34394 28.2528 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.45056 28.0997 57.4
+      vertex -5.43326 27.3149 57.4
+      vertex -4.3567 27.5071 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.55032 27.9033 57.4
+      vertex -5.43326 27.3149 57.4
+      vertex -4.45056 28.0997 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.55032 27.9033 57.4
+      vertex -6.50145 27.0805 57.4
+      vertex -5.43326 27.3149 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -6.64152 27.6639 57.4
+      vertex -6.50145 27.0805 57.4
+      vertex -5.55032 27.9033 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.64152 27.6639 57.4
+      vertex -7.55962 26.8044 57.4
+      vertex -6.50145 27.0805 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -7.72248 27.3819 57.4
+      vertex -7.55962 26.8044 57.4
+      vertex -6.64152 27.6639 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.72248 27.3819 57.4
+      vertex -8.60612 26.4869 57.4
+      vertex -7.55962 26.8044 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -8.79153 27.0576 57.4
+      vertex -8.60612 26.4869 57.4
+      vertex -7.72248 27.3819 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.79153 27.0576 57.4
+      vertex -9.63936 26.1286 57.4
+      vertex -8.60612 26.4869 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.84703 26.6915 57.4
+      vertex -9.63936 26.1286 57.4
+      vertex -8.79153 27.0576 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.84703 26.6915 57.4
+      vertex -10.6577 25.73 57.4
+      vertex -9.63936 26.1286 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.8873 26.2844 57.4
+      vertex -10.6577 25.73 57.4
+      vertex -9.84703 26.6915 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.8873 26.2844 57.4
+      vertex -11.6597 25.2918 57.4
+      vertex -10.6577 25.73 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.9109 25.8367 57.4
+      vertex -11.6597 25.2918 57.4
+      vertex -10.8873 26.2844 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.9109 25.8367 57.4
+      vertex -12.6436 24.8145 57.4
+      vertex -11.6597 25.2918 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.916 25.3491 57.4
+      vertex -12.6436 24.8145 57.4
+      vertex -11.9109 25.8367 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.916 25.3491 57.4
+      vertex -13.6081 24.299 57.4
+      vertex -12.6436 24.8145 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.9013 24.8225 57.4
+      vertex -13.6081 24.299 57.4
+      vertex -12.916 25.3491 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.9013 24.8225 57.4
+      vertex -14.5516 23.746 57.4
+      vertex -13.6081 24.299 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.8651 24.2576 57.4
+      vertex -14.5516 23.746 57.4
+      vertex -13.9013 24.8225 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8651 24.2576 57.4
+      vertex -15.4726 23.1564 57.4
+      vertex -14.5516 23.746 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.806 23.6553 57.4
+      vertex -15.4726 23.1564 57.4
+      vertex -14.8651 24.2576 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.806 23.6553 57.4
+      vertex -16.3698 22.5311 57.4
+      vertex -15.4726 23.1564 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.7225 23.0165 57.4
+      vertex -16.3698 22.5311 57.4
+      vertex -15.806 23.6553 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.7225 23.0165 57.4
+      vertex -17.2418 21.8711 57.4
+      vertex -16.3698 22.5311 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.6132 22.3423 57.4
+      vertex -17.2418 21.8711 57.4
+      vertex -16.7225 23.0165 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6132 22.3423 57.4
+      vertex -18.0871 21.1773 57.4
+      vertex -17.2418 21.8711 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.4768 21.6335 57.4
+      vertex -18.0871 21.1773 57.4
+      vertex -17.6132 22.3423 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4768 21.6335 57.4
+      vertex -18.9046 20.4509 57.4
+      vertex -18.0871 21.1773 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.3119 20.8915 57.4
+      vertex -18.9046 20.4509 57.4
+      vertex -18.4768 21.6335 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3119 20.8915 57.4
+      vertex -19.6929 19.6929 57.4
+      vertex -18.9046 20.4509 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.1172 20.1172 57.4
+      vertex -19.6929 19.6929 57.4
+      vertex -19.3119 20.8915 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1172 20.1172 57.4
+      vertex -20.4509 18.9046 57.4
+      vertex -19.6929 19.6929 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.8915 19.3119 57.4
+      vertex -20.4509 18.9046 57.4
+      vertex -20.1172 20.1172 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.8915 19.3119 57.4
+      vertex -21.1773 18.0871 57.4
+      vertex -20.4509 18.9046 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.6335 18.4768 57.4
+      vertex -21.1773 18.0871 57.4
+      vertex -20.8915 19.3119 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.6335 18.4768 57.4
+      vertex -21.8711 17.2418 57.4
+      vertex -21.1773 18.0871 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.3423 17.6132 57.4
+      vertex -21.8711 17.2418 57.4
+      vertex -21.6335 18.4768 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.3423 17.6132 57.4
+      vertex -22.5311 16.3698 57.4
+      vertex -21.8711 17.2418 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.0165 16.7225 57.4
+      vertex -22.5311 16.3698 57.4
+      vertex -22.3423 17.6132 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0165 16.7225 57.4
+      vertex -23.1564 15.4726 57.4
+      vertex -22.5311 16.3698 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.6553 15.806 57.4
+      vertex -23.1564 15.4726 57.4
+      vertex -23.0165 16.7225 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.6553 15.806 57.4
+      vertex -23.746 14.5516 57.4
+      vertex -23.1564 15.4726 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.2576 14.8651 57.4
+      vertex -23.746 14.5516 57.4
+      vertex -23.6553 15.806 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.2576 14.8651 57.4
+      vertex -24.299 13.6081 57.4
+      vertex -23.746 14.5516 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.8225 13.9013 57.4
+      vertex -24.299 13.6081 57.4
+      vertex -24.2576 14.8651 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.299 13.6081 57.4
+      vertex -24.8225 13.9013 57.4
+      vertex -24.8145 12.6436 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -25.3491 12.916 57.4
+      vertex -24.8145 12.6436 57.4
+      vertex -24.8225 13.9013 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8145 12.6436 57.4
+      vertex -25.3491 12.916 57.4
+      vertex -25.2918 11.6597 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -25.8367 11.9109 57.4
+      vertex -25.2918 11.6597 57.4
+      vertex -25.3491 12.916 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.2918 11.6597 57.4
+      vertex -25.8367 11.9109 57.4
+      vertex -25.73 10.6577 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -26.2844 10.8873 57.4
+      vertex -25.73 10.6577 57.4
+      vertex -25.8367 11.9109 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.73 10.6577 57.4
+      vertex -26.2844 10.8873 57.4
+      vertex -26.1286 9.63936 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -26.6915 9.84703 57.4
+      vertex -26.1286 9.63936 57.4
+      vertex -26.2844 10.8873 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1286 9.63936 57.4
+      vertex -26.6915 9.84703 57.4
+      vertex -26.4869 8.60612 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.0576 8.79153 57.4
+      vertex -26.4869 8.60612 57.4
+      vertex -26.6915 9.84703 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.4869 8.60612 57.4
+      vertex -27.0576 8.79153 57.4
+      vertex -26.8044 7.55962 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.3819 7.72248 57.4
+      vertex -26.8044 7.55962 57.4
+      vertex -27.0576 8.79153 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8044 7.55962 57.4
+      vertex -27.3819 7.72248 57.4
+      vertex -27.0805 6.50145 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.6639 6.64152 57.4
+      vertex -27.0805 6.50145 57.4
+      vertex -27.3819 7.72248 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0805 6.50145 57.4
+      vertex -27.6639 6.64152 57.4
+      vertex -27.3149 5.43326 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.9033 5.55032 57.4
+      vertex -27.3149 5.43326 57.4
+      vertex -27.6639 6.64152 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3149 5.43326 57.4
+      vertex -27.9033 5.55032 57.4
+      vertex -27.5071 4.3567 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.0997 4.45056 57.4
+      vertex -27.5071 4.3567 57.4
+      vertex -27.9033 5.55032 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.5071 4.3567 57.4
+      vertex -28.0997 4.45056 57.4
+      vertex -27.657 3.27342 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.657 3.27342 57.4
+      vertex -28.2528 3.34394 57.4
+      vertex -27.7641 2.18509 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.2528 3.34394 57.4
+      vertex -27.657 3.27342 57.4
+      vertex -28.0997 4.45056 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.657 -3.27342 57.4
+      vertex 28.2528 -3.34394 57.4
+      vertex 27.7641 -2.18509 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.2528 -3.34394 57.4
+      vertex 27.657 -3.27342 57.4
+      vertex 28.0997 -4.45056 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.5071 -4.3567 57.4
+      vertex 28.0997 -4.45056 57.4
+      vertex 27.657 -3.27342 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.0997 -4.45056 57.4
+      vertex 27.5071 -4.3567 57.4
+      vertex 27.9033 -5.55032 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.3149 -5.43326 57.4
+      vertex 27.9033 -5.55032 57.4
+      vertex 27.5071 -4.3567 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.9033 -5.55032 57.4
+      vertex 27.3149 -5.43326 57.4
+      vertex 27.6639 -6.64152 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.0805 -6.50145 57.4
+      vertex 27.6639 -6.64152 57.4
+      vertex 27.3149 -5.43326 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.6639 -6.64152 57.4
+      vertex 27.0805 -6.50145 57.4
+      vertex 27.3819 -7.72248 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.8044 -7.55962 57.4
+      vertex 27.3819 -7.72248 57.4
+      vertex 27.0805 -6.50145 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.3819 -7.72248 57.4
+      vertex 26.8044 -7.55962 57.4
+      vertex 27.0576 -8.79153 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.4869 -8.60612 57.4
+      vertex 27.0576 -8.79153 57.4
+      vertex 26.8044 -7.55962 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.0576 -8.79153 57.4
+      vertex 26.4869 -8.60612 57.4
+      vertex 26.6915 -9.84703 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.1286 -9.63936 57.4
+      vertex 26.6915 -9.84703 57.4
+      vertex 26.4869 -8.60612 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6915 -9.84703 57.4
+      vertex 26.1286 -9.63936 57.4
+      vertex 26.2844 -10.8873 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.73 -10.6577 57.4
+      vertex 26.2844 -10.8873 57.4
+      vertex 26.1286 -9.63936 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.2844 -10.8873 57.4
+      vertex 25.73 -10.6577 57.4
+      vertex 25.8367 -11.9109 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.2918 -11.6597 57.4
+      vertex 25.8367 -11.9109 57.4
+      vertex 25.73 -10.6577 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.8367 -11.9109 57.4
+      vertex 25.2918 -11.6597 57.4
+      vertex 25.3491 -12.916 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.8145 -12.6436 57.4
+      vertex 25.3491 -12.916 57.4
+      vertex 25.2918 -11.6597 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.3491 -12.916 57.4
+      vertex 24.8145 -12.6436 57.4
+      vertex 24.8225 -13.9013 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.299 -13.6081 57.4
+      vertex 24.8225 -13.9013 57.4
+      vertex 24.8145 -12.6436 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.299 -13.6081 57.4
+      vertex 24.2576 -14.8651 57.4
+      vertex 24.8225 -13.9013 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.746 -14.5516 57.4
+      vertex 24.2576 -14.8651 57.4
+      vertex 24.299 -13.6081 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.746 -14.5516 57.4
+      vertex 23.6553 -15.806 57.4
+      vertex 24.2576 -14.8651 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.1564 -15.4726 57.4
+      vertex 23.6553 -15.806 57.4
+      vertex 23.746 -14.5516 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.1564 -15.4726 57.4
+      vertex 23.0165 -16.7225 57.4
+      vertex 23.6553 -15.806 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.5311 -16.3698 57.4
+      vertex 23.0165 -16.7225 57.4
+      vertex 23.1564 -15.4726 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.5311 -16.3698 57.4
+      vertex 22.3423 -17.6132 57.4
+      vertex 23.0165 -16.7225 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.8711 -17.2418 57.4
+      vertex 22.3423 -17.6132 57.4
+      vertex 22.5311 -16.3698 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.8711 -17.2418 57.4
+      vertex 21.6335 -18.4768 57.4
+      vertex 22.3423 -17.6132 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.1773 -18.0871 57.4
+      vertex 21.6335 -18.4768 57.4
+      vertex 21.8711 -17.2418 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.1773 -18.0871 57.4
+      vertex 20.8915 -19.3119 57.4
+      vertex 21.6335 -18.4768 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.4509 -18.9046 57.4
+      vertex 20.8915 -19.3119 57.4
+      vertex 21.1773 -18.0871 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.4509 -18.9046 57.4
+      vertex 20.1172 -20.1172 57.4
+      vertex 20.8915 -19.3119 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.6929 -19.6929 57.4
+      vertex 20.1172 -20.1172 57.4
+      vertex 20.4509 -18.9046 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.6929 -19.6929 57.4
+      vertex 19.3119 -20.8915 57.4
+      vertex 20.1172 -20.1172 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.9046 -20.4509 57.4
+      vertex 19.3119 -20.8915 57.4
+      vertex 19.6929 -19.6929 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.9046 -20.4509 57.4
+      vertex 18.4768 -21.6335 57.4
+      vertex 19.3119 -20.8915 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.0871 -21.1773 57.4
+      vertex 18.4768 -21.6335 57.4
+      vertex 18.9046 -20.4509 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0871 -21.1773 57.4
+      vertex 17.6132 -22.3423 57.4
+      vertex 18.4768 -21.6335 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.2418 -21.8711 57.4
+      vertex 17.6132 -22.3423 57.4
+      vertex 18.0871 -21.1773 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.2418 -21.8711 57.4
+      vertex 16.7225 -23.0165 57.4
+      vertex 17.6132 -22.3423 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.3698 -22.5311 57.4
+      vertex 16.7225 -23.0165 57.4
+      vertex 17.2418 -21.8711 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.3698 -22.5311 57.4
+      vertex 15.806 -23.6553 57.4
+      vertex 16.7225 -23.0165 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.4726 -23.1564 57.4
+      vertex 15.806 -23.6553 57.4
+      vertex 16.3698 -22.5311 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4726 -23.1564 57.4
+      vertex 14.8651 -24.2576 57.4
+      vertex 15.806 -23.6553 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.5516 -23.746 57.4
+      vertex 14.8651 -24.2576 57.4
+      vertex 15.4726 -23.1564 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.5516 -23.746 57.4
+      vertex 13.9013 -24.8225 57.4
+      vertex 14.8651 -24.2576 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.6081 -24.299 57.4
+      vertex 13.9013 -24.8225 57.4
+      vertex 14.5516 -23.746 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6081 -24.299 57.4
+      vertex 12.916 -25.3491 57.4
+      vertex 13.9013 -24.8225 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.6436 -24.8145 57.4
+      vertex 12.916 -25.3491 57.4
+      vertex 13.6081 -24.299 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.6436 -24.8145 57.4
+      vertex 11.9109 -25.8367 57.4
+      vertex 12.916 -25.3491 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.6597 -25.2918 57.4
+      vertex 11.9109 -25.8367 57.4
+      vertex 12.6436 -24.8145 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.6597 -25.2918 57.4
+      vertex 10.8873 -26.2844 57.4
+      vertex 11.9109 -25.8367 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.6577 -25.73 57.4
+      vertex 10.8873 -26.2844 57.4
+      vertex 11.6597 -25.2918 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.6577 -25.73 57.4
+      vertex 9.84703 -26.6915 57.4
+      vertex 10.8873 -26.2844 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.63936 -26.1286 57.4
+      vertex 9.84703 -26.6915 57.4
+      vertex 10.6577 -25.73 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.63936 -26.1286 57.4
+      vertex 8.79153 -27.0576 57.4
+      vertex 9.84703 -26.6915 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 8.60612 -26.4869 57.4
+      vertex 8.79153 -27.0576 57.4
+      vertex 9.63936 -26.1286 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.60612 -26.4869 57.4
+      vertex 7.72248 -27.3819 57.4
+      vertex 8.79153 -27.0576 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 7.55962 -26.8044 57.4
+      vertex 7.72248 -27.3819 57.4
+      vertex 8.60612 -26.4869 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.55962 -26.8044 57.4
+      vertex 6.64152 -27.6639 57.4
+      vertex 7.72248 -27.3819 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 6.50145 -27.0805 57.4
+      vertex 6.64152 -27.6639 57.4
+      vertex 7.55962 -26.8044 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.50145 -27.0805 57.4
+      vertex 5.55032 -27.9033 57.4
+      vertex 6.64152 -27.6639 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.43326 -27.3149 57.4
+      vertex 5.55032 -27.9033 57.4
+      vertex 6.50145 -27.0805 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.43326 -27.3149 57.4
+      vertex 4.45056 -28.0997 57.4
+      vertex 5.55032 -27.9033 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.3567 -27.5071 57.4
+      vertex 4.45056 -28.0997 57.4
+      vertex 5.43326 -27.3149 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.3567 -27.5071 57.4
+      vertex 3.34394 -28.2528 57.4
+      vertex 4.45056 -28.0997 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.27342 -27.657 57.4
+      vertex 3.34394 -28.2528 57.4
+      vertex 4.3567 -27.5071 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.27342 -27.657 57.4
+      vertex 2.23216 -28.3623 57.4
+      vertex 3.34394 -28.2528 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.18509 -27.7641 57.4
+      vertex 2.23216 -28.3623 57.4
+      vertex 3.27342 -27.657 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.18509 -27.7641 57.4
+      vertex 1.11694 -28.4281 57.4
+      vertex 2.23216 -28.3623 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.09339 -27.8285 57.4
+      vertex 1.11694 -28.4281 57.4
+      vertex 2.18509 -27.7641 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 -27.85 57.4
+      vertex 1.11694 -28.4281 57.4
+      vertex 1.09339 -27.8285 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -27.85 57.4
+      vertex 0 -28.45 57.4
+      vertex 1.11694 -28.4281 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.09339 -27.8285 57.4
+      vertex 0 -28.45 57.4
+      vertex 0 -27.85 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.09339 -27.8285 57.4
+      vertex -1.11694 -28.4281 57.4
+      vertex 0 -28.45 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.18509 -27.7641 57.4
+      vertex -1.11694 -28.4281 57.4
+      vertex -1.09339 -27.8285 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.18509 -27.7641 57.4
+      vertex -2.23216 -28.3623 57.4
+      vertex -1.11694 -28.4281 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.27342 -27.657 57.4
+      vertex -2.23216 -28.3623 57.4
+      vertex -2.18509 -27.7641 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.27342 -27.657 57.4
+      vertex -3.34394 -28.2528 57.4
+      vertex -2.23216 -28.3623 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.3567 -27.5071 57.4
+      vertex -3.34394 -28.2528 57.4
+      vertex -3.27342 -27.657 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.3567 -27.5071 57.4
+      vertex -4.45056 -28.0997 57.4
+      vertex -3.34394 -28.2528 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.43326 -27.3149 57.4
+      vertex -4.45056 -28.0997 57.4
+      vertex -4.3567 -27.5071 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.43326 -27.3149 57.4
+      vertex -5.55032 -27.9033 57.4
+      vertex -4.45056 -28.0997 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.50145 -27.0805 57.4
+      vertex -5.55032 -27.9033 57.4
+      vertex -5.43326 -27.3149 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.50145 -27.0805 57.4
+      vertex -6.64152 -27.6639 57.4
+      vertex -5.55032 -27.9033 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.55962 -26.8044 57.4
+      vertex -6.64152 -27.6639 57.4
+      vertex -6.50145 -27.0805 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.55962 -26.8044 57.4
+      vertex -7.72248 -27.3819 57.4
+      vertex -6.64152 -27.6639 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.60612 -26.4869 57.4
+      vertex -7.72248 -27.3819 57.4
+      vertex -7.55962 -26.8044 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.60612 -26.4869 57.4
+      vertex -8.79153 -27.0576 57.4
+      vertex -7.72248 -27.3819 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.63936 -26.1286 57.4
+      vertex -8.79153 -27.0576 57.4
+      vertex -8.60612 -26.4869 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.63936 -26.1286 57.4
+      vertex -9.84703 -26.6915 57.4
+      vertex -8.79153 -27.0576 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.6577 -25.73 57.4
+      vertex -9.84703 -26.6915 57.4
+      vertex -9.63936 -26.1286 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.6577 -25.73 57.4
+      vertex -10.8873 -26.2844 57.4
+      vertex -9.84703 -26.6915 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.6597 -25.2918 57.4
+      vertex -10.8873 -26.2844 57.4
+      vertex -10.6577 -25.73 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.6597 -25.2918 57.4
+      vertex -11.9109 -25.8367 57.4
+      vertex -10.8873 -26.2844 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.6436 -24.8145 57.4
+      vertex -11.9109 -25.8367 57.4
+      vertex -11.6597 -25.2918 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.6436 -24.8145 57.4
+      vertex -12.916 -25.3491 57.4
+      vertex -11.9109 -25.8367 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.6081 -24.299 57.4
+      vertex -12.916 -25.3491 57.4
+      vertex -12.6436 -24.8145 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.6081 -24.299 57.4
+      vertex -13.9013 -24.8225 57.4
+      vertex -12.916 -25.3491 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.5516 -23.746 57.4
+      vertex -13.9013 -24.8225 57.4
+      vertex -13.6081 -24.299 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.5516 -23.746 57.4
+      vertex -14.8651 -24.2576 57.4
+      vertex -13.9013 -24.8225 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.4726 -23.1564 57.4
+      vertex -14.8651 -24.2576 57.4
+      vertex -14.5516 -23.746 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.4726 -23.1564 57.4
+      vertex -15.806 -23.6553 57.4
+      vertex -14.8651 -24.2576 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.3698 -22.5311 57.4
+      vertex -15.806 -23.6553 57.4
+      vertex -15.4726 -23.1564 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.3698 -22.5311 57.4
+      vertex -16.7225 -23.0165 57.4
+      vertex -15.806 -23.6553 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.2418 -21.8711 57.4
+      vertex -16.7225 -23.0165 57.4
+      vertex -16.3698 -22.5311 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.2418 -21.8711 57.4
+      vertex -17.6132 -22.3423 57.4
+      vertex -16.7225 -23.0165 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0871 -21.1773 57.4
+      vertex -17.6132 -22.3423 57.4
+      vertex -17.2418 -21.8711 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0871 -21.1773 57.4
+      vertex -18.4768 -21.6335 57.4
+      vertex -17.6132 -22.3423 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9046 -20.4509 57.4
+      vertex -18.4768 -21.6335 57.4
+      vertex -18.0871 -21.1773 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9046 -20.4509 57.4
+      vertex -19.3119 -20.8915 57.4
+      vertex -18.4768 -21.6335 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.6929 -19.6929 57.4
+      vertex -19.3119 -20.8915 57.4
+      vertex -18.9046 -20.4509 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.6929 -19.6929 57.4
+      vertex -20.1172 -20.1172 57.4
+      vertex -19.3119 -20.8915 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.4509 -18.9046 57.4
+      vertex -20.1172 -20.1172 57.4
+      vertex -19.6929 -19.6929 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.4509 -18.9046 57.4
+      vertex -20.8915 -19.3119 57.4
+      vertex -20.1172 -20.1172 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.1773 -18.0871 57.4
+      vertex -20.8915 -19.3119 57.4
+      vertex -20.4509 -18.9046 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.1773 -18.0871 57.4
+      vertex -21.6335 -18.4768 57.4
+      vertex -20.8915 -19.3119 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.8711 -17.2418 57.4
+      vertex -21.6335 -18.4768 57.4
+      vertex -21.1773 -18.0871 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.8711 -17.2418 57.4
+      vertex -22.3423 -17.6132 57.4
+      vertex -21.6335 -18.4768 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5311 -16.3698 57.4
+      vertex -22.3423 -17.6132 57.4
+      vertex -21.8711 -17.2418 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5311 -16.3698 57.4
+      vertex -23.0165 -16.7225 57.4
+      vertex -22.3423 -17.6132 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1564 -15.4726 57.4
+      vertex -23.0165 -16.7225 57.4
+      vertex -22.5311 -16.3698 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1564 -15.4726 57.4
+      vertex -23.6553 -15.806 57.4
+      vertex -23.0165 -16.7225 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.746 -14.5516 57.4
+      vertex -23.6553 -15.806 57.4
+      vertex -23.1564 -15.4726 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.746 -14.5516 57.4
+      vertex -24.2576 -14.8651 57.4
+      vertex -23.6553 -15.806 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.299 -13.6081 57.4
+      vertex -24.2576 -14.8651 57.4
+      vertex -23.746 -14.5516 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8225 -13.9013 57.4
+      vertex -24.299 -13.6081 57.4
+      vertex -24.8145 -12.6436 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.299 -13.6081 57.4
+      vertex -24.8225 -13.9013 57.4
+      vertex -24.2576 -14.8651 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3491 -12.916 57.4
+      vertex -24.8145 -12.6436 57.4
+      vertex -25.2918 -11.6597 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8145 -12.6436 57.4
+      vertex -25.3491 -12.916 57.4
+      vertex -24.8225 -13.9013 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.8367 -11.9109 57.4
+      vertex -25.2918 -11.6597 57.4
+      vertex -25.73 -10.6577 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.2918 -11.6597 57.4
+      vertex -25.8367 -11.9109 57.4
+      vertex -25.3491 -12.916 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.2844 -10.8873 57.4
+      vertex -25.73 -10.6577 57.4
+      vertex -26.1286 -9.63936 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.73 -10.6577 57.4
+      vertex -26.2844 -10.8873 57.4
+      vertex -25.8367 -11.9109 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.6915 -9.84703 57.4
+      vertex -26.1286 -9.63936 57.4
+      vertex -26.4869 -8.60612 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1286 -9.63936 57.4
+      vertex -26.6915 -9.84703 57.4
+      vertex -26.2844 -10.8873 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0576 -8.79153 57.4
+      vertex -26.4869 -8.60612 57.4
+      vertex -26.8044 -7.55962 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.4869 -8.60612 57.4
+      vertex -27.0576 -8.79153 57.4
+      vertex -26.6915 -9.84703 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3819 -7.72248 57.4
+      vertex -26.8044 -7.55962 57.4
+      vertex -27.0805 -6.50145 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6639 -6.64152 57.4
+      vertex -27.0805 -6.50145 57.4
+      vertex -27.3149 -5.43326 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8044 -7.55962 57.4
+      vertex -27.3819 -7.72248 57.4
+      vertex -27.0576 -8.79153 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.9033 -5.55032 57.4
+      vertex -27.3149 -5.43326 57.4
+      vertex -27.5071 -4.3567 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.0997 -4.45056 57.4
+      vertex -27.5071 -4.3567 57.4
+      vertex -27.657 -3.27342 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0805 -6.50145 57.4
+      vertex -27.6639 -6.64152 57.4
+      vertex -27.3819 -7.72248 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.2528 -3.34394 57.4
+      vertex -27.657 -3.27342 57.4
+      vertex -27.7641 -2.18509 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.3623 -2.23216 57.4
+      vertex -27.7641 -2.18509 57.4
+      vertex -27.8285 -1.09339 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3149 -5.43326 57.4
+      vertex -27.9033 -5.55032 57.4
+      vertex -27.6639 -6.64152 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.4281 -1.11694 57.4
+      vertex -27.8285 -1.09339 57.4
+      vertex -27.85 0 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.3623 2.23216 57.4
+      vertex -27.7641 2.18509 57.4
+      vertex -28.2528 3.34394 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.7641 2.18509 57.4
+      vertex -28.3623 2.23216 57.4
+      vertex -27.8285 1.09339 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.5071 -4.3567 57.4
+      vertex -28.0997 -4.45056 57.4
+      vertex -27.9033 -5.55032 57.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.4281 1.11694 57.4
+      vertex -27.8285 1.09339 57.4
+      vertex -28.3623 2.23216 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.657 -3.27342 57.4
+      vertex -28.2528 -3.34394 57.4
+      vertex -28.0997 -4.45056 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.8285 1.09339 57.4
+      vertex -28.4281 1.11694 57.4
+      vertex -27.85 0 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.7641 -2.18509 57.4
+      vertex -28.3623 -2.23216 57.4
+      vertex -28.2528 -3.34394 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.45 0 57.4
+      vertex -27.85 0 57.4
+      vertex -28.4281 1.11694 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.8285 -1.09339 57.4
+      vertex -28.4281 -1.11694 57.4
+      vertex -28.3623 -2.23216 57.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.85 0 57.4
+      vertex -28.45 0 57.4
+      vertex -28.4281 -1.11694 57.4
+    endloop
+  endfacet
+  facet normal 0.436464 -0.899722 0
+    outer loop
+      vertex -12.6436 24.8145 0.599999
+      vertex -11.6597 25.2918 57.4
+      vertex -12.6436 24.8145 57.4
+    endloop
+  endfacet
+  facet normal 0.436464 -0.899722 0
+    outer loop
+      vertex -11.6597 25.2918 57.4
+      vertex -12.6436 24.8145 0.599999
+      vertex -11.6597 25.2918 0.599999
+    endloop
+  endfacet
+  facet normal 0.899722 0.436464 0
+    outer loop
+      vertex -24.8145 -12.6436 57.4
+      vertex -25.2918 -11.6597 0.599999
+      vertex -25.2918 -11.6597 57.4
+    endloop
+  endfacet
+  facet normal 0.899722 0.436464 0
+    outer loop
+      vertex -25.2918 -11.6597 0.599999
+      vertex -24.8145 -12.6436 57.4
+      vertex -24.8145 -12.6436 0.599999
+    endloop
+  endfacet
+  facet normal -0.772974 -0.634437 0
+    outer loop
+      vertex 21.8711 17.2418 0.599999
+      vertex 21.1773 18.0871 57.4
+      vertex 21.1773 18.0871 0.599999
+    endloop
+  endfacet
+  facet normal -0.772974 -0.634437 0
+    outer loop
+      vertex 21.1773 18.0871 57.4
+      vertex 21.8711 17.2418 0.599999
+      vertex 21.8711 17.2418 57.4
+    endloop
+  endfacet
+  facet normal 0.57178 0.820407 -0
+    outer loop
+      vertex -15.4726 -23.1564 0.599999
+      vertex -16.3698 -22.5311 57.4
+      vertex -15.4726 -23.1564 57.4
+    endloop
+  endfacet
+  facet normal 0.57178 0.820407 0
+    outer loop
+      vertex -16.3698 -22.5311 57.4
+      vertex -15.4726 -23.1564 0.599999
+      vertex -16.3698 -22.5311 0.599999
+    endloop
+  endfacet
+  facet normal 0.290325 0.956928 -0
+    outer loop
+      vertex -7.55962 -26.8044 0.599999
+      vertex -8.60612 -26.4869 57.4
+      vertex -7.55962 -26.8044 57.4
+    endloop
+  endfacet
+  facet normal 0.290325 0.956928 0
+    outer loop
+      vertex -8.60612 -26.4869 57.4
+      vertex -7.55962 -26.8044 0.599999
+      vertex -8.60612 -26.4869 0.599999
+    endloop
+  endfacet
+  facet normal -0.214337 -0.97676 0
+    outer loop
+      vertex 5.43326 27.3149 0.599999
+      vertex 6.50145 27.0805 57.4
+      vertex 5.43326 27.3149 57.4
+    endloop
+  endfacet
+  facet normal -0.214337 -0.97676 -0
+    outer loop
+      vertex 6.50145 27.0805 57.4
+      vertex 5.43326 27.3149 0.599999
+      vertex 6.50145 27.0805 0.599999
+    endloop
+  endfacet
+  facet normal 0.967605 0.25247 0
+    outer loop
+      vertex -26.8044 -7.55962 57.4
+      vertex -27.0805 -6.50145 0.599999
+      vertex -27.0805 -6.50145 57.4
+    endloop
+  endfacet
+  facet normal 0.967605 0.25247 0
+    outer loop
+      vertex -27.0805 -6.50145 0.599999
+      vertex -26.8044 -7.55962 57.4
+      vertex -26.8044 -7.55962 0.599999
+    endloop
+  endfacet
+  facet normal 0.693118 0.720824 -0
+    outer loop
+      vertex -18.9046 -20.4509 0.599999
+      vertex -19.6929 -19.6929 57.4
+      vertex -18.9046 -20.4509 57.4
+    endloop
+  endfacet
+  facet normal 0.693118 0.720824 0
+    outer loop
+      vertex -19.6929 -19.6929 57.4
+      vertex -18.9046 -20.4509 0.599999
+      vertex -19.6929 -19.6929 0.599999
+    endloop
+  endfacet
+  facet normal -0.797359 -0.603506 0
+    outer loop
+      vertex 22.5311 16.3698 0.599999
+      vertex 21.8711 17.2418 57.4
+      vertex 21.8711 17.2418 0.599999
+    endloop
+  endfacet
+  facet normal -0.797359 -0.603506 0
+    outer loop
+      vertex 21.8711 17.2418 57.4
+      vertex 22.5311 16.3698 0.599999
+      vertex 22.5311 16.3698 57.4
+    endloop
+  endfacet
+  facet normal 0.505661 0.862732 -0
+    outer loop
+      vertex -13.6081 -24.299 0.599999
+      vertex -14.5516 -23.746 57.4
+      vertex -13.6081 -24.299 57.4
+    endloop
+  endfacet
+  facet normal 0.505661 0.862732 0
+    outer loop
+      vertex -14.5516 -23.746 57.4
+      vertex -13.6081 -24.299 0.599999
+      vertex -14.5516 -23.746 0.599999
+    endloop
+  endfacet
+  facet normal 0.400685 0.916216 -0
+    outer loop
+      vertex -10.6577 -25.73 0.599999
+      vertex -11.6597 -25.2918 57.4
+      vertex -10.6577 -25.73 57.4
+    endloop
+  endfacet
+  facet normal 0.400685 0.916216 0
+    outer loop
+      vertex -11.6597 -25.2918 57.4
+      vertex -10.6577 -25.73 0.599999
+      vertex -11.6597 -25.2918 0.599999
+    endloop
+  endfacet
+  facet normal 0.842205 -0.539157 0
+    outer loop
+      vertex -23.746 14.5516 57.4
+      vertex -23.1564 15.4726 0.599999
+      vertex -23.1564 15.4726 57.4
+    endloop
+  endfacet
+  facet normal 0.842205 -0.539157 0
+    outer loop
+      vertex -23.1564 15.4726 0.599999
+      vertex -23.746 14.5516 57.4
+      vertex -23.746 14.5516 0.599999
+    endloop
+  endfacet
+  facet normal -0.707038 -0.0139029 0.707039
+    outer loop
+      vertex 27.85 0 0
+      vertex 28.45 0 0.599999
+      vertex 27.8285 1.09339 0
+    endloop
+  endfacet
+  facet normal 0.528651 -0.469715 0.707033
+    outer loop
+      vertex -21.1773 18.0871 0
+      vertex -20.8915 19.3119 0.599999
+      vertex -21.6335 18.4768 0.599999
+    endloop
+  endfacet
+  facet normal -0.696168 -0.124325 0.707032
+    outer loop
+      vertex 28.0997 4.45056 0.599999
+      vertex 27.9033 5.55032 0.599999
+      vertex 27.5071 4.3567 0
+    endloop
+  endfacet
+  facet normal -0.509741 0.490148 0.70705
+    outer loop
+      vertex 20.8915 -19.3119 0.599999
+      vertex 20.4509 -18.9046 0
+      vertex 19.6929 -19.6929 0
+    endloop
+  endfacet
+  facet normal -0.333329 -0.623679 0.707048
+    outer loop
+      vertex 13.6081 24.299 0
+      vertex 13.9013 24.8225 0.599999
+      vertex 12.916 25.3491 0.599999
+    endloop
+  endfacet
+  facet normal -0.703793 0.0693171 0.707015
+    outer loop
+      vertex 28.2528 -3.34394 0.599999
+      vertex 28.3623 -2.23216 0.599999
+      vertex 27.657 -3.27342 0
+    endloop
+  endfacet
+  facet normal -0.580133 -0.404353 0.707067
+    outer loop
+      vertex 23.1564 15.4726 0
+      vertex 23.6553 15.806 0.599999
+      vertex 23.0165 16.7225 0.599999
+    endloop
+  endfacet
+  facet normal -0.595574 -0.381246 0.707067
+    outer loop
+      vertex 24.2576 14.8651 0.599999
+      vertex 23.6553 15.806 0.599999
+      vertex 23.1564 15.4726 0
+    endloop
+  endfacet
+  facet normal -0.676702 -0.205306 0.707053
+    outer loop
+      vertex 26.8044 7.55962 0
+      vertex 27.3819 7.72248 0.599999
+      vertex 26.4869 8.60612 0
+    endloop
+  endfacet
+  facet normal 0.178543 -0.684277 0.707027
+    outer loop
+      vertex -6.50145 27.0805 0
+      vertex -6.64152 27.6639 0.599999
+      vertex -7.55962 26.8044 0
+    endloop
+  endfacet
+  facet normal -0.469715 0.528651 0.707033
+    outer loop
+      vertex 18.4768 -21.6335 0.599999
+      vertex 19.3119 -20.8915 0.599999
+      vertex 18.0871 -21.1773 0
+    endloop
+  endfacet
+  facet normal -0.610094 -0.357587 0.707049
+    outer loop
+      vertex 24.299 13.6081 0
+      vertex 24.8225 13.9013 0.599999
+      vertex 24.2576 14.8651 0.599999
+    endloop
+  endfacet
+  facet normal -0.04165 -0.70591 0.707076
+    outer loop
+      vertex 2.23216 28.3623 0.599999
+      vertex 1.11694 28.4281 0.599999
+      vertex 1.09339 27.8285 0
+    endloop
+  endfacet
+  facet normal 0.04165 -0.70591 0.707076
+    outer loop
+      vertex -1.09339 27.8285 0
+      vertex -1.11694 28.4281 0.599999
+      vertex -2.23216 28.3623 0.599999
+    endloop
+  endfacet
+  facet normal -0.404353 0.580133 0.707067
+    outer loop
+      vertex 15.806 -23.6553 0.599999
+      vertex 16.7225 -23.0165 0.599999
+      vertex 15.4726 -23.1564 0
+    endloop
+  endfacet
+  facet normal 0.0138623 -0.707002 0.707076
+    outer loop
+      vertex -1.09339 27.8285 0
+      vertex 0 28.45 0.599999
+      vertex -1.11694 28.4281 0.599999
+    endloop
+  endfacet
+  facet normal -0.684259 -0.178509 0.707053
+    outer loop
+      vertex 27.6639 6.64152 0.599999
+      vertex 27.3819 7.72248 0.599999
+      vertex 26.8044 7.55962 0
+    endloop
+  endfacet
+  facet normal -0.205306 0.676702 0.707053
+    outer loop
+      vertex 7.72248 -27.3819 0.599999
+      vertex 8.60612 -26.4869 0
+      vertex 7.55962 -26.8044 0
+    endloop
+  endfacet
+  facet normal 0.705918 0.0416425 0.707068
+    outer loop
+      vertex -27.7641 -2.18509 0
+      vertex -27.8285 -1.09339 0
+      vertex -28.3623 -2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0.610094 0.357587 0.707049
+    outer loop
+      vertex -24.2576 -14.8651 0.599999
+      vertex -24.299 -13.6081 0
+      vertex -24.8225 -13.9013 0.599999
+    endloop
+  endfacet
+  facet normal 0.381274 -0.595579 0.707047
+    outer loop
+      vertex -14.5516 23.746 0
+      vertex -14.8651 24.2576 0.599999
+      vertex -15.4726 23.1564 0
+    endloop
+  endfacet
+  facet normal -0.64789 0.283339 0.707076
+    outer loop
+      vertex 26.2844 -10.8873 0.599999
+      vertex 25.73 -10.6577 0
+      vertex 25.2918 -11.6597 0
+    endloop
+  endfacet
+  facet normal -0.151576 -0.690751 0.707027
+    outer loop
+      vertex 6.50145 27.0805 0
+      vertex 6.64152 27.6639 0.599999
+      vertex 5.43326 27.3149 0
+    endloop
+  endfacet
+  facet normal -0.65849 0.257747 0.707077
+    outer loop
+      vertex 26.2844 -10.8873 0.599999
+      vertex 26.1286 -9.63936 0
+      vertex 25.73 -10.6577 0
+    endloop
+  endfacet
+  facet normal -0.580133 0.404353 0.707067
+    outer loop
+      vertex 23.6553 -15.806 0.599999
+      vertex 23.1564 -15.4726 0
+      vertex 23.0165 -16.7225 0.599999
+    endloop
+  endfacet
+  facet normal -0.580167 0.404345 0.707044
+    outer loop
+      vertex 23.0165 -16.7225 0.599999
+      vertex 23.1564 -15.4726 0
+      vertex 22.5311 -16.3698 0
+    endloop
+  endfacet
+  facet normal -0.563853 0.426799 0.707045
+    outer loop
+      vertex 23.0165 -16.7225 0.599999
+      vertex 22.5311 -16.3698 0
+      vertex 22.3423 -17.6132 0.599999
+    endloop
+  endfacet
+  facet normal 0.0139029 -0.707038 0.707039
+    outer loop
+      vertex 0 27.85 0
+      vertex 0 28.45 0.599999
+      vertex -1.09339 27.8285 0
+    endloop
+  endfacet
+  facet normal -0.0693171 0.703793 0.707015
+    outer loop
+      vertex 3.34394 -28.2528 0.599999
+      vertex 3.27342 -27.657 0
+      vertex 2.23216 -28.3623 0.599999
+    endloop
+  endfacet
+  facet normal 0.124325 -0.696168 0.707032
+    outer loop
+      vertex -4.3567 27.5071 0
+      vertex -4.45056 28.0997 0.599999
+      vertex -5.55032 27.9033 0.599999
+    endloop
+  endfacet
+  facet normal -0.610095 -0.357586 0.707048
+    outer loop
+      vertex 24.299 13.6081 0
+      vertex 24.2576 14.8651 0.599999
+      vertex 23.746 14.5516 0
+    endloop
+  endfacet
+  facet normal -0.357586 -0.610095 0.707048
+    outer loop
+      vertex 14.5516 23.746 0
+      vertex 14.8651 24.2576 0.599999
+      vertex 13.6081 24.299 0
+    endloop
+  endfacet
+  facet normal 0.563853 -0.426799 0.707045
+    outer loop
+      vertex -22.5311 16.3698 0
+      vertex -22.3423 17.6132 0.599999
+      vertex -23.0165 16.7225 0.599999
+    endloop
+  endfacet
+  facet normal 0.610094 -0.357587 0.707049
+    outer loop
+      vertex -24.299 13.6081 0
+      vertex -24.2576 14.8651 0.599999
+      vertex -24.8225 13.9013 0.599999
+    endloop
+  endfacet
+  facet normal 0.65855 -0.257718 0.707031
+    outer loop
+      vertex -26.1286 9.63936 0
+      vertex -26.2844 10.8873 0.599999
+      vertex -26.6915 9.84703 0.599999
+    endloop
+  endfacet
+  facet normal 0.703746 -0.069254 0.707069
+    outer loop
+      vertex -27.7641 2.18509 0
+      vertex -27.657 3.27342 0
+      vertex -28.3623 2.23216 0.599999
+    endloop
+  endfacet
+  facet normal -0.509741 -0.490148 0.70705
+    outer loop
+      vertex 20.4509 18.9046 0
+      vertex 20.8915 19.3119 0.599999
+      vertex 19.6929 19.6929 0
+    endloop
+  endfacet
+  facet normal 0.696168 0.124325 0.707032
+    outer loop
+      vertex -27.9033 -5.55032 0.599999
+      vertex -27.5071 -4.3567 0
+      vertex -28.0997 -4.45056 0.599999
+    endloop
+  endfacet
+  facet normal 0.580133 -0.404353 0.707067
+    outer loop
+      vertex -23.1564 15.4726 0
+      vertex -23.0165 16.7225 0.599999
+      vertex -23.6553 15.806 0.599999
+    endloop
+  endfacet
+  facet normal -0.610095 0.357586 0.707048
+    outer loop
+      vertex 24.2576 -14.8651 0.599999
+      vertex 24.299 -13.6081 0
+      vertex 23.746 -14.5516 0
+    endloop
+  endfacet
+  facet normal -0.528651 -0.469715 0.707033
+    outer loop
+      vertex 21.1773 18.0871 0
+      vertex 21.6335 18.4768 0.599999
+      vertex 20.8915 19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0.509742 -0.490119 0.707069
+    outer loop
+      vertex -19.6929 19.6929 0
+      vertex -20.1172 20.1172 0.599999
+      vertex -20.8915 19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0.357586 -0.610095 0.707048
+    outer loop
+      vertex -14.5516 23.746 0
+      vertex -13.6081 24.299 0
+      vertex -14.8651 24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0.580167 -0.404345 0.707044
+    outer loop
+      vertex -22.5311 16.3698 0
+      vertex -23.0165 16.7225 0.599999
+      vertex -23.1564 15.4726 0
+    endloop
+  endfacet
+  facet normal 0.700524 -0.0969357 0.707015
+    outer loop
+      vertex -27.657 3.27342 0
+      vertex -27.5071 4.3567 0
+      vertex -28.2528 3.34394 0.599999
+    endloop
+  endfacet
+  facet normal -0.509742 0.490119 0.707069
+    outer loop
+      vertex 20.1172 -20.1172 0.599999
+      vertex 20.8915 -19.3119 0.599999
+      vertex 19.6929 -19.6929 0
+    endloop
+  endfacet
+  facet normal -0.528651 0.469715 0.707033
+    outer loop
+      vertex 21.6335 -18.4768 0.599999
+      vertex 21.1773 -18.0871 0
+      vertex 20.8915 -19.3119 0.599999
+    endloop
+  endfacet
+  facet normal -0.70591 -0.04165 0.707076
+    outer loop
+      vertex 28.4281 1.11694 0.599999
+      vertex 28.3623 2.23216 0.599999
+      vertex 27.8285 1.09339 0
+    endloop
+  endfacet
+  facet normal 0.151576 0.690751 0.707027
+    outer loop
+      vertex -5.43326 -27.3149 0
+      vertex -6.50145 -27.0805 0
+      vertex -6.64152 -27.6639 0.599999
+    endloop
+  endfacet
+  facet normal 0.381246 -0.595574 0.707067
+    outer loop
+      vertex -15.4726 23.1564 0
+      vertex -14.8651 24.2576 0.599999
+      vertex -15.806 23.6553 0.599999
+    endloop
+  endfacet
+  facet normal -0.65849 -0.257747 0.707077
+    outer loop
+      vertex 26.1286 9.63936 0
+      vertex 26.2844 10.8873 0.599999
+      vertex 25.73 10.6577 0
+    endloop
+  endfacet
+  facet normal 0.448663 0.546634 0.707031
+    outer loop
+      vertex -17.2418 -21.8711 0
+      vertex -18.0871 -21.1773 0
+      vertex -18.4768 -21.6335 0.599999
+    endloop
+  endfacet
+  facet normal -0.426799 0.563853 0.707045
+    outer loop
+      vertex 16.7225 -23.0165 0.599999
+      vertex 17.6132 -22.3423 0.599999
+      vertex 16.3698 -22.5311 0
+    endloop
+  endfacet
+  facet normal 0.448661 0.546647 0.707022
+    outer loop
+      vertex -17.6132 -22.3423 0.599999
+      vertex -17.2418 -21.8711 0
+      vertex -18.4768 -21.6335 0.599999
+    endloop
+  endfacet
+  facet normal 0.668133 0.231742 0.707031
+    outer loop
+      vertex -26.6915 -9.84703 0.599999
+      vertex -26.1286 -9.63936 0
+      vertex -27.0576 -8.79153 0.599999
+    endloop
+  endfacet
+  facet normal 0.381246 0.595574 0.707067
+    outer loop
+      vertex -14.8651 -24.2576 0.599999
+      vertex -15.4726 -23.1564 0
+      vertex -15.806 -23.6553 0.599999
+    endloop
+  endfacet
+  facet normal -0.178543 0.684277 0.707027
+    outer loop
+      vertex 6.64152 -27.6639 0.599999
+      vertex 7.55962 -26.8044 0
+      vertex 6.50145 -27.0805 0
+    endloop
+  endfacet
+  facet normal -0.668107 0.231682 0.707076
+    outer loop
+      vertex 27.0576 -8.79153 0.599999
+      vertex 26.4869 -8.60612 0
+      vertex 26.1286 -9.63936 0
+    endloop
+  endfacet
+  facet normal -0.283339 -0.64789 0.707076
+    outer loop
+      vertex 11.6597 25.2918 0
+      vertex 10.8873 26.2844 0.599999
+      vertex 10.6577 25.73 0
+    endloop
+  endfacet
+  facet normal 0.690785 -0.151552 0.706999
+    outer loop
+      vertex -27.3149 5.43326 0
+      vertex -27.6639 6.64152 0.599999
+      vertex -27.9033 5.55032 0.599999
+    endloop
+  endfacet
+  facet normal -0.528627 0.469718 0.707049
+    outer loop
+      vertex 20.8915 -19.3119 0.599999
+      vertex 21.1773 -18.0871 0
+      vertex 20.4509 -18.9046 0
+    endloop
+  endfacet
+  facet normal -0.308661 -0.636249 0.707047
+    outer loop
+      vertex 12.916 25.3491 0.599999
+      vertex 11.9109 25.8367 0.599999
+      vertex 11.6597 25.2918 0
+    endloop
+  endfacet
+  facet normal 0.580133 0.404353 0.707067
+    outer loop
+      vertex -23.0165 -16.7225 0.599999
+      vertex -23.1564 -15.4726 0
+      vertex -23.6553 -15.806 0.599999
+    endloop
+  endfacet
+  facet normal 0.490119 -0.509742 0.707069
+    outer loop
+      vertex -19.6929 19.6929 0
+      vertex -19.3119 20.8915 0.599999
+      vertex -20.1172 20.1172 0.599999
+    endloop
+  endfacet
+  facet normal 0.528651 0.469715 0.707033
+    outer loop
+      vertex -20.8915 -19.3119 0.599999
+      vertex -21.1773 -18.0871 0
+      vertex -21.6335 -18.4768 0.599999
+    endloop
+  endfacet
+  facet normal -0.580167 -0.404345 0.707044
+    outer loop
+      vertex 23.1564 15.4726 0
+      vertex 23.0165 16.7225 0.599999
+      vertex 22.5311 16.3698 0
+    endloop
+  endfacet
+  facet normal 0.178509 -0.684259 0.707053
+    outer loop
+      vertex -7.55962 26.8044 0
+      vertex -6.64152 27.6639 0.599999
+      vertex -7.72248 27.3819 0.599999
+    endloop
+  endfacet
+  facet normal 0.124295 -0.696207 0.706998
+    outer loop
+      vertex -5.43326 27.3149 0
+      vertex -4.3567 27.5071 0
+      vertex -5.55032 27.9033 0.599999
+    endloop
+  endfacet
+  facet normal -0.63626 -0.308656 0.707039
+    outer loop
+      vertex 25.2918 11.6597 0
+      vertex 25.3491 12.916 0.599999
+      vertex 24.8145 12.6436 0
+    endloop
+  endfacet
+  facet normal -0.690751 -0.151576 0.707027
+    outer loop
+      vertex 27.3149 5.43326 0
+      vertex 27.6639 6.64152 0.599999
+      vertex 27.0805 6.50145 0
+    endloop
+  endfacet
+  facet normal -0.684259 0.178509 0.707053
+    outer loop
+      vertex 27.3819 -7.72248 0.599999
+      vertex 27.6639 -6.64152 0.599999
+      vertex 26.8044 -7.55962 0
+    endloop
+  endfacet
+  facet normal 0.580167 0.404345 0.707044
+    outer loop
+      vertex -23.0165 -16.7225 0.599999
+      vertex -22.5311 -16.3698 0
+      vertex -23.1564 -15.4726 0
+    endloop
+  endfacet
+  facet normal -0.707002 -0.0138623 0.707076
+    outer loop
+      vertex 28.45 0 0.599999
+      vertex 28.4281 1.11694 0.599999
+      vertex 27.8285 1.09339 0
+    endloop
+  endfacet
+  facet normal -0.707002 0.0138623 0.707076
+    outer loop
+      vertex 28.4281 -1.11694 0.599999
+      vertex 28.45 0 0.599999
+      vertex 27.8285 -1.09339 0
+    endloop
+  endfacet
+  facet normal -0.04165 0.70591 0.707076
+    outer loop
+      vertex 1.11694 -28.4281 0.599999
+      vertex 2.23216 -28.3623 0.599999
+      vertex 1.09339 -27.8285 0
+    endloop
+  endfacet
+  facet normal -0.700524 -0.0969357 0.707015
+    outer loop
+      vertex 27.657 3.27342 0
+      vertex 28.2528 3.34394 0.599999
+      vertex 27.5071 4.3567 0
+    endloop
+  endfacet
+  facet normal -0.696207 0.124295 0.706998
+    outer loop
+      vertex 27.9033 -5.55032 0.599999
+      vertex 27.5071 -4.3567 0
+      vertex 27.3149 -5.43326 0
+    endloop
+  endfacet
+  facet normal -0.469715 -0.528651 0.707033
+    outer loop
+      vertex 19.3119 20.8915 0.599999
+      vertex 18.4768 21.6335 0.599999
+      vertex 18.0871 21.1773 0
+    endloop
+  endfacet
+  facet normal -0.70591 0.04165 0.707076
+    outer loop
+      vertex 28.3623 -2.23216 0.599999
+      vertex 28.4281 -1.11694 0.599999
+      vertex 27.8285 -1.09339 0
+    endloop
+  endfacet
+  facet normal -0.528627 -0.469718 0.707049
+    outer loop
+      vertex 21.1773 18.0871 0
+      vertex 20.8915 19.3119 0.599999
+      vertex 20.4509 18.9046 0
+    endloop
+  endfacet
+  facet normal -0.257747 0.65849 0.707077
+    outer loop
+      vertex 10.8873 -26.2844 0.599999
+      vertex 10.6577 -25.73 0
+      vertex 9.63936 -26.1286 0
+    endloop
+  endfacet
+  facet normal 0.509741 -0.490148 0.70705
+    outer loop
+      vertex -20.4509 18.9046 0
+      vertex -19.6929 19.6929 0
+      vertex -20.8915 19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0.528627 -0.469718 0.707049
+    outer loop
+      vertex -20.4509 18.9046 0
+      vertex -20.8915 19.3119 0.599999
+      vertex -21.1773 18.0871 0
+    endloop
+  endfacet
+  facet normal 0.703793 -0.0693171 0.707015
+    outer loop
+      vertex -27.657 3.27342 0
+      vertex -28.2528 3.34394 0.599999
+      vertex -28.3623 2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0.70591 -0.04165 0.707076
+    outer loop
+      vertex -27.8285 1.09339 0
+      vertex -28.3623 2.23216 0.599999
+      vertex -28.4281 1.11694 0.599999
+    endloop
+  endfacet
+  facet normal 0.448663 -0.546634 0.707031
+    outer loop
+      vertex -18.0871 21.1773 0
+      vertex -17.2418 21.8711 0
+      vertex -18.4768 21.6335 0.599999
+    endloop
+  endfacet
+  facet normal -0.151552 -0.690785 0.706999
+    outer loop
+      vertex 6.64152 27.6639 0.599999
+      vertex 5.55032 27.9033 0.599999
+      vertex 5.43326 27.3149 0
+    endloop
+  endfacet
+  facet normal -0.381274 -0.595579 0.707047
+    outer loop
+      vertex 15.4726 23.1564 0
+      vertex 14.8651 24.2576 0.599999
+      vertex 14.5516 23.746 0
+    endloop
+  endfacet
+  facet normal -0.404353 -0.580133 0.707067
+    outer loop
+      vertex 16.7225 23.0165 0.599999
+      vertex 15.806 23.6553 0.599999
+      vertex 15.4726 23.1564 0
+    endloop
+  endfacet
+  facet normal -0.509742 -0.490119 0.707069
+    outer loop
+      vertex 20.8915 19.3119 0.599999
+      vertex 20.1172 20.1172 0.599999
+      vertex 19.6929 19.6929 0
+    endloop
+  endfacet
+  facet normal 0.64789 0.283339 0.707076
+    outer loop
+      vertex -25.2918 -11.6597 0
+      vertex -25.73 -10.6577 0
+      vertex -26.2844 -10.8873 0.599999
+    endloop
+  endfacet
+  facet normal 0.610095 0.357586 0.707048
+    outer loop
+      vertex -24.2576 -14.8651 0.599999
+      vertex -23.746 -14.5516 0
+      vertex -24.299 -13.6081 0
+    endloop
+  endfacet
+  facet normal 0.0416425 0.705918 0.707068
+    outer loop
+      vertex -1.09339 -27.8285 0
+      vertex -2.18509 -27.7641 0
+      vertex -2.23216 -28.3623 0.599999
+    endloop
+  endfacet
+  facet normal 0.705918 -0.0416425 0.707068
+    outer loop
+      vertex -27.8285 1.09339 0
+      vertex -27.7641 2.18509 0
+      vertex -28.3623 2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0.333329 0.623679 0.707048
+    outer loop
+      vertex -12.916 -25.3491 0.599999
+      vertex -13.6081 -24.299 0
+      vertex -13.9013 -24.8225 0.599999
+    endloop
+  endfacet
+  facet normal 0.0969149 0.700509 0.707032
+    outer loop
+      vertex -3.34394 -28.2528 0.599999
+      vertex -4.3567 -27.5071 0
+      vertex -4.45056 -28.0997 0.599999
+    endloop
+  endfacet
+  facet normal -0.563884 -0.426793 0.707023
+    outer loop
+      vertex 22.5311 16.3698 0
+      vertex 22.3423 17.6132 0.599999
+      vertex 21.8711 17.2418 0
+    endloop
+  endfacet
+  facet normal -0.0138623 -0.707002 0.707076
+    outer loop
+      vertex 1.09339 27.8285 0
+      vertex 1.11694 28.4281 0.599999
+      vertex 0 28.45 0.599999
+    endloop
+  endfacet
+  facet normal -0.0969149 0.700509 0.707032
+    outer loop
+      vertex 4.45056 -28.0997 0.599999
+      vertex 4.3567 -27.5071 0
+      vertex 3.34394 -28.2528 0.599999
+    endloop
+  endfacet
+  facet normal -0.668133 0.231742 0.707031
+    outer loop
+      vertex 26.6915 -9.84703 0.599999
+      vertex 27.0576 -8.79153 0.599999
+      vertex 26.1286 -9.63936 0
+    endloop
+  endfacet
+  facet normal -0.0416425 -0.705918 0.707068
+    outer loop
+      vertex 2.18509 27.7641 0
+      vertex 2.23216 28.3623 0.599999
+      vertex 1.09339 27.8285 0
+    endloop
+  endfacet
+  facet normal -0.0139029 0.707038 0.707039
+    outer loop
+      vertex 1.09339 -27.8285 0
+      vertex 0 -27.85 0
+      vertex 0 -28.45 0.599999
+    endloop
+  endfacet
+  facet normal 0.546634 -0.448663 0.707031
+    outer loop
+      vertex -21.1773 18.0871 0
+      vertex -21.6335 18.4768 0.599999
+      vertex -21.8711 17.2418 0
+    endloop
+  endfacet
+  facet normal -0.448661 0.546647 0.707022
+    outer loop
+      vertex 17.6132 -22.3423 0.599999
+      vertex 18.4768 -21.6335 0.599999
+      vertex 17.2418 -21.8711 0
+    endloop
+  endfacet
+  facet normal 0.65849 0.257747 0.707077
+    outer loop
+      vertex -25.73 -10.6577 0
+      vertex -26.1286 -9.63936 0
+      vertex -26.2844 -10.8873 0.599999
+    endloop
+  endfacet
+  facet normal -0.546634 -0.448663 0.707031
+    outer loop
+      vertex 21.8711 17.2418 0
+      vertex 21.6335 18.4768 0.599999
+      vertex 21.1773 18.0871 0
+    endloop
+  endfacet
+  facet normal -0.333342 -0.623682 0.707039
+    outer loop
+      vertex 13.6081 24.299 0
+      vertex 12.916 25.3491 0.599999
+      vertex 12.6436 24.8145 0
+    endloop
+  endfacet
+  facet normal 0.64789 -0.283339 0.707076
+    outer loop
+      vertex -25.73 10.6577 0
+      vertex -25.2918 11.6597 0
+      vertex -26.2844 10.8873 0.599999
+    endloop
+  endfacet
+  facet normal -0.448663 0.546634 0.707031
+    outer loop
+      vertex 18.4768 -21.6335 0.599999
+      vertex 18.0871 -21.1773 0
+      vertex 17.2418 -21.8711 0
+    endloop
+  endfacet
+  facet normal -0.069254 -0.703746 0.707069
+    outer loop
+      vertex 3.27342 27.657 0
+      vertex 2.23216 28.3623 0.599999
+      vertex 2.18509 27.7641 0
+    endloop
+  endfacet
+  facet normal 0.684259 0.178509 0.707053
+    outer loop
+      vertex -27.3819 -7.72248 0.599999
+      vertex -26.8044 -7.55962 0
+      vertex -27.6639 -6.64152 0.599999
+    endloop
+  endfacet
+  facet normal 0.490148 0.509741 0.70705
+    outer loop
+      vertex -19.3119 -20.8915 0.599999
+      vertex -18.9046 -20.4509 0
+      vertex -19.6929 -19.6929 0
+    endloop
+  endfacet
+  facet normal -0.0693171 -0.703793 0.707015
+    outer loop
+      vertex 3.27342 27.657 0
+      vertex 3.34394 28.2528 0.599999
+      vertex 2.23216 28.3623 0.599999
+    endloop
+  endfacet
+  facet normal 0.257718 0.65855 0.707031
+    outer loop
+      vertex -9.84703 -26.6915 0.599999
+      vertex -9.63936 -26.1286 0
+      vertex -10.8873 -26.2844 0.599999
+    endloop
+  endfacet
+  facet normal 0.676702 -0.205306 0.707053
+    outer loop
+      vertex -26.8044 7.55962 0
+      vertex -26.4869 8.60612 0
+      vertex -27.3819 7.72248 0.599999
+    endloop
+  endfacet
+  facet normal -0.610094 0.357587 0.707049
+    outer loop
+      vertex 24.8225 -13.9013 0.599999
+      vertex 24.299 -13.6081 0
+      vertex 24.2576 -14.8651 0.599999
+    endloop
+  endfacet
+  facet normal 0.546634 0.448663 0.707031
+    outer loop
+      vertex -21.6335 -18.4768 0.599999
+      vertex -21.1773 -18.0871 0
+      vertex -21.8711 -17.2418 0
+    endloop
+  endfacet
+  facet normal -0.257718 0.65855 0.707031
+    outer loop
+      vertex 9.84703 -26.6915 0.599999
+      vertex 10.8873 -26.2844 0.599999
+      vertex 9.63936 -26.1286 0
+    endloop
+  endfacet
+  facet normal -0.700509 -0.0969149 0.707032
+    outer loop
+      vertex 28.2528 3.34394 0.599999
+      vertex 28.0997 4.45056 0.599999
+      vertex 27.5071 4.3567 0
+    endloop
+  endfacet
+  facet normal -0.707038 0.0139029 0.707039
+    outer loop
+      vertex 28.45 0 0.599999
+      vertex 27.85 0 0
+      vertex 27.8285 -1.09339 0
+    endloop
+  endfacet
+  facet normal -0.690785 0.151552 0.706999
+    outer loop
+      vertex 27.6639 -6.64152 0.599999
+      vertex 27.9033 -5.55032 0.599999
+      vertex 27.3149 -5.43326 0
+    endloop
+  endfacet
+  facet normal -0.703793 -0.0693171 0.707015
+    outer loop
+      vertex 28.3623 2.23216 0.599999
+      vertex 28.2528 3.34394 0.599999
+      vertex 27.657 3.27342 0
+    endloop
+  endfacet
+  facet normal 0.490148 -0.509741 0.70705
+    outer loop
+      vertex -18.9046 20.4509 0
+      vertex -19.3119 20.8915 0.599999
+      vertex -19.6929 19.6929 0
+    endloop
+  endfacet
+  facet normal -0.64789 -0.283339 0.707076
+    outer loop
+      vertex 25.73 10.6577 0
+      vertex 26.2844 10.8873 0.599999
+      vertex 25.2918 11.6597 0
+    endloop
+  endfacet
+  facet normal -0.595574 0.381246 0.707067
+    outer loop
+      vertex 23.6553 -15.806 0.599999
+      vertex 24.2576 -14.8651 0.599999
+      vertex 23.1564 -15.4726 0
+    endloop
+  endfacet
+  facet normal -0.623679 -0.333329 0.707048
+    outer loop
+      vertex 25.3491 12.916 0.599999
+      vertex 24.8225 13.9013 0.599999
+      vertex 24.299 13.6081 0
+    endloop
+  endfacet
+  facet normal 0.623682 0.333342 0.707039
+    outer loop
+      vertex -24.299 -13.6081 0
+      vertex -24.8145 -12.6436 0
+      vertex -25.3491 -12.916 0.599999
+    endloop
+  endfacet
+  facet normal 0.231742 -0.668133 0.707031
+    outer loop
+      vertex -9.63936 26.1286 0
+      vertex -8.79153 27.0576 0.599999
+      vertex -9.84703 26.6915 0.599999
+    endloop
+  endfacet
+  facet normal 0.469718 -0.528627 0.707049
+    outer loop
+      vertex -18.9046 20.4509 0
+      vertex -18.0871 21.1773 0
+      vertex -19.3119 20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0.595574 0.381246 0.707067
+    outer loop
+      vertex -23.6553 -15.806 0.599999
+      vertex -23.1564 -15.4726 0
+      vertex -24.2576 -14.8651 0.599999
+    endloop
+  endfacet
+  facet normal -0.448661 -0.546647 0.707022
+    outer loop
+      vertex 18.4768 21.6335 0.599999
+      vertex 17.6132 22.3423 0.599999
+      vertex 17.2418 21.8711 0
+    endloop
+  endfacet
+  facet normal -0.647904 -0.283379 0.707048
+    outer loop
+      vertex 26.2844 10.8873 0.599999
+      vertex 25.8367 11.9109 0.599999
+      vertex 25.2918 11.6597 0
+    endloop
+  endfacet
+  facet normal -0.205306 -0.676702 0.707053
+    outer loop
+      vertex 8.60612 26.4869 0
+      vertex 7.72248 27.3819 0.599999
+      vertex 7.55962 26.8044 0
+    endloop
+  endfacet
+  facet normal -0.563853 -0.426799 0.707045
+    outer loop
+      vertex 22.5311 16.3698 0
+      vertex 23.0165 16.7225 0.599999
+      vertex 22.3423 17.6132 0.599999
+    endloop
+  endfacet
+  facet normal 0.151552 0.690785 0.706999
+    outer loop
+      vertex -5.55032 -27.9033 0.599999
+      vertex -5.43326 -27.3149 0
+      vertex -6.64152 -27.6639 0.599999
+    endloop
+  endfacet
+  facet normal 0.0693171 0.703793 0.707015
+    outer loop
+      vertex -2.23216 -28.3623 0.599999
+      vertex -3.27342 -27.657 0
+      vertex -3.34394 -28.2528 0.599999
+    endloop
+  endfacet
+  facet normal -0.490119 0.509742 0.707069
+    outer loop
+      vertex 20.1172 -20.1172 0.599999
+      vertex 19.6929 -19.6929 0
+      vertex 19.3119 -20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0.696207 -0.124295 0.706998
+    outer loop
+      vertex -27.5071 4.3567 0
+      vertex -27.3149 5.43326 0
+      vertex -27.9033 5.55032 0.599999
+    endloop
+  endfacet
+  facet normal -0.647904 0.283379 0.707048
+    outer loop
+      vertex 25.8367 -11.9109 0.599999
+      vertex 26.2844 -10.8873 0.599999
+      vertex 25.2918 -11.6597 0
+    endloop
+  endfacet
+  facet normal -0.0416425 0.705918 0.707068
+    outer loop
+      vertex 2.23216 -28.3623 0.599999
+      vertex 2.18509 -27.7641 0
+      vertex 1.09339 -27.8285 0
+    endloop
+  endfacet
+  facet normal 0.257747 -0.65849 0.707077
+    outer loop
+      vertex -10.6577 25.73 0
+      vertex -9.63936 26.1286 0
+      vertex -10.8873 26.2844 0.599999
+    endloop
+  endfacet
+  facet normal -0.308656 -0.63626 0.707039
+    outer loop
+      vertex 12.6436 24.8145 0
+      vertex 12.916 25.3491 0.599999
+      vertex 11.6597 25.2918 0
+    endloop
+  endfacet
+  facet normal -0.546634 0.448663 0.707031
+    outer loop
+      vertex 21.6335 -18.4768 0.599999
+      vertex 21.8711 -17.2418 0
+      vertex 21.1773 -18.0871 0
+    endloop
+  endfacet
+  facet normal -0.333342 0.623682 0.707039
+    outer loop
+      vertex 12.916 -25.3491 0.599999
+      vertex 13.6081 -24.299 0
+      vertex 12.6436 -24.8145 0
+    endloop
+  endfacet
+  facet normal -0.308661 0.636249 0.707047
+    outer loop
+      vertex 11.9109 -25.8367 0.599999
+      vertex 12.916 -25.3491 0.599999
+      vertex 11.6597 -25.2918 0
+    endloop
+  endfacet
+  facet normal 0.70591 0.04165 0.707076
+    outer loop
+      vertex -28.3623 -2.23216 0.599999
+      vertex -27.8285 -1.09339 0
+      vertex -28.4281 -1.11694 0.599999
+    endloop
+  endfacet
+  facet normal -0.595579 -0.381274 0.707047
+    outer loop
+      vertex 23.746 14.5516 0
+      vertex 24.2576 14.8651 0.599999
+      vertex 23.1564 15.4726 0
+    endloop
+  endfacet
+  facet normal 0.178509 0.684259 0.707053
+    outer loop
+      vertex -6.64152 -27.6639 0.599999
+      vertex -7.55962 -26.8044 0
+      vertex -7.72248 -27.3819 0.599999
+    endloop
+  endfacet
+  facet normal 0.178543 0.684277 0.707027
+    outer loop
+      vertex -6.64152 -27.6639 0.599999
+      vertex -6.50145 -27.0805 0
+      vertex -7.55962 -26.8044 0
+    endloop
+  endfacet
+  facet normal 0.707038 -0.0139029 0.707039
+    outer loop
+      vertex -27.85 0 0
+      vertex -27.8285 1.09339 0
+      vertex -28.45 0 0.599999
+    endloop
+  endfacet
+  facet normal 0.707002 -0.0138623 0.707076
+    outer loop
+      vertex -27.8285 1.09339 0
+      vertex -28.4281 1.11694 0.599999
+      vertex -28.45 0 0.599999
+    endloop
+  endfacet
+  facet normal 0.684259 -0.178509 0.707053
+    outer loop
+      vertex -26.8044 7.55962 0
+      vertex -27.3819 7.72248 0.599999
+      vertex -27.6639 6.64152 0.599999
+    endloop
+  endfacet
+  facet normal -0.676702 0.205306 0.707053
+    outer loop
+      vertex 27.3819 -7.72248 0.599999
+      vertex 26.8044 -7.55962 0
+      vertex 26.4869 -8.60612 0
+    endloop
+  endfacet
+  facet normal -0.0969357 0.700524 0.707015
+    outer loop
+      vertex 3.34394 -28.2528 0.599999
+      vertex 4.3567 -27.5071 0
+      vertex 3.27342 -27.657 0
+    endloop
+  endfacet
+  facet normal 0.595574 -0.381246 0.707067
+    outer loop
+      vertex -23.1564 15.4726 0
+      vertex -23.6553 15.806 0.599999
+      vertex -24.2576 14.8651 0.599999
+    endloop
+  endfacet
+  facet normal -0.124295 -0.696207 0.706998
+    outer loop
+      vertex 5.43326 27.3149 0
+      vertex 5.55032 27.9033 0.599999
+      vertex 4.3567 27.5071 0
+    endloop
+  endfacet
+  facet normal -0.283339 0.64789 0.707076
+    outer loop
+      vertex 10.8873 -26.2844 0.599999
+      vertex 11.6597 -25.2918 0
+      vertex 10.6577 -25.73 0
+    endloop
+  endfacet
+  facet normal -0.684277 0.178543 0.707027
+    outer loop
+      vertex 27.6639 -6.64152 0.599999
+      vertex 27.0805 -6.50145 0
+      vertex 26.8044 -7.55962 0
+    endloop
+  endfacet
+  facet normal -0.178509 0.684259 0.707053
+    outer loop
+      vertex 7.72248 -27.3819 0.599999
+      vertex 7.55962 -26.8044 0
+      vertex 6.64152 -27.6639 0.599999
+    endloop
+  endfacet
+  facet normal -0.205275 0.676687 0.707076
+    outer loop
+      vertex 8.79153 -27.0576 0.599999
+      vertex 8.60612 -26.4869 0
+      vertex 7.72248 -27.3819 0.599999
+    endloop
+  endfacet
+  facet normal 0.623679 -0.333329 0.707048
+    outer loop
+      vertex -24.299 13.6081 0
+      vertex -24.8225 13.9013 0.599999
+      vertex -25.3491 12.916 0.599999
+    endloop
+  endfacet
+  facet normal 0.623679 0.333329 0.707048
+    outer loop
+      vertex -24.8225 -13.9013 0.599999
+      vertex -24.299 -13.6081 0
+      vertex -25.3491 -12.916 0.599999
+    endloop
+  endfacet
+  facet normal -0.676687 -0.205275 0.707076
+    outer loop
+      vertex 27.3819 7.72248 0.599999
+      vertex 27.0576 8.79153 0.599999
+      vertex 26.4869 8.60612 0
+    endloop
+  endfacet
+  facet normal 0.151552 -0.690785 0.706999
+    outer loop
+      vertex -5.43326 27.3149 0
+      vertex -5.55032 27.9033 0.599999
+      vertex -6.64152 27.6639 0.599999
+    endloop
+  endfacet
+  facet normal -0.283379 -0.647904 0.707048
+    outer loop
+      vertex 11.6597 25.2918 0
+      vertex 11.9109 25.8367 0.599999
+      vertex 10.8873 26.2844 0.599999
+    endloop
+  endfacet
+  facet normal -0.490119 -0.509742 0.707069
+    outer loop
+      vertex 19.6929 19.6929 0
+      vertex 20.1172 20.1172 0.599999
+      vertex 19.3119 20.8915 0.599999
+    endloop
+  endfacet
+  facet normal -0.0139029 -0.707038 0.707039
+    outer loop
+      vertex 1.09339 27.8285 0
+      vertex 0 28.45 0.599999
+      vertex 0 27.85 0
+    endloop
+  endfacet
+  facet normal -0.490148 -0.509741 0.70705
+    outer loop
+      vertex 19.6929 19.6929 0
+      vertex 19.3119 20.8915 0.599999
+      vertex 18.9046 20.4509 0
+    endloop
+  endfacet
+  facet normal -0.490148 0.509741 0.70705
+    outer loop
+      vertex 19.3119 -20.8915 0.599999
+      vertex 19.6929 -19.6929 0
+      vertex 18.9046 -20.4509 0
+    endloop
+  endfacet
+  facet normal -0.690751 0.151576 0.707027
+    outer loop
+      vertex 27.6639 -6.64152 0.599999
+      vertex 27.3149 -5.43326 0
+      vertex 27.0805 -6.50145 0
+    endloop
+  endfacet
+  facet normal 0.623682 -0.333342 0.707039
+    outer loop
+      vertex -24.8145 12.6436 0
+      vertex -24.299 13.6081 0
+      vertex -25.3491 12.916 0.599999
+    endloop
+  endfacet
+  facet normal 0.308656 -0.63626 0.707039
+    outer loop
+      vertex -12.6436 24.8145 0
+      vertex -11.6597 25.2918 0
+      vertex -12.916 25.3491 0.599999
+    endloop
+  endfacet
+  facet normal 0.700524 0.0969357 0.707015
+    outer loop
+      vertex -27.5071 -4.3567 0
+      vertex -27.657 -3.27342 0
+      vertex -28.2528 -3.34394 0.599999
+    endloop
+  endfacet
+  facet normal 0.490119 0.509742 0.707069
+    outer loop
+      vertex -19.3119 -20.8915 0.599999
+      vertex -19.6929 -19.6929 0
+      vertex -20.1172 -20.1172 0.599999
+    endloop
+  endfacet
+  facet normal -0.668133 -0.231742 0.707031
+    outer loop
+      vertex 27.0576 8.79153 0.599999
+      vertex 26.6915 9.84703 0.599999
+      vertex 26.1286 9.63936 0
+    endloop
+  endfacet
+  facet normal -0.700509 0.0969149 0.707032
+    outer loop
+      vertex 28.0997 -4.45056 0.599999
+      vertex 28.2528 -3.34394 0.599999
+      vertex 27.5071 -4.3567 0
+    endloop
+  endfacet
+  facet normal -0.124295 0.696207 0.706998
+    outer loop
+      vertex 5.55032 -27.9033 0.599999
+      vertex 5.43326 -27.3149 0
+      vertex 4.3567 -27.5071 0
+    endloop
+  endfacet
+  facet normal 0.636249 -0.308661 0.707047
+    outer loop
+      vertex -25.2918 11.6597 0
+      vertex -25.3491 12.916 0.599999
+      vertex -25.8367 11.9109 0.599999
+    endloop
+  endfacet
+  facet normal 0.700509 -0.0969149 0.707032
+    outer loop
+      vertex -27.5071 4.3567 0
+      vertex -28.0997 4.45056 0.599999
+      vertex -28.2528 3.34394 0.599999
+    endloop
+  endfacet
+  facet normal -0.0138623 0.707002 0.707076
+    outer loop
+      vertex 1.11694 -28.4281 0.599999
+      vertex 1.09339 -27.8285 0
+      vertex 0 -28.45 0.599999
+    endloop
+  endfacet
+  facet normal -0.546647 -0.448661 0.707022
+    outer loop
+      vertex 21.8711 17.2418 0
+      vertex 22.3423 17.6132 0.599999
+      vertex 21.6335 18.4768 0.599999
+    endloop
+  endfacet
+  facet normal 0.04165 0.70591 0.707076
+    outer loop
+      vertex -1.11694 -28.4281 0.599999
+      vertex -1.09339 -27.8285 0
+      vertex -2.23216 -28.3623 0.599999
+    endloop
+  endfacet
+  facet normal -0.257718 -0.65855 0.707031
+    outer loop
+      vertex 10.8873 26.2844 0.599999
+      vertex 9.84703 26.6915 0.599999
+      vertex 9.63936 26.1286 0
+    endloop
+  endfacet
+  facet normal -0.469718 0.528627 0.707049
+    outer loop
+      vertex 19.3119 -20.8915 0.599999
+      vertex 18.9046 -20.4509 0
+      vertex 18.0871 -21.1773 0
+    endloop
+  endfacet
+  facet normal 0.647904 -0.283379 0.707048
+    outer loop
+      vertex -25.2918 11.6597 0
+      vertex -25.8367 11.9109 0.599999
+      vertex -26.2844 10.8873 0.599999
+    endloop
+  endfacet
+  facet normal -0.595579 0.381274 0.707047
+    outer loop
+      vertex 24.2576 -14.8651 0.599999
+      vertex 23.746 -14.5516 0
+      vertex 23.1564 -15.4726 0
+    endloop
+  endfacet
+  facet normal 0.404345 -0.580167 0.707044
+    outer loop
+      vertex -16.3698 22.5311 0
+      vertex -15.4726 23.1564 0
+      vertex -16.7225 23.0165 0.599999
+    endloop
+  endfacet
+  facet normal -0.546647 0.448661 0.707022
+    outer loop
+      vertex 22.3423 -17.6132 0.599999
+      vertex 21.8711 -17.2418 0
+      vertex 21.6335 -18.4768 0.599999
+    endloop
+  endfacet
+  facet normal -0.676687 0.205275 0.707076
+    outer loop
+      vertex 27.0576 -8.79153 0.599999
+      vertex 27.3819 -7.72248 0.599999
+      vertex 26.4869 -8.60612 0
+    endloop
+  endfacet
+  facet normal -0.705918 0.0416425 0.707068
+    outer loop
+      vertex 28.3623 -2.23216 0.599999
+      vertex 27.8285 -1.09339 0
+      vertex 27.7641 -2.18509 0
+    endloop
+  endfacet
+  facet normal -0.703746 0.069254 0.707069
+    outer loop
+      vertex 28.3623 -2.23216 0.599999
+      vertex 27.7641 -2.18509 0
+      vertex 27.657 -3.27342 0
+    endloop
+  endfacet
+  facet normal 0.668133 -0.231742 0.707031
+    outer loop
+      vertex -26.1286 9.63936 0
+      vertex -26.6915 9.84703 0.599999
+      vertex -27.0576 8.79153 0.599999
+    endloop
+  endfacet
+  facet normal -0.426793 0.563884 0.707023
+    outer loop
+      vertex 17.6132 -22.3423 0.599999
+      vertex 17.2418 -21.8711 0
+      vertex 16.3698 -22.5311 0
+    endloop
+  endfacet
+  facet normal 0.528627 0.469718 0.707049
+    outer loop
+      vertex -20.8915 -19.3119 0.599999
+      vertex -20.4509 -18.9046 0
+      vertex -21.1773 -18.0871 0
+    endloop
+  endfacet
+  facet normal -0.703746 -0.069254 0.707069
+    outer loop
+      vertex 27.7641 2.18509 0
+      vertex 28.3623 2.23216 0.599999
+      vertex 27.657 3.27342 0
+    endloop
+  endfacet
+  facet normal -0.705918 -0.0416425 0.707068
+    outer loop
+      vertex 27.8285 1.09339 0
+      vertex 28.3623 2.23216 0.599999
+      vertex 27.7641 2.18509 0
+    endloop
+  endfacet
+  facet normal 0.690751 -0.151576 0.707027
+    outer loop
+      vertex -27.3149 5.43326 0
+      vertex -27.0805 6.50145 0
+      vertex -27.6639 6.64152 0.599999
+    endloop
+  endfacet
+  facet normal -0.151552 0.690785 0.706999
+    outer loop
+      vertex 5.55032 -27.9033 0.599999
+      vertex 6.64152 -27.6639 0.599999
+      vertex 5.43326 -27.3149 0
+    endloop
+  endfacet
+  facet normal 0.205306 -0.676702 0.707053
+    outer loop
+      vertex -7.55962 26.8044 0
+      vertex -7.72248 27.3819 0.599999
+      vertex -8.60612 26.4869 0
+    endloop
+  endfacet
+  facet normal 0.205275 -0.676687 0.707076
+    outer loop
+      vertex -8.60612 26.4869 0
+      vertex -7.72248 27.3819 0.599999
+      vertex -8.79153 27.0576 0.599999
+    endloop
+  endfacet
+  facet normal -0.636249 -0.308661 0.707047
+    outer loop
+      vertex 25.8367 11.9109 0.599999
+      vertex 25.3491 12.916 0.599999
+      vertex 25.2918 11.6597 0
+    endloop
+  endfacet
+  facet normal -0.231742 0.668133 0.707031
+    outer loop
+      vertex 9.84703 -26.6915 0.599999
+      vertex 9.63936 -26.1286 0
+      vertex 8.79153 -27.0576 0.599999
+    endloop
+  endfacet
+  facet normal -0.283379 0.647904 0.707048
+    outer loop
+      vertex 11.9109 -25.8367 0.599999
+      vertex 11.6597 -25.2918 0
+      vertex 10.8873 -26.2844 0.599999
+    endloop
+  endfacet
+  facet normal -0.563884 0.426793 0.707023
+    outer loop
+      vertex 22.3423 -17.6132 0.599999
+      vertex 22.5311 -16.3698 0
+      vertex 21.8711 -17.2418 0
+    endloop
+  endfacet
+  facet normal -0.381246 -0.595574 0.707067
+    outer loop
+      vertex 15.4726 23.1564 0
+      vertex 15.806 23.6553 0.599999
+      vertex 14.8651 24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0.426793 -0.563884 0.707023
+    outer loop
+      vertex -17.2418 21.8711 0
+      vertex -16.3698 22.5311 0
+      vertex -17.6132 22.3423 0.599999
+    endloop
+  endfacet
+  facet normal 0.707002 0.0138623 0.707076
+    outer loop
+      vertex -28.4281 -1.11694 0.599999
+      vertex -27.8285 -1.09339 0
+      vertex -28.45 0 0.599999
+    endloop
+  endfacet
+  facet normal 0.707038 0.0139029 0.707039
+    outer loop
+      vertex -27.8285 -1.09339 0
+      vertex -27.85 0 0
+      vertex -28.45 0 0.599999
+    endloop
+  endfacet
+  facet normal -0.469718 -0.528627 0.707049
+    outer loop
+      vertex 18.9046 20.4509 0
+      vertex 19.3119 20.8915 0.599999
+      vertex 18.0871 21.1773 0
+    endloop
+  endfacet
+  facet normal 0.448661 -0.546647 0.707022
+    outer loop
+      vertex -17.2418 21.8711 0
+      vertex -17.6132 22.3423 0.599999
+      vertex -18.4768 21.6335 0.599999
+    endloop
+  endfacet
+  facet normal 0.308656 0.63626 0.707039
+    outer loop
+      vertex -11.6597 -25.2918 0
+      vertex -12.6436 -24.8145 0
+      vertex -12.916 -25.3491 0.599999
+    endloop
+  endfacet
+  facet normal -0.623682 0.333342 0.707039
+    outer loop
+      vertex 25.3491 -12.916 0.599999
+      vertex 24.8145 -12.6436 0
+      vertex 24.299 -13.6081 0
+    endloop
+  endfacet
+  facet normal -0.623679 0.333329 0.707048
+    outer loop
+      vertex 24.8225 -13.9013 0.599999
+      vertex 25.3491 -12.916 0.599999
+      vertex 24.299 -13.6081 0
+    endloop
+  endfacet
+  facet normal 0.426793 0.563884 0.707023
+    outer loop
+      vertex -16.3698 -22.5311 0
+      vertex -17.2418 -21.8711 0
+      vertex -17.6132 -22.3423 0.599999
+    endloop
+  endfacet
+  facet normal 0.595579 -0.381274 0.707047
+    outer loop
+      vertex -23.746 14.5516 0
+      vertex -23.1564 15.4726 0
+      vertex -24.2576 14.8651 0.599999
+    endloop
+  endfacet
+  facet normal -0.63626 0.308656 0.707039
+    outer loop
+      vertex 25.3491 -12.916 0.599999
+      vertex 25.2918 -11.6597 0
+      vertex 24.8145 -12.6436 0
+    endloop
+  endfacet
+  facet normal 0.257718 -0.65855 0.707031
+    outer loop
+      vertex -9.63936 26.1286 0
+      vertex -9.84703 26.6915 0.599999
+      vertex -10.8873 26.2844 0.599999
+    endloop
+  endfacet
+  facet normal -0.178509 -0.684259 0.707053
+    outer loop
+      vertex 7.55962 26.8044 0
+      vertex 7.72248 27.3819 0.599999
+      vertex 6.64152 27.6639 0.599999
+    endloop
+  endfacet
+  facet normal 0.333342 0.623682 0.707039
+    outer loop
+      vertex -12.916 -25.3491 0.599999
+      vertex -12.6436 -24.8145 0
+      vertex -13.6081 -24.299 0
+    endloop
+  endfacet
+  facet normal -0.668107 -0.231682 0.707076
+    outer loop
+      vertex 26.4869 8.60612 0
+      vertex 27.0576 8.79153 0.599999
+      vertex 26.1286 9.63936 0
+    endloop
+  endfacet
+  facet normal -0.65855 -0.257718 0.707031
+    outer loop
+      vertex 26.6915 9.84703 0.599999
+      vertex 26.2844 10.8873 0.599999
+      vertex 26.1286 9.63936 0
+    endloop
+  endfacet
+  facet normal 0.283339 -0.64789 0.707076
+    outer loop
+      vertex -10.6577 25.73 0
+      vertex -10.8873 26.2844 0.599999
+      vertex -11.6597 25.2918 0
+    endloop
+  endfacet
+  facet normal 0.684277 -0.178543 0.707027
+    outer loop
+      vertex -27.0805 6.50145 0
+      vertex -26.8044 7.55962 0
+      vertex -27.6639 6.64152 0.599999
+    endloop
+  endfacet
+  facet normal 0.696207 0.124295 0.706998
+    outer loop
+      vertex -27.3149 -5.43326 0
+      vertex -27.5071 -4.3567 0
+      vertex -27.9033 -5.55032 0.599999
+    endloop
+  endfacet
+  facet normal 0.0969357 0.700524 0.707015
+    outer loop
+      vertex -3.34394 -28.2528 0.599999
+      vertex -3.27342 -27.657 0
+      vertex -4.3567 -27.5071 0
+    endloop
+  endfacet
+  facet normal -0.636249 0.308661 0.707047
+    outer loop
+      vertex 25.3491 -12.916 0.599999
+      vertex 25.8367 -11.9109 0.599999
+      vertex 25.2918 -11.6597 0
+    endloop
+  endfacet
+  facet normal 0.283379 0.647904 0.707048
+    outer loop
+      vertex -10.8873 -26.2844 0.599999
+      vertex -11.6597 -25.2918 0
+      vertex -11.9109 -25.8367 0.599999
+    endloop
+  endfacet
+  facet normal 0.0139029 0.707038 0.707039
+    outer loop
+      vertex 0 -28.45 0.599999
+      vertex 0 -27.85 0
+      vertex -1.09339 -27.8285 0
+    endloop
+  endfacet
+  facet normal 0.426799 -0.563853 0.707045
+    outer loop
+      vertex -16.3698 22.5311 0
+      vertex -16.7225 23.0165 0.599999
+      vertex -17.6132 22.3423 0.599999
+    endloop
+  endfacet
+  facet normal -0.623682 -0.333342 0.707039
+    outer loop
+      vertex 24.8145 12.6436 0
+      vertex 25.3491 12.916 0.599999
+      vertex 24.299 13.6081 0
+    endloop
+  endfacet
+  facet normal -0.124325 0.696168 0.707032
+    outer loop
+      vertex 4.45056 -28.0997 0.599999
+      vertex 5.55032 -27.9033 0.599999
+      vertex 4.3567 -27.5071 0
+    endloop
+  endfacet
+  facet normal 0.404353 0.580133 0.707067
+    outer loop
+      vertex -15.806 -23.6553 0.599999
+      vertex -15.4726 -23.1564 0
+      vertex -16.7225 -23.0165 0.599999
+    endloop
+  endfacet
+  facet normal 0.469715 -0.528651 0.707033
+    outer loop
+      vertex -18.0871 21.1773 0
+      vertex -18.4768 21.6335 0.599999
+      vertex -19.3119 20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0.283379 -0.647904 0.707048
+    outer loop
+      vertex -11.6597 25.2918 0
+      vertex -10.8873 26.2844 0.599999
+      vertex -11.9109 25.8367 0.599999
+    endloop
+  endfacet
+  facet normal 0.703746 0.069254 0.707069
+    outer loop
+      vertex -27.657 -3.27342 0
+      vertex -27.7641 -2.18509 0
+      vertex -28.3623 -2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0.357587 0.610094 0.707049
+    outer loop
+      vertex -13.9013 -24.8225 0.599999
+      vertex -13.6081 -24.299 0
+      vertex -14.8651 -24.2576 0.599999
+    endloop
+  endfacet
+  facet normal -0.205275 -0.676687 0.707076
+    outer loop
+      vertex 8.60612 26.4869 0
+      vertex 8.79153 27.0576 0.599999
+      vertex 7.72248 27.3819 0.599999
+    endloop
+  endfacet
+  facet normal -0.696207 -0.124295 0.706998
+    outer loop
+      vertex 27.5071 4.3567 0
+      vertex 27.9033 5.55032 0.599999
+      vertex 27.3149 5.43326 0
+    endloop
+  endfacet
+  facet normal -0.690785 -0.151552 0.706999
+    outer loop
+      vertex 27.9033 5.55032 0.599999
+      vertex 27.6639 6.64152 0.599999
+      vertex 27.3149 5.43326 0
+    endloop
+  endfacet
+  facet normal 0.124325 0.696168 0.707032
+    outer loop
+      vertex -4.45056 -28.0997 0.599999
+      vertex -4.3567 -27.5071 0
+      vertex -5.55032 -27.9033 0.599999
+    endloop
+  endfacet
+  facet normal -0.124325 -0.696168 0.707032
+    outer loop
+      vertex 5.55032 27.9033 0.599999
+      vertex 4.45056 28.0997 0.599999
+      vertex 4.3567 27.5071 0
+    endloop
+  endfacet
+  facet normal -0.257747 -0.65849 0.707077
+    outer loop
+      vertex 10.6577 25.73 0
+      vertex 10.8873 26.2844 0.599999
+      vertex 9.63936 26.1286 0
+    endloop
+  endfacet
+  facet normal -0.426793 -0.563884 0.707023
+    outer loop
+      vertex 17.2418 21.8711 0
+      vertex 17.6132 22.3423 0.599999
+      vertex 16.3698 22.5311 0
+    endloop
+  endfacet
+  facet normal 0.696168 -0.124325 0.707032
+    outer loop
+      vertex -27.5071 4.3567 0
+      vertex -27.9033 5.55032 0.599999
+      vertex -28.0997 4.45056 0.599999
+    endloop
+  endfacet
+  facet normal 0.381274 0.595579 0.707047
+    outer loop
+      vertex -14.8651 -24.2576 0.599999
+      vertex -14.5516 -23.746 0
+      vertex -15.4726 -23.1564 0
+    endloop
+  endfacet
+  facet normal -0.231682 -0.668107 0.707076
+    outer loop
+      vertex 9.63936 26.1286 0
+      vertex 8.79153 27.0576 0.599999
+      vertex 8.60612 26.4869 0
+    endloop
+  endfacet
+  facet normal -0.308656 0.63626 0.707039
+    outer loop
+      vertex 12.916 -25.3491 0.599999
+      vertex 12.6436 -24.8145 0
+      vertex 11.6597 -25.2918 0
+    endloop
+  endfacet
+  facet normal 0.469715 0.528651 0.707033
+    outer loop
+      vertex -18.4768 -21.6335 0.599999
+      vertex -18.0871 -21.1773 0
+      vertex -19.3119 -20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0.563884 0.426793 0.707023
+    outer loop
+      vertex -22.3423 -17.6132 0.599999
+      vertex -21.8711 -17.2418 0
+      vertex -22.5311 -16.3698 0
+    endloop
+  endfacet
+  facet normal 0.65855 0.257718 0.707031
+    outer loop
+      vertex -26.2844 -10.8873 0.599999
+      vertex -26.1286 -9.63936 0
+      vertex -26.6915 -9.84703 0.599999
+    endloop
+  endfacet
+  facet normal 0.700509 0.0969149 0.707032
+    outer loop
+      vertex -28.0997 -4.45056 0.599999
+      vertex -27.5071 -4.3567 0
+      vertex -28.2528 -3.34394 0.599999
+    endloop
+  endfacet
+  facet normal -0.0969149 -0.700509 0.707032
+    outer loop
+      vertex 4.3567 27.5071 0
+      vertex 4.45056 28.0997 0.599999
+      vertex 3.34394 28.2528 0.599999
+    endloop
+  endfacet
+  facet normal -0.0969357 -0.700524 0.707015
+    outer loop
+      vertex 4.3567 27.5071 0
+      vertex 3.34394 28.2528 0.599999
+      vertex 3.27342 27.657 0
+    endloop
+  endfacet
+  facet normal -0.357587 -0.610094 0.707049
+    outer loop
+      vertex 14.8651 24.2576 0.599999
+      vertex 13.9013 24.8225 0.599999
+      vertex 13.6081 24.299 0
+    endloop
+  endfacet
+  facet normal -0.381274 0.595579 0.707047
+    outer loop
+      vertex 14.8651 -24.2576 0.599999
+      vertex 15.4726 -23.1564 0
+      vertex 14.5516 -23.746 0
+    endloop
+  endfacet
+  facet normal -0.069254 0.703746 0.707069
+    outer loop
+      vertex 2.23216 -28.3623 0.599999
+      vertex 3.27342 -27.657 0
+      vertex 2.18509 -27.7641 0
+    endloop
+  endfacet
+  facet normal -0.357586 0.610095 0.707048
+    outer loop
+      vertex 14.8651 -24.2576 0.599999
+      vertex 14.5516 -23.746 0
+      vertex 13.6081 -24.299 0
+    endloop
+  endfacet
+  facet normal -0.700524 0.0969357 0.707015
+    outer loop
+      vertex 28.2528 -3.34394 0.599999
+      vertex 27.657 -3.27342 0
+      vertex 27.5071 -4.3567 0
+    endloop
+  endfacet
+  facet normal -0.696168 0.124325 0.707032
+    outer loop
+      vertex 27.9033 -5.55032 0.599999
+      vertex 28.0997 -4.45056 0.599999
+      vertex 27.5071 -4.3567 0
+    endloop
+  endfacet
+  facet normal -0.65855 0.257718 0.707031
+    outer loop
+      vertex 26.2844 -10.8873 0.599999
+      vertex 26.6915 -9.84703 0.599999
+      vertex 26.1286 -9.63936 0
+    endloop
+  endfacet
+  facet normal 0.676687 0.205275 0.707076
+    outer loop
+      vertex -27.0576 -8.79153 0.599999
+      vertex -26.4869 -8.60612 0
+      vertex -27.3819 -7.72248 0.599999
+    endloop
+  endfacet
+  facet normal -0.404345 0.580167 0.707044
+    outer loop
+      vertex 16.7225 -23.0165 0.599999
+      vertex 16.3698 -22.5311 0
+      vertex 15.4726 -23.1564 0
+    endloop
+  endfacet
+  facet normal -0.404345 -0.580167 0.707044
+    outer loop
+      vertex 16.3698 22.5311 0
+      vertex 16.7225 23.0165 0.599999
+      vertex 15.4726 23.1564 0
+    endloop
+  endfacet
+  facet normal 0.703793 0.0693171 0.707015
+    outer loop
+      vertex -28.2528 -3.34394 0.599999
+      vertex -27.657 -3.27342 0
+      vertex -28.3623 -2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0.069254 -0.703746 0.707069
+    outer loop
+      vertex -2.18509 27.7641 0
+      vertex -2.23216 28.3623 0.599999
+      vertex -3.27342 27.657 0
+    endloop
+  endfacet
+  facet normal 0.690751 0.151576 0.707027
+    outer loop
+      vertex -27.0805 -6.50145 0
+      vertex -27.3149 -5.43326 0
+      vertex -27.6639 -6.64152 0.599999
+    endloop
+  endfacet
+  facet normal 0.63626 -0.308656 0.707039
+    outer loop
+      vertex -25.2918 11.6597 0
+      vertex -24.8145 12.6436 0
+      vertex -25.3491 12.916 0.599999
+    endloop
+  endfacet
+  facet normal -0.231682 0.668107 0.707076
+    outer loop
+      vertex 8.79153 -27.0576 0.599999
+      vertex 9.63936 -26.1286 0
+      vertex 8.60612 -26.4869 0
+    endloop
+  endfacet
+  facet normal 0.684277 0.178543 0.707027
+    outer loop
+      vertex -26.8044 -7.55962 0
+      vertex -27.0805 -6.50145 0
+      vertex -27.6639 -6.64152 0.599999
+    endloop
+  endfacet
+  facet normal 0.151576 -0.690751 0.707027
+    outer loop
+      vertex -6.50145 27.0805 0
+      vertex -5.43326 27.3149 0
+      vertex -6.64152 27.6639 0.599999
+    endloop
+  endfacet
+  facet normal 0.469718 0.528627 0.707049
+    outer loop
+      vertex -18.0871 -21.1773 0
+      vertex -18.9046 -20.4509 0
+      vertex -19.3119 -20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0.690785 0.151552 0.706999
+    outer loop
+      vertex -27.6639 -6.64152 0.599999
+      vertex -27.3149 -5.43326 0
+      vertex -27.9033 -5.55032 0.599999
+    endloop
+  endfacet
+  facet normal -0.684277 -0.178543 0.707027
+    outer loop
+      vertex 27.0805 6.50145 0
+      vertex 27.6639 6.64152 0.599999
+      vertex 26.8044 7.55962 0
+    endloop
+  endfacet
+  facet normal 0.65849 -0.257747 0.707077
+    outer loop
+      vertex -26.1286 9.63936 0
+      vertex -25.73 10.6577 0
+      vertex -26.2844 10.8873 0.599999
+    endloop
+  endfacet
+  facet normal 0.231742 0.668133 0.707031
+    outer loop
+      vertex -8.79153 -27.0576 0.599999
+      vertex -9.63936 -26.1286 0
+      vertex -9.84703 -26.6915 0.599999
+    endloop
+  endfacet
+  facet normal 0.546647 0.448661 0.707022
+    outer loop
+      vertex -21.6335 -18.4768 0.599999
+      vertex -21.8711 -17.2418 0
+      vertex -22.3423 -17.6132 0.599999
+    endloop
+  endfacet
+  facet normal 0.231682 0.668107 0.707076
+    outer loop
+      vertex -8.79153 -27.0576 0.599999
+      vertex -8.60612 -26.4869 0
+      vertex -9.63936 -26.1286 0
+    endloop
+  endfacet
+  facet normal 0.636249 0.308661 0.707047
+    outer loop
+      vertex -25.3491 -12.916 0.599999
+      vertex -25.2918 -11.6597 0
+      vertex -25.8367 -11.9109 0.599999
+    endloop
+  endfacet
+  facet normal -0.151576 0.690751 0.707027
+    outer loop
+      vertex 6.64152 -27.6639 0.599999
+      vertex 6.50145 -27.0805 0
+      vertex 5.43326 -27.3149 0
+    endloop
+  endfacet
+  facet normal 0.509742 0.490119 0.707069
+    outer loop
+      vertex -20.1172 -20.1172 0.599999
+      vertex -19.6929 -19.6929 0
+      vertex -20.8915 -19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0.509741 0.490148 0.70705
+    outer loop
+      vertex -19.6929 -19.6929 0
+      vertex -20.4509 -18.9046 0
+      vertex -20.8915 -19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0.426799 0.563853 0.707045
+    outer loop
+      vertex -16.7225 -23.0165 0.599999
+      vertex -16.3698 -22.5311 0
+      vertex -17.6132 -22.3423 0.599999
+    endloop
+  endfacet
+  facet normal -0.381246 0.595574 0.707067
+    outer loop
+      vertex 15.806 -23.6553 0.599999
+      vertex 15.4726 -23.1564 0
+      vertex 14.8651 -24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0.333342 -0.623682 0.707039
+    outer loop
+      vertex -12.6436 24.8145 0
+      vertex -12.916 25.3491 0.599999
+      vertex -13.6081 24.299 0
+    endloop
+  endfacet
+  facet normal 0.563853 0.426799 0.707045
+    outer loop
+      vertex -22.3423 -17.6132 0.599999
+      vertex -22.5311 -16.3698 0
+      vertex -23.0165 -16.7225 0.599999
+    endloop
+  endfacet
+  facet normal 0.357587 -0.610094 0.707049
+    outer loop
+      vertex -13.6081 24.299 0
+      vertex -13.9013 24.8225 0.599999
+      vertex -14.8651 24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0.610095 -0.357586 0.707048
+    outer loop
+      vertex -23.746 14.5516 0
+      vertex -24.2576 14.8651 0.599999
+      vertex -24.299 13.6081 0
+    endloop
+  endfacet
+  facet normal 0.308661 -0.636249 0.707047
+    outer loop
+      vertex -11.6597 25.2918 0
+      vertex -11.9109 25.8367 0.599999
+      vertex -12.916 25.3491 0.599999
+    endloop
+  endfacet
+  facet normal -0.178543 -0.684277 0.707027
+    outer loop
+      vertex 7.55962 26.8044 0
+      vertex 6.64152 27.6639 0.599999
+      vertex 6.50145 27.0805 0
+    endloop
+  endfacet
+  facet normal -0.426799 -0.563853 0.707045
+    outer loop
+      vertex 17.6132 22.3423 0.599999
+      vertex 16.7225 23.0165 0.599999
+      vertex 16.3698 22.5311 0
+    endloop
+  endfacet
+  facet normal 0.0969149 -0.700509 0.707032
+    outer loop
+      vertex -4.3567 27.5071 0
+      vertex -3.34394 28.2528 0.599999
+      vertex -4.45056 28.0997 0.599999
+    endloop
+  endfacet
+  facet normal 0.563884 -0.426793 0.707023
+    outer loop
+      vertex -21.8711 17.2418 0
+      vertex -22.3423 17.6132 0.599999
+      vertex -22.5311 16.3698 0
+    endloop
+  endfacet
+  facet normal 0.546647 -0.448661 0.707022
+    outer loop
+      vertex -21.8711 17.2418 0
+      vertex -21.6335 18.4768 0.599999
+      vertex -22.3423 17.6132 0.599999
+    endloop
+  endfacet
+  facet normal 0.0969357 -0.700524 0.707015
+    outer loop
+      vertex -3.27342 27.657 0
+      vertex -3.34394 28.2528 0.599999
+      vertex -4.3567 27.5071 0
+    endloop
+  endfacet
+  facet normal 0.0693171 -0.703793 0.707015
+    outer loop
+      vertex -3.27342 27.657 0
+      vertex -2.23216 28.3623 0.599999
+      vertex -3.34394 28.2528 0.599999
+    endloop
+  endfacet
+  facet normal 0.205306 0.676702 0.707053
+    outer loop
+      vertex -7.72248 -27.3819 0.599999
+      vertex -7.55962 -26.8044 0
+      vertex -8.60612 -26.4869 0
+    endloop
+  endfacet
+  facet normal 0.231682 -0.668107 0.707076
+    outer loop
+      vertex -8.60612 26.4869 0
+      vertex -8.79153 27.0576 0.599999
+      vertex -9.63936 26.1286 0
+    endloop
+  endfacet
+  facet normal 0.124295 0.696207 0.706998
+    outer loop
+      vertex -4.3567 -27.5071 0
+      vertex -5.43326 -27.3149 0
+      vertex -5.55032 -27.9033 0.599999
+    endloop
+  endfacet
+  facet normal 0.595579 0.381274 0.707047
+    outer loop
+      vertex -23.1564 -15.4726 0
+      vertex -23.746 -14.5516 0
+      vertex -24.2576 -14.8651 0.599999
+    endloop
+  endfacet
+  facet normal 0.63626 0.308656 0.707039
+    outer loop
+      vertex -24.8145 -12.6436 0
+      vertex -25.2918 -11.6597 0
+      vertex -25.3491 -12.916 0.599999
+    endloop
+  endfacet
+  facet normal -0.448663 -0.546634 0.707031
+    outer loop
+      vertex 18.0871 21.1773 0
+      vertex 18.4768 21.6335 0.599999
+      vertex 17.2418 21.8711 0
+    endloop
+  endfacet
+  facet normal 0.0416425 -0.705918 0.707068
+    outer loop
+      vertex -2.18509 27.7641 0
+      vertex -1.09339 27.8285 0
+      vertex -2.23216 28.3623 0.599999
+    endloop
+  endfacet
+  facet normal 0.647904 0.283379 0.707048
+    outer loop
+      vertex -25.8367 -11.9109 0.599999
+      vertex -25.2918 -11.6597 0
+      vertex -26.2844 -10.8873 0.599999
+    endloop
+  endfacet
+  facet normal 0.069254 0.703746 0.707069
+    outer loop
+      vertex -2.23216 -28.3623 0.599999
+      vertex -2.18509 -27.7641 0
+      vertex -3.27342 -27.657 0
+    endloop
+  endfacet
+  facet normal 0.308661 0.636249 0.707047
+    outer loop
+      vertex -11.9109 -25.8367 0.599999
+      vertex -11.6597 -25.2918 0
+      vertex -12.916 -25.3491 0.599999
+    endloop
+  endfacet
+  facet normal 0.668107 0.231682 0.707076
+    outer loop
+      vertex -26.1286 -9.63936 0
+      vertex -26.4869 -8.60612 0
+      vertex -27.0576 -8.79153 0.599999
+    endloop
+  endfacet
+  facet normal 0.283339 0.64789 0.707076
+    outer loop
+      vertex -10.8873 -26.2844 0.599999
+      vertex -10.6577 -25.73 0
+      vertex -11.6597 -25.2918 0
+    endloop
+  endfacet
+  facet normal 0.676702 0.205306 0.707053
+    outer loop
+      vertex -26.4869 -8.60612 0
+      vertex -26.8044 -7.55962 0
+      vertex -27.3819 -7.72248 0.599999
+    endloop
+  endfacet
+  facet normal 0.0138623 0.707002 0.707076
+    outer loop
+      vertex 0 -28.45 0.599999
+      vertex -1.09339 -27.8285 0
+      vertex -1.11694 -28.4281 0.599999
+    endloop
+  endfacet
+  facet normal 0.357586 0.610095 0.707048
+    outer loop
+      vertex -13.6081 -24.299 0
+      vertex -14.5516 -23.746 0
+      vertex -14.8651 -24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0.257747 0.65849 0.707077
+    outer loop
+      vertex -9.63936 -26.1286 0
+      vertex -10.6577 -25.73 0
+      vertex -10.8873 -26.2844 0.599999
+    endloop
+  endfacet
+  facet normal -0.231742 -0.668133 0.707031
+    outer loop
+      vertex 9.63936 26.1286 0
+      vertex 9.84703 26.6915 0.599999
+      vertex 8.79153 27.0576 0.599999
+    endloop
+  endfacet
+  facet normal 0.676687 -0.205275 0.707076
+    outer loop
+      vertex -26.4869 8.60612 0
+      vertex -27.0576 8.79153 0.599999
+      vertex -27.3819 7.72248 0.599999
+    endloop
+  endfacet
+  facet normal 0.668107 -0.231682 0.707076
+    outer loop
+      vertex -26.4869 8.60612 0
+      vertex -26.1286 9.63936 0
+      vertex -27.0576 8.79153 0.599999
+    endloop
+  endfacet
+  facet normal 0.333329 -0.623679 0.707048
+    outer loop
+      vertex -13.6081 24.299 0
+      vertex -12.916 25.3491 0.599999
+      vertex -13.9013 24.8225 0.599999
+    endloop
+  endfacet
+  facet normal -0.357587 0.610094 0.707049
+    outer loop
+      vertex 13.9013 -24.8225 0.599999
+      vertex 14.8651 -24.2576 0.599999
+      vertex 13.6081 -24.299 0
+    endloop
+  endfacet
+  facet normal 0.404345 0.580167 0.707044
+    outer loop
+      vertex -15.4726 -23.1564 0
+      vertex -16.3698 -22.5311 0
+      vertex -16.7225 -23.0165 0.599999
+    endloop
+  endfacet
+  facet normal -0.333329 0.623679 0.707048
+    outer loop
+      vertex 13.9013 -24.8225 0.599999
+      vertex 13.6081 -24.299 0
+      vertex 12.916 -25.3491 0.599999
+    endloop
+  endfacet
+  facet normal 0.205275 0.676687 0.707076
+    outer loop
+      vertex -7.72248 -27.3819 0.599999
+      vertex -8.60612 -26.4869 0
+      vertex -8.79153 -27.0576 0.599999
+    endloop
+  endfacet
+  facet normal 0.404353 -0.580133 0.707067
+    outer loop
+      vertex -15.4726 23.1564 0
+      vertex -15.806 23.6553 0.599999
+      vertex -16.7225 23.0165 0.599999
+    endloop
+  endfacet
+  facet normal 0.124325 0.696168 -0.707031
+    outer loop
+      vertex -4.3567 -27.5071 58
+      vertex -4.45056 -28.0997 57.4
+      vertex -5.55032 -27.9033 57.4
+    endloop
+  endfacet
+  facet normal -0.684259 0.178509 -0.707053
+    outer loop
+      vertex 27.6639 -6.64152 57.4
+      vertex 27.3819 -7.72248 57.4
+      vertex 26.8044 -7.55962 58
+    endloop
+  endfacet
+  facet normal -0.707038 -0.0139029 -0.707038
+    outer loop
+      vertex 28.45 0 57.4
+      vertex 27.85 0 58
+      vertex 27.8285 1.09339 58
+    endloop
+  endfacet
+  facet normal -0.707002 -0.0138623 -0.707075
+    outer loop
+      vertex 28.4281 1.11694 57.4
+      vertex 28.45 0 57.4
+      vertex 27.8285 1.09339 58
+    endloop
+  endfacet
+  facet normal -0.563854 -0.426799 -0.707044
+    outer loop
+      vertex 23.0165 16.7225 57.4
+      vertex 22.5311 16.3698 58
+      vertex 22.3423 17.6132 57.4
+    endloop
+  endfacet
+  facet normal 0.647905 -0.283379 -0.707047
+    outer loop
+      vertex -25.8367 11.9109 57.4
+      vertex -25.2918 11.6597 58
+      vertex -26.2844 10.8873 57.4
+    endloop
+  endfacet
+  facet normal 0.528652 0.469716 -0.707032
+    outer loop
+      vertex -21.1773 -18.0871 58
+      vertex -20.8915 -19.3119 57.4
+      vertex -21.6335 -18.4768 57.4
+    endloop
+  endfacet
+  facet normal -0.70051 -0.096915 -0.707031
+    outer loop
+      vertex 28.0997 4.45056 57.4
+      vertex 28.2528 3.34394 57.4
+      vertex 27.5071 4.3567 58
+    endloop
+  endfacet
+  facet normal -0.178543 0.684277 -0.707027
+    outer loop
+      vertex 7.55962 -26.8044 58
+      vertex 6.64152 -27.6639 57.4
+      vertex 6.50145 -27.0805 58
+    endloop
+  endfacet
+  facet normal 0.70051 0.096915 -0.707031
+    outer loop
+      vertex -27.5071 -4.3567 58
+      vertex -28.0997 -4.45056 57.4
+      vertex -28.2528 -3.34394 57.4
+    endloop
+  endfacet
+  facet normal 0.690786 0.151553 -0.706998
+    outer loop
+      vertex -27.3149 -5.43326 58
+      vertex -27.6639 -6.64152 57.4
+      vertex -27.9033 -5.55032 57.4
+    endloop
+  endfacet
+  facet normal 0.684259 0.178509 -0.707053
+    outer loop
+      vertex -26.8044 -7.55962 58
+      vertex -27.3819 -7.72248 57.4
+      vertex -27.6639 -6.64152 57.4
+    endloop
+  endfacet
+  facet normal -0.0416425 -0.705919 -0.707068
+    outer loop
+      vertex 2.23216 28.3623 57.4
+      vertex 2.18509 27.7641 58
+      vertex 1.09339 27.8285 58
+    endloop
+  endfacet
+  facet normal 0.563885 -0.426794 -0.707023
+    outer loop
+      vertex -22.3423 17.6132 57.4
+      vertex -21.8711 17.2418 58
+      vertex -22.5311 16.3698 58
+    endloop
+  endfacet
+  facet normal -0.469716 0.528652 -0.707032
+    outer loop
+      vertex 19.3119 -20.8915 57.4
+      vertex 18.4768 -21.6335 57.4
+      vertex 18.0871 -21.1773 58
+    endloop
+  endfacet
+  facet normal -0.684277 -0.178543 -0.707027
+    outer loop
+      vertex 27.6639 6.64152 57.4
+      vertex 27.0805 6.50145 58
+      vertex 26.8044 7.55962 58
+    endloop
+  endfacet
+  facet normal 0.283379 0.647905 -0.707047
+    outer loop
+      vertex -11.6597 -25.2918 58
+      vertex -10.8873 -26.2844 57.4
+      vertex -11.9109 -25.8367 57.4
+    endloop
+  endfacet
+  facet normal 0.04165 -0.705911 -0.707075
+    outer loop
+      vertex -1.11694 28.4281 57.4
+      vertex -1.09339 27.8285 58
+      vertex -2.23216 28.3623 57.4
+    endloop
+  endfacet
+  facet normal 0.580134 -0.404353 -0.707067
+    outer loop
+      vertex -23.0165 16.7225 57.4
+      vertex -23.1564 15.4726 58
+      vertex -23.6553 15.806 57.4
+    endloop
+  endfacet
+  facet normal 0.595579 0.381274 -0.707047
+    outer loop
+      vertex -23.746 -14.5516 58
+      vertex -23.1564 -15.4726 58
+      vertex -24.2576 -14.8651 57.4
+    endloop
+  endfacet
+  facet normal -0.0139029 0.707038 -0.707038
+    outer loop
+      vertex 0 -27.85 58
+      vertex 1.09339 -27.8285 58
+      vertex 0 -28.45 57.4
+    endloop
+  endfacet
+  facet normal 0.0139029 0.707038 -0.707038
+    outer loop
+      vertex 0 -27.85 58
+      vertex 0 -28.45 57.4
+      vertex -1.09339 -27.8285 58
+    endloop
+  endfacet
+  facet normal -0.490148 -0.509741 -0.707049
+    outer loop
+      vertex 19.3119 20.8915 57.4
+      vertex 19.6929 19.6929 58
+      vertex 18.9046 20.4509 58
+    endloop
+  endfacet
+  facet normal -0.096915 -0.70051 -0.707031
+    outer loop
+      vertex 4.45056 28.0997 57.4
+      vertex 4.3567 27.5071 58
+      vertex 3.34394 28.2528 57.4
+    endloop
+  endfacet
+  facet normal -0.283379 0.647905 -0.707047
+    outer loop
+      vertex 11.6597 -25.2918 58
+      vertex 11.9109 -25.8367 57.4
+      vertex 10.8873 -26.2844 57.4
+    endloop
+  endfacet
+  facet normal -0.580134 -0.404353 -0.707067
+    outer loop
+      vertex 23.6553 15.806 57.4
+      vertex 23.1564 15.4726 58
+      vertex 23.0165 16.7225 57.4
+    endloop
+  endfacet
+  facet normal 0.231742 -0.668134 -0.707031
+    outer loop
+      vertex -8.79153 27.0576 57.4
+      vertex -9.63936 26.1286 58
+      vertex -9.84703 26.6915 57.4
+    endloop
+  endfacet
+  facet normal -0.696168 -0.124325 -0.707031
+    outer loop
+      vertex 27.9033 5.55032 57.4
+      vertex 28.0997 4.45056 57.4
+      vertex 27.5071 4.3567 58
+    endloop
+  endfacet
+  facet normal -0.703794 -0.0693172 -0.707014
+    outer loop
+      vertex 28.2528 3.34394 57.4
+      vertex 28.3623 2.23216 57.4
+      vertex 27.657 3.27342 58
+    endloop
+  endfacet
+  facet normal 0.690786 -0.151553 -0.706998
+    outer loop
+      vertex -27.6639 6.64152 57.4
+      vertex -27.3149 5.43326 58
+      vertex -27.9033 5.55032 57.4
+    endloop
+  endfacet
+  facet normal 0.509741 0.490148 -0.707049
+    outer loop
+      vertex -20.4509 -18.9046 58
+      vertex -19.6929 -19.6929 58
+      vertex -20.8915 -19.3119 57.4
+    endloop
+  endfacet
+  facet normal 0.703746 0.069254 -0.707068
+    outer loop
+      vertex -27.7641 -2.18509 58
+      vertex -27.657 -3.27342 58
+      vertex -28.3623 -2.23216 57.4
+    endloop
+  endfacet
+  facet normal -0.658551 0.257718 -0.707031
+    outer loop
+      vertex 26.6915 -9.84703 57.4
+      vertex 26.2844 -10.8873 57.4
+      vertex 26.1286 -9.63936 58
+    endloop
+  endfacet
+  facet normal 0.178509 -0.684259 -0.707053
+    outer loop
+      vertex -6.64152 27.6639 57.4
+      vertex -7.55962 26.8044 58
+      vertex -7.72248 27.3819 57.4
+    endloop
+  endfacet
+  facet normal 0.469718 0.528627 -0.707049
+    outer loop
+      vertex -18.9046 -20.4509 58
+      vertex -18.0871 -21.1773 58
+      vertex -19.3119 -20.8915 57.4
+    endloop
+  endfacet
+  facet normal 0.509742 0.490119 -0.707069
+    outer loop
+      vertex -19.6929 -19.6929 58
+      vertex -20.1172 -20.1172 57.4
+      vertex -20.8915 -19.3119 57.4
+    endloop
+  endfacet
+  facet normal 0.580134 0.404353 -0.707067
+    outer loop
+      vertex -23.1564 -15.4726 58
+      vertex -23.0165 -16.7225 57.4
+      vertex -23.6553 -15.806 57.4
+    endloop
+  endfacet
+  facet normal 0.696168 -0.124325 -0.707031
+    outer loop
+      vertex -27.9033 5.55032 57.4
+      vertex -27.5071 4.3567 58
+      vertex -28.0997 4.45056 57.4
+    endloop
+  endfacet
+  facet normal -0.700525 0.0969358 -0.707014
+    outer loop
+      vertex 27.657 -3.27342 58
+      vertex 28.2528 -3.34394 57.4
+      vertex 27.5071 -4.3567 58
+    endloop
+  endfacet
+  facet normal 0.658551 -0.257718 -0.707031
+    outer loop
+      vertex -26.2844 10.8873 57.4
+      vertex -26.1286 9.63936 58
+      vertex -26.6915 9.84703 57.4
+    endloop
+  endfacet
+  facet normal 0.151553 -0.690786 -0.706998
+    outer loop
+      vertex -5.55032 27.9033 57.4
+      vertex -5.43326 27.3149 58
+      vertex -6.64152 27.6639 57.4
+    endloop
+  endfacet
+  facet normal 0.703794 0.0693172 -0.707014
+    outer loop
+      vertex -27.657 -3.27342 58
+      vertex -28.2528 -3.34394 57.4
+      vertex -28.3623 -2.23216 57.4
+    endloop
+  endfacet
+  facet normal -0.703746 -0.069254 -0.707068
+    outer loop
+      vertex 28.3623 2.23216 57.4
+      vertex 27.7641 2.18509 58
+      vertex 27.657 3.27342 58
+    endloop
+  endfacet
+  facet normal 0.0138623 0.707002 -0.707075
+    outer loop
+      vertex -1.09339 -27.8285 58
+      vertex 0 -28.45 57.4
+      vertex -1.11694 -28.4281 57.4
+    endloop
+  endfacet
+  facet normal 0.381246 0.595575 -0.707066
+    outer loop
+      vertex -15.4726 -23.1564 58
+      vertex -14.8651 -24.2576 57.4
+      vertex -15.806 -23.6553 57.4
+    endloop
+  endfacet
+  facet normal -0.647891 -0.283339 -0.707076
+    outer loop
+      vertex 26.2844 10.8873 57.4
+      vertex 25.73 10.6577 58
+      vertex 25.2918 11.6597 58
+    endloop
+  endfacet
+  facet normal -0.546634 0.448663 -0.707031
+    outer loop
+      vertex 21.8711 -17.2418 58
+      vertex 21.6335 -18.4768 57.4
+      vertex 21.1773 -18.0871 58
+    endloop
+  endfacet
+  facet normal -0.690786 0.151553 -0.706998
+    outer loop
+      vertex 27.9033 -5.55032 57.4
+      vertex 27.6639 -6.64152 57.4
+      vertex 27.3149 -5.43326 58
+    endloop
+  endfacet
+  facet normal 0.580168 0.404346 -0.707043
+    outer loop
+      vertex -22.5311 -16.3698 58
+      vertex -23.0165 -16.7225 57.4
+      vertex -23.1564 -15.4726 58
+    endloop
+  endfacet
+  facet normal 0.563854 0.426799 -0.707044
+    outer loop
+      vertex -22.5311 -16.3698 58
+      vertex -22.3423 -17.6132 57.4
+      vertex -23.0165 -16.7225 57.4
+    endloop
+  endfacet
+  facet normal -0.610094 -0.357587 -0.707048
+    outer loop
+      vertex 24.8225 13.9013 57.4
+      vertex 24.299 13.6081 58
+      vertex 24.2576 14.8651 57.4
+    endloop
+  endfacet
+  facet normal -0.151553 0.690786 -0.706998
+    outer loop
+      vertex 6.64152 -27.6639 57.4
+      vertex 5.55032 -27.9033 57.4
+      vertex 5.43326 -27.3149 58
+    endloop
+  endfacet
+  facet normal 0.448663 0.546634 -0.707031
+    outer loop
+      vertex -18.0871 -21.1773 58
+      vertex -17.2418 -21.8711 58
+      vertex -18.4768 -21.6335 57.4
+    endloop
+  endfacet
+  facet normal -0.0969358 0.700525 -0.707014
+    outer loop
+      vertex 4.3567 -27.5071 58
+      vertex 3.34394 -28.2528 57.4
+      vertex 3.27342 -27.657 58
+    endloop
+  endfacet
+  facet normal -0.690752 -0.151576 -0.707027
+    outer loop
+      vertex 27.6639 6.64152 57.4
+      vertex 27.3149 5.43326 58
+      vertex 27.0805 6.50145 58
+    endloop
+  endfacet
+  facet normal -0.700525 -0.0969358 -0.707014
+    outer loop
+      vertex 28.2528 3.34394 57.4
+      vertex 27.657 3.27342 58
+      vertex 27.5071 4.3567 58
+    endloop
+  endfacet
+  facet normal 0.448663 -0.546634 -0.707031
+    outer loop
+      vertex -17.2418 21.8711 58
+      vertex -18.0871 21.1773 58
+      vertex -18.4768 21.6335 57.4
+    endloop
+  endfacet
+  facet normal -0.04165 -0.705911 -0.707075
+    outer loop
+      vertex 1.11694 28.4281 57.4
+      vertex 2.23216 28.3623 57.4
+      vertex 1.09339 27.8285 58
+    endloop
+  endfacet
+  facet normal -0.668108 -0.231682 -0.707075
+    outer loop
+      vertex 27.0576 8.79153 57.4
+      vertex 26.4869 8.60612 58
+      vertex 26.1286 9.63936 58
+    endloop
+  endfacet
+  facet normal -0.469718 -0.528627 -0.707049
+    outer loop
+      vertex 19.3119 20.8915 57.4
+      vertex 18.9046 20.4509 58
+      vertex 18.0871 21.1773 58
+    endloop
+  endfacet
+  facet normal -0.658551 -0.257718 -0.707031
+    outer loop
+      vertex 26.2844 10.8873 57.4
+      vertex 26.6915 9.84703 57.4
+      vertex 26.1286 9.63936 58
+    endloop
+  endfacet
+  facet normal 0.357586 -0.610095 -0.707047
+    outer loop
+      vertex -13.6081 24.299 58
+      vertex -14.5516 23.746 58
+      vertex -14.8651 24.2576 57.4
+    endloop
+  endfacet
+  facet normal -0.257747 0.65849 -0.707076
+    outer loop
+      vertex 10.6577 -25.73 58
+      vertex 10.8873 -26.2844 57.4
+      vertex 9.63936 -26.1286 58
+    endloop
+  endfacet
+  facet normal 0.707038 0.0139029 -0.707038
+    outer loop
+      vertex -27.85 0 58
+      vertex -27.8285 -1.09339 58
+      vertex -28.45 0 57.4
+    endloop
+  endfacet
+  facet normal 0.257747 -0.65849 -0.707076
+    outer loop
+      vertex -9.63936 26.1286 58
+      vertex -10.6577 25.73 58
+      vertex -10.8873 26.2844 57.4
+    endloop
+  endfacet
+  facet normal 0.668134 -0.231742 -0.707031
+    outer loop
+      vertex -26.6915 9.84703 57.4
+      vertex -26.1286 9.63936 58
+      vertex -27.0576 8.79153 57.4
+    endloop
+  endfacet
+  facet normal 0.257747 0.65849 -0.707076
+    outer loop
+      vertex -10.6577 -25.73 58
+      vertex -9.63936 -26.1286 58
+      vertex -10.8873 -26.2844 57.4
+    endloop
+  endfacet
+  facet normal -0.0138623 0.707002 -0.707075
+    outer loop
+      vertex 1.09339 -27.8285 58
+      vertex 1.11694 -28.4281 57.4
+      vertex 0 -28.45 57.4
+    endloop
+  endfacet
+  facet normal 0.151576 0.690752 -0.707027
+    outer loop
+      vertex -6.50145 -27.0805 58
+      vertex -5.43326 -27.3149 58
+      vertex -6.64152 -27.6639 57.4
+    endloop
+  endfacet
+  facet normal -0.469718 0.528627 -0.707049
+    outer loop
+      vertex 18.9046 -20.4509 58
+      vertex 19.3119 -20.8915 57.4
+      vertex 18.0871 -21.1773 58
+    endloop
+  endfacet
+  facet normal -0.448663 0.546634 -0.707031
+    outer loop
+      vertex 18.0871 -21.1773 58
+      vertex 18.4768 -21.6335 57.4
+      vertex 17.2418 -21.8711 58
+    endloop
+  endfacet
+  facet normal 0.124295 0.696208 -0.706998
+    outer loop
+      vertex -5.43326 -27.3149 58
+      vertex -4.3567 -27.5071 58
+      vertex -5.55032 -27.9033 57.4
+    endloop
+  endfacet
+  facet normal -0.705911 -0.04165 -0.707075
+    outer loop
+      vertex 28.3623 2.23216 57.4
+      vertex 28.4281 1.11694 57.4
+      vertex 27.8285 1.09339 58
+    endloop
+  endfacet
+  facet normal 0.404346 -0.580168 -0.707043
+    outer loop
+      vertex -15.4726 23.1564 58
+      vertex -16.3698 22.5311 58
+      vertex -16.7225 23.0165 57.4
+    endloop
+  endfacet
+  facet normal -0.490119 -0.509742 -0.707069
+    outer loop
+      vertex 20.1172 20.1172 57.4
+      vertex 19.6929 19.6929 58
+      vertex 19.3119 20.8915 57.4
+    endloop
+  endfacet
+  facet normal -0.705911 0.04165 -0.707075
+    outer loop
+      vertex 28.4281 -1.11694 57.4
+      vertex 28.3623 -2.23216 57.4
+      vertex 27.8285 -1.09339 58
+    endloop
+  endfacet
+  facet normal -0.333329 -0.623679 -0.707047
+    outer loop
+      vertex 13.9013 24.8225 57.4
+      vertex 13.6081 24.299 58
+      vertex 12.916 25.3491 57.4
+    endloop
+  endfacet
+  facet normal 0.283339 -0.647891 -0.707076
+    outer loop
+      vertex -10.8873 26.2844 57.4
+      vertex -10.6577 25.73 58
+      vertex -11.6597 25.2918 58
+    endloop
+  endfacet
+  facet normal -0.696168 0.124325 -0.707031
+    outer loop
+      vertex 28.0997 -4.45056 57.4
+      vertex 27.9033 -5.55032 57.4
+      vertex 27.5071 -4.3567 58
+    endloop
+  endfacet
+  facet normal -0.684277 0.178543 -0.707027
+    outer loop
+      vertex 27.0805 -6.50145 58
+      vertex 27.6639 -6.64152 57.4
+      vertex 26.8044 -7.55962 58
+    endloop
+  endfacet
+  facet normal 0.65849 0.257747 -0.707076
+    outer loop
+      vertex -26.1286 -9.63936 58
+      vertex -25.73 -10.6577 58
+      vertex -26.2844 -10.8873 57.4
+    endloop
+  endfacet
+  facet normal -0.595575 0.381246 -0.707066
+    outer loop
+      vertex 24.2576 -14.8651 57.4
+      vertex 23.6553 -15.806 57.4
+      vertex 23.1564 -15.4726 58
+    endloop
+  endfacet
+  facet normal 0.0969358 0.700525 -0.707014
+    outer loop
+      vertex -3.27342 -27.657 58
+      vertex -3.34394 -28.2528 57.4
+      vertex -4.3567 -27.5071 58
+    endloop
+  endfacet
+  facet normal -0.580134 0.404353 -0.707067
+    outer loop
+      vertex 23.1564 -15.4726 58
+      vertex 23.6553 -15.806 57.4
+      vertex 23.0165 -16.7225 57.4
+    endloop
+  endfacet
+  facet normal -0.580168 -0.404346 -0.707043
+    outer loop
+      vertex 23.0165 16.7225 57.4
+      vertex 23.1564 15.4726 58
+      vertex 22.5311 16.3698 58
+    endloop
+  endfacet
+  facet normal -0.0139029 -0.707038 -0.707038
+    outer loop
+      vertex 0 28.45 57.4
+      vertex 1.09339 27.8285 58
+      vertex 0 27.85 58
+    endloop
+  endfacet
+  facet normal -0.705919 -0.0416425 -0.707068
+    outer loop
+      vertex 28.3623 2.23216 57.4
+      vertex 27.8285 1.09339 58
+      vertex 27.7641 2.18509 58
+    endloop
+  endfacet
+  facet normal -0.70051 0.096915 -0.707031
+    outer loop
+      vertex 28.2528 -3.34394 57.4
+      vertex 28.0997 -4.45056 57.4
+      vertex 27.5071 -4.3567 58
+    endloop
+  endfacet
+  facet normal -0.563885 -0.426794 -0.707023
+    outer loop
+      vertex 22.3423 17.6132 57.4
+      vertex 22.5311 16.3698 58
+      vertex 21.8711 17.2418 58
+    endloop
+  endfacet
+  facet normal 0.623683 0.333342 -0.707038
+    outer loop
+      vertex -24.8145 -12.6436 58
+      vertex -24.299 -13.6081 58
+      vertex -25.3491 -12.916 57.4
+    endloop
+  endfacet
+  facet normal -0.623679 0.333329 -0.707047
+    outer loop
+      vertex 25.3491 -12.916 57.4
+      vertex 24.8225 -13.9013 57.4
+      vertex 24.299 -13.6081 58
+    endloop
+  endfacet
+  facet normal 0.595579 -0.381274 -0.707047
+    outer loop
+      vertex -23.1564 15.4726 58
+      vertex -23.746 14.5516 58
+      vertex -24.2576 14.8651 57.4
+    endloop
+  endfacet
+  facet normal -0.696208 -0.124295 -0.706998
+    outer loop
+      vertex 27.9033 5.55032 57.4
+      vertex 27.5071 4.3567 58
+      vertex 27.3149 5.43326 58
+    endloop
+  endfacet
+  facet normal 0.528652 -0.469716 -0.707032
+    outer loop
+      vertex -20.8915 19.3119 57.4
+      vertex -21.1773 18.0871 58
+      vertex -21.6335 18.4768 57.4
+    endloop
+  endfacet
+  facet normal -0.528652 0.469716 -0.707032
+    outer loop
+      vertex 21.1773 -18.0871 58
+      vertex 21.6335 -18.4768 57.4
+      vertex 20.8915 -19.3119 57.4
+    endloop
+  endfacet
+  facet normal -0.0693172 -0.703794 -0.707014
+    outer loop
+      vertex 3.34394 28.2528 57.4
+      vertex 3.27342 27.657 58
+      vertex 2.23216 28.3623 57.4
+    endloop
+  endfacet
+  facet normal 0.509742 -0.490119 -0.707069
+    outer loop
+      vertex -20.1172 20.1172 57.4
+      vertex -19.6929 19.6929 58
+      vertex -20.8915 19.3119 57.4
+    endloop
+  endfacet
+  facet normal -0.404353 0.580134 -0.707067
+    outer loop
+      vertex 16.7225 -23.0165 57.4
+      vertex 15.806 -23.6553 57.4
+      vertex 15.4726 -23.1564 58
+    endloop
+  endfacet
+  facet normal 0.707038 -0.0139029 -0.707038
+    outer loop
+      vertex -27.8285 1.09339 58
+      vertex -27.85 0 58
+      vertex -28.45 0 57.4
+    endloop
+  endfacet
+  facet normal 0.490148 -0.509741 -0.707049
+    outer loop
+      vertex -19.3119 20.8915 57.4
+      vertex -18.9046 20.4509 58
+      vertex -19.6929 19.6929 58
+    endloop
+  endfacet
+  facet normal 0.490119 -0.509742 -0.707069
+    outer loop
+      vertex -19.3119 20.8915 57.4
+      vertex -19.6929 19.6929 58
+      vertex -20.1172 20.1172 57.4
+    endloop
+  endfacet
+  facet normal -0.490148 0.509741 -0.707049
+    outer loop
+      vertex 19.6929 -19.6929 58
+      vertex 19.3119 -20.8915 57.4
+      vertex 18.9046 -20.4509 58
+    endloop
+  endfacet
+  facet normal 0.676687 0.205275 -0.707076
+    outer loop
+      vertex -26.4869 -8.60612 58
+      vertex -27.0576 -8.79153 57.4
+      vertex -27.3819 -7.72248 57.4
+    endloop
+  endfacet
+  facet normal -0.490119 0.509742 -0.707069
+    outer loop
+      vertex 19.6929 -19.6929 58
+      vertex 20.1172 -20.1172 57.4
+      vertex 19.3119 -20.8915 57.4
+    endloop
+  endfacet
+  facet normal 0.257718 0.658551 -0.707031
+    outer loop
+      vertex -9.63936 -26.1286 58
+      vertex -9.84703 -26.6915 57.4
+      vertex -10.8873 -26.2844 57.4
+    endloop
+  endfacet
+  facet normal -0.668134 -0.231742 -0.707031
+    outer loop
+      vertex 26.6915 9.84703 57.4
+      vertex 27.0576 8.79153 57.4
+      vertex 26.1286 9.63936 58
+    endloop
+  endfacet
+  facet normal -0.707002 0.0138623 -0.707075
+    outer loop
+      vertex 28.45 0 57.4
+      vertex 28.4281 -1.11694 57.4
+      vertex 27.8285 -1.09339 58
+    endloop
+  endfacet
+  facet normal -0.707038 0.0139029 -0.707038
+    outer loop
+      vertex 27.85 0 58
+      vertex 28.45 0 57.4
+      vertex 27.8285 -1.09339 58
+    endloop
+  endfacet
+  facet normal -0.636249 -0.308661 -0.707047
+    outer loop
+      vertex 25.3491 12.916 57.4
+      vertex 25.8367 11.9109 57.4
+      vertex 25.2918 11.6597 58
+    endloop
+  endfacet
+  facet normal -0.647905 -0.283379 -0.707047
+    outer loop
+      vertex 25.8367 11.9109 57.4
+      vertex 26.2844 10.8873 57.4
+      vertex 25.2918 11.6597 58
+    endloop
+  endfacet
+  facet normal 0.469716 0.528652 -0.707032
+    outer loop
+      vertex -18.0871 -21.1773 58
+      vertex -18.4768 -21.6335 57.4
+      vertex -19.3119 -20.8915 57.4
+    endloop
+  endfacet
+  facet normal -0.696208 0.124295 -0.706998
+    outer loop
+      vertex 27.5071 -4.3567 58
+      vertex 27.9033 -5.55032 57.4
+      vertex 27.3149 -5.43326 58
+    endloop
+  endfacet
+  facet normal 0.668108 -0.231682 -0.707075
+    outer loop
+      vertex -26.1286 9.63936 58
+      vertex -26.4869 8.60612 58
+      vertex -27.0576 8.79153 57.4
+    endloop
+  endfacet
+  facet normal 0.0693172 -0.703794 -0.707014
+    outer loop
+      vertex -2.23216 28.3623 57.4
+      vertex -3.27342 27.657 58
+      vertex -3.34394 28.2528 57.4
+    endloop
+  endfacet
+  facet normal -0.595579 0.381274 -0.707047
+    outer loop
+      vertex 23.746 -14.5516 58
+      vertex 24.2576 -14.8651 57.4
+      vertex 23.1564 -15.4726 58
+    endloop
+  endfacet
+  facet normal -0.528652 -0.469716 -0.707032
+    outer loop
+      vertex 21.6335 18.4768 57.4
+      vertex 21.1773 18.0871 58
+      vertex 20.8915 19.3119 57.4
+    endloop
+  endfacet
+  facet normal -0.426794 0.563885 -0.707023
+    outer loop
+      vertex 17.2418 -21.8711 58
+      vertex 17.6132 -22.3423 57.4
+      vertex 16.3698 -22.5311 58
+    endloop
+  endfacet
+  facet normal -0.257718 -0.658551 -0.707031
+    outer loop
+      vertex 9.84703 26.6915 57.4
+      vertex 10.8873 26.2844 57.4
+      vertex 9.63936 26.1286 58
+    endloop
+  endfacet
+  facet normal 0.205275 0.676687 -0.707076
+    outer loop
+      vertex -8.60612 -26.4869 58
+      vertex -7.72248 -27.3819 57.4
+      vertex -8.79153 -27.0576 57.4
+    endloop
+  endfacet
+  facet normal 0.381274 -0.595579 -0.707047
+    outer loop
+      vertex -14.8651 24.2576 57.4
+      vertex -14.5516 23.746 58
+      vertex -15.4726 23.1564 58
+    endloop
+  endfacet
+  facet normal 0.696208 -0.124295 -0.706998
+    outer loop
+      vertex -27.3149 5.43326 58
+      vertex -27.5071 4.3567 58
+      vertex -27.9033 5.55032 57.4
+    endloop
+  endfacet
+  facet normal 0.546647 0.448661 -0.707022
+    outer loop
+      vertex -21.8711 -17.2418 58
+      vertex -21.6335 -18.4768 57.4
+      vertex -22.3423 -17.6132 57.4
+    endloop
+  endfacet
+  facet normal -0.676702 0.205306 -0.707053
+    outer loop
+      vertex 26.8044 -7.55962 58
+      vertex 27.3819 -7.72248 57.4
+      vertex 26.4869 -8.60612 58
+    endloop
+  endfacet
+  facet normal -0.151576 0.690752 -0.707027
+    outer loop
+      vertex 6.50145 -27.0805 58
+      vertex 6.64152 -27.6639 57.4
+      vertex 5.43326 -27.3149 58
+    endloop
+  endfacet
+  facet normal -0.469716 -0.528652 -0.707032
+    outer loop
+      vertex 18.4768 21.6335 57.4
+      vertex 19.3119 20.8915 57.4
+      vertex 18.0871 21.1773 58
+    endloop
+  endfacet
+  facet normal 0.703746 -0.069254 -0.707068
+    outer loop
+      vertex -27.657 3.27342 58
+      vertex -27.7641 2.18509 58
+      vertex -28.3623 2.23216 57.4
+    endloop
+  endfacet
+  facet normal 0.546634 -0.448663 -0.707031
+    outer loop
+      vertex -21.6335 18.4768 57.4
+      vertex -21.1773 18.0871 58
+      vertex -21.8711 17.2418 58
+    endloop
+  endfacet
+  facet normal 0.205306 -0.676702 -0.707053
+    outer loop
+      vertex -7.72248 27.3819 57.4
+      vertex -7.55962 26.8044 58
+      vertex -8.60612 26.4869 58
+    endloop
+  endfacet
+  facet normal -0.124295 -0.696208 -0.706998
+    outer loop
+      vertex 5.55032 27.9033 57.4
+      vertex 5.43326 27.3149 58
+      vertex 4.3567 27.5071 58
+    endloop
+  endfacet
+  facet normal 0.124295 -0.696208 -0.706998
+    outer loop
+      vertex -4.3567 27.5071 58
+      vertex -5.43326 27.3149 58
+      vertex -5.55032 27.9033 57.4
+    endloop
+  endfacet
+  facet normal 0.668108 0.231682 -0.707075
+    outer loop
+      vertex -26.4869 -8.60612 58
+      vertex -26.1286 -9.63936 58
+      vertex -27.0576 -8.79153 57.4
+    endloop
+  endfacet
+  facet normal 0.684259 -0.178509 -0.707053
+    outer loop
+      vertex -27.3819 7.72248 57.4
+      vertex -26.8044 7.55962 58
+      vertex -27.6639 6.64152 57.4
+    endloop
+  endfacet
+  facet normal 0.178543 0.684277 -0.707027
+    outer loop
+      vertex -6.50145 -27.0805 58
+      vertex -6.64152 -27.6639 57.4
+      vertex -7.55962 -26.8044 58
+    endloop
+  endfacet
+  facet normal -0.0969358 -0.700525 -0.707014
+    outer loop
+      vertex 3.34394 28.2528 57.4
+      vertex 4.3567 27.5071 58
+      vertex 3.27342 27.657 58
+    endloop
+  endfacet
+  facet normal -0.283339 -0.647891 -0.707076
+    outer loop
+      vertex 10.8873 26.2844 57.4
+      vertex 11.6597 25.2918 58
+      vertex 10.6577 25.73 58
+    endloop
+  endfacet
+  facet normal -0.703794 0.0693172 -0.707014
+    outer loop
+      vertex 28.3623 -2.23216 57.4
+      vertex 28.2528 -3.34394 57.4
+      vertex 27.657 -3.27342 58
+    endloop
+  endfacet
+  facet normal 0.610094 0.357587 -0.707048
+    outer loop
+      vertex -24.299 -13.6081 58
+      vertex -24.2576 -14.8651 57.4
+      vertex -24.8225 -13.9013 57.4
+    endloop
+  endfacet
+  facet normal -0.426799 -0.563854 -0.707044
+    outer loop
+      vertex 16.7225 23.0165 57.4
+      vertex 17.6132 22.3423 57.4
+      vertex 16.3698 22.5311 58
+    endloop
+  endfacet
+  facet normal 0.546634 0.448663 -0.707031
+    outer loop
+      vertex -21.1773 -18.0871 58
+      vertex -21.6335 -18.4768 57.4
+      vertex -21.8711 -17.2418 58
+    endloop
+  endfacet
+  facet normal 0.636261 0.308657 -0.707038
+    outer loop
+      vertex -25.2918 -11.6597 58
+      vertex -24.8145 -12.6436 58
+      vertex -25.3491 -12.916 57.4
+    endloop
+  endfacet
+  facet normal 0.124325 -0.696168 -0.707031
+    outer loop
+      vertex -4.45056 28.0997 57.4
+      vertex -4.3567 27.5071 58
+      vertex -5.55032 27.9033 57.4
+    endloop
+  endfacet
+  facet normal 0.205306 0.676702 -0.707053
+    outer loop
+      vertex -7.55962 -26.8044 58
+      vertex -7.72248 -27.3819 57.4
+      vertex -8.60612 -26.4869 58
+    endloop
+  endfacet
+  facet normal -0.308657 -0.636261 -0.707038
+    outer loop
+      vertex 12.916 25.3491 57.4
+      vertex 12.6436 24.8145 58
+      vertex 11.6597 25.2918 58
+    endloop
+  endfacet
+  facet normal 0.178543 -0.684277 -0.707027
+    outer loop
+      vertex -6.64152 27.6639 57.4
+      vertex -6.50145 27.0805 58
+      vertex -7.55962 26.8044 58
+    endloop
+  endfacet
+  facet normal 0.690752 0.151576 -0.707027
+    outer loop
+      vertex -27.3149 -5.43326 58
+      vertex -27.0805 -6.50145 58
+      vertex -27.6639 -6.64152 57.4
+    endloop
+  endfacet
+  facet normal -0.0693172 0.703794 -0.707014
+    outer loop
+      vertex 3.27342 -27.657 58
+      vertex 3.34394 -28.2528 57.4
+      vertex 2.23216 -28.3623 57.4
+    endloop
+  endfacet
+  facet normal -0.381246 0.595575 -0.707066
+    outer loop
+      vertex 15.4726 -23.1564 58
+      vertex 15.806 -23.6553 57.4
+      vertex 14.8651 -24.2576 57.4
+    endloop
+  endfacet
+  facet normal 0.595575 -0.381246 -0.707066
+    outer loop
+      vertex -23.6553 15.806 57.4
+      vertex -23.1564 15.4726 58
+      vertex -24.2576 14.8651 57.4
+    endloop
+  endfacet
+  facet normal 0.707002 0.0138623 -0.707075
+    outer loop
+      vertex -27.8285 -1.09339 58
+      vertex -28.4281 -1.11694 57.4
+      vertex -28.45 0 57.4
+    endloop
+  endfacet
+  facet normal 0.705911 0.04165 -0.707075
+    outer loop
+      vertex -27.8285 -1.09339 58
+      vertex -28.3623 -2.23216 57.4
+      vertex -28.4281 -1.11694 57.4
+    endloop
+  endfacet
+  facet normal -0.610094 0.357587 -0.707048
+    outer loop
+      vertex 24.299 -13.6081 58
+      vertex 24.8225 -13.9013 57.4
+      vertex 24.2576 -14.8651 57.4
+    endloop
+  endfacet
+  facet normal 0.333342 -0.623683 -0.707038
+    outer loop
+      vertex -12.916 25.3491 57.4
+      vertex -12.6436 24.8145 58
+      vertex -13.6081 24.299 58
+    endloop
+  endfacet
+  facet normal -0.636261 0.308657 -0.707038
+    outer loop
+      vertex 25.2918 -11.6597 58
+      vertex 25.3491 -12.916 57.4
+      vertex 24.8145 -12.6436 58
+    endloop
+  endfacet
+  facet normal -0.65849 -0.257747 -0.707076
+    outer loop
+      vertex 26.2844 10.8873 57.4
+      vertex 26.1286 9.63936 58
+      vertex 25.73 10.6577 58
+    endloop
+  endfacet
+  facet normal 0.528627 -0.469718 -0.707049
+    outer loop
+      vertex -20.8915 19.3119 57.4
+      vertex -20.4509 18.9046 58
+      vertex -21.1773 18.0871 58
+    endloop
+  endfacet
+  facet normal -0.205306 0.676702 -0.707053
+    outer loop
+      vertex 8.60612 -26.4869 58
+      vertex 7.72248 -27.3819 57.4
+      vertex 7.55962 -26.8044 58
+    endloop
+  endfacet
+  facet normal -0.65849 0.257747 -0.707076
+    outer loop
+      vertex 26.1286 -9.63936 58
+      vertex 26.2844 -10.8873 57.4
+      vertex 25.73 -10.6577 58
+    endloop
+  endfacet
+  facet normal -0.668108 0.231682 -0.707075
+    outer loop
+      vertex 26.4869 -8.60612 58
+      vertex 27.0576 -8.79153 57.4
+      vertex 26.1286 -9.63936 58
+    endloop
+  endfacet
+  facet normal 0.0139029 -0.707038 -0.707038
+    outer loop
+      vertex 0 28.45 57.4
+      vertex 0 27.85 58
+      vertex -1.09339 27.8285 58
+    endloop
+  endfacet
+  facet normal 0.595575 0.381246 -0.707066
+    outer loop
+      vertex -23.1564 -15.4726 58
+      vertex -23.6553 -15.806 57.4
+      vertex -24.2576 -14.8651 57.4
+    endloop
+  endfacet
+  facet normal 0.04165 0.705911 -0.707075
+    outer loop
+      vertex -1.09339 -27.8285 58
+      vertex -1.11694 -28.4281 57.4
+      vertex -2.23216 -28.3623 57.4
+    endloop
+  endfacet
+  facet normal -0.257718 0.658551 -0.707031
+    outer loop
+      vertex 10.8873 -26.2844 57.4
+      vertex 9.84703 -26.6915 57.4
+      vertex 9.63936 -26.1286 58
+    endloop
+  endfacet
+  facet normal 0.096915 0.70051 -0.707031
+    outer loop
+      vertex -4.3567 -27.5071 58
+      vertex -3.34394 -28.2528 57.4
+      vertex -4.45056 -28.0997 57.4
+    endloop
+  endfacet
+  facet normal -0.647891 0.283339 -0.707076
+    outer loop
+      vertex 25.73 -10.6577 58
+      vertex 26.2844 -10.8873 57.4
+      vertex 25.2918 -11.6597 58
+    endloop
+  endfacet
+  facet normal 0.151553 0.690786 -0.706998
+    outer loop
+      vertex -5.43326 -27.3149 58
+      vertex -5.55032 -27.9033 57.4
+      vertex -6.64152 -27.6639 57.4
+    endloop
+  endfacet
+  facet normal 0.448661 0.546647 -0.707022
+    outer loop
+      vertex -17.2418 -21.8711 58
+      vertex -17.6132 -22.3423 57.4
+      vertex -18.4768 -21.6335 57.4
+    endloop
+  endfacet
+  facet normal 0.151576 -0.690752 -0.707027
+    outer loop
+      vertex -5.43326 27.3149 58
+      vertex -6.50145 27.0805 58
+      vertex -6.64152 27.6639 57.4
+    endloop
+  endfacet
+  facet normal 0.623679 -0.333329 -0.707047
+    outer loop
+      vertex -24.8225 13.9013 57.4
+      vertex -24.299 13.6081 58
+      vertex -25.3491 12.916 57.4
+    endloop
+  endfacet
+  facet normal 0.636249 0.308661 -0.707047
+    outer loop
+      vertex -25.2918 -11.6597 58
+      vertex -25.3491 -12.916 57.4
+      vertex -25.8367 -11.9109 57.4
+    endloop
+  endfacet
+  facet normal 0.528627 0.469718 -0.707049
+    outer loop
+      vertex -20.4509 -18.9046 58
+      vertex -20.8915 -19.3119 57.4
+      vertex -21.1773 -18.0871 58
+    endloop
+  endfacet
+  facet normal -0.124325 0.696168 -0.707031
+    outer loop
+      vertex 5.55032 -27.9033 57.4
+      vertex 4.45056 -28.0997 57.4
+      vertex 4.3567 -27.5071 58
+    endloop
+  endfacet
+  facet normal -0.308657 0.636261 -0.707038
+    outer loop
+      vertex 12.6436 -24.8145 58
+      vertex 12.916 -25.3491 57.4
+      vertex 11.6597 -25.2918 58
+    endloop
+  endfacet
+  facet normal -0.308661 0.636249 -0.707047
+    outer loop
+      vertex 12.916 -25.3491 57.4
+      vertex 11.9109 -25.8367 57.4
+      vertex 11.6597 -25.2918 58
+    endloop
+  endfacet
+  facet normal -0.676687 0.205275 -0.707076
+    outer loop
+      vertex 27.3819 -7.72248 57.4
+      vertex 27.0576 -8.79153 57.4
+      vertex 26.4869 -8.60612 58
+    endloop
+  endfacet
+  facet normal -0.563885 0.426794 -0.707023
+    outer loop
+      vertex 22.5311 -16.3698 58
+      vertex 22.3423 -17.6132 57.4
+      vertex 21.8711 -17.2418 58
+    endloop
+  endfacet
+  facet normal -0.404346 -0.580168 -0.707043
+    outer loop
+      vertex 16.7225 23.0165 57.4
+      vertex 16.3698 22.5311 58
+      vertex 15.4726 23.1564 58
+    endloop
+  endfacet
+  facet normal 0.469716 -0.528652 -0.707032
+    outer loop
+      vertex -18.4768 21.6335 57.4
+      vertex -18.0871 21.1773 58
+      vertex -19.3119 20.8915 57.4
+    endloop
+  endfacet
+  facet normal -0.0416425 0.705919 -0.707068
+    outer loop
+      vertex 2.18509 -27.7641 58
+      vertex 2.23216 -28.3623 57.4
+      vertex 1.09339 -27.8285 58
+    endloop
+  endfacet
+  facet normal 0.333342 0.623683 -0.707038
+    outer loop
+      vertex -12.6436 -24.8145 58
+      vertex -12.916 -25.3491 57.4
+      vertex -13.6081 -24.299 58
+    endloop
+  endfacet
+  facet normal -0.610095 0.357586 -0.707047
+    outer loop
+      vertex 24.299 -13.6081 58
+      vertex 24.2576 -14.8651 57.4
+      vertex 23.746 -14.5516 58
+    endloop
+  endfacet
+  facet normal -0.509741 -0.490148 -0.707049
+    outer loop
+      vertex 20.8915 19.3119 57.4
+      vertex 20.4509 18.9046 58
+      vertex 19.6929 19.6929 58
+    endloop
+  endfacet
+  facet normal -0.546647 0.448661 -0.707022
+    outer loop
+      vertex 21.8711 -17.2418 58
+      vertex 22.3423 -17.6132 57.4
+      vertex 21.6335 -18.4768 57.4
+    endloop
+  endfacet
+  facet normal 0.490148 0.509741 -0.707049
+    outer loop
+      vertex -18.9046 -20.4509 58
+      vertex -19.3119 -20.8915 57.4
+      vertex -19.6929 -19.6929 58
+    endloop
+  endfacet
+  facet normal -0.04165 0.705911 -0.707075
+    outer loop
+      vertex 2.23216 -28.3623 57.4
+      vertex 1.11694 -28.4281 57.4
+      vertex 1.09339 -27.8285 58
+    endloop
+  endfacet
+  facet normal -0.231742 -0.668134 -0.707031
+    outer loop
+      vertex 9.84703 26.6915 57.4
+      vertex 9.63936 26.1286 58
+      vertex 8.79153 27.0576 57.4
+    endloop
+  endfacet
+  facet normal -0.231682 0.668108 -0.707075
+    outer loop
+      vertex 9.63936 -26.1286 58
+      vertex 8.79153 -27.0576 57.4
+      vertex 8.60612 -26.4869 58
+    endloop
+  endfacet
+  facet normal 0.696208 0.124295 -0.706998
+    outer loop
+      vertex -27.5071 -4.3567 58
+      vertex -27.3149 -5.43326 58
+      vertex -27.9033 -5.55032 57.4
+    endloop
+  endfacet
+  facet normal -0.623683 -0.333342 -0.707038
+    outer loop
+      vertex 25.3491 12.916 57.4
+      vertex 24.8145 12.6436 58
+      vertex 24.299 13.6081 58
+    endloop
+  endfacet
+  facet normal 0.0138623 -0.707002 -0.707075
+    outer loop
+      vertex 0 28.45 57.4
+      vertex -1.09339 27.8285 58
+      vertex -1.11694 28.4281 57.4
+    endloop
+  endfacet
+  facet normal -0.448661 -0.546647 -0.707022
+    outer loop
+      vertex 17.6132 22.3423 57.4
+      vertex 18.4768 21.6335 57.4
+      vertex 17.2418 21.8711 58
+    endloop
+  endfacet
+  facet normal -0.124295 0.696208 -0.706998
+    outer loop
+      vertex 5.43326 -27.3149 58
+      vertex 5.55032 -27.9033 57.4
+      vertex 4.3567 -27.5071 58
+    endloop
+  endfacet
+  facet normal 0.509741 -0.490148 -0.707049
+    outer loop
+      vertex -19.6929 19.6929 58
+      vertex -20.4509 18.9046 58
+      vertex -20.8915 19.3119 57.4
+    endloop
+  endfacet
+  facet normal 0.705919 0.0416425 -0.707068
+    outer loop
+      vertex -27.8285 -1.09339 58
+      vertex -27.7641 -2.18509 58
+      vertex -28.3623 -2.23216 57.4
+    endloop
+  endfacet
+  facet normal 0.580168 -0.404346 -0.707043
+    outer loop
+      vertex -23.0165 16.7225 57.4
+      vertex -22.5311 16.3698 58
+      vertex -23.1564 15.4726 58
+    endloop
+  endfacet
+  facet normal -0.357586 -0.610095 -0.707047
+    outer loop
+      vertex 14.8651 24.2576 57.4
+      vertex 14.5516 23.746 58
+      vertex 13.6081 24.299 58
+    endloop
+  endfacet
+  facet normal 0.469718 -0.528627 -0.707049
+    outer loop
+      vertex -18.0871 21.1773 58
+      vertex -18.9046 20.4509 58
+      vertex -19.3119 20.8915 57.4
+    endloop
+  endfacet
+  facet normal -0.231682 -0.668108 -0.707075
+    outer loop
+      vertex 8.79153 27.0576 57.4
+      vertex 9.63936 26.1286 58
+      vertex 8.60612 26.4869 58
+    endloop
+  endfacet
+  facet normal -0.205275 0.676687 -0.707076
+    outer loop
+      vertex 8.60612 -26.4869 58
+      vertex 8.79153 -27.0576 57.4
+      vertex 7.72248 -27.3819 57.4
+    endloop
+  endfacet
+  facet normal 0.231682 -0.668108 -0.707075
+    outer loop
+      vertex -8.79153 27.0576 57.4
+      vertex -8.60612 26.4869 58
+      vertex -9.63936 26.1286 58
+    endloop
+  endfacet
+  facet normal -0.690786 -0.151553 -0.706998
+    outer loop
+      vertex 27.6639 6.64152 57.4
+      vertex 27.9033 5.55032 57.4
+      vertex 27.3149 5.43326 58
+    endloop
+  endfacet
+  facet normal -0.676687 -0.205275 -0.707076
+    outer loop
+      vertex 27.0576 8.79153 57.4
+      vertex 27.3819 7.72248 57.4
+      vertex 26.4869 8.60612 58
+    endloop
+  endfacet
+  facet normal 0.0969358 -0.700525 -0.707014
+    outer loop
+      vertex -3.34394 28.2528 57.4
+      vertex -3.27342 27.657 58
+      vertex -4.3567 27.5071 58
+    endloop
+  endfacet
+  facet normal -0.509742 -0.490119 -0.707069
+    outer loop
+      vertex 20.1172 20.1172 57.4
+      vertex 20.8915 19.3119 57.4
+      vertex 19.6929 19.6929 58
+    endloop
+  endfacet
+  facet normal 0.696168 0.124325 -0.707031
+    outer loop
+      vertex -27.5071 -4.3567 58
+      vertex -27.9033 -5.55032 57.4
+      vertex -28.0997 -4.45056 57.4
+    endloop
+  endfacet
+  facet normal -0.283339 0.647891 -0.707076
+    outer loop
+      vertex 11.6597 -25.2918 58
+      vertex 10.8873 -26.2844 57.4
+      vertex 10.6577 -25.73 58
+    endloop
+  endfacet
+  facet normal -0.636249 0.308661 -0.707047
+    outer loop
+      vertex 25.8367 -11.9109 57.4
+      vertex 25.3491 -12.916 57.4
+      vertex 25.2918 -11.6597 58
+    endloop
+  endfacet
+  facet normal -0.647905 0.283379 -0.707047
+    outer loop
+      vertex 26.2844 -10.8873 57.4
+      vertex 25.8367 -11.9109 57.4
+      vertex 25.2918 -11.6597 58
+    endloop
+  endfacet
+  facet normal -0.069254 -0.703746 -0.707068
+    outer loop
+      vertex 2.23216 28.3623 57.4
+      vertex 3.27342 27.657 58
+      vertex 2.18509 27.7641 58
+    endloop
+  endfacet
+  facet normal 0.700525 0.0969358 -0.707014
+    outer loop
+      vertex -27.657 -3.27342 58
+      vertex -27.5071 -4.3567 58
+      vertex -28.2528 -3.34394 57.4
+    endloop
+  endfacet
+  facet normal 0.703794 -0.0693172 -0.707014
+    outer loop
+      vertex -28.2528 3.34394 57.4
+      vertex -27.657 3.27342 58
+      vertex -28.3623 2.23216 57.4
+    endloop
+  endfacet
+  facet normal 0.705911 -0.04165 -0.707075
+    outer loop
+      vertex -28.3623 2.23216 57.4
+      vertex -27.8285 1.09339 58
+      vertex -28.4281 1.11694 57.4
+    endloop
+  endfacet
+  facet normal 0.707002 -0.0138623 -0.707075
+    outer loop
+      vertex -28.4281 1.11694 57.4
+      vertex -27.8285 1.09339 58
+      vertex -28.45 0 57.4
+    endloop
+  endfacet
+  facet normal -0.668134 0.231742 -0.707031
+    outer loop
+      vertex 27.0576 -8.79153 57.4
+      vertex 26.6915 -9.84703 57.4
+      vertex 26.1286 -9.63936 58
+    endloop
+  endfacet
+  facet normal -0.151576 -0.690752 -0.707027
+    outer loop
+      vertex 6.64152 27.6639 57.4
+      vertex 6.50145 27.0805 58
+      vertex 5.43326 27.3149 58
+    endloop
+  endfacet
+  facet normal 0.668134 0.231742 -0.707031
+    outer loop
+      vertex -26.1286 -9.63936 58
+      vertex -26.6915 -9.84703 57.4
+      vertex -27.0576 -8.79153 57.4
+    endloop
+  endfacet
+  facet normal -0.178509 0.684259 -0.707053
+    outer loop
+      vertex 7.55962 -26.8044 58
+      vertex 7.72248 -27.3819 57.4
+      vertex 6.64152 -27.6639 57.4
+    endloop
+  endfacet
+  facet normal 0.610095 -0.357586 -0.707047
+    outer loop
+      vertex -24.2576 14.8651 57.4
+      vertex -23.746 14.5516 58
+      vertex -24.299 13.6081 58
+    endloop
+  endfacet
+  facet normal 0.205275 -0.676687 -0.707076
+    outer loop
+      vertex -7.72248 27.3819 57.4
+      vertex -8.60612 26.4869 58
+      vertex -8.79153 27.0576 57.4
+    endloop
+  endfacet
+  facet normal 0.178509 0.684259 -0.707053
+    outer loop
+      vertex -7.55962 -26.8044 58
+      vertex -6.64152 -27.6639 57.4
+      vertex -7.72248 -27.3819 57.4
+    endloop
+  endfacet
+  facet normal 0.448661 -0.546647 -0.707022
+    outer loop
+      vertex -17.6132 22.3423 57.4
+      vertex -17.2418 21.8711 58
+      vertex -18.4768 21.6335 57.4
+    endloop
+  endfacet
+  facet normal -0.0138623 -0.707002 -0.707075
+    outer loop
+      vertex 1.11694 28.4281 57.4
+      vertex 1.09339 27.8285 58
+      vertex 0 28.45 57.4
+    endloop
+  endfacet
+  facet normal -0.178509 -0.684259 -0.707053
+    outer loop
+      vertex 7.72248 27.3819 57.4
+      vertex 7.55962 26.8044 58
+      vertex 6.64152 27.6639 57.4
+    endloop
+  endfacet
+  facet normal 0.426799 0.563854 -0.707044
+    outer loop
+      vertex -16.3698 -22.5311 58
+      vertex -16.7225 -23.0165 57.4
+      vertex -17.6132 -22.3423 57.4
+    endloop
+  endfacet
+  facet normal 0.623679 0.333329 -0.707047
+    outer loop
+      vertex -24.299 -13.6081 58
+      vertex -24.8225 -13.9013 57.4
+      vertex -25.3491 -12.916 57.4
+    endloop
+  endfacet
+  facet normal 0.647905 0.283379 -0.707047
+    outer loop
+      vertex -25.2918 -11.6597 58
+      vertex -25.8367 -11.9109 57.4
+      vertex -26.2844 -10.8873 57.4
+    endloop
+  endfacet
+  facet normal 0.623683 -0.333342 -0.707038
+    outer loop
+      vertex -24.299 13.6081 58
+      vertex -24.8145 12.6436 58
+      vertex -25.3491 12.916 57.4
+    endloop
+  endfacet
+  facet normal -0.333342 -0.623683 -0.707038
+    outer loop
+      vertex 12.916 25.3491 57.4
+      vertex 13.6081 24.299 58
+      vertex 12.6436 24.8145 58
+    endloop
+  endfacet
+  facet normal 0.426799 -0.563854 -0.707044
+    outer loop
+      vertex -16.7225 23.0165 57.4
+      vertex -16.3698 22.5311 58
+      vertex -17.6132 22.3423 57.4
+    endloop
+  endfacet
+  facet normal -0.509742 0.490119 -0.707069
+    outer loop
+      vertex 20.8915 -19.3119 57.4
+      vertex 20.1172 -20.1172 57.4
+      vertex 19.6929 -19.6929 58
+    endloop
+  endfacet
+  facet normal 0.426794 -0.563885 -0.707023
+    outer loop
+      vertex -16.3698 22.5311 58
+      vertex -17.2418 21.8711 58
+      vertex -17.6132 22.3423 57.4
+    endloop
+  endfacet
+  facet normal -0.623683 0.333342 -0.707038
+    outer loop
+      vertex 24.8145 -12.6436 58
+      vertex 25.3491 -12.916 57.4
+      vertex 24.299 -13.6081 58
+    endloop
+  endfacet
+  facet normal 0.647891 0.283339 -0.707076
+    outer loop
+      vertex -25.73 -10.6577 58
+      vertex -25.2918 -11.6597 58
+      vertex -26.2844 -10.8873 57.4
+    endloop
+  endfacet
+  facet normal -0.357587 -0.610094 -0.707048
+    outer loop
+      vertex 13.9013 24.8225 57.4
+      vertex 14.8651 24.2576 57.4
+      vertex 13.6081 24.299 58
+    endloop
+  endfacet
+  facet normal -0.595579 -0.381274 -0.707047
+    outer loop
+      vertex 24.2576 14.8651 57.4
+      vertex 23.746 14.5516 58
+      vertex 23.1564 15.4726 58
+    endloop
+  endfacet
+  facet normal 0.257718 -0.658551 -0.707031
+    outer loop
+      vertex -9.84703 26.6915 57.4
+      vertex -9.63936 26.1286 58
+      vertex -10.8873 26.2844 57.4
+    endloop
+  endfacet
+  facet normal 0.676702 0.205306 -0.707053
+    outer loop
+      vertex -26.8044 -7.55962 58
+      vertex -26.4869 -8.60612 58
+      vertex -27.3819 -7.72248 57.4
+    endloop
+  endfacet
+  facet normal -0.333329 0.623679 -0.707047
+    outer loop
+      vertex 13.6081 -24.299 58
+      vertex 13.9013 -24.8225 57.4
+      vertex 12.916 -25.3491 57.4
+    endloop
+  endfacet
+  facet normal -0.151553 -0.690786 -0.706998
+    outer loop
+      vertex 5.55032 27.9033 57.4
+      vertex 6.64152 27.6639 57.4
+      vertex 5.43326 27.3149 58
+    endloop
+  endfacet
+  facet normal 0.426794 0.563885 -0.707023
+    outer loop
+      vertex -17.2418 -21.8711 58
+      vertex -16.3698 -22.5311 58
+      vertex -17.6132 -22.3423 57.4
+    endloop
+  endfacet
+  facet normal 0.069254 -0.703746 -0.707068
+    outer loop
+      vertex -2.23216 28.3623 57.4
+      vertex -2.18509 27.7641 58
+      vertex -3.27342 27.657 58
+    endloop
+  endfacet
+  facet normal 0.0416425 -0.705919 -0.707068
+    outer loop
+      vertex -1.09339 27.8285 58
+      vertex -2.18509 27.7641 58
+      vertex -2.23216 28.3623 57.4
+    endloop
+  endfacet
+  facet normal -0.623679 -0.333329 -0.707047
+    outer loop
+      vertex 24.8225 13.9013 57.4
+      vertex 25.3491 12.916 57.4
+      vertex 24.299 13.6081 58
+    endloop
+  endfacet
+  facet normal 0.283339 0.647891 -0.707076
+    outer loop
+      vertex -10.6577 -25.73 58
+      vertex -10.8873 -26.2844 57.4
+      vertex -11.6597 -25.2918 58
+    endloop
+  endfacet
+  facet normal 0.684277 0.178543 -0.707027
+    outer loop
+      vertex -27.0805 -6.50145 58
+      vertex -26.8044 -7.55962 58
+      vertex -27.6639 -6.64152 57.4
+    endloop
+  endfacet
+  facet normal 0.610094 -0.357587 -0.707048
+    outer loop
+      vertex -24.2576 14.8651 57.4
+      vertex -24.299 13.6081 58
+      vertex -24.8225 13.9013 57.4
+    endloop
+  endfacet
+  facet normal -0.096915 0.70051 -0.707031
+    outer loop
+      vertex 4.3567 -27.5071 58
+      vertex 4.45056 -28.0997 57.4
+      vertex 3.34394 -28.2528 57.4
+    endloop
+  endfacet
+  facet normal -0.205275 -0.676687 -0.707076
+    outer loop
+      vertex 8.79153 27.0576 57.4
+      vertex 8.60612 26.4869 58
+      vertex 7.72248 27.3819 57.4
+    endloop
+  endfacet
+  facet normal -0.178543 -0.684277 -0.707027
+    outer loop
+      vertex 6.64152 27.6639 57.4
+      vertex 7.55962 26.8044 58
+      vertex 6.50145 27.0805 58
+    endloop
+  endfacet
+  facet normal -0.528627 -0.469718 -0.707049
+    outer loop
+      vertex 20.8915 19.3119 57.4
+      vertex 21.1773 18.0871 58
+      vertex 20.4509 18.9046 58
+    endloop
+  endfacet
+  facet normal -0.703746 0.069254 -0.707068
+    outer loop
+      vertex 27.7641 -2.18509 58
+      vertex 28.3623 -2.23216 57.4
+      vertex 27.657 -3.27342 58
+    endloop
+  endfacet
+  facet normal -0.690752 0.151576 -0.707027
+    outer loop
+      vertex 27.3149 -5.43326 58
+      vertex 27.6639 -6.64152 57.4
+      vertex 27.0805 -6.50145 58
+    endloop
+  endfacet
+  facet normal -0.381274 -0.595579 -0.707047
+    outer loop
+      vertex 14.8651 24.2576 57.4
+      vertex 15.4726 23.1564 58
+      vertex 14.5516 23.746 58
+    endloop
+  endfacet
+  facet normal 0.490119 0.509742 -0.707069
+    outer loop
+      vertex -19.6929 -19.6929 58
+      vertex -19.3119 -20.8915 57.4
+      vertex -20.1172 -20.1172 57.4
+    endloop
+  endfacet
+  facet normal 0.563885 0.426794 -0.707023
+    outer loop
+      vertex -21.8711 -17.2418 58
+      vertex -22.3423 -17.6132 57.4
+      vertex -22.5311 -16.3698 58
+    endloop
+  endfacet
+  facet normal 0.0416425 0.705919 -0.707068
+    outer loop
+      vertex -2.18509 -27.7641 58
+      vertex -1.09339 -27.8285 58
+      vertex -2.23216 -28.3623 57.4
+    endloop
+  endfacet
+  facet normal -0.333342 0.623683 -0.707038
+    outer loop
+      vertex 13.6081 -24.299 58
+      vertex 12.916 -25.3491 57.4
+      vertex 12.6436 -24.8145 58
+    endloop
+  endfacet
+  facet normal -0.636261 -0.308657 -0.707038
+    outer loop
+      vertex 25.3491 12.916 57.4
+      vertex 25.2918 11.6597 58
+      vertex 24.8145 12.6436 58
+    endloop
+  endfacet
+  facet normal 0.70051 -0.096915 -0.707031
+    outer loop
+      vertex -28.0997 4.45056 57.4
+      vertex -27.5071 4.3567 58
+      vertex -28.2528 3.34394 57.4
+    endloop
+  endfacet
+  facet normal 0.610095 0.357586 -0.707047
+    outer loop
+      vertex -23.746 -14.5516 58
+      vertex -24.2576 -14.8651 57.4
+      vertex -24.299 -13.6081 58
+    endloop
+  endfacet
+  facet normal 0.404353 -0.580134 -0.707067
+    outer loop
+      vertex -15.806 23.6553 57.4
+      vertex -15.4726 23.1564 58
+      vertex -16.7225 23.0165 57.4
+    endloop
+  endfacet
+  facet normal -0.381246 -0.595575 -0.707066
+    outer loop
+      vertex 15.806 23.6553 57.4
+      vertex 15.4726 23.1564 58
+      vertex 14.8651 24.2576 57.4
+    endloop
+  endfacet
+  facet normal 0.308661 -0.636249 -0.707047
+    outer loop
+      vertex -11.9109 25.8367 57.4
+      vertex -11.6597 25.2918 58
+      vertex -12.916 25.3491 57.4
+    endloop
+  endfacet
+  facet normal 0.333329 -0.623679 -0.707047
+    outer loop
+      vertex -12.916 25.3491 57.4
+      vertex -13.6081 24.299 58
+      vertex -13.9013 24.8225 57.4
+    endloop
+  endfacet
+  facet normal -0.705919 0.0416425 -0.707068
+    outer loop
+      vertex 27.8285 -1.09339 58
+      vertex 28.3623 -2.23216 57.4
+      vertex 27.7641 -2.18509 58
+    endloop
+  endfacet
+  facet normal -0.595575 -0.381246 -0.707066
+    outer loop
+      vertex 23.6553 15.806 57.4
+      vertex 24.2576 14.8651 57.4
+      vertex 23.1564 15.4726 58
+    endloop
+  endfacet
+  facet normal -0.563854 0.426799 -0.707044
+    outer loop
+      vertex 22.5311 -16.3698 58
+      vertex 23.0165 -16.7225 57.4
+      vertex 22.3423 -17.6132 57.4
+    endloop
+  endfacet
+  facet normal -0.580168 0.404346 -0.707043
+    outer loop
+      vertex 23.1564 -15.4726 58
+      vertex 23.0165 -16.7225 57.4
+      vertex 22.5311 -16.3698 58
+    endloop
+  endfacet
+  facet normal -0.546634 -0.448663 -0.707031
+    outer loop
+      vertex 21.6335 18.4768 57.4
+      vertex 21.8711 17.2418 58
+      vertex 21.1773 18.0871 58
+    endloop
+  endfacet
+  facet normal -0.069254 0.703746 -0.707068
+    outer loop
+      vertex 3.27342 -27.657 58
+      vertex 2.23216 -28.3623 57.4
+      vertex 2.18509 -27.7641 58
+    endloop
+  endfacet
+  facet normal -0.124325 -0.696168 -0.707031
+    outer loop
+      vertex 4.45056 28.0997 57.4
+      vertex 5.55032 27.9033 57.4
+      vertex 4.3567 27.5071 58
+    endloop
+  endfacet
+  facet normal -0.676702 -0.205306 -0.707053
+    outer loop
+      vertex 27.3819 7.72248 57.4
+      vertex 26.8044 7.55962 58
+      vertex 26.4869 8.60612 58
+    endloop
+  endfacet
+  facet normal -0.684259 -0.178509 -0.707053
+    outer loop
+      vertex 27.3819 7.72248 57.4
+      vertex 27.6639 6.64152 57.4
+      vertex 26.8044 7.55962 58
+    endloop
+  endfacet
+  facet normal -0.357587 0.610094 -0.707048
+    outer loop
+      vertex 14.8651 -24.2576 57.4
+      vertex 13.9013 -24.8225 57.4
+      vertex 13.6081 -24.299 58
+    endloop
+  endfacet
+  facet normal -0.308661 -0.636249 -0.707047
+    outer loop
+      vertex 11.9109 25.8367 57.4
+      vertex 12.916 25.3491 57.4
+      vertex 11.6597 25.2918 58
+    endloop
+  endfacet
+  facet normal -0.283379 -0.647905 -0.707047
+    outer loop
+      vertex 11.9109 25.8367 57.4
+      vertex 11.6597 25.2918 58
+      vertex 10.8873 26.2844 57.4
+    endloop
+  endfacet
+  facet normal -0.404353 -0.580134 -0.707067
+    outer loop
+      vertex 15.806 23.6553 57.4
+      vertex 16.7225 23.0165 57.4
+      vertex 15.4726 23.1564 58
+    endloop
+  endfacet
+  facet normal 0.563854 -0.426799 -0.707044
+    outer loop
+      vertex -22.3423 17.6132 57.4
+      vertex -22.5311 16.3698 58
+      vertex -23.0165 16.7225 57.4
+    endloop
+  endfacet
+  facet normal -0.448663 -0.546634 -0.707031
+    outer loop
+      vertex 18.4768 21.6335 57.4
+      vertex 18.0871 21.1773 58
+      vertex 17.2418 21.8711 58
+    endloop
+  endfacet
+  facet normal 0.636249 -0.308661 -0.707047
+    outer loop
+      vertex -25.3491 12.916 57.4
+      vertex -25.2918 11.6597 58
+      vertex -25.8367 11.9109 57.4
+    endloop
+  endfacet
+  facet normal -0.257747 -0.65849 -0.707076
+    outer loop
+      vertex 10.8873 26.2844 57.4
+      vertex 10.6577 25.73 58
+      vertex 9.63936 26.1286 58
+    endloop
+  endfacet
+  facet normal -0.231742 0.668134 -0.707031
+    outer loop
+      vertex 9.63936 -26.1286 58
+      vertex 9.84703 -26.6915 57.4
+      vertex 8.79153 -27.0576 57.4
+    endloop
+  endfacet
+  facet normal 0.308657 0.636261 -0.707038
+    outer loop
+      vertex -12.6436 -24.8145 58
+      vertex -11.6597 -25.2918 58
+      vertex -12.916 -25.3491 57.4
+    endloop
+  endfacet
+  facet normal -0.610095 -0.357586 -0.707047
+    outer loop
+      vertex 24.2576 14.8651 57.4
+      vertex 24.299 13.6081 58
+      vertex 23.746 14.5516 58
+    endloop
+  endfacet
+  facet normal 0.65849 -0.257747 -0.707076
+    outer loop
+      vertex -25.73 10.6577 58
+      vertex -26.1286 9.63936 58
+      vertex -26.2844 10.8873 57.4
+    endloop
+  endfacet
+  facet normal 0.647891 -0.283339 -0.707076
+    outer loop
+      vertex -25.2918 11.6597 58
+      vertex -25.73 10.6577 58
+      vertex -26.2844 10.8873 57.4
+    endloop
+  endfacet
+  facet normal 0.096915 -0.70051 -0.707031
+    outer loop
+      vertex -3.34394 28.2528 57.4
+      vertex -4.3567 27.5071 58
+      vertex -4.45056 28.0997 57.4
+    endloop
+  endfacet
+  facet normal -0.357586 0.610095 -0.707047
+    outer loop
+      vertex 14.5516 -23.746 58
+      vertex 14.8651 -24.2576 57.4
+      vertex 13.6081 -24.299 58
+    endloop
+  endfacet
+  facet normal 0.0693172 0.703794 -0.707014
+    outer loop
+      vertex -3.27342 -27.657 58
+      vertex -2.23216 -28.3623 57.4
+      vertex -3.34394 -28.2528 57.4
+    endloop
+  endfacet
+  facet normal 0.700525 -0.0969358 -0.707014
+    outer loop
+      vertex -27.5071 4.3567 58
+      vertex -27.657 3.27342 58
+      vertex -28.2528 3.34394 57.4
+    endloop
+  endfacet
+  facet normal -0.426794 -0.563885 -0.707023
+    outer loop
+      vertex 17.6132 22.3423 57.4
+      vertex 17.2418 21.8711 58
+      vertex 16.3698 22.5311 58
+    endloop
+  endfacet
+  facet normal 0.308661 0.636249 -0.707047
+    outer loop
+      vertex -11.6597 -25.2918 58
+      vertex -11.9109 -25.8367 57.4
+      vertex -12.916 -25.3491 57.4
+    endloop
+  endfacet
+  facet normal 0.658551 0.257718 -0.707031
+    outer loop
+      vertex -26.1286 -9.63936 58
+      vertex -26.2844 -10.8873 57.4
+      vertex -26.6915 -9.84703 57.4
+    endloop
+  endfacet
+  facet normal -0.404346 0.580168 -0.707043
+    outer loop
+      vertex 16.3698 -22.5311 58
+      vertex 16.7225 -23.0165 57.4
+      vertex 15.4726 -23.1564 58
+    endloop
+  endfacet
+  facet normal -0.381274 0.595579 -0.707047
+    outer loop
+      vertex 15.4726 -23.1564 58
+      vertex 14.8651 -24.2576 57.4
+      vertex 14.5516 -23.746 58
+    endloop
+  endfacet
+  facet normal 0.705919 -0.0416425 -0.707068
+    outer loop
+      vertex -27.7641 2.18509 58
+      vertex -27.8285 1.09339 58
+      vertex -28.3623 2.23216 57.4
+    endloop
+  endfacet
+  facet normal 0.231742 0.668134 -0.707031
+    outer loop
+      vertex -9.63936 -26.1286 58
+      vertex -8.79153 -27.0576 57.4
+      vertex -9.84703 -26.6915 57.4
+    endloop
+  endfacet
+  facet normal -0.205306 -0.676702 -0.707053
+    outer loop
+      vertex 7.72248 27.3819 57.4
+      vertex 8.60612 26.4869 58
+      vertex 7.55962 26.8044 58
+    endloop
+  endfacet
+  facet normal -0.448661 0.546647 -0.707022
+    outer loop
+      vertex 18.4768 -21.6335 57.4
+      vertex 17.6132 -22.3423 57.4
+      vertex 17.2418 -21.8711 58
+    endloop
+  endfacet
+  facet normal 0.283379 -0.647905 -0.707047
+    outer loop
+      vertex -10.8873 26.2844 57.4
+      vertex -11.6597 25.2918 58
+      vertex -11.9109 25.8367 57.4
+    endloop
+  endfacet
+  facet normal 0.308657 -0.636261 -0.707038
+    outer loop
+      vertex -11.6597 25.2918 58
+      vertex -12.6436 24.8145 58
+      vertex -12.916 25.3491 57.4
+    endloop
+  endfacet
+  facet normal 0.690752 -0.151576 -0.707027
+    outer loop
+      vertex -27.0805 6.50145 58
+      vertex -27.3149 5.43326 58
+      vertex -27.6639 6.64152 57.4
+    endloop
+  endfacet
+  facet normal 0.676702 -0.205306 -0.707053
+    outer loop
+      vertex -26.4869 8.60612 58
+      vertex -26.8044 7.55962 58
+      vertex -27.3819 7.72248 57.4
+    endloop
+  endfacet
+  facet normal 0.357586 0.610095 -0.707047
+    outer loop
+      vertex -14.5516 -23.746 58
+      vertex -13.6081 -24.299 58
+      vertex -14.8651 -24.2576 57.4
+    endloop
+  endfacet
+  facet normal 0.231682 0.668108 -0.707075
+    outer loop
+      vertex -8.60612 -26.4869 58
+      vertex -8.79153 -27.0576 57.4
+      vertex -9.63936 -26.1286 58
+    endloop
+  endfacet
+  facet normal 0.381274 0.595579 -0.707047
+    outer loop
+      vertex -14.5516 -23.746 58
+      vertex -14.8651 -24.2576 57.4
+      vertex -15.4726 -23.1564 58
+    endloop
+  endfacet
+  facet normal 0.684277 -0.178543 -0.707027
+    outer loop
+      vertex -26.8044 7.55962 58
+      vertex -27.0805 6.50145 58
+      vertex -27.6639 6.64152 57.4
+    endloop
+  endfacet
+  facet normal 0.636261 -0.308657 -0.707038
+    outer loop
+      vertex -24.8145 12.6436 58
+      vertex -25.2918 11.6597 58
+      vertex -25.3491 12.916 57.4
+    endloop
+  endfacet
+  facet normal -0.509741 0.490148 -0.707049
+    outer loop
+      vertex 20.4509 -18.9046 58
+      vertex 20.8915 -19.3119 57.4
+      vertex 19.6929 -19.6929 58
+    endloop
+  endfacet
+  facet normal -0.528627 0.469718 -0.707049
+    outer loop
+      vertex 21.1773 -18.0871 58
+      vertex 20.8915 -19.3119 57.4
+      vertex 20.4509 -18.9046 58
+    endloop
+  endfacet
+  facet normal 0.357587 -0.610094 -0.707048
+    outer loop
+      vertex -13.9013 24.8225 57.4
+      vertex -13.6081 24.299 58
+      vertex -14.8651 24.2576 57.4
+    endloop
+  endfacet
+  facet normal 0.357587 0.610094 -0.707048
+    outer loop
+      vertex -13.6081 -24.299 58
+      vertex -13.9013 -24.8225 57.4
+      vertex -14.8651 -24.2576 57.4
+    endloop
+  endfacet
+  facet normal 0.676687 -0.205275 -0.707076
+    outer loop
+      vertex -27.0576 8.79153 57.4
+      vertex -26.4869 8.60612 58
+      vertex -27.3819 7.72248 57.4
+    endloop
+  endfacet
+  facet normal 0.381246 -0.595575 -0.707066
+    outer loop
+      vertex -14.8651 24.2576 57.4
+      vertex -15.4726 23.1564 58
+      vertex -15.806 23.6553 57.4
+    endloop
+  endfacet
+  facet normal 0.546647 -0.448661 -0.707022
+    outer loop
+      vertex -21.6335 18.4768 57.4
+      vertex -21.8711 17.2418 58
+      vertex -22.3423 17.6132 57.4
+    endloop
+  endfacet
+  facet normal -0.546647 -0.448661 -0.707022
+    outer loop
+      vertex 22.3423 17.6132 57.4
+      vertex 21.8711 17.2418 58
+      vertex 21.6335 18.4768 57.4
+    endloop
+  endfacet
+  facet normal -0.426799 0.563854 -0.707044
+    outer loop
+      vertex 17.6132 -22.3423 57.4
+      vertex 16.7225 -23.0165 57.4
+      vertex 16.3698 -22.5311 58
+    endloop
+  endfacet
+  facet normal 0.069254 0.703746 -0.707068
+    outer loop
+      vertex -2.18509 -27.7641 58
+      vertex -2.23216 -28.3623 57.4
+      vertex -3.27342 -27.657 58
+    endloop
+  endfacet
+  facet normal 0.333329 0.623679 -0.707047
+    outer loop
+      vertex -13.6081 -24.299 58
+      vertex -12.916 -25.3491 57.4
+      vertex -13.9013 -24.8225 57.4
+    endloop
+  endfacet
+  facet normal 0.404346 0.580168 -0.707043
+    outer loop
+      vertex -16.3698 -22.5311 58
+      vertex -15.4726 -23.1564 58
+      vertex -16.7225 -23.0165 57.4
+    endloop
+  endfacet
+  facet normal 0.404353 0.580134 -0.707067
+    outer loop
+      vertex -15.4726 -23.1564 58
+      vertex -15.806 -23.6553 57.4
+      vertex -16.7225 -23.0165 57.4
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/stl/spool_core_sleeve/bambu55p5_to73_len59.stl
+++ b/stl/spool_core_sleeve/bambu55p5_to73_len59.stl
@@ -1,0 +1,22402 @@
+solid OpenSCAD_Model
+  facet normal -0.505693 0.862714 0
+    outer loop
+      vertex -17.7858 31.7589 0.799999
+      vertex -19.0189 31.0361 58.2
+      vertex -17.7858 31.7589 58.2
+    endloop
+  endfacet
+  facet normal -0.505693 0.862714 0
+    outer loop
+      vertex -19.0189 31.0361 58.2
+      vertex -17.7858 31.7589 0.799999
+      vertex -19.0189 31.0361 0.799999
+    endloop
+  endfacet
+  facet normal 0.998267 0.0588389 0
+    outer loop
+      vertex 36.3719 1.42906 58.2
+      vertex 36.2878 2.85591 0.799999
+      vertex 36.2878 2.85591 58.2
+    endloop
+  endfacet
+  facet normal 0.998267 0.0588389 0
+    outer loop
+      vertex 36.2878 2.85591 0.799999
+      vertex 36.3719 1.42906 58.2
+      vertex 36.3719 1.42906 0.799999
+    endloop
+  endfacet
+  facet normal 0.999807 0.0196595 0
+    outer loop
+      vertex 36.4 0 58.2
+      vertex 36.3719 1.42906 0.799999
+      vertex 36.3719 1.42906 58.2
+    endloop
+  endfacet
+  facet normal 0.999807 0.0196595 0
+    outer loop
+      vertex 36.3719 1.42906 0.799999
+      vertex 36.4 0 58.2
+      vertex 36.4 0 0.799999
+    endloop
+  endfacet
+  facet normal 0.995185 0.0980178 0
+    outer loop
+      vertex 36.2878 2.85591 58.2
+      vertex 36.1477 4.27836 0.799999
+      vertex 36.1477 4.27836 58.2
+    endloop
+  endfacet
+  facet normal 0.995185 0.0980178 0
+    outer loop
+      vertex 36.1477 4.27836 0.799999
+      vertex 36.2878 2.85591 58.2
+      vertex 36.2878 2.85591 0.799999
+    endloop
+  endfacet
+  facet normal -0.603576 -0.797305 0
+    outer loop
+      vertex -22.535 -28.5855 0.799999
+      vertex -21.3954 -29.4482 58.2
+      vertex -22.535 -28.5855 58.2
+    endloop
+  endfacet
+  facet normal -0.603576 -0.797305 -0
+    outer loop
+      vertex -21.3954 -29.4482 58.2
+      vertex -22.535 -28.5855 0.799999
+      vertex -21.3954 -29.4482 0.799999
+    endloop
+  endfacet
+  facet normal -0.693047 -0.720892 0
+    outer loop
+      vertex -25.7387 -25.7387 0.799999
+      vertex -24.7083 -26.7293 58.2
+      vertex -25.7387 -25.7387 58.2
+    endloop
+  endfacet
+  facet normal -0.693047 -0.720892 -0
+    outer loop
+      vertex -24.7083 -26.7293 58.2
+      vertex -25.7387 -25.7387 0.799999
+      vertex -24.7083 -26.7293 0.799999
+    endloop
+  endfacet
+  facet normal 0.747475 0.66429 0
+    outer loop
+      vertex 27.6788 23.6399 58.2
+      vertex 26.7293 24.7083 0.799999
+      vertex 26.7293 24.7083 58.2
+    endloop
+  endfacet
+  facet normal 0.747475 0.66429 0
+    outer loop
+      vertex 26.7293 24.7083 0.799999
+      vertex 27.6788 23.6399 58.2
+      vertex 27.6788 23.6399 0.799999
+    endloop
+  endfacet
+  facet normal -0.603576 0.797305 0
+    outer loop
+      vertex -21.3954 29.4482 0.799999
+      vertex -22.535 28.5855 58.2
+      vertex -21.3954 29.4482 58.2
+    endloop
+  endfacet
+  facet normal -0.603576 0.797305 0
+    outer loop
+      vertex -22.535 28.5855 58.2
+      vertex -21.3954 29.4482 0.799999
+      vertex -22.535 28.5855 0.799999
+    endloop
+  endfacet
+  facet normal 0.747475 -0.66429 0
+    outer loop
+      vertex 26.7293 -24.7083 58.2
+      vertex 27.6788 -23.6399 0.799999
+      vertex 27.6788 -23.6399 58.2
+    endloop
+  endfacet
+  facet normal 0.747475 -0.66429 0
+    outer loop
+      vertex 27.6788 -23.6399 0.799999
+      vertex 26.7293 -24.7083 58.2
+      vertex 26.7293 -24.7083 0.799999
+    endloop
+  endfacet
+  facet normal 0.820387 0.571808 0
+    outer loop
+      vertex 30.2655 20.2228 58.2
+      vertex 29.4482 21.3954 0.799999
+      vertex 29.4482 21.3954 58.2
+    endloop
+  endfacet
+  facet normal 0.820387 0.571808 0
+    outer loop
+      vertex 29.4482 21.3954 0.799999
+      vertex 30.2655 20.2228 58.2
+      vertex 30.2655 20.2228 0.799999
+    endloop
+  endfacet
+  facet normal -0.471369 0.881936 0
+    outer loop
+      vertex -16.5253 32.4326 0.799999
+      vertex -17.7858 31.7589 58.2
+      vertex -16.5253 32.4326 58.2
+    endloop
+  endfacet
+  facet normal -0.471369 0.881936 0
+    outer loop
+      vertex -17.7858 31.7589 58.2
+      vertex -16.5253 32.4326 0.799999
+      vertex -17.7858 31.7589 0.799999
+    endloop
+  endfacet
+  facet normal 0.175815 -0.984423 0
+    outer loop
+      vertex 5.69421 -35.9519 0.799999
+      vertex 7.10129 -35.7006 58.2
+      vertex 5.69421 -35.9519 58.2
+    endloop
+  endfacet
+  facet normal 0.175815 -0.984423 0
+    outer loop
+      vertex 7.10129 -35.7006 58.2
+      vertex 5.69421 -35.9519 0.799999
+      vertex 7.10129 -35.7006 0.799999
+    endloop
+  endfacet
+  facet normal -0.916185 -0.400756 0
+    outer loop
+      vertex -33.0564 -15.2392 0.799999
+      vertex -33.6292 -13.9297 58.2
+      vertex -33.6292 -13.9297 0.799999
+    endloop
+  endfacet
+  facet normal -0.916185 -0.400756 0
+    outer loop
+      vertex -33.6292 -13.9297 58.2
+      vertex -33.0564 -15.2392 0.799999
+      vertex -33.0564 -15.2392 58.2
+    endloop
+  endfacet
+  facet normal -0.571808 -0.820387 0
+    outer loop
+      vertex -21.3954 -29.4482 0.799999
+      vertex -20.2228 -30.2655 58.2
+      vertex -21.3954 -29.4482 58.2
+    endloop
+  endfacet
+  facet normal -0.571808 -0.820387 -0
+    outer loop
+      vertex -20.2228 -30.2655 58.2
+      vertex -21.3954 -29.4482 0.799999
+      vertex -20.2228 -30.2655 0.799999
+    endloop
+  endfacet
+  facet normal 0.436407 -0.899749 0
+    outer loop
+      vertex 15.2392 -33.0564 0.799999
+      vertex 16.5253 -32.4326 58.2
+      vertex 15.2392 -33.0564 58.2
+    endloop
+  endfacet
+  facet normal 0.436407 -0.899749 0
+    outer loop
+      vertex 16.5253 -32.4326 58.2
+      vertex 15.2392 -33.0564 0.799999
+      vertex 16.5253 -32.4326 0.799999
+    endloop
+  endfacet
+  facet normal -0.990573 -0.136988 0
+    outer loop
+      vertex -35.9519 -5.69421 0.799999
+      vertex -36.1477 -4.27836 58.2
+      vertex -36.1477 -4.27836 0.799999
+    endloop
+  endfacet
+  facet normal -0.990573 -0.136988 0
+    outer loop
+      vertex -36.1477 -4.27836 58.2
+      vertex -35.9519 -5.69421 0.799999
+      vertex -35.9519 -5.69421 58.2
+    endloop
+  endfacet
+  facet normal -0.634365 -0.773034 0
+    outer loop
+      vertex -23.6399 -27.6788 0.799999
+      vertex -22.535 -28.5855 58.2
+      vertex -23.6399 -27.6788 58.2
+    endloop
+  endfacet
+  facet normal -0.634365 -0.773034 -0
+    outer loop
+      vertex -22.535 -28.5855 58.2
+      vertex -23.6399 -27.6788 0.799999
+      vertex -22.535 -28.5855 0.799999
+    endloop
+  endfacet
+  facet normal 0.842238 -0.539105 0
+    outer loop
+      vertex 30.2655 -20.2228 58.2
+      vertex 31.0361 -19.0189 0.799999
+      vertex 31.0361 -19.0189 58.2
+    endloop
+  endfacet
+  facet normal 0.842238 -0.539105 0
+    outer loop
+      vertex 31.0361 -19.0189 0.799999
+      vertex 30.2655 -20.2228 58.2
+      vertex 30.2655 -20.2228 0.799999
+    endloop
+  endfacet
+  facet normal 0.967598 0.252495 0
+    outer loop
+      vertex 35.3943 8.49741 58.2
+      vertex 35.0334 9.88043 0.799999
+      vertex 35.0334 9.88043 58.2
+    endloop
+  endfacet
+  facet normal 0.967598 0.252495 0
+    outer loop
+      vertex 35.0334 9.88043 0.799999
+      vertex 35.3943 8.49741 58.2
+      vertex 35.3943 8.49741 0.799999
+    endloop
+  endfacet
+  facet normal 0.327622 0.944809 -0
+    outer loop
+      vertex 12.5987 34.1502 0.799999
+      vertex 11.2482 34.6185 58.2
+      vertex 12.5987 34.1502 58.2
+    endloop
+  endfacet
+  facet normal 0.327622 0.944809 0
+    outer loop
+      vertex 11.2482 34.6185 58.2
+      vertex 12.5987 34.1502 0.799999
+      vertex 11.2482 34.6185 0.799999
+    endloop
+  endfacet
+  facet normal -0.881936 -0.471369 0
+    outer loop
+      vertex -31.7589 -17.7858 0.799999
+      vertex -32.4326 -16.5253 58.2
+      vertex -32.4326 -16.5253 0.799999
+    endloop
+  endfacet
+  facet normal -0.881936 -0.471369 0
+    outer loop
+      vertex -32.4326 -16.5253 58.2
+      vertex -31.7589 -17.7858 0.799999
+      vertex -31.7589 -17.7858 58.2
+    endloop
+  endfacet
+  facet normal 0.505693 0.862714 -0
+    outer loop
+      vertex 19.0189 31.0361 0.799999
+      vertex 17.7858 31.7589 58.2
+      vertex 19.0189 31.0361 58.2
+    endloop
+  endfacet
+  facet normal 0.505693 0.862714 0
+    outer loop
+      vertex 17.7858 31.7589 58.2
+      vertex 19.0189 31.0361 0.799999
+      vertex 17.7858 31.7589 0.799999
+    endloop
+  endfacet
+  facet normal 0.881936 -0.471369 0
+    outer loop
+      vertex 31.7589 -17.7858 58.2
+      vertex 32.4326 -16.5253 0.799999
+      vertex 32.4326 -16.5253 58.2
+    endloop
+  endfacet
+  facet normal 0.881936 -0.471369 0
+    outer loop
+      vertex 32.4326 -16.5253 0.799999
+      vertex 31.7589 -17.7858 58.2
+      vertex 31.7589 -17.7858 0.799999
+    endloop
+  endfacet
+  facet normal -0.842238 -0.539105 0
+    outer loop
+      vertex -30.2655 -20.2228 0.799999
+      vertex -31.0361 -19.0189 58.2
+      vertex -31.0361 -19.0189 0.799999
+    endloop
+  endfacet
+  facet normal -0.842238 -0.539105 0
+    outer loop
+      vertex -31.0361 -19.0189 58.2
+      vertex -30.2655 -20.2228 0.799999
+      vertex -30.2655 -20.2228 58.2
+    endloop
+  endfacet
+  facet normal 0.136988 -0.990573 0
+    outer loop
+      vertex 4.27836 -36.1477 0.799999
+      vertex 5.69421 -35.9519 58.2
+      vertex 4.27836 -36.1477 58.2
+    endloop
+  endfacet
+  facet normal 0.136988 -0.990573 0
+    outer loop
+      vertex 5.69421 -35.9519 58.2
+      vertex 4.27836 -36.1477 0.799999
+      vertex 5.69421 -35.9519 0.799999
+    endloop
+  endfacet
+  facet normal 0.571808 0.820387 -0
+    outer loop
+      vertex 21.3954 29.4482 0.799999
+      vertex 20.2228 30.2655 58.2
+      vertex 21.3954 29.4482 58.2
+    endloop
+  endfacet
+  facet normal 0.571808 0.820387 0
+    outer loop
+      vertex 20.2228 30.2655 58.2
+      vertex 21.3954 29.4482 0.799999
+      vertex 20.2228 30.2655 0.799999
+    endloop
+  endfacet
+  facet normal 0.998267 -0.0588389 0
+    outer loop
+      vertex 36.2878 -2.85591 58.2
+      vertex 36.3719 -1.42906 0.799999
+      vertex 36.3719 -1.42906 58.2
+    endloop
+  endfacet
+  facet normal 0.998267 -0.0588389 0
+    outer loop
+      vertex 36.3719 -1.42906 0.799999
+      vertex 36.2878 -2.85591 58.2
+      vertex 36.2878 -2.85591 0.799999
+    endloop
+  endfacet
+  facet normal -0.0588389 0.998267 0
+    outer loop
+      vertex -1.42906 36.3719 0.799999
+      vertex -2.85591 36.2878 58.2
+      vertex -1.42906 36.3719 58.2
+    endloop
+  endfacet
+  facet normal -0.0588389 0.998267 0
+    outer loop
+      vertex -2.85591 36.2878 58.2
+      vertex -1.42906 36.3719 0.799999
+      vertex -2.85591 36.2878 0.799999
+    endloop
+  endfacet
+  facet normal 0.571808 -0.820387 0
+    outer loop
+      vertex 20.2228 -30.2655 0.799999
+      vertex 21.3954 -29.4482 58.2
+      vertex 20.2228 -30.2655 58.2
+    endloop
+  endfacet
+  facet normal 0.571808 -0.820387 0
+    outer loop
+      vertex 21.3954 -29.4482 58.2
+      vertex 20.2228 -30.2655 0.799999
+      vertex 21.3954 -29.4482 0.799999
+    endloop
+  endfacet
+  facet normal 0.956942 -0.290279 0
+    outer loop
+      vertex 34.6185 -11.2482 58.2
+      vertex 35.0334 -9.88043 0.799999
+      vertex 35.0334 -9.88043 58.2
+    endloop
+  endfacet
+  facet normal 0.956942 -0.290279 0
+    outer loop
+      vertex 35.0334 -9.88043 0.799999
+      vertex 34.6185 -11.2482 58.2
+      vertex 34.6185 -11.2482 0.799999
+    endloop
+  endfacet
+  facet normal -0.956942 0.290279 0
+    outer loop
+      vertex -35.0334 9.88043 0.799999
+      vertex -34.6185 11.2482 58.2
+      vertex -34.6185 11.2482 0.799999
+    endloop
+  endfacet
+  facet normal -0.956942 0.290279 0
+    outer loop
+      vertex -34.6185 11.2482 58.2
+      vertex -35.0334 9.88043 0.799999
+      vertex -35.0334 9.88043 58.2
+    endloop
+  endfacet
+  facet normal 0.944809 -0.327622 0
+    outer loop
+      vertex 34.1502 -12.5987 58.2
+      vertex 34.6185 -11.2482 0.799999
+      vertex 34.6185 -11.2482 58.2
+    endloop
+  endfacet
+  facet normal 0.944809 -0.327622 0
+    outer loop
+      vertex 34.6185 -11.2482 0.799999
+      vertex 34.1502 -12.5987 58.2
+      vertex 34.1502 -12.5987 0.799999
+    endloop
+  endfacet
+  facet normal -0.984423 -0.175815 0
+    outer loop
+      vertex -35.7006 -7.10129 0.799999
+      vertex -35.9519 -5.69421 58.2
+      vertex -35.9519 -5.69421 0.799999
+    endloop
+  endfacet
+  facet normal -0.984423 -0.175815 0
+    outer loop
+      vertex -35.9519 -5.69421 58.2
+      vertex -35.7006 -7.10129 0.799999
+      vertex -35.7006 -7.10129 58.2
+    endloop
+  endfacet
+  facet normal -0.539105 -0.842238 0
+    outer loop
+      vertex -20.2228 -30.2655 0.799999
+      vertex -19.0189 -31.0361 58.2
+      vertex -20.2228 -30.2655 58.2
+    endloop
+  endfacet
+  facet normal -0.539105 -0.842238 -0
+    outer loop
+      vertex -19.0189 -31.0361 58.2
+      vertex -20.2228 -30.2655 0.799999
+      vertex -19.0189 -31.0361 0.799999
+    endloop
+  endfacet
+  facet normal -0.66429 -0.747475 0
+    outer loop
+      vertex -24.7083 -26.7293 0.799999
+      vertex -23.6399 -27.6788 58.2
+      vertex -24.7083 -26.7293 58.2
+    endloop
+  endfacet
+  facet normal -0.66429 -0.747475 -0
+    outer loop
+      vertex -23.6399 -27.6788 58.2
+      vertex -24.7083 -26.7293 0.799999
+      vertex -23.6399 -27.6788 0.799999
+    endloop
+  endfacet
+  facet normal -0.214297 -0.976769 0
+    outer loop
+      vertex -8.49741 -35.3943 0.799999
+      vertex -7.10129 -35.7006 58.2
+      vertex -8.49741 -35.3943 58.2
+    endloop
+  endfacet
+  facet normal -0.214297 -0.976769 -0
+    outer loop
+      vertex -7.10129 -35.7006 58.2
+      vertex -8.49741 -35.3943 0.799999
+      vertex -7.10129 -35.7006 0.799999
+    endloop
+  endfacet
+  facet normal -0.364505 0.931201 0
+    outer loop
+      vertex -12.5987 34.1502 0.799999
+      vertex -13.9297 33.6292 58.2
+      vertex -12.5987 34.1502 58.2
+    endloop
+  endfacet
+  facet normal -0.364505 0.931201 0
+    outer loop
+      vertex -13.9297 33.6292 58.2
+      vertex -12.5987 34.1502 0.799999
+      vertex -13.9297 33.6292 0.799999
+    endloop
+  endfacet
+  facet normal 0.862714 0.505693 0
+    outer loop
+      vertex 31.7589 17.7858 58.2
+      vertex 31.0361 19.0189 0.799999
+      vertex 31.0361 19.0189 58.2
+    endloop
+  endfacet
+  facet normal 0.862714 0.505693 0
+    outer loop
+      vertex 31.0361 19.0189 0.799999
+      vertex 31.7589 17.7858 58.2
+      vertex 31.7589 17.7858 0.799999
+    endloop
+  endfacet
+  facet normal -0.634365 0.773034 0
+    outer loop
+      vertex -22.535 28.5855 0.799999
+      vertex -23.6399 27.6788 58.2
+      vertex -22.535 28.5855 58.2
+    endloop
+  endfacet
+  facet normal -0.634365 0.773034 0
+    outer loop
+      vertex -23.6399 27.6788 58.2
+      vertex -22.535 28.5855 0.799999
+      vertex -23.6399 27.6788 0.799999
+    endloop
+  endfacet
+  facet normal 0.136988 0.990573 -0
+    outer loop
+      vertex 5.69421 35.9519 0.799999
+      vertex 4.27836 36.1477 58.2
+      vertex 5.69421 35.9519 58.2
+    endloop
+  endfacet
+  facet normal 0.136988 0.990573 0
+    outer loop
+      vertex 4.27836 36.1477 58.2
+      vertex 5.69421 35.9519 0.799999
+      vertex 4.27836 36.1477 0.799999
+    endloop
+  endfacet
+  facet normal 0.995185 -0.0980178 0
+    outer loop
+      vertex 36.1477 -4.27836 58.2
+      vertex 36.2878 -2.85591 0.799999
+      vertex 36.2878 -2.85591 58.2
+    endloop
+  endfacet
+  facet normal 0.995185 -0.0980178 0
+    outer loop
+      vertex 36.2878 -2.85591 0.799999
+      vertex 36.1477 -4.27836 58.2
+      vertex 36.1477 -4.27836 0.799999
+    endloop
+  endfacet
+  facet normal -0.944809 0.327622 0
+    outer loop
+      vertex -34.6185 11.2482 0.799999
+      vertex -34.1502 12.5987 58.2
+      vertex -34.1502 12.5987 0.799999
+    endloop
+  endfacet
+  facet normal -0.944809 0.327622 0
+    outer loop
+      vertex -34.1502 12.5987 58.2
+      vertex -34.6185 11.2482 0.799999
+      vertex -34.6185 11.2482 58.2
+    endloop
+  endfacet
+  facet normal -0.720892 -0.693047 0
+    outer loop
+      vertex -25.7387 -25.7387 0.799999
+      vertex -26.7293 -24.7083 58.2
+      vertex -26.7293 -24.7083 0.799999
+    endloop
+  endfacet
+  facet normal -0.720892 -0.693047 0
+    outer loop
+      vertex -26.7293 -24.7083 58.2
+      vertex -25.7387 -25.7387 0.799999
+      vertex -25.7387 -25.7387 58.2
+    endloop
+  endfacet
+  facet normal -0.773034 0.634365 0
+    outer loop
+      vertex -28.5855 22.535 0.799999
+      vertex -27.6788 23.6399 58.2
+      vertex -27.6788 23.6399 0.799999
+    endloop
+  endfacet
+  facet normal -0.773034 0.634365 0
+    outer loop
+      vertex -27.6788 23.6399 58.2
+      vertex -28.5855 22.535 0.799999
+      vertex -28.5855 22.535 58.2
+    endloop
+  endfacet
+  facet normal 0.634365 -0.773034 0
+    outer loop
+      vertex 22.535 -28.5855 0.799999
+      vertex 23.6399 -27.6788 58.2
+      vertex 22.535 -28.5855 58.2
+    endloop
+  endfacet
+  facet normal 0.634365 -0.773034 0
+    outer loop
+      vertex 23.6399 -27.6788 58.2
+      vertex 22.535 -28.5855 0.799999
+      vertex 23.6399 -27.6788 0.799999
+    endloop
+  endfacet
+  facet normal 0.773034 0.634365 0
+    outer loop
+      vertex 28.5855 22.535 58.2
+      vertex 27.6788 23.6399 0.799999
+      vertex 27.6788 23.6399 58.2
+    endloop
+  endfacet
+  facet normal 0.773034 0.634365 0
+    outer loop
+      vertex 27.6788 23.6399 0.799999
+      vertex 28.5855 22.535 58.2
+      vertex 28.5855 22.535 0.799999
+    endloop
+  endfacet
+  facet normal 0.0980178 -0.995185 0
+    outer loop
+      vertex 2.85591 -36.2878 0.799999
+      vertex 4.27836 -36.1477 58.2
+      vertex 2.85591 -36.2878 58.2
+    endloop
+  endfacet
+  facet normal 0.0980178 -0.995185 0
+    outer loop
+      vertex 4.27836 -36.1477 58.2
+      vertex 2.85591 -36.2878 0.799999
+      vertex 4.27836 -36.1477 0.799999
+    endloop
+  endfacet
+  facet normal -0.999807 -0.0196595 0
+    outer loop
+      vertex -36.3719 -1.42906 0.799999
+      vertex -36.4 0 58.2
+      vertex -36.4 0 0.799999
+    endloop
+  endfacet
+  facet normal -0.999807 -0.0196595 0
+    outer loop
+      vertex -36.4 0 58.2
+      vertex -36.3719 -1.42906 0.799999
+      vertex -36.3719 -1.42906 58.2
+    endloop
+  endfacet
+  facet normal -0.0196595 0.999807 0
+    outer loop
+      vertex 0 36.4 0.799999
+      vertex -1.42906 36.3719 58.2
+      vertex 0 36.4 58.2
+    endloop
+  endfacet
+  facet normal -0.0196595 0.999807 0
+    outer loop
+      vertex -1.42906 36.3719 58.2
+      vertex 0 36.4 0.799999
+      vertex -1.42906 36.3719 0.799999
+    endloop
+  endfacet
+  facet normal -0.984423 0.175815 0
+    outer loop
+      vertex -35.9519 5.69421 0.799999
+      vertex -35.7006 7.10129 58.2
+      vertex -35.7006 7.10129 0.799999
+    endloop
+  endfacet
+  facet normal -0.984423 0.175815 0
+    outer loop
+      vertex -35.7006 7.10129 58.2
+      vertex -35.9519 5.69421 0.799999
+      vertex -35.9519 5.69421 58.2
+    endloop
+  endfacet
+  facet normal -0.999807 0.0196595 0
+    outer loop
+      vertex -36.4 0 0.799999
+      vertex -36.3719 1.42906 58.2
+      vertex -36.3719 1.42906 0.799999
+    endloop
+  endfacet
+  facet normal -0.999807 0.0196595 0
+    outer loop
+      vertex -36.3719 1.42906 58.2
+      vertex -36.4 0 0.799999
+      vertex -36.4 0 58.2
+    endloop
+  endfacet
+  facet normal 0.944809 0.327622 0
+    outer loop
+      vertex 34.6185 11.2482 58.2
+      vertex 34.1502 12.5987 0.799999
+      vertex 34.1502 12.5987 58.2
+    endloop
+  endfacet
+  facet normal 0.944809 0.327622 0
+    outer loop
+      vertex 34.1502 12.5987 0.799999
+      vertex 34.6185 11.2482 58.2
+      vertex 34.6185 11.2482 0.799999
+    endloop
+  endfacet
+  facet normal -0.327622 -0.944809 0
+    outer loop
+      vertex -12.5987 -34.1502 0.799999
+      vertex -11.2482 -34.6185 58.2
+      vertex -12.5987 -34.1502 58.2
+    endloop
+  endfacet
+  facet normal -0.327622 -0.944809 -0
+    outer loop
+      vertex -11.2482 -34.6185 58.2
+      vertex -12.5987 -34.1502 0.799999
+      vertex -11.2482 -34.6185 0.799999
+    endloop
+  endfacet
+  facet normal -0.539105 0.842238 0
+    outer loop
+      vertex -19.0189 31.0361 0.799999
+      vertex -20.2228 30.2655 58.2
+      vertex -19.0189 31.0361 58.2
+    endloop
+  endfacet
+  facet normal -0.539105 0.842238 0
+    outer loop
+      vertex -20.2228 30.2655 58.2
+      vertex -19.0189 31.0361 0.799999
+      vertex -20.2228 30.2655 0.799999
+    endloop
+  endfacet
+  facet normal 0.436407 0.899749 -0
+    outer loop
+      vertex 16.5253 32.4326 0.799999
+      vertex 15.2392 33.0564 58.2
+      vertex 16.5253 32.4326 58.2
+    endloop
+  endfacet
+  facet normal 0.436407 0.899749 0
+    outer loop
+      vertex 15.2392 33.0564 58.2
+      vertex 16.5253 32.4326 0.799999
+      vertex 15.2392 33.0564 0.799999
+    endloop
+  endfacet
+  facet normal -0.175815 -0.984423 0
+    outer loop
+      vertex -7.10129 -35.7006 0.799999
+      vertex -5.69421 -35.9519 58.2
+      vertex -7.10129 -35.7006 58.2
+    endloop
+  endfacet
+  facet normal -0.175815 -0.984423 -0
+    outer loop
+      vertex -5.69421 -35.9519 58.2
+      vertex -7.10129 -35.7006 0.799999
+      vertex -5.69421 -35.9519 0.799999
+    endloop
+  endfacet
+  facet normal 0.400756 -0.916185 0
+    outer loop
+      vertex 13.9297 -33.6292 0.799999
+      vertex 15.2392 -33.0564 58.2
+      vertex 13.9297 -33.6292 58.2
+    endloop
+  endfacet
+  facet normal 0.400756 -0.916185 0
+    outer loop
+      vertex 15.2392 -33.0564 58.2
+      vertex 13.9297 -33.6292 0.799999
+      vertex 15.2392 -33.0564 0.799999
+    endloop
+  endfacet
+  facet normal 0.0196595 0.999807 -0
+    outer loop
+      vertex 1.42906 36.3719 0.799999
+      vertex 0 36.4 58.2
+      vertex 1.42906 36.3719 58.2
+    endloop
+  endfacet
+  facet normal 0.0196595 0.999807 0
+    outer loop
+      vertex 0 36.4 58.2
+      vertex 1.42906 36.3719 0.799999
+      vertex 0 36.4 0.799999
+    endloop
+  endfacet
+  facet normal -0.990573 0.136988 0
+    outer loop
+      vertex -36.1477 4.27836 0.799999
+      vertex -35.9519 5.69421 58.2
+      vertex -35.9519 5.69421 0.799999
+    endloop
+  endfacet
+  facet normal -0.990573 0.136988 0
+    outer loop
+      vertex -35.9519 5.69421 58.2
+      vertex -36.1477 4.27836 0.799999
+      vertex -36.1477 4.27836 58.2
+    endloop
+  endfacet
+  facet normal 0.990573 -0.136988 0
+    outer loop
+      vertex 35.9519 -5.69421 58.2
+      vertex 36.1477 -4.27836 0.799999
+      vertex 36.1477 -4.27836 58.2
+    endloop
+  endfacet
+  facet normal 0.990573 -0.136988 0
+    outer loop
+      vertex 36.1477 -4.27836 0.799999
+      vertex 35.9519 -5.69421 58.2
+      vertex 35.9519 -5.69421 0.799999
+    endloop
+  endfacet
+  facet normal -0.720892 0.693047 0
+    outer loop
+      vertex -26.7293 24.7083 0.799999
+      vertex -25.7387 25.7387 58.2
+      vertex -25.7387 25.7387 0.799999
+    endloop
+  endfacet
+  facet normal -0.720892 0.693047 0
+    outer loop
+      vertex -25.7387 25.7387 58.2
+      vertex -26.7293 24.7083 0.799999
+      vertex -26.7293 24.7083 58.2
+    endloop
+  endfacet
+  facet normal -0.252495 -0.967598 0
+    outer loop
+      vertex -9.88043 -35.0334 0.799999
+      vertex -8.49741 -35.3943 58.2
+      vertex -9.88043 -35.0334 58.2
+    endloop
+  endfacet
+  facet normal -0.252495 -0.967598 -0
+    outer loop
+      vertex -8.49741 -35.3943 58.2
+      vertex -9.88043 -35.0334 0.799999
+      vertex -8.49741 -35.3943 0.799999
+    endloop
+  endfacet
+  facet normal 0.773034 -0.634365 0
+    outer loop
+      vertex 27.6788 -23.6399 58.2
+      vertex 28.5855 -22.535 0.799999
+      vertex 28.5855 -22.535 58.2
+    endloop
+  endfacet
+  facet normal 0.773034 -0.634365 0
+    outer loop
+      vertex 28.5855 -22.535 0.799999
+      vertex 27.6788 -23.6399 58.2
+      vertex 27.6788 -23.6399 0.799999
+    endloop
+  endfacet
+  facet normal 0.999807 -0.0196595 0
+    outer loop
+      vertex 36.3719 -1.42906 58.2
+      vertex 36.4 0 0.799999
+      vertex 36.4 0 58.2
+    endloop
+  endfacet
+  facet normal 0.999807 -0.0196595 0
+    outer loop
+      vertex 36.4 0 0.799999
+      vertex 36.3719 -1.42906 58.2
+      vertex 36.3719 -1.42906 0.799999
+    endloop
+  endfacet
+  facet normal -0.899749 0.436407 0
+    outer loop
+      vertex -33.0564 15.2392 0.799999
+      vertex -32.4326 16.5253 58.2
+      vertex -32.4326 16.5253 0.799999
+    endloop
+  endfacet
+  facet normal -0.899749 0.436407 0
+    outer loop
+      vertex -32.4326 16.5253 58.2
+      vertex -33.0564 15.2392 0.799999
+      vertex -33.0564 15.2392 58.2
+    endloop
+  endfacet
+  facet normal 0.603576 0.797305 -0
+    outer loop
+      vertex 22.535 28.5855 0.799999
+      vertex 21.3954 29.4482 58.2
+      vertex 22.535 28.5855 58.2
+    endloop
+  endfacet
+  facet normal 0.603576 0.797305 0
+    outer loop
+      vertex 21.3954 29.4482 58.2
+      vertex 22.535 28.5855 0.799999
+      vertex 21.3954 29.4482 0.799999
+    endloop
+  endfacet
+  facet normal -0.931201 0.364505 0
+    outer loop
+      vertex -34.1502 12.5987 0.799999
+      vertex -33.6292 13.9297 58.2
+      vertex -33.6292 13.9297 0.799999
+    endloop
+  endfacet
+  facet normal -0.931201 0.364505 0
+    outer loop
+      vertex -33.6292 13.9297 58.2
+      vertex -34.1502 12.5987 0.799999
+      vertex -34.1502 12.5987 58.2
+    endloop
+  endfacet
+  facet normal -0.571808 0.820387 0
+    outer loop
+      vertex -20.2228 30.2655 0.799999
+      vertex -21.3954 29.4482 58.2
+      vertex -20.2228 30.2655 58.2
+    endloop
+  endfacet
+  facet normal -0.571808 0.820387 0
+    outer loop
+      vertex -21.3954 29.4482 58.2
+      vertex -20.2228 30.2655 0.799999
+      vertex -21.3954 29.4482 0.799999
+    endloop
+  endfacet
+  facet normal -0.899749 -0.436407 0
+    outer loop
+      vertex -32.4326 -16.5253 0.799999
+      vertex -33.0564 -15.2392 58.2
+      vertex -33.0564 -15.2392 0.799999
+    endloop
+  endfacet
+  facet normal -0.899749 -0.436407 0
+    outer loop
+      vertex -33.0564 -15.2392 58.2
+      vertex -32.4326 -16.5253 0.799999
+      vertex -32.4326 -16.5253 58.2
+    endloop
+  endfacet
+  facet normal 0.252495 -0.967598 0
+    outer loop
+      vertex 8.49741 -35.3943 0.799999
+      vertex 9.88043 -35.0334 58.2
+      vertex 8.49741 -35.3943 58.2
+    endloop
+  endfacet
+  facet normal 0.252495 -0.967598 0
+    outer loop
+      vertex 9.88043 -35.0334 58.2
+      vertex 8.49741 -35.3943 0.799999
+      vertex 9.88043 -35.0334 0.799999
+    endloop
+  endfacet
+  facet normal -0.175815 0.984423 0
+    outer loop
+      vertex -5.69421 35.9519 0.799999
+      vertex -7.10129 35.7006 58.2
+      vertex -5.69421 35.9519 58.2
+    endloop
+  endfacet
+  facet normal -0.175815 0.984423 0
+    outer loop
+      vertex -7.10129 35.7006 58.2
+      vertex -5.69421 35.9519 0.799999
+      vertex -7.10129 35.7006 0.799999
+    endloop
+  endfacet
+  facet normal -0.881936 0.471369 0
+    outer loop
+      vertex -32.4326 16.5253 0.799999
+      vertex -31.7589 17.7858 58.2
+      vertex -31.7589 17.7858 0.799999
+    endloop
+  endfacet
+  facet normal -0.881936 0.471369 0
+    outer loop
+      vertex -31.7589 17.7858 58.2
+      vertex -32.4326 16.5253 0.799999
+      vertex -32.4326 16.5253 58.2
+    endloop
+  endfacet
+  facet normal 0.539105 -0.842238 0
+    outer loop
+      vertex 19.0189 -31.0361 0.799999
+      vertex 20.2228 -30.2655 58.2
+      vertex 19.0189 -31.0361 58.2
+    endloop
+  endfacet
+  facet normal 0.539105 -0.842238 0
+    outer loop
+      vertex 20.2228 -30.2655 58.2
+      vertex 19.0189 -31.0361 0.799999
+      vertex 20.2228 -30.2655 0.799999
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980178 0
+    outer loop
+      vertex -36.1477 -4.27836 0.799999
+      vertex -36.2878 -2.85591 58.2
+      vertex -36.2878 -2.85591 0.799999
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980178 0
+    outer loop
+      vertex -36.2878 -2.85591 58.2
+      vertex -36.1477 -4.27836 0.799999
+      vertex -36.1477 -4.27836 58.2
+    endloop
+  endfacet
+  facet normal -0.136988 -0.990573 0
+    outer loop
+      vertex -5.69421 -35.9519 0.799999
+      vertex -4.27836 -36.1477 58.2
+      vertex -5.69421 -35.9519 58.2
+    endloop
+  endfacet
+  facet normal -0.136988 -0.990573 -0
+    outer loop
+      vertex -4.27836 -36.1477 58.2
+      vertex -5.69421 -35.9519 0.799999
+      vertex -4.27836 -36.1477 0.799999
+    endloop
+  endfacet
+  facet normal 0.862714 -0.505693 0
+    outer loop
+      vertex 31.0361 -19.0189 58.2
+      vertex 31.7589 -17.7858 0.799999
+      vertex 31.7589 -17.7858 58.2
+    endloop
+  endfacet
+  facet normal 0.862714 -0.505693 0
+    outer loop
+      vertex 31.7589 -17.7858 0.799999
+      vertex 31.0361 -19.0189 58.2
+      vertex 31.0361 -19.0189 0.799999
+    endloop
+  endfacet
+  facet normal 0.842238 0.539105 0
+    outer loop
+      vertex 31.0361 19.0189 58.2
+      vertex 30.2655 20.2228 0.799999
+      vertex 30.2655 20.2228 58.2
+    endloop
+  endfacet
+  facet normal 0.842238 0.539105 0
+    outer loop
+      vertex 30.2655 20.2228 0.799999
+      vertex 31.0361 19.0189 58.2
+      vertex 31.0361 19.0189 0.799999
+    endloop
+  endfacet
+  facet normal 0.984423 -0.175815 0
+    outer loop
+      vertex 35.7006 -7.10129 58.2
+      vertex 35.9519 -5.69421 0.799999
+      vertex 35.9519 -5.69421 58.2
+    endloop
+  endfacet
+  facet normal 0.984423 -0.175815 0
+    outer loop
+      vertex 35.9519 -5.69421 0.799999
+      vertex 35.7006 -7.10129 58.2
+      vertex 35.7006 -7.10129 0.799999
+    endloop
+  endfacet
+  facet normal 0.327622 -0.944809 0
+    outer loop
+      vertex 11.2482 -34.6185 0.799999
+      vertex 12.5987 -34.1502 58.2
+      vertex 11.2482 -34.6185 58.2
+    endloop
+  endfacet
+  facet normal 0.327622 -0.944809 0
+    outer loop
+      vertex 12.5987 -34.1502 58.2
+      vertex 11.2482 -34.6185 0.799999
+      vertex 12.5987 -34.1502 0.799999
+    endloop
+  endfacet
+  facet normal -0.136988 0.990573 0
+    outer loop
+      vertex -4.27836 36.1477 0.799999
+      vertex -5.69421 35.9519 58.2
+      vertex -4.27836 36.1477 58.2
+    endloop
+  endfacet
+  facet normal -0.136988 0.990573 0
+    outer loop
+      vertex -5.69421 35.9519 58.2
+      vertex -4.27836 36.1477 0.799999
+      vertex -5.69421 35.9519 0.799999
+    endloop
+  endfacet
+  facet normal -0.967598 -0.252495 0
+    outer loop
+      vertex -35.0334 -9.88043 0.799999
+      vertex -35.3943 -8.49741 58.2
+      vertex -35.3943 -8.49741 0.799999
+    endloop
+  endfacet
+  facet normal -0.967598 -0.252495 0
+    outer loop
+      vertex -35.3943 -8.49741 58.2
+      vertex -35.0334 -9.88043 0.799999
+      vertex -35.0334 -9.88043 58.2
+    endloop
+  endfacet
+  facet normal 0.0588389 -0.998267 0
+    outer loop
+      vertex 1.42906 -36.3719 0.799999
+      vertex 2.85591 -36.2878 58.2
+      vertex 1.42906 -36.3719 58.2
+    endloop
+  endfacet
+  facet normal 0.0588389 -0.998267 0
+    outer loop
+      vertex 2.85591 -36.2878 58.2
+      vertex 1.42906 -36.3719 0.799999
+      vertex 2.85591 -36.2878 0.799999
+    endloop
+  endfacet
+  facet normal 0.899749 0.436407 0
+    outer loop
+      vertex 33.0564 15.2392 58.2
+      vertex 32.4326 16.5253 0.799999
+      vertex 32.4326 16.5253 58.2
+    endloop
+  endfacet
+  facet normal 0.899749 0.436407 0
+    outer loop
+      vertex 32.4326 16.5253 0.799999
+      vertex 33.0564 15.2392 58.2
+      vertex 33.0564 15.2392 0.799999
+    endloop
+  endfacet
+  facet normal -0.693047 0.720892 0
+    outer loop
+      vertex -24.7083 26.7293 0.799999
+      vertex -25.7387 25.7387 58.2
+      vertex -24.7083 26.7293 58.2
+    endloop
+  endfacet
+  facet normal -0.693047 0.720892 0
+    outer loop
+      vertex -25.7387 25.7387 58.2
+      vertex -24.7083 26.7293 0.799999
+      vertex -25.7387 25.7387 0.799999
+    endloop
+  endfacet
+  facet normal 0.976769 0.214297 0
+    outer loop
+      vertex 35.7006 7.10129 58.2
+      vertex 35.3943 8.49741 0.799999
+      vertex 35.3943 8.49741 58.2
+    endloop
+  endfacet
+  facet normal 0.976769 0.214297 0
+    outer loop
+      vertex 35.3943 8.49741 0.799999
+      vertex 35.7006 7.10129 58.2
+      vertex 35.7006 7.10129 0.799999
+    endloop
+  endfacet
+  facet normal 0.916185 -0.400756 0
+    outer loop
+      vertex 33.0564 -15.2392 58.2
+      vertex 33.6292 -13.9297 0.799999
+      vertex 33.6292 -13.9297 58.2
+    endloop
+  endfacet
+  facet normal 0.916185 -0.400756 0
+    outer loop
+      vertex 33.6292 -13.9297 0.799999
+      vertex 33.0564 -15.2392 58.2
+      vertex 33.0564 -15.2392 0.799999
+    endloop
+  endfacet
+  facet normal -0.400756 -0.916185 0
+    outer loop
+      vertex -15.2392 -33.0564 0.799999
+      vertex -13.9297 -33.6292 58.2
+      vertex -15.2392 -33.0564 58.2
+    endloop
+  endfacet
+  facet normal -0.400756 -0.916185 -0
+    outer loop
+      vertex -13.9297 -33.6292 58.2
+      vertex -15.2392 -33.0564 0.799999
+      vertex -13.9297 -33.6292 0.799999
+    endloop
+  endfacet
+  facet normal -0.797305 -0.603576 0
+    outer loop
+      vertex -28.5855 -22.535 0.799999
+      vertex -29.4482 -21.3954 58.2
+      vertex -29.4482 -21.3954 0.799999
+    endloop
+  endfacet
+  facet normal -0.797305 -0.603576 0
+    outer loop
+      vertex -29.4482 -21.3954 58.2
+      vertex -28.5855 -22.535 0.799999
+      vertex -28.5855 -22.535 58.2
+    endloop
+  endfacet
+  facet normal 0.539105 0.842238 -0
+    outer loop
+      vertex 20.2228 30.2655 0.799999
+      vertex 19.0189 31.0361 58.2
+      vertex 20.2228 30.2655 58.2
+    endloop
+  endfacet
+  facet normal 0.539105 0.842238 0
+    outer loop
+      vertex 19.0189 31.0361 58.2
+      vertex 20.2228 30.2655 0.799999
+      vertex 19.0189 31.0361 0.799999
+    endloop
+  endfacet
+  facet normal -0.976769 0.214297 0
+    outer loop
+      vertex -35.7006 7.10129 0.799999
+      vertex -35.3943 8.49741 58.2
+      vertex -35.3943 8.49741 0.799999
+    endloop
+  endfacet
+  facet normal -0.976769 0.214297 0
+    outer loop
+      vertex -35.3943 8.49741 58.2
+      vertex -35.7006 7.10129 0.799999
+      vertex -35.7006 7.10129 58.2
+    endloop
+  endfacet
+  facet normal -0.931201 -0.364505 0
+    outer loop
+      vertex -33.6292 -13.9297 0.799999
+      vertex -34.1502 -12.5987 58.2
+      vertex -34.1502 -12.5987 0.799999
+    endloop
+  endfacet
+  facet normal -0.931201 -0.364505 0
+    outer loop
+      vertex -34.1502 -12.5987 58.2
+      vertex -33.6292 -13.9297 0.799999
+      vertex -33.6292 -13.9297 58.2
+    endloop
+  endfacet
+  facet normal 0.364505 0.931201 -0
+    outer loop
+      vertex 13.9297 33.6292 0.799999
+      vertex 12.5987 34.1502 58.2
+      vertex 13.9297 33.6292 58.2
+    endloop
+  endfacet
+  facet normal 0.364505 0.931201 0
+    outer loop
+      vertex 12.5987 34.1502 58.2
+      vertex 13.9297 33.6292 0.799999
+      vertex 12.5987 34.1502 0.799999
+    endloop
+  endfacet
+  facet normal -0.400756 0.916185 0
+    outer loop
+      vertex -13.9297 33.6292 0.799999
+      vertex -15.2392 33.0564 58.2
+      vertex -13.9297 33.6292 58.2
+    endloop
+  endfacet
+  facet normal -0.400756 0.916185 0
+    outer loop
+      vertex -15.2392 33.0564 58.2
+      vertex -13.9297 33.6292 0.799999
+      vertex -15.2392 33.0564 0.799999
+    endloop
+  endfacet
+  facet normal 0.720892 -0.693047 0
+    outer loop
+      vertex 25.7387 -25.7387 58.2
+      vertex 26.7293 -24.7083 0.799999
+      vertex 26.7293 -24.7083 58.2
+    endloop
+  endfacet
+  facet normal 0.720892 -0.693047 0
+    outer loop
+      vertex 26.7293 -24.7083 0.799999
+      vertex 25.7387 -25.7387 58.2
+      vertex 25.7387 -25.7387 0.799999
+    endloop
+  endfacet
+  facet normal 0.931201 0.364505 0
+    outer loop
+      vertex 34.1502 12.5987 58.2
+      vertex 33.6292 13.9297 0.799999
+      vertex 33.6292 13.9297 58.2
+    endloop
+  endfacet
+  facet normal 0.931201 0.364505 0
+    outer loop
+      vertex 33.6292 13.9297 0.799999
+      vertex 34.1502 12.5987 58.2
+      vertex 34.1502 12.5987 0.799999
+    endloop
+  endfacet
+  facet normal -0.747475 0.66429 0
+    outer loop
+      vertex -27.6788 23.6399 0.799999
+      vertex -26.7293 24.7083 58.2
+      vertex -26.7293 24.7083 0.799999
+    endloop
+  endfacet
+  facet normal -0.747475 0.66429 0
+    outer loop
+      vertex -26.7293 24.7083 58.2
+      vertex -27.6788 23.6399 0.799999
+      vertex -27.6788 23.6399 58.2
+    endloop
+  endfacet
+  facet normal 0.66429 0.747475 -0
+    outer loop
+      vertex 24.7083 26.7293 0.799999
+      vertex 23.6399 27.6788 58.2
+      vertex 24.7083 26.7293 58.2
+    endloop
+  endfacet
+  facet normal 0.66429 0.747475 0
+    outer loop
+      vertex 23.6399 27.6788 58.2
+      vertex 24.7083 26.7293 0.799999
+      vertex 23.6399 27.6788 0.799999
+    endloop
+  endfacet
+  facet normal -0.944809 -0.327622 0
+    outer loop
+      vertex -34.1502 -12.5987 0.799999
+      vertex -34.6185 -11.2482 58.2
+      vertex -34.6185 -11.2482 0.799999
+    endloop
+  endfacet
+  facet normal -0.944809 -0.327622 0
+    outer loop
+      vertex -34.6185 -11.2482 58.2
+      vertex -34.1502 -12.5987 0.799999
+      vertex -34.1502 -12.5987 58.2
+    endloop
+  endfacet
+  facet normal 0.471369 -0.881936 0
+    outer loop
+      vertex 16.5253 -32.4326 0.799999
+      vertex 17.7858 -31.7589 58.2
+      vertex 16.5253 -32.4326 58.2
+    endloop
+  endfacet
+  facet normal 0.471369 -0.881936 0
+    outer loop
+      vertex 17.7858 -31.7589 58.2
+      vertex 16.5253 -32.4326 0.799999
+      vertex 17.7858 -31.7589 0.799999
+    endloop
+  endfacet
+  facet normal -0.214297 0.976769 0
+    outer loop
+      vertex -7.10129 35.7006 0.799999
+      vertex -8.49741 35.3943 58.2
+      vertex -7.10129 35.7006 58.2
+    endloop
+  endfacet
+  facet normal -0.214297 0.976769 0
+    outer loop
+      vertex -8.49741 35.3943 58.2
+      vertex -7.10129 35.7006 0.799999
+      vertex -8.49741 35.3943 0.799999
+    endloop
+  endfacet
+  facet normal -0.995185 0.0980178 0
+    outer loop
+      vertex -36.2878 2.85591 0.799999
+      vertex -36.1477 4.27836 58.2
+      vertex -36.1477 4.27836 0.799999
+    endloop
+  endfacet
+  facet normal -0.995185 0.0980178 0
+    outer loop
+      vertex -36.1477 4.27836 58.2
+      vertex -36.2878 2.85591 0.799999
+      vertex -36.2878 2.85591 58.2
+    endloop
+  endfacet
+  facet normal 0.634365 0.773034 -0
+    outer loop
+      vertex 23.6399 27.6788 0.799999
+      vertex 22.535 28.5855 58.2
+      vertex 23.6399 27.6788 58.2
+    endloop
+  endfacet
+  facet normal 0.634365 0.773034 0
+    outer loop
+      vertex 22.535 28.5855 58.2
+      vertex 23.6399 27.6788 0.799999
+      vertex 22.535 28.5855 0.799999
+    endloop
+  endfacet
+  facet normal -0.0980178 -0.995185 0
+    outer loop
+      vertex -4.27836 -36.1477 0.799999
+      vertex -2.85591 -36.2878 58.2
+      vertex -4.27836 -36.1477 58.2
+    endloop
+  endfacet
+  facet normal -0.0980178 -0.995185 -0
+    outer loop
+      vertex -2.85591 -36.2878 58.2
+      vertex -4.27836 -36.1477 0.799999
+      vertex -2.85591 -36.2878 0.799999
+    endloop
+  endfacet
+  facet normal 0.0196595 -0.999807 0
+    outer loop
+      vertex 0 -36.4 0.799999
+      vertex 1.42906 -36.3719 58.2
+      vertex 0 -36.4 58.2
+    endloop
+  endfacet
+  facet normal 0.0196595 -0.999807 0
+    outer loop
+      vertex 1.42906 -36.3719 58.2
+      vertex 0 -36.4 0.799999
+      vertex 1.42906 -36.3719 0.799999
+    endloop
+  endfacet
+  facet normal -0.0588389 -0.998267 0
+    outer loop
+      vertex -2.85591 -36.2878 0.799999
+      vertex -1.42906 -36.3719 58.2
+      vertex -2.85591 -36.2878 58.2
+    endloop
+  endfacet
+  facet normal -0.0588389 -0.998267 -0
+    outer loop
+      vertex -1.42906 -36.3719 58.2
+      vertex -2.85591 -36.2878 0.799999
+      vertex -1.42906 -36.3719 0.799999
+    endloop
+  endfacet
+  facet normal -0.66429 0.747475 0
+    outer loop
+      vertex -23.6399 27.6788 0.799999
+      vertex -24.7083 26.7293 58.2
+      vertex -23.6399 27.6788 58.2
+    endloop
+  endfacet
+  facet normal -0.66429 0.747475 0
+    outer loop
+      vertex -24.7083 26.7293 58.2
+      vertex -23.6399 27.6788 0.799999
+      vertex -24.7083 26.7293 0.799999
+    endloop
+  endfacet
+  facet normal -0.0980178 0.995185 0
+    outer loop
+      vertex -2.85591 36.2878 0.799999
+      vertex -4.27836 36.1477 58.2
+      vertex -2.85591 36.2878 58.2
+    endloop
+  endfacet
+  facet normal -0.0980178 0.995185 0
+    outer loop
+      vertex -4.27836 36.1477 58.2
+      vertex -2.85591 36.2878 0.799999
+      vertex -4.27836 36.1477 0.799999
+    endloop
+  endfacet
+  facet normal 0.820387 -0.571808 0
+    outer loop
+      vertex 29.4482 -21.3954 58.2
+      vertex 30.2655 -20.2228 0.799999
+      vertex 30.2655 -20.2228 58.2
+    endloop
+  endfacet
+  facet normal 0.820387 -0.571808 0
+    outer loop
+      vertex 30.2655 -20.2228 0.799999
+      vertex 29.4482 -21.3954 58.2
+      vertex 29.4482 -21.3954 0.799999
+    endloop
+  endfacet
+  facet normal 0.66429 -0.747475 0
+    outer loop
+      vertex 23.6399 -27.6788 0.799999
+      vertex 24.7083 -26.7293 58.2
+      vertex 23.6399 -27.6788 58.2
+    endloop
+  endfacet
+  facet normal 0.66429 -0.747475 0
+    outer loop
+      vertex 24.7083 -26.7293 58.2
+      vertex 23.6399 -27.6788 0.799999
+      vertex 24.7083 -26.7293 0.799999
+    endloop
+  endfacet
+  facet normal 0.400756 0.916185 -0
+    outer loop
+      vertex 15.2392 33.0564 0.799999
+      vertex 13.9297 33.6292 58.2
+      vertex 15.2392 33.0564 58.2
+    endloop
+  endfacet
+  facet normal 0.400756 0.916185 0
+    outer loop
+      vertex 13.9297 33.6292 58.2
+      vertex 15.2392 33.0564 0.799999
+      vertex 13.9297 33.6292 0.799999
+    endloop
+  endfacet
+  facet normal -0.0196595 -0.999807 0
+    outer loop
+      vertex -1.42906 -36.3719 0.799999
+      vertex 0 -36.4 58.2
+      vertex -1.42906 -36.3719 58.2
+    endloop
+  endfacet
+  facet normal -0.0196595 -0.999807 -0
+    outer loop
+      vertex 0 -36.4 58.2
+      vertex -1.42906 -36.3719 0.799999
+      vertex 0 -36.4 0.799999
+    endloop
+  endfacet
+  facet normal 0.693047 0.720892 -0
+    outer loop
+      vertex 25.7387 25.7387 0.799999
+      vertex 24.7083 26.7293 58.2
+      vertex 25.7387 25.7387 58.2
+    endloop
+  endfacet
+  facet normal 0.693047 0.720892 0
+    outer loop
+      vertex 24.7083 26.7293 58.2
+      vertex 25.7387 25.7387 0.799999
+      vertex 24.7083 26.7293 0.799999
+    endloop
+  endfacet
+  facet normal 0.693047 -0.720892 0
+    outer loop
+      vertex 24.7083 -26.7293 0.799999
+      vertex 25.7387 -25.7387 58.2
+      vertex 24.7083 -26.7293 58.2
+    endloop
+  endfacet
+  facet normal 0.693047 -0.720892 0
+    outer loop
+      vertex 25.7387 -25.7387 58.2
+      vertex 24.7083 -26.7293 0.799999
+      vertex 25.7387 -25.7387 0.799999
+    endloop
+  endfacet
+  facet normal 0.881936 0.471369 0
+    outer loop
+      vertex 32.4326 16.5253 58.2
+      vertex 31.7589 17.7858 0.799999
+      vertex 31.7589 17.7858 58.2
+    endloop
+  endfacet
+  facet normal 0.881936 0.471369 0
+    outer loop
+      vertex 31.7589 17.7858 0.799999
+      vertex 32.4326 16.5253 58.2
+      vertex 32.4326 16.5253 0.799999
+    endloop
+  endfacet
+  facet normal 0.899749 -0.436407 0
+    outer loop
+      vertex 32.4326 -16.5253 58.2
+      vertex 33.0564 -15.2392 0.799999
+      vertex 33.0564 -15.2392 58.2
+    endloop
+  endfacet
+  facet normal 0.899749 -0.436407 0
+    outer loop
+      vertex 33.0564 -15.2392 0.799999
+      vertex 32.4326 -16.5253 58.2
+      vertex 32.4326 -16.5253 0.799999
+    endloop
+  endfacet
+  facet normal -0.797305 0.603576 0
+    outer loop
+      vertex -29.4482 21.3954 0.799999
+      vertex -28.5855 22.535 58.2
+      vertex -28.5855 22.535 0.799999
+    endloop
+  endfacet
+  facet normal -0.797305 0.603576 0
+    outer loop
+      vertex -28.5855 22.535 58.2
+      vertex -29.4482 21.3954 0.799999
+      vertex -29.4482 21.3954 58.2
+    endloop
+  endfacet
+  facet normal -0.747475 -0.66429 0
+    outer loop
+      vertex -26.7293 -24.7083 0.799999
+      vertex -27.6788 -23.6399 58.2
+      vertex -27.6788 -23.6399 0.799999
+    endloop
+  endfacet
+  facet normal -0.747475 -0.66429 0
+    outer loop
+      vertex -27.6788 -23.6399 58.2
+      vertex -26.7293 -24.7083 0.799999
+      vertex -26.7293 -24.7083 58.2
+    endloop
+  endfacet
+  facet normal 0.916185 0.400756 0
+    outer loop
+      vertex 33.6292 13.9297 58.2
+      vertex 33.0564 15.2392 0.799999
+      vertex 33.0564 15.2392 58.2
+    endloop
+  endfacet
+  facet normal 0.916185 0.400756 0
+    outer loop
+      vertex 33.0564 15.2392 0.799999
+      vertex 33.6292 13.9297 58.2
+      vertex 33.6292 13.9297 0.799999
+    endloop
+  endfacet
+  facet normal -0.998267 -0.0588389 0
+    outer loop
+      vertex -36.2878 -2.85591 0.799999
+      vertex -36.3719 -1.42906 58.2
+      vertex -36.3719 -1.42906 0.799999
+    endloop
+  endfacet
+  facet normal -0.998267 -0.0588389 0
+    outer loop
+      vertex -36.3719 -1.42906 58.2
+      vertex -36.2878 -2.85591 0.799999
+      vertex -36.2878 -2.85591 58.2
+    endloop
+  endfacet
+  facet normal 0.290279 0.956942 -0
+    outer loop
+      vertex 11.2482 34.6185 0.799999
+      vertex 9.88043 35.0334 58.2
+      vertex 11.2482 34.6185 58.2
+    endloop
+  endfacet
+  facet normal 0.290279 0.956942 0
+    outer loop
+      vertex 9.88043 35.0334 58.2
+      vertex 11.2482 34.6185 0.799999
+      vertex 9.88043 35.0334 0.799999
+    endloop
+  endfacet
+  facet normal 0.214297 -0.976769 0
+    outer loop
+      vertex 7.10129 -35.7006 0.799999
+      vertex 8.49741 -35.3943 58.2
+      vertex 7.10129 -35.7006 58.2
+    endloop
+  endfacet
+  facet normal 0.214297 -0.976769 0
+    outer loop
+      vertex 8.49741 -35.3943 58.2
+      vertex 7.10129 -35.7006 0.799999
+      vertex 8.49741 -35.3943 0.799999
+    endloop
+  endfacet
+  facet normal -0.290279 0.956942 0
+    outer loop
+      vertex -9.88043 35.0334 0.799999
+      vertex -11.2482 34.6185 58.2
+      vertex -9.88043 35.0334 58.2
+    endloop
+  endfacet
+  facet normal -0.290279 0.956942 0
+    outer loop
+      vertex -11.2482 34.6185 58.2
+      vertex -9.88043 35.0334 0.799999
+      vertex -11.2482 34.6185 0.799999
+    endloop
+  endfacet
+  facet normal 0.967598 -0.252495 0
+    outer loop
+      vertex 35.0334 -9.88043 58.2
+      vertex 35.3943 -8.49741 0.799999
+      vertex 35.3943 -8.49741 58.2
+    endloop
+  endfacet
+  facet normal 0.967598 -0.252495 0
+    outer loop
+      vertex 35.3943 -8.49741 0.799999
+      vertex 35.0334 -9.88043 58.2
+      vertex 35.0334 -9.88043 0.799999
+    endloop
+  endfacet
+  facet normal -0.290279 -0.956942 0
+    outer loop
+      vertex -11.2482 -34.6185 0.799999
+      vertex -9.88043 -35.0334 58.2
+      vertex -11.2482 -34.6185 58.2
+    endloop
+  endfacet
+  facet normal -0.290279 -0.956942 -0
+    outer loop
+      vertex -9.88043 -35.0334 58.2
+      vertex -11.2482 -34.6185 0.799999
+      vertex -9.88043 -35.0334 0.799999
+    endloop
+  endfacet
+  facet normal 0.364505 -0.931201 0
+    outer loop
+      vertex 12.5987 -34.1502 0.799999
+      vertex 13.9297 -33.6292 58.2
+      vertex 12.5987 -34.1502 58.2
+    endloop
+  endfacet
+  facet normal 0.364505 -0.931201 0
+    outer loop
+      vertex 13.9297 -33.6292 58.2
+      vertex 12.5987 -34.1502 0.799999
+      vertex 13.9297 -33.6292 0.799999
+    endloop
+  endfacet
+  facet normal 0.984423 0.175815 0
+    outer loop
+      vertex 35.9519 5.69421 58.2
+      vertex 35.7006 7.10129 0.799999
+      vertex 35.7006 7.10129 58.2
+    endloop
+  endfacet
+  facet normal 0.984423 0.175815 0
+    outer loop
+      vertex 35.7006 7.10129 0.799999
+      vertex 35.9519 5.69421 58.2
+      vertex 35.9519 5.69421 0.799999
+    endloop
+  endfacet
+  facet normal -0.252495 0.967598 0
+    outer loop
+      vertex -8.49741 35.3943 0.799999
+      vertex -9.88043 35.0334 58.2
+      vertex -8.49741 35.3943 58.2
+    endloop
+  endfacet
+  facet normal -0.252495 0.967598 0
+    outer loop
+      vertex -9.88043 35.0334 58.2
+      vertex -8.49741 35.3943 0.799999
+      vertex -9.88043 35.0334 0.799999
+    endloop
+  endfacet
+  facet normal 0.976769 -0.214297 0
+    outer loop
+      vertex 35.3943 -8.49741 58.2
+      vertex 35.7006 -7.10129 0.799999
+      vertex 35.7006 -7.10129 58.2
+    endloop
+  endfacet
+  facet normal 0.976769 -0.214297 0
+    outer loop
+      vertex 35.7006 -7.10129 0.799999
+      vertex 35.3943 -8.49741 58.2
+      vertex 35.3943 -8.49741 0.799999
+    endloop
+  endfacet
+  facet normal 0.990573 0.136988 0
+    outer loop
+      vertex 36.1477 4.27836 58.2
+      vertex 35.9519 5.69421 0.799999
+      vertex 35.9519 5.69421 58.2
+    endloop
+  endfacet
+  facet normal 0.990573 0.136988 0
+    outer loop
+      vertex 35.9519 5.69421 0.799999
+      vertex 36.1477 4.27836 58.2
+      vertex 36.1477 4.27836 0.799999
+    endloop
+  endfacet
+  facet normal 0.956942 0.290279 0
+    outer loop
+      vertex 35.0334 9.88043 58.2
+      vertex 34.6185 11.2482 0.799999
+      vertex 34.6185 11.2482 58.2
+    endloop
+  endfacet
+  facet normal 0.956942 0.290279 0
+    outer loop
+      vertex 34.6185 11.2482 0.799999
+      vertex 35.0334 9.88043 58.2
+      vertex 35.0334 9.88043 0.799999
+    endloop
+  endfacet
+  facet normal -0.976769 -0.214297 0
+    outer loop
+      vertex -35.3943 -8.49741 0.799999
+      vertex -35.7006 -7.10129 58.2
+      vertex -35.7006 -7.10129 0.799999
+    endloop
+  endfacet
+  facet normal -0.976769 -0.214297 0
+    outer loop
+      vertex -35.7006 -7.10129 58.2
+      vertex -35.3943 -8.49741 0.799999
+      vertex -35.3943 -8.49741 58.2
+    endloop
+  endfacet
+  facet normal 0.471369 0.881936 -0
+    outer loop
+      vertex 17.7858 31.7589 0.799999
+      vertex 16.5253 32.4326 58.2
+      vertex 17.7858 31.7589 58.2
+    endloop
+  endfacet
+  facet normal 0.471369 0.881936 0
+    outer loop
+      vertex 16.5253 32.4326 58.2
+      vertex 17.7858 31.7589 0.799999
+      vertex 16.5253 32.4326 0.799999
+    endloop
+  endfacet
+  facet normal 0.0980178 0.995185 -0
+    outer loop
+      vertex 4.27836 36.1477 0.799999
+      vertex 2.85591 36.2878 58.2
+      vertex 4.27836 36.1477 58.2
+    endloop
+  endfacet
+  facet normal 0.0980178 0.995185 0
+    outer loop
+      vertex 2.85591 36.2878 58.2
+      vertex 4.27836 36.1477 0.799999
+      vertex 2.85591 36.2878 0.799999
+    endloop
+  endfacet
+  facet normal 0.290279 -0.956942 0
+    outer loop
+      vertex 9.88043 -35.0334 0.799999
+      vertex 11.2482 -34.6185 58.2
+      vertex 9.88043 -35.0334 58.2
+    endloop
+  endfacet
+  facet normal 0.290279 -0.956942 0
+    outer loop
+      vertex 11.2482 -34.6185 58.2
+      vertex 9.88043 -35.0334 0.799999
+      vertex 11.2482 -34.6185 0.799999
+    endloop
+  endfacet
+  facet normal -0.862714 -0.505693 0
+    outer loop
+      vertex -31.0361 -19.0189 0.799999
+      vertex -31.7589 -17.7858 58.2
+      vertex -31.7589 -17.7858 0.799999
+    endloop
+  endfacet
+  facet normal -0.862714 -0.505693 0
+    outer loop
+      vertex -31.7589 -17.7858 58.2
+      vertex -31.0361 -19.0189 0.799999
+      vertex -31.0361 -19.0189 58.2
+    endloop
+  endfacet
+  facet normal -0.862714 0.505693 0
+    outer loop
+      vertex -31.7589 17.7858 0.799999
+      vertex -31.0361 19.0189 58.2
+      vertex -31.0361 19.0189 0.799999
+    endloop
+  endfacet
+  facet normal -0.862714 0.505693 0
+    outer loop
+      vertex -31.0361 19.0189 58.2
+      vertex -31.7589 17.7858 0.799999
+      vertex -31.7589 17.7858 58.2
+    endloop
+  endfacet
+  facet normal 0.505693 -0.862714 0
+    outer loop
+      vertex 17.7858 -31.7589 0.799999
+      vertex 19.0189 -31.0361 58.2
+      vertex 17.7858 -31.7589 58.2
+    endloop
+  endfacet
+  facet normal 0.505693 -0.862714 0
+    outer loop
+      vertex 19.0189 -31.0361 58.2
+      vertex 17.7858 -31.7589 0.799999
+      vertex 19.0189 -31.0361 0.799999
+    endloop
+  endfacet
+  facet normal -0.327622 0.944809 0
+    outer loop
+      vertex -11.2482 34.6185 0.799999
+      vertex -12.5987 34.1502 58.2
+      vertex -11.2482 34.6185 58.2
+    endloop
+  endfacet
+  facet normal -0.327622 0.944809 0
+    outer loop
+      vertex -12.5987 34.1502 58.2
+      vertex -11.2482 34.6185 0.799999
+      vertex -12.5987 34.1502 0.799999
+    endloop
+  endfacet
+  facet normal 0.931201 -0.364505 0
+    outer loop
+      vertex 33.6292 -13.9297 58.2
+      vertex 34.1502 -12.5987 0.799999
+      vertex 34.1502 -12.5987 58.2
+    endloop
+  endfacet
+  facet normal 0.931201 -0.364505 0
+    outer loop
+      vertex 34.1502 -12.5987 0.799999
+      vertex 33.6292 -13.9297 58.2
+      vertex 33.6292 -13.9297 0.799999
+    endloop
+  endfacet
+  facet normal 0.797305 0.603576 0
+    outer loop
+      vertex 29.4482 21.3954 58.2
+      vertex 28.5855 22.535 0.799999
+      vertex 28.5855 22.535 58.2
+    endloop
+  endfacet
+  facet normal 0.797305 0.603576 0
+    outer loop
+      vertex 28.5855 22.535 0.799999
+      vertex 29.4482 21.3954 58.2
+      vertex 29.4482 21.3954 0.799999
+    endloop
+  endfacet
+  facet normal -0.998267 0.0588389 0
+    outer loop
+      vertex -36.3719 1.42906 0.799999
+      vertex -36.2878 2.85591 58.2
+      vertex -36.2878 2.85591 0.799999
+    endloop
+  endfacet
+  facet normal -0.998267 0.0588389 0
+    outer loop
+      vertex -36.2878 2.85591 58.2
+      vertex -36.3719 1.42906 0.799999
+      vertex -36.3719 1.42906 58.2
+    endloop
+  endfacet
+  facet normal 0.603576 -0.797305 0
+    outer loop
+      vertex 21.3954 -29.4482 0.799999
+      vertex 22.535 -28.5855 58.2
+      vertex 21.3954 -29.4482 58.2
+    endloop
+  endfacet
+  facet normal 0.603576 -0.797305 0
+    outer loop
+      vertex 22.535 -28.5855 58.2
+      vertex 21.3954 -29.4482 0.799999
+      vertex 22.535 -28.5855 0.799999
+    endloop
+  endfacet
+  facet normal -0.842238 0.539105 0
+    outer loop
+      vertex -31.0361 19.0189 0.799999
+      vertex -30.2655 20.2228 58.2
+      vertex -30.2655 20.2228 0.799999
+    endloop
+  endfacet
+  facet normal -0.842238 0.539105 0
+    outer loop
+      vertex -30.2655 20.2228 58.2
+      vertex -31.0361 19.0189 0.799999
+      vertex -31.0361 19.0189 58.2
+    endloop
+  endfacet
+  facet normal -0.820387 -0.571808 0
+    outer loop
+      vertex -29.4482 -21.3954 0.799999
+      vertex -30.2655 -20.2228 58.2
+      vertex -30.2655 -20.2228 0.799999
+    endloop
+  endfacet
+  facet normal -0.820387 -0.571808 0
+    outer loop
+      vertex -30.2655 -20.2228 58.2
+      vertex -29.4482 -21.3954 0.799999
+      vertex -29.4482 -21.3954 58.2
+    endloop
+  endfacet
+  facet normal 0.720892 0.693047 0
+    outer loop
+      vertex 26.7293 24.7083 58.2
+      vertex 25.7387 25.7387 0.799999
+      vertex 25.7387 25.7387 58.2
+    endloop
+  endfacet
+  facet normal 0.720892 0.693047 0
+    outer loop
+      vertex 25.7387 25.7387 0.799999
+      vertex 26.7293 24.7083 58.2
+      vertex 26.7293 24.7083 0.799999
+    endloop
+  endfacet
+  facet normal -0.956942 -0.290279 0
+    outer loop
+      vertex -34.6185 -11.2482 0.799999
+      vertex -35.0334 -9.88043 58.2
+      vertex -35.0334 -9.88043 0.799999
+    endloop
+  endfacet
+  facet normal -0.956942 -0.290279 0
+    outer loop
+      vertex -35.0334 -9.88043 58.2
+      vertex -34.6185 -11.2482 0.799999
+      vertex -34.6185 -11.2482 58.2
+    endloop
+  endfacet
+  facet normal 0.175815 0.984423 -0
+    outer loop
+      vertex 7.10129 35.7006 0.799999
+      vertex 5.69421 35.9519 58.2
+      vertex 7.10129 35.7006 58.2
+    endloop
+  endfacet
+  facet normal 0.175815 0.984423 0
+    outer loop
+      vertex 5.69421 35.9519 58.2
+      vertex 7.10129 35.7006 0.799999
+      vertex 5.69421 35.9519 0.799999
+    endloop
+  endfacet
+  facet normal -0.820387 0.571808 0
+    outer loop
+      vertex -30.2655 20.2228 0.799999
+      vertex -29.4482 21.3954 58.2
+      vertex -29.4482 21.3954 0.799999
+    endloop
+  endfacet
+  facet normal -0.820387 0.571808 0
+    outer loop
+      vertex -29.4482 21.3954 58.2
+      vertex -30.2655 20.2228 0.799999
+      vertex -30.2655 20.2228 58.2
+    endloop
+  endfacet
+  facet normal 0.797305 -0.603576 0
+    outer loop
+      vertex 28.5855 -22.535 58.2
+      vertex 29.4482 -21.3954 0.799999
+      vertex 29.4482 -21.3954 58.2
+    endloop
+  endfacet
+  facet normal 0.797305 -0.603576 0
+    outer loop
+      vertex 29.4482 -21.3954 0.799999
+      vertex 28.5855 -22.535 58.2
+      vertex 28.5855 -22.535 0.799999
+    endloop
+  endfacet
+  facet normal -0.436407 0.899749 0
+    outer loop
+      vertex -15.2392 33.0564 0.799999
+      vertex -16.5253 32.4326 58.2
+      vertex -15.2392 33.0564 58.2
+    endloop
+  endfacet
+  facet normal -0.436407 0.899749 0
+    outer loop
+      vertex -16.5253 32.4326 58.2
+      vertex -15.2392 33.0564 0.799999
+      vertex -16.5253 32.4326 0.799999
+    endloop
+  endfacet
+  facet normal 0.0588389 0.998267 -0
+    outer loop
+      vertex 2.85591 36.2878 0.799999
+      vertex 1.42906 36.3719 58.2
+      vertex 2.85591 36.2878 58.2
+    endloop
+  endfacet
+  facet normal 0.0588389 0.998267 0
+    outer loop
+      vertex 1.42906 36.3719 58.2
+      vertex 2.85591 36.2878 0.799999
+      vertex 1.42906 36.3719 0.799999
+    endloop
+  endfacet
+  facet normal -0.436407 -0.899749 0
+    outer loop
+      vertex -16.5253 -32.4326 0.799999
+      vertex -15.2392 -33.0564 58.2
+      vertex -16.5253 -32.4326 58.2
+    endloop
+  endfacet
+  facet normal -0.436407 -0.899749 -0
+    outer loop
+      vertex -15.2392 -33.0564 58.2
+      vertex -16.5253 -32.4326 0.799999
+      vertex -15.2392 -33.0564 0.799999
+    endloop
+  endfacet
+  facet normal 0.214297 0.976769 -0
+    outer loop
+      vertex 8.49741 35.3943 0.799999
+      vertex 7.10129 35.7006 58.2
+      vertex 8.49741 35.3943 58.2
+    endloop
+  endfacet
+  facet normal 0.214297 0.976769 0
+    outer loop
+      vertex 7.10129 35.7006 58.2
+      vertex 8.49741 35.3943 0.799999
+      vertex 7.10129 35.7006 0.799999
+    endloop
+  endfacet
+  facet normal -0.364505 -0.931201 0
+    outer loop
+      vertex -13.9297 -33.6292 0.799999
+      vertex -12.5987 -34.1502 58.2
+      vertex -13.9297 -33.6292 58.2
+    endloop
+  endfacet
+  facet normal -0.364505 -0.931201 -0
+    outer loop
+      vertex -12.5987 -34.1502 58.2
+      vertex -13.9297 -33.6292 0.799999
+      vertex -12.5987 -34.1502 0.799999
+    endloop
+  endfacet
+  facet normal -0.967598 0.252495 0
+    outer loop
+      vertex -35.3943 8.49741 0.799999
+      vertex -35.0334 9.88043 58.2
+      vertex -35.0334 9.88043 0.799999
+    endloop
+  endfacet
+  facet normal -0.967598 0.252495 0
+    outer loop
+      vertex -35.0334 9.88043 58.2
+      vertex -35.3943 8.49741 0.799999
+      vertex -35.3943 8.49741 58.2
+    endloop
+  endfacet
+  facet normal -0.773034 -0.634365 0
+    outer loop
+      vertex -27.6788 -23.6399 0.799999
+      vertex -28.5855 -22.535 58.2
+      vertex -28.5855 -22.535 0.799999
+    endloop
+  endfacet
+  facet normal -0.773034 -0.634365 0
+    outer loop
+      vertex -28.5855 -22.535 58.2
+      vertex -27.6788 -23.6399 0.799999
+      vertex -27.6788 -23.6399 58.2
+    endloop
+  endfacet
+  facet normal 0.252495 0.967598 -0
+    outer loop
+      vertex 9.88043 35.0334 0.799999
+      vertex 8.49741 35.3943 58.2
+      vertex 9.88043 35.0334 58.2
+    endloop
+  endfacet
+  facet normal 0.252495 0.967598 0
+    outer loop
+      vertex 8.49741 35.3943 58.2
+      vertex 9.88043 35.0334 0.799999
+      vertex 8.49741 35.3943 0.799999
+    endloop
+  endfacet
+  facet normal -0.916185 0.400756 0
+    outer loop
+      vertex -33.6292 13.9297 0.799999
+      vertex -33.0564 15.2392 58.2
+      vertex -33.0564 15.2392 0.799999
+    endloop
+  endfacet
+  facet normal -0.916185 0.400756 0
+    outer loop
+      vertex -33.0564 15.2392 58.2
+      vertex -33.6292 13.9297 0.799999
+      vertex -33.6292 13.9297 58.2
+    endloop
+  endfacet
+  facet normal -0.471369 -0.881936 0
+    outer loop
+      vertex -17.7858 -31.7589 0.799999
+      vertex -16.5253 -32.4326 58.2
+      vertex -17.7858 -31.7589 58.2
+    endloop
+  endfacet
+  facet normal -0.471369 -0.881936 -0
+    outer loop
+      vertex -16.5253 -32.4326 58.2
+      vertex -17.7858 -31.7589 0.799999
+      vertex -16.5253 -32.4326 0.799999
+    endloop
+  endfacet
+  facet normal -0.505693 -0.862714 0
+    outer loop
+      vertex -19.0189 -31.0361 0.799999
+      vertex -17.7858 -31.7589 58.2
+      vertex -19.0189 -31.0361 58.2
+    endloop
+  endfacet
+  facet normal -0.505693 -0.862714 -0
+    outer loop
+      vertex -17.7858 -31.7589 58.2
+      vertex -19.0189 -31.0361 0.799999
+      vertex -17.7858 -31.7589 0.799999
+    endloop
+  endfacet
+  facet normal 0.707038 0.013861 -0.707039
+    outer loop
+      vertex 35.6 0 0
+      vertex 35.5726 1.39765 0
+      vertex 36.4 0 0.799999
+    endloop
+  endfacet
+  facet normal 0.684242 0.178569 -0.707054
+    outer loop
+      vertex 34.6164 8.31065 0
+      vertex 34.2634 9.66328 0
+      vertex 35.0334 9.88043 0.799999
+    endloop
+  endfacet
+  facet normal 0.257766 0.658515 -0.707046
+    outer loop
+      vertex 13.6235 32.8901 0
+      vertex 12.5987 34.1502 0.799999
+      vertex 13.9297 33.6292 0.799999
+    endloop
+  endfacet
+  facet normal 0.308627 0.636275 -0.707039
+    outer loop
+      vertex 16.1621 31.7198 0
+      vertex 14.9043 32.3299 0
+      vertex 16.5253 32.4326 0.799999
+    endloop
+  endfacet
+  facet normal -0.0693532 -0.703745 -0.707059
+    outer loop
+      vertex -2.79314 -35.4903 0
+      vertex -4.27836 -36.1477 0.799999
+      vertex -4.18433 -35.3532 0
+    endloop
+  endfacet
+  facet normal -0.0416346 0.705963 -0.707024
+    outer loop
+      vertex -2.79314 35.4903 0
+      vertex -2.85591 36.2878 0.799999
+      vertex -1.39765 35.5726 0
+    endloop
+  endfacet
+  facet normal 0.448617 -0.546657 -0.707042
+    outer loop
+      vertex 23.6399 -27.6788 0.799999
+      vertex 22.0397 -27.9573 0
+      vertex 23.1203 -27.0705 0
+    endloop
+  endfacet
+  facet normal -0.283409 0.647912 -0.707028
+    outer loop
+      vertex -14.9043 32.3299 0
+      vertex -15.2392 33.0564 0.799999
+      vertex -13.9297 33.6292 0.799999
+    endloop
+  endfacet
+  facet normal -0.333339 0.623681 -0.707041
+    outer loop
+      vertex -17.3949 31.0609 0
+      vertex -17.7858 31.7589 0.799999
+      vertex -16.5253 32.4326 0.799999
+    endloop
+  endfacet
+  facet normal -0.381231 -0.595593 -0.707058
+    outer loop
+      vertex -19.0189 -31.0361 0.799999
+      vertex -20.2228 -30.2655 0.799999
+      vertex -19.7783 -29.6003 0
+    endloop
+  endfacet
+  facet normal 0.658515 0.257766 -0.707046
+    outer loop
+      vertex 34.1502 12.5987 0.799999
+      vertex 32.8901 13.6235 0
+      vertex 33.6292 13.9297 0.799999
+    endloop
+  endfacet
+  facet normal -0.647904 0.283382 -0.707047
+    outer loop
+      vertex -32.8901 13.6235 0
+      vertex -33.6292 13.9297 0.799999
+      vertex -32.3299 14.9043 0
+    endloop
+  endfacet
+  facet normal 0.151561 0.69074 -0.707041
+    outer loop
+      vertex 8.31065 34.6164 0
+      vertex 6.94522 34.916 0
+      vertex 8.49741 35.3943 0.799999
+    endloop
+  endfacet
+  facet normal 0.636275 -0.308627 -0.707039
+    outer loop
+      vertex 32.4326 -16.5253 0.799999
+      vertex 31.7198 -16.1621 0
+      vertex 32.3299 -14.9043 0
+    endloop
+  endfacet
+  facet normal 0.0693171 -0.703784 -0.707024
+    outer loop
+      vertex 2.85591 -36.2878 0.799999
+      vertex 2.79314 -35.4903 0
+      vertex 4.27836 -36.1477 0.799999
+    endloop
+  endfacet
+  facet normal -0.676702 0.205279 -0.707061
+    outer loop
+      vertex -34.2634 9.66328 0
+      vertex -34.6185 11.2482 0.799999
+      vertex -33.8576 11.001 0
+    endloop
+  endfacet
+  facet normal 0.0139034 -0.707074 -0.707002
+    outer loop
+      vertex 1.42906 -36.3719 0.799999
+      vertex 0 -36.4 0.799999
+      vertex 1.39765 -35.5726 0
+    endloop
+  endfacet
+  facet normal -0.509819 0.490126 -0.707009
+    outer loop
+      vertex -26.1419 24.1653 0
+      vertex -26.7293 24.7083 0.799999
+      vertex -25.7387 25.7387 0.799999
+    endloop
+  endfacet
+  facet normal -0.696145 -0.124291 -0.70706
+    outer loop
+      vertex -34.916 -6.94522 0
+      vertex -35.9519 -5.69421 0.799999
+      vertex -35.1617 -5.56907 0
+    endloop
+  endfacet
+  facet normal 0.448617 0.546657 -0.707042
+    outer loop
+      vertex 23.1203 27.0705 0
+      vertex 22.0397 27.9573 0
+      vertex 23.6399 27.6788 0.799999
+    endloop
+  endfacet
+  facet normal 0.509819 0.490126 -0.707009
+    outer loop
+      vertex 26.1419 24.1653 0
+      vertex 25.7387 25.7387 0.799999
+      vertex 26.7293 24.7083 0.799999
+    endloop
+  endfacet
+  facet normal -0.63629 0.308621 -0.707028
+    outer loop
+      vertex -32.3299 14.9043 0
+      vertex -33.0564 15.2392 0.799999
+      vertex -32.4326 16.5253 0.799999
+    endloop
+  endfacet
+  facet normal 0.509759 -0.490131 -0.707048
+    outer loop
+      vertex 25.7387 -25.7387 0.799999
+      vertex 25.173 -25.173 0
+      vertex 26.1419 -24.1653 0
+    endloop
+  endfacet
+  facet normal 0.490131 0.509759 -0.707048
+    outer loop
+      vertex 25.173 25.173 0
+      vertex 24.1653 26.1419 0
+      vertex 25.7387 25.7387 0.799999
+    endloop
+  endfacet
+  facet normal 0.707074 0.0139034 -0.707002
+    outer loop
+      vertex 36.4 0 0.799999
+      vertex 35.5726 1.39765 0
+      vertex 36.3719 1.42906 0.799999
+    endloop
+  endfacet
+  facet normal 0.0693532 0.703745 -0.707059
+    outer loop
+      vertex 4.18433 35.3532 0
+      vertex 2.79314 35.4903 0
+      vertex 4.27836 36.1477 0.799999
+    endloop
+  endfacet
+  facet normal 0.658508 -0.257748 -0.707059
+    outer loop
+      vertex 34.1502 -12.5987 0.799999
+      vertex 32.8901 -13.6235 0
+      vertex 33.3996 -12.3218 0
+    endloop
+  endfacet
+  facet normal 0.703745 0.0693532 -0.707059
+    outer loop
+      vertex 35.4903 2.79314 0
+      vertex 35.3532 4.18433 0
+      vertex 36.1477 4.27836 0.799999
+    endloop
+  endfacet
+  facet normal 0.528618 -0.469789 -0.707008
+    outer loop
+      vertex 26.7293 -24.7083 0.799999
+      vertex 26.1419 -24.1653 0
+      vertex 27.6788 -23.6399 0.799999
+    endloop
+  endfacet
+  facet normal 0.0416346 0.705963 -0.707024
+    outer loop
+      vertex 2.79314 35.4903 0
+      vertex 1.39765 35.5726 0
+      vertex 2.85591 36.2878 0.799999
+    endloop
+  endfacet
+  facet normal 0.707038 -0.013861 -0.707039
+    outer loop
+      vertex 36.4 0 0.799999
+      vertex 35.5726 -1.39765 0
+      vertex 35.6 0 0
+    endloop
+  endfacet
+  facet normal 0.703784 0.0693171 -0.707024
+    outer loop
+      vertex 36.2878 2.85591 0.799999
+      vertex 35.4903 2.79314 0
+      vertex 36.1477 4.27836 0.799999
+    endloop
+  endfacet
+  facet normal 0.490131 -0.509759 -0.707048
+    outer loop
+      vertex 25.7387 -25.7387 0.799999
+      vertex 24.1653 -26.1419 0
+      vertex 25.173 -25.173 0
+    endloop
+  endfacet
+  facet normal 0.580141 0.404357 -0.707059
+    outer loop
+      vertex 29.6003 19.7783 0
+      vertex 29.4482 21.3954 0.799999
+      vertex 30.2655 20.2228 0.799999
+    endloop
+  endfacet
+  facet normal 0.63629 -0.308621 -0.707028
+    outer loop
+      vertex 32.4326 -16.5253 0.799999
+      vertex 32.3299 -14.9043 0
+      vertex 33.0564 -15.2392 0.799999
+    endloop
+  endfacet
+  facet normal 0.124334 0.696171 -0.707027
+    outer loop
+      vertex 6.94522 34.916 0
+      vertex 5.69421 35.9519 0.799999
+      vertex 7.10129 35.7006 0.799999
+    endloop
+  endfacet
+  facet normal -0.707074 0.0139034 -0.707002
+    outer loop
+      vertex -35.5726 1.39765 0
+      vertex -36.4 0 0.799999
+      vertex -36.3719 1.42906 0.799999
+    endloop
+  endfacet
+  facet normal 0.595593 0.381231 -0.707058
+    outer loop
+      vertex 31.0361 19.0189 0.799999
+      vertex 29.6003 19.7783 0
+      vertex 30.2655 20.2228 0.799999
+    endloop
+  endfacet
+  facet normal -0.333339 -0.623681 -0.707041
+    outer loop
+      vertex -16.5253 -32.4326 0.799999
+      vertex -17.7858 -31.7589 0.799999
+      vertex -17.3949 -31.0609 0
+    endloop
+  endfacet
+  facet normal 0.151548 -0.690758 -0.707027
+    outer loop
+      vertex 7.10129 -35.7006 0.799999
+      vertex 6.94522 -34.916 0
+      vertex 8.49741 -35.3943 0.799999
+    endloop
+  endfacet
+  facet normal 0.69074 -0.151561 -0.707041
+    outer loop
+      vertex 35.3943 -8.49741 0.799999
+      vertex 34.6164 -8.31065 0
+      vertex 34.916 -6.94522 0
+    endloop
+  endfacet
+  facet normal -0.580141 0.404357 -0.707059
+    outer loop
+      vertex -29.6003 19.7783 0
+      vertex -30.2655 20.2228 0.799999
+      vertex -29.4482 21.3954 0.799999
+    endloop
+  endfacet
+  facet normal -0.490126 -0.509819 -0.707009
+    outer loop
+      vertex -24.7083 -26.7293 0.799999
+      vertex -25.7387 -25.7387 0.799999
+      vertex -24.1653 -26.1419 0
+    endloop
+  endfacet
+  facet normal 0.696171 -0.124334 -0.707027
+    outer loop
+      vertex 35.7006 -7.10129 0.799999
+      vertex 34.916 -6.94522 0
+      vertex 35.9519 -5.69421 0.799999
+    endloop
+  endfacet
+  facet normal -0.469789 -0.528618 -0.707008
+    outer loop
+      vertex -23.6399 -27.6788 0.799999
+      vertex -24.7083 -26.7293 0.799999
+      vertex -24.1653 -26.1419 0
+    endloop
+  endfacet
+  facet normal 0.700488 0.0968726 -0.707059
+    outer loop
+      vertex 35.3532 4.18433 0
+      vertex 35.1617 5.56907 0
+      vertex 36.1477 4.27836 0.799999
+    endloop
+  endfacet
+  facet normal -0.283409 -0.647912 -0.707028
+    outer loop
+      vertex -13.9297 -33.6292 0.799999
+      vertex -15.2392 -33.0564 0.799999
+      vertex -14.9043 -32.3299 0
+    endloop
+  endfacet
+  facet normal -0.658508 0.257748 -0.707059
+    outer loop
+      vertex -33.3996 12.3218 0
+      vertex -34.1502 12.5987 0.799999
+      vertex -32.8901 13.6235 0
+    endloop
+  endfacet
+  facet normal -0.205279 0.676702 -0.707061
+    outer loop
+      vertex -11.001 33.8576 0
+      vertex -11.2482 34.6185 0.799999
+      vertex -9.66328 34.2634 0
+    endloop
+  endfacet
+  facet normal 0.013861 0.707038 -0.707039
+    outer loop
+      vertex 1.39765 35.5726 0
+      vertex 0 35.6 0
+      vertex 0 36.4 0.799999
+    endloop
+  endfacet
+  facet normal 0.610096 -0.357609 -0.707035
+    outer loop
+      vertex 31.0361 -19.0189 0.799999
+      vertex 30.354 -18.6009 0
+      vertex 31.0609 -17.3949 0
+    endloop
+  endfacet
+  facet normal -0.700488 -0.0968726 -0.707059
+    outer loop
+      vertex -35.1617 -5.56907 0
+      vertex -36.1477 -4.27836 0.799999
+      vertex -35.3532 -4.18433 0
+    endloop
+  endfacet
+  facet normal -0.013861 0.707038 -0.707039
+    outer loop
+      vertex 0 35.6 0
+      vertex -1.39765 35.5726 0
+      vertex 0 36.4 0.799999
+    endloop
+  endfacet
+  facet normal 0.668125 0.231679 -0.70706
+    outer loop
+      vertex 34.6185 11.2482 0.799999
+      vertex 33.3996 12.3218 0
+      vertex 34.1502 12.5987 0.799999
+    endloop
+  endfacet
+  facet normal 0.676711 -0.205274 -0.707054
+    outer loop
+      vertex 34.6185 -11.2482 0.799999
+      vertex 34.2634 -9.66328 0
+      vertex 35.0334 -9.88043 0.799999
+    endloop
+  endfacet
+  facet normal -0.231679 -0.668125 -0.70706
+    outer loop
+      vertex -11.2482 -34.6185 0.799999
+      vertex -12.5987 -34.1502 0.799999
+      vertex -12.3218 -33.3996 0
+    endloop
+  endfacet
+  facet normal 0.124291 0.696145 -0.70706
+    outer loop
+      vertex 6.94522 34.916 0
+      vertex 5.56907 35.1617 0
+      vertex 5.69421 35.9519 0.799999
+    endloop
+  endfacet
+  facet normal -0.595599 0.381266 -0.707035
+    outer loop
+      vertex -30.354 18.6009 0
+      vertex -31.0361 19.0189 0.799999
+      vertex -29.6003 19.7783 0
+    endloop
+  endfacet
+  facet normal -0.668125 0.231679 -0.70706
+    outer loop
+      vertex -33.3996 12.3218 0
+      vertex -34.6185 11.2482 0.799999
+      vertex -34.1502 12.5987 0.799999
+    endloop
+  endfacet
+  facet normal -0.357612 0.610088 -0.707041
+    outer loop
+      vertex -17.3949 31.0609 0
+      vertex -19.0189 31.0361 0.799999
+      vertex -17.7858 31.7589 0.799999
+    endloop
+  endfacet
+  facet normal 0.690758 -0.151548 -0.707027
+    outer loop
+      vertex 35.3943 -8.49741 0.799999
+      vertex 34.916 -6.94522 0
+      vertex 35.7006 -7.10129 0.799999
+    endloop
+  endfacet
+  facet normal 0.469789 -0.528618 -0.707008
+    outer loop
+      vertex 24.7083 -26.7293 0.799999
+      vertex 23.6399 -27.6788 0.799999
+      vertex 24.1653 -26.1419 0
+    endloop
+  endfacet
+  facet normal -0.658515 0.257766 -0.707046
+    outer loop
+      vertex -32.8901 13.6235 0
+      vertex -34.1502 12.5987 0.799999
+      vertex -33.6292 13.9297 0.799999
+    endloop
+  endfacet
+  facet normal -0.448614 -0.546678 -0.707028
+    outer loop
+      vertex -22.535 -28.5855 0.799999
+      vertex -23.6399 -27.6788 0.799999
+      vertex -22.0397 -27.9573 0
+    endloop
+  endfacet
+  facet normal 0.0416115 0.705986 -0.707003
+    outer loop
+      vertex 2.85591 36.2878 0.799999
+      vertex 1.39765 35.5726 0
+      vertex 1.42906 36.3719 0.799999
+    endloop
+  endfacet
+  facet normal -0.546657 -0.448617 -0.707042
+    outer loop
+      vertex -27.6788 -23.6399 0.799999
+      vertex -27.9573 -22.0397 0
+      vertex -27.0705 -23.1203 0
+    endloop
+  endfacet
+  facet normal -0.690758 0.151548 -0.707027
+    outer loop
+      vertex -34.916 6.94522 0
+      vertex -35.7006 7.10129 0.799999
+      vertex -35.3943 8.49741 0.799999
+    endloop
+  endfacet
+  facet normal -0.705986 0.0416115 -0.707003
+    outer loop
+      vertex -35.5726 1.39765 0
+      vertex -36.3719 1.42906 0.799999
+      vertex -36.2878 2.85591 0.799999
+    endloop
+  endfacet
+  facet normal 0.647912 -0.283409 -0.707028
+    outer loop
+      vertex 33.0564 -15.2392 0.799999
+      vertex 32.3299 -14.9043 0
+      vertex 33.6292 -13.9297 0.799999
+    endloop
+  endfacet
+  facet normal 0.0693171 0.703784 -0.707024
+    outer loop
+      vertex 4.27836 36.1477 0.799999
+      vertex 2.79314 35.4903 0
+      vertex 2.85591 36.2878 0.799999
+    endloop
+  endfacet
+  facet normal 0.013861 -0.707038 -0.707039
+    outer loop
+      vertex 1.39765 -35.5726 0
+      vertex 0 -36.4 0.799999
+      vertex 0 -35.6 0
+    endloop
+  endfacet
+  facet normal 0.684242 -0.178569 -0.707054
+    outer loop
+      vertex 35.0334 -9.88043 0.799999
+      vertex 34.2634 -9.66328 0
+      vertex 34.6164 -8.31065 0
+    endloop
+  endfacet
+  facet normal -0.231679 0.668125 -0.70706
+    outer loop
+      vertex -12.3218 33.3996 0
+      vertex -12.5987 34.1502 0.799999
+      vertex -11.2482 34.6185 0.799999
+    endloop
+  endfacet
+  facet normal 0.658515 -0.257766 -0.707046
+    outer loop
+      vertex 33.6292 -13.9297 0.799999
+      vertex 32.8901 -13.6235 0
+      vertex 34.1502 -12.5987 0.799999
+    endloop
+  endfacet
+  facet normal 0.623681 0.333339 -0.707041
+    outer loop
+      vertex 32.4326 16.5253 0.799999
+      vertex 31.0609 17.3949 0
+      vertex 31.7589 17.7858 0.799999
+    endloop
+  endfacet
+  facet normal 0.404357 -0.580141 -0.707059
+    outer loop
+      vertex 20.2228 -30.2655 0.799999
+      vertex 19.7783 -29.6003 0
+      vertex 21.3954 -29.4482 0.799999
+    endloop
+  endfacet
+  facet normal -0.700487 0.0968714 -0.70706
+    outer loop
+      vertex -35.1617 5.56907 0
+      vertex -36.1477 4.27836 0.799999
+      vertex -35.9519 5.69421 0.799999
+    endloop
+  endfacet
+  facet normal 0.357609 0.610096 -0.707035
+    outer loop
+      vertex 18.6009 30.354 0
+      vertex 17.3949 31.0609 0
+      vertex 19.0189 31.0361 0.799999
+    endloop
+  endfacet
+  facet normal -0.700488 0.0968726 -0.707059
+    outer loop
+      vertex -35.3532 4.18433 0
+      vertex -36.1477 4.27836 0.799999
+      vertex -35.1617 5.56907 0
+    endloop
+  endfacet
+  facet normal -0.696145 0.124291 -0.70706
+    outer loop
+      vertex -35.1617 5.56907 0
+      vertex -35.9519 5.69421 0.799999
+      vertex -34.916 6.94522 0
+    endloop
+  endfacet
+  facet normal 0.205279 -0.676702 -0.707061
+    outer loop
+      vertex 11.2482 -34.6185 0.799999
+      vertex 9.66328 -34.2634 0
+      vertex 11.001 -33.8576 0
+    endloop
+  endfacet
+  facet normal -0.696171 0.124334 -0.707027
+    outer loop
+      vertex -34.916 6.94522 0
+      vertex -35.9519 5.69421 0.799999
+      vertex -35.7006 7.10129 0.799999
+    endloop
+  endfacet
+  facet normal -0.684242 -0.178569 -0.707054
+    outer loop
+      vertex -34.2634 -9.66328 0
+      vertex -35.0334 -9.88043 0.799999
+      vertex -34.6164 -8.31065 0
+    endloop
+  endfacet
+  facet normal 0.580141 -0.404357 -0.707059
+    outer loop
+      vertex 30.2655 -20.2228 0.799999
+      vertex 29.4482 -21.3954 0.799999
+      vertex 29.6003 -19.7783 0
+    endloop
+  endfacet
+  facet normal -0.381231 0.595593 -0.707058
+    outer loop
+      vertex -19.7783 29.6003 0
+      vertex -20.2228 30.2655 0.799999
+      vertex -19.0189 31.0361 0.799999
+    endloop
+  endfacet
+  facet normal 0.231679 -0.668125 -0.70706
+    outer loop
+      vertex 12.5987 -34.1502 0.799999
+      vertex 11.2482 -34.6185 0.799999
+      vertex 12.3218 -33.3996 0
+    endloop
+  endfacet
+  facet normal -0.404346 0.580188 -0.707027
+    outer loop
+      vertex -20.9252 28.801 0
+      vertex -21.3954 29.4482 0.799999
+      vertex -19.7783 29.6003 0
+    endloop
+  endfacet
+  facet normal -0.490131 0.509759 -0.707048
+    outer loop
+      vertex -25.173 25.173 0
+      vertex -25.7387 25.7387 0.799999
+      vertex -24.1653 26.1419 0
+    endloop
+  endfacet
+  facet normal 0.546678 -0.448614 -0.707028
+    outer loop
+      vertex 28.5855 -22.535 0.799999
+      vertex 27.6788 -23.6399 0.799999
+      vertex 27.9573 -22.0397 0
+    endloop
+  endfacet
+  facet normal 0.490126 -0.509819 -0.707009
+    outer loop
+      vertex 24.7083 -26.7293 0.799999
+      vertex 24.1653 -26.1419 0
+      vertex 25.7387 -25.7387 0.799999
+    endloop
+  endfacet
+  facet normal 0.308621 0.63629 -0.707028
+    outer loop
+      vertex 16.5253 32.4326 0.799999
+      vertex 14.9043 32.3299 0
+      vertex 15.2392 33.0564 0.799999
+    endloop
+  endfacet
+  facet normal -0.205274 -0.676711 -0.707054
+    outer loop
+      vertex -9.88043 -35.0334 0.799999
+      vertex -11.2482 -34.6185 0.799999
+      vertex -9.66328 -34.2634 0
+    endloop
+  endfacet
+  facet normal -0.257748 -0.658508 -0.707059
+    outer loop
+      vertex -12.5987 -34.1502 0.799999
+      vertex -13.6235 -32.8901 0
+      vertex -12.3218 -33.3996 0
+    endloop
+  endfacet
+  facet normal 0.528618 0.469789 -0.707008
+    outer loop
+      vertex 27.6788 23.6399 0.799999
+      vertex 26.1419 24.1653 0
+      vertex 26.7293 24.7083 0.799999
+    endloop
+  endfacet
+  facet normal 0.705986 0.0416115 -0.707003
+    outer loop
+      vertex 36.3719 1.42906 0.799999
+      vertex 35.5726 1.39765 0
+      vertex 36.2878 2.85591 0.799999
+    endloop
+  endfacet
+  facet normal 0.0968714 -0.700487 -0.70706
+    outer loop
+      vertex 5.69421 -35.9519 0.799999
+      vertex 4.27836 -36.1477 0.799999
+      vertex 5.56907 -35.1617 0
+    endloop
+  endfacet
+  facet normal 0.205279 0.676702 -0.707061
+    outer loop
+      vertex 11.001 33.8576 0
+      vertex 9.66328 34.2634 0
+      vertex 11.2482 34.6185 0.799999
+    endloop
+  endfacet
+  facet normal 0.0139034 0.707074 -0.707002
+    outer loop
+      vertex 1.39765 35.5726 0
+      vertex 0 36.4 0.799999
+      vertex 1.42906 36.3719 0.799999
+    endloop
+  endfacet
+  facet normal -0.0416346 -0.705963 -0.707024
+    outer loop
+      vertex -1.39765 -35.5726 0
+      vertex -2.85591 -36.2878 0.799999
+      vertex -2.79314 -35.4903 0
+    endloop
+  endfacet
+  facet normal 0.0693532 -0.703745 -0.707059
+    outer loop
+      vertex 4.27836 -36.1477 0.799999
+      vertex 2.79314 -35.4903 0
+      vertex 4.18433 -35.3532 0
+    endloop
+  endfacet
+  facet normal 0.668125 -0.231679 -0.70706
+    outer loop
+      vertex 34.6185 -11.2482 0.799999
+      vertex 33.3996 -12.3218 0
+      vertex 33.8576 -11.001 0
+    endloop
+  endfacet
+  facet normal -0.658508 -0.257748 -0.707059
+    outer loop
+      vertex -32.8901 -13.6235 0
+      vertex -34.1502 -12.5987 0.799999
+      vertex -33.3996 -12.3218 0
+    endloop
+  endfacet
+  facet normal 0.595593 -0.381231 -0.707058
+    outer loop
+      vertex 30.2655 -20.2228 0.799999
+      vertex 29.6003 -19.7783 0
+      vertex 31.0361 -19.0189 0.799999
+    endloop
+  endfacet
+  facet normal -0.178569 -0.684242 -0.707054
+    outer loop
+      vertex -8.31065 -34.6164 0
+      vertex -9.88043 -35.0334 0.799999
+      vertex -9.66328 -34.2634 0
+    endloop
+  endfacet
+  facet normal 0.705986 -0.0416115 -0.707003
+    outer loop
+      vertex 36.2878 -2.85591 0.799999
+      vertex 35.5726 -1.39765 0
+      vertex 36.3719 -1.42906 0.799999
+    endloop
+  endfacet
+  facet normal -0.703784 0.0693171 -0.707024
+    outer loop
+      vertex -35.4903 2.79314 0
+      vertex -36.2878 2.85591 0.799999
+      vertex -36.1477 4.27836 0.799999
+    endloop
+  endfacet
+  facet normal -0.546678 -0.448614 -0.707028
+    outer loop
+      vertex -27.6788 -23.6399 0.799999
+      vertex -28.5855 -22.535 0.799999
+      vertex -27.9573 -22.0397 0
+    endloop
+  endfacet
+  facet normal -0.668125 -0.231679 -0.70706
+    outer loop
+      vertex -34.1502 -12.5987 0.799999
+      vertex -34.6185 -11.2482 0.799999
+      vertex -33.3996 -12.3218 0
+    endloop
+  endfacet
+  facet normal 0.707074 -0.0139034 -0.707002
+    outer loop
+      vertex 36.3719 -1.42906 0.799999
+      vertex 35.5726 -1.39765 0
+      vertex 36.4 0 0.799999
+    endloop
+  endfacet
+  facet normal 0.703784 -0.0693171 -0.707024
+    outer loop
+      vertex 36.1477 -4.27836 0.799999
+      vertex 35.4903 -2.79314 0
+      vertex 36.2878 -2.85591 0.799999
+    endloop
+  endfacet
+  facet normal 0.705963 -0.0416346 -0.707024
+    outer loop
+      vertex 36.2878 -2.85591 0.799999
+      vertex 35.4903 -2.79314 0
+      vertex 35.5726 -1.39765 0
+    endloop
+  endfacet
+  facet normal -0.623681 -0.333339 -0.707041
+    outer loop
+      vertex -31.7589 -17.7858 0.799999
+      vertex -32.4326 -16.5253 0.799999
+      vertex -31.0609 -17.3949 0
+    endloop
+  endfacet
+  facet normal -0.696171 -0.124334 -0.707027
+    outer loop
+      vertex -35.7006 -7.10129 0.799999
+      vertex -35.9519 -5.69421 0.799999
+      vertex -34.916 -6.94522 0
+    endloop
+  endfacet
+  facet normal 0.703745 -0.0693532 -0.707059
+    outer loop
+      vertex 36.1477 -4.27836 0.799999
+      vertex 35.3532 -4.18433 0
+      vertex 35.4903 -2.79314 0
+    endloop
+  endfacet
+  facet normal 0.563844 -0.426842 -0.707027
+    outer loop
+      vertex 29.4482 -21.3954 0.799999
+      vertex 27.9573 -22.0397 0
+      vertex 28.801 -20.9252 0
+    endloop
+  endfacet
+  facet normal 0.700487 0.0968714 -0.70706
+    outer loop
+      vertex 36.1477 4.27836 0.799999
+      vertex 35.1617 5.56907 0
+      vertex 35.9519 5.69421 0.799999
+    endloop
+  endfacet
+  facet normal 0.696145 0.124291 -0.70706
+    outer loop
+      vertex 35.1617 5.56907 0
+      vertex 34.916 6.94522 0
+      vertex 35.9519 5.69421 0.799999
+    endloop
+  endfacet
+  facet normal 0.676702 -0.205279 -0.707061
+    outer loop
+      vertex 34.6185 -11.2482 0.799999
+      vertex 33.8576 -11.001 0
+      vertex 34.2634 -9.66328 0
+    endloop
+  endfacet
+  facet normal 0.381266 -0.595599 -0.707035
+    outer loop
+      vertex 19.0189 -31.0361 0.799999
+      vertex 18.6009 -30.354 0
+      vertex 19.7783 -29.6003 0
+    endloop
+  endfacet
+  facet normal 0.357609 -0.610096 -0.707035
+    outer loop
+      vertex 19.0189 -31.0361 0.799999
+      vertex 17.3949 -31.0609 0
+      vertex 18.6009 -30.354 0
+    endloop
+  endfacet
+  facet normal -0.705963 0.0416346 -0.707024
+    outer loop
+      vertex -35.5726 1.39765 0
+      vertex -36.2878 2.85591 0.799999
+      vertex -35.4903 2.79314 0
+    endloop
+  endfacet
+  facet normal -0.357609 -0.610096 -0.707035
+    outer loop
+      vertex -17.3949 -31.0609 0
+      vertex -19.0189 -31.0361 0.799999
+      vertex -18.6009 -30.354 0
+    endloop
+  endfacet
+  facet normal -0.124334 0.696171 -0.707027
+    outer loop
+      vertex -6.94522 34.916 0
+      vertex -7.10129 35.7006 0.799999
+      vertex -5.69421 35.9519 0.799999
+    endloop
+  endfacet
+  facet normal -0.469737 0.528618 -0.707043
+    outer loop
+      vertex -23.1203 27.0705 0
+      vertex -24.1653 26.1419 0
+      vertex -23.6399 27.6788 0.799999
+    endloop
+  endfacet
+  facet normal -0.426841 -0.563844 -0.707027
+    outer loop
+      vertex -21.3954 -29.4482 0.799999
+      vertex -22.535 -28.5855 0.799999
+      vertex -22.0397 -27.9573 0
+    endloop
+  endfacet
+  facet normal 0.178569 0.684242 -0.707054
+    outer loop
+      vertex 9.66328 34.2634 0
+      vertex 8.31065 34.6164 0
+      vertex 9.88043 35.0334 0.799999
+    endloop
+  endfacet
+  facet normal 0.426841 -0.563844 -0.707027
+    outer loop
+      vertex 22.535 -28.5855 0.799999
+      vertex 21.3954 -29.4482 0.799999
+      vertex 22.0397 -27.9573 0
+    endloop
+  endfacet
+  facet normal -0.509759 0.490131 -0.707048
+    outer loop
+      vertex -25.173 25.173 0
+      vertex -26.1419 24.1653 0
+      vertex -25.7387 25.7387 0.799999
+    endloop
+  endfacet
+  facet normal -0.0139034 0.707074 -0.707002
+    outer loop
+      vertex -1.39765 35.5726 0
+      vertex -1.42906 36.3719 0.799999
+      vertex 0 36.4 0.799999
+    endloop
+  endfacet
+  facet normal -0.703745 0.0693532 -0.707059
+    outer loop
+      vertex -35.4903 2.79314 0
+      vertex -36.1477 4.27836 0.799999
+      vertex -35.3532 4.18433 0
+    endloop
+  endfacet
+  facet normal 0.283409 0.647912 -0.707028
+    outer loop
+      vertex 14.9043 32.3299 0
+      vertex 13.9297 33.6292 0.799999
+      vertex 15.2392 33.0564 0.799999
+    endloop
+  endfacet
+  facet normal 0.69074 0.151561 -0.707041
+    outer loop
+      vertex 34.916 6.94522 0
+      vertex 34.6164 8.31065 0
+      vertex 35.3943 8.49741 0.799999
+    endloop
+  endfacet
+  facet normal 0.381231 -0.595593 -0.707058
+    outer loop
+      vertex 20.2228 -30.2655 0.799999
+      vertex 19.0189 -31.0361 0.799999
+      vertex 19.7783 -29.6003 0
+    endloop
+  endfacet
+  facet normal -0.490131 -0.509759 -0.707048
+    outer loop
+      vertex -24.1653 -26.1419 0
+      vertex -25.7387 -25.7387 0.799999
+      vertex -25.173 -25.173 0
+    endloop
+  endfacet
+  facet normal -0.636275 0.308627 -0.707039
+    outer loop
+      vertex -32.3299 14.9043 0
+      vertex -32.4326 16.5253 0.799999
+      vertex -31.7198 16.1621 0
+    endloop
+  endfacet
+  facet normal 0.647904 -0.283382 -0.707047
+    outer loop
+      vertex 33.6292 -13.9297 0.799999
+      vertex 32.3299 -14.9043 0
+      vertex 32.8901 -13.6235 0
+    endloop
+  endfacet
+  facet normal 0.595599 -0.381266 -0.707035
+    outer loop
+      vertex 31.0361 -19.0189 0.799999
+      vertex 29.6003 -19.7783 0
+      vertex 30.354 -18.6009 0
+    endloop
+  endfacet
+  facet normal 0.381231 0.595593 -0.707058
+    outer loop
+      vertex 19.7783 29.6003 0
+      vertex 19.0189 31.0361 0.799999
+      vertex 20.2228 30.2655 0.799999
+    endloop
+  endfacet
+  facet normal -0.0693532 0.703745 -0.707059
+    outer loop
+      vertex -4.18433 35.3532 0
+      vertex -4.27836 36.1477 0.799999
+      vertex -2.79314 35.4903 0
+    endloop
+  endfacet
+  facet normal -0.528618 -0.469737 -0.707043
+    outer loop
+      vertex -26.1419 -24.1653 0
+      vertex -27.6788 -23.6399 0.799999
+      vertex -27.0705 -23.1203 0
+    endloop
+  endfacet
+  facet normal 0.63629 0.308621 -0.707028
+    outer loop
+      vertex 33.0564 15.2392 0.799999
+      vertex 32.3299 14.9043 0
+      vertex 32.4326 16.5253 0.799999
+    endloop
+  endfacet
+  facet normal -0.563844 -0.426842 -0.707027
+    outer loop
+      vertex -27.9573 -22.0397 0
+      vertex -29.4482 -21.3954 0.799999
+      vertex -28.801 -20.9252 0
+    endloop
+  endfacet
+  facet normal 0.563844 0.426841 -0.707027
+    outer loop
+      vertex 29.4482 21.3954 0.799999
+      vertex 27.9573 22.0397 0
+      vertex 28.5855 22.535 0.799999
+    endloop
+  endfacet
+  facet normal -0.231679 0.668125 -0.70706
+    outer loop
+      vertex -11.001 33.8576 0
+      vertex -12.3218 33.3996 0
+      vertex -11.2482 34.6185 0.799999
+    endloop
+  endfacet
+  facet normal -0.580141 -0.404357 -0.707059
+    outer loop
+      vertex -29.4482 -21.3954 0.799999
+      vertex -30.2655 -20.2228 0.799999
+      vertex -29.6003 -19.7783 0
+    endloop
+  endfacet
+  facet normal -0.426842 0.563844 -0.707027
+    outer loop
+      vertex -20.9252 28.801 0
+      vertex -22.0397 27.9573 0
+      vertex -21.3954 29.4482 0.799999
+    endloop
+  endfacet
+  facet normal 0.610088 0.357612 -0.707041
+    outer loop
+      vertex 31.0609 17.3949 0
+      vertex 31.0361 19.0189 0.799999
+      vertex 31.7589 17.7858 0.799999
+    endloop
+  endfacet
+  facet normal -0.63629 -0.308621 -0.707028
+    outer loop
+      vertex -32.4326 -16.5253 0.799999
+      vertex -33.0564 -15.2392 0.799999
+      vertex -32.3299 -14.9043 0
+    endloop
+  endfacet
+  facet normal -0.707038 0.013861 -0.707039
+    outer loop
+      vertex -35.6 0 0
+      vertex -36.4 0 0.799999
+      vertex -35.5726 1.39765 0
+    endloop
+  endfacet
+  facet normal -0.676711 0.205274 -0.707054
+    outer loop
+      vertex -34.2634 9.66328 0
+      vertex -35.0334 9.88043 0.799999
+      vertex -34.6185 11.2482 0.799999
+    endloop
+  endfacet
+  facet normal -0.580188 0.404346 -0.707027
+    outer loop
+      vertex -28.801 20.9252 0
+      vertex -29.6003 19.7783 0
+      vertex -29.4482 21.3954 0.799999
+    endloop
+  endfacet
+  facet normal -0.684259 -0.178558 -0.707041
+    outer loop
+      vertex -35.0334 -9.88043 0.799999
+      vertex -35.3943 -8.49741 0.799999
+      vertex -34.6164 -8.31065 0
+    endloop
+  endfacet
+  facet normal 0.469737 -0.528618 -0.707043
+    outer loop
+      vertex 23.6399 -27.6788 0.799999
+      vertex 23.1203 -27.0705 0
+      vertex 24.1653 -26.1419 0
+    endloop
+  endfacet
+  facet normal -0.676711 -0.205274 -0.707054
+    outer loop
+      vertex -34.6185 -11.2482 0.799999
+      vertex -35.0334 -9.88043 0.799999
+      vertex -34.2634 -9.66328 0
+    endloop
+  endfacet
+  facet normal 0.205274 0.676711 -0.707054
+    outer loop
+      vertex 11.2482 34.6185 0.799999
+      vertex 9.66328 34.2634 0
+      vertex 9.88043 35.0334 0.799999
+    endloop
+  endfacet
+  facet normal -0.178569 0.684242 -0.707054
+    outer loop
+      vertex -9.66328 34.2634 0
+      vertex -9.88043 35.0334 0.799999
+      vertex -8.31065 34.6164 0
+    endloop
+  endfacet
+  facet normal 0.668125 -0.231679 -0.70706
+    outer loop
+      vertex 34.1502 -12.5987 0.799999
+      vertex 33.3996 -12.3218 0
+      vertex 34.6185 -11.2482 0.799999
+    endloop
+  endfacet
+  facet normal 0.381266 0.595599 -0.707035
+    outer loop
+      vertex 19.7783 29.6003 0
+      vertex 18.6009 30.354 0
+      vertex 19.0189 31.0361 0.799999
+    endloop
+  endfacet
+  facet normal 0.178558 -0.684259 -0.707041
+    outer loop
+      vertex 8.49741 -35.3943 0.799999
+      vertex 8.31065 -34.6164 0
+      vertex 9.88043 -35.0334 0.799999
+    endloop
+  endfacet
+  facet normal -0.595593 -0.381231 -0.707058
+    outer loop
+      vertex -30.2655 -20.2228 0.799999
+      vertex -31.0361 -19.0189 0.799999
+      vertex -29.6003 -19.7783 0
+    endloop
+  endfacet
+  facet normal 0.563844 -0.426841 -0.707027
+    outer loop
+      vertex 28.5855 -22.535 0.799999
+      vertex 27.9573 -22.0397 0
+      vertex 29.4482 -21.3954 0.799999
+    endloop
+  endfacet
+  facet normal 0.231679 -0.668125 -0.70706
+    outer loop
+      vertex 11.2482 -34.6185 0.799999
+      vertex 11.001 -33.8576 0
+      vertex 12.3218 -33.3996 0
+    endloop
+  endfacet
+  facet normal 0.647912 0.283409 -0.707028
+    outer loop
+      vertex 33.6292 13.9297 0.799999
+      vertex 32.3299 14.9043 0
+      vertex 33.0564 15.2392 0.799999
+    endloop
+  endfacet
+  facet normal 0.528618 0.469737 -0.707043
+    outer loop
+      vertex 27.0705 23.1203 0
+      vertex 26.1419 24.1653 0
+      vertex 27.6788 23.6399 0.799999
+    endloop
+  endfacet
+  facet normal 0.404346 -0.580188 -0.707027
+    outer loop
+      vertex 21.3954 -29.4482 0.799999
+      vertex 19.7783 -29.6003 0
+      vertex 20.9252 -28.801 0
+    endloop
+  endfacet
+  facet normal 0.610096 0.357609 -0.707035
+    outer loop
+      vertex 31.0609 17.3949 0
+      vertex 30.354 18.6009 0
+      vertex 31.0361 19.0189 0.799999
+    endloop
+  endfacet
+  facet normal 0.623681 -0.333339 -0.707041
+    outer loop
+      vertex 31.7589 -17.7858 0.799999
+      vertex 31.0609 -17.3949 0
+      vertex 32.4326 -16.5253 0.799999
+    endloop
+  endfacet
+  facet normal 0.546657 0.448617 -0.707042
+    outer loop
+      vertex 27.9573 22.0397 0
+      vertex 27.0705 23.1203 0
+      vertex 27.6788 23.6399 0.799999
+    endloop
+  endfacet
+  facet normal 0.231679 0.668125 -0.70706
+    outer loop
+      vertex 12.3218 33.3996 0
+      vertex 11.2482 34.6185 0.799999
+      vertex 12.5987 34.1502 0.799999
+    endloop
+  endfacet
+  facet normal -0.0693171 -0.703784 -0.707024
+    outer loop
+      vertex -2.85591 -36.2878 0.799999
+      vertex -4.27836 -36.1477 0.799999
+      vertex -2.79314 -35.4903 0
+    endloop
+  endfacet
+  facet normal -0.448614 0.546678 -0.707028
+    outer loop
+      vertex -22.0397 27.9573 0
+      vertex -23.6399 27.6788 0.799999
+      vertex -22.535 28.5855 0.799999
+    endloop
+  endfacet
+  facet normal -0.580188 -0.404346 -0.707027
+    outer loop
+      vertex -29.4482 -21.3954 0.799999
+      vertex -29.6003 -19.7783 0
+      vertex -28.801 -20.9252 0
+    endloop
+  endfacet
+  facet normal -0.448617 0.546657 -0.707042
+    outer loop
+      vertex -23.1203 27.0705 0
+      vertex -23.6399 27.6788 0.799999
+      vertex -22.0397 27.9573 0
+    endloop
+  endfacet
+  facet normal -0.205274 0.676711 -0.707054
+    outer loop
+      vertex -9.66328 34.2634 0
+      vertex -11.2482 34.6185 0.799999
+      vertex -9.88043 35.0334 0.799999
+    endloop
+  endfacet
+  facet normal -0.700487 -0.0968714 -0.70706
+    outer loop
+      vertex -35.9519 -5.69421 0.799999
+      vertex -36.1477 -4.27836 0.799999
+      vertex -35.1617 -5.56907 0
+    endloop
+  endfacet
+  facet normal -0.509759 -0.490131 -0.707048
+    outer loop
+      vertex -25.7387 -25.7387 0.799999
+      vertex -26.1419 -24.1653 0
+      vertex -25.173 -25.173 0
+    endloop
+  endfacet
+  facet normal 0.700488 -0.0968726 -0.707059
+    outer loop
+      vertex 36.1477 -4.27836 0.799999
+      vertex 35.1617 -5.56907 0
+      vertex 35.3532 -4.18433 0
+    endloop
+  endfacet
+  facet normal 0.696145 -0.124291 -0.70706
+    outer loop
+      vertex 35.9519 -5.69421 0.799999
+      vertex 34.916 -6.94522 0
+      vertex 35.1617 -5.56907 0
+    endloop
+  endfacet
+  facet normal 0.283382 -0.647904 -0.707047
+    outer loop
+      vertex 13.9297 -33.6292 0.799999
+      vertex 13.6235 -32.8901 0
+      vertex 14.9043 -32.3299 0
+    endloop
+  endfacet
+  facet normal 0.705963 0.0416346 -0.707024
+    outer loop
+      vertex 35.5726 1.39765 0
+      vertex 35.4903 2.79314 0
+      vertex 36.2878 2.85591 0.799999
+    endloop
+  endfacet
+  facet normal 0.700487 -0.0968714 -0.70706
+    outer loop
+      vertex 35.9519 -5.69421 0.799999
+      vertex 35.1617 -5.56907 0
+      vertex 36.1477 -4.27836 0.799999
+    endloop
+  endfacet
+  facet normal 0.696171 0.124334 -0.707027
+    outer loop
+      vertex 35.9519 5.69421 0.799999
+      vertex 34.916 6.94522 0
+      vertex 35.7006 7.10129 0.799999
+    endloop
+  endfacet
+  facet normal 0.647904 0.283382 -0.707047
+    outer loop
+      vertex 32.8901 13.6235 0
+      vertex 32.3299 14.9043 0
+      vertex 33.6292 13.9297 0.799999
+    endloop
+  endfacet
+  facet normal 0.426841 0.563844 -0.707027
+    outer loop
+      vertex 22.0397 27.9573 0
+      vertex 21.3954 29.4482 0.799999
+      vertex 22.535 28.5855 0.799999
+    endloop
+  endfacet
+  facet normal -0.0416115 0.705986 -0.707003
+    outer loop
+      vertex -1.39765 35.5726 0
+      vertex -2.85591 36.2878 0.799999
+      vertex -1.42906 36.3719 0.799999
+    endloop
+  endfacet
+  facet normal 0.658508 0.257748 -0.707059
+    outer loop
+      vertex 33.3996 12.3218 0
+      vertex 32.8901 13.6235 0
+      vertex 34.1502 12.5987 0.799999
+    endloop
+  endfacet
+  facet normal 0.676711 0.205274 -0.707054
+    outer loop
+      vertex 35.0334 9.88043 0.799999
+      vertex 34.2634 9.66328 0
+      vertex 34.6185 11.2482 0.799999
+    endloop
+  endfacet
+  facet normal -0.426842 -0.563844 -0.707027
+    outer loop
+      vertex -21.3954 -29.4482 0.799999
+      vertex -22.0397 -27.9573 0
+      vertex -20.9252 -28.801 0
+    endloop
+  endfacet
+  facet normal 0.610088 -0.357612 -0.707041
+    outer loop
+      vertex 31.7589 -17.7858 0.799999
+      vertex 31.0361 -19.0189 0.799999
+      vertex 31.0609 -17.3949 0
+    endloop
+  endfacet
+  facet normal 0.333342 0.623682 -0.707039
+    outer loop
+      vertex 17.3949 31.0609 0
+      vertex 16.1621 31.7198 0
+      vertex 16.5253 32.4326 0.799999
+    endloop
+  endfacet
+  facet normal -0.647912 0.283409 -0.707028
+    outer loop
+      vertex -32.3299 14.9043 0
+      vertex -33.6292 13.9297 0.799999
+      vertex -33.0564 15.2392 0.799999
+    endloop
+  endfacet
+  facet normal 0.257748 0.658508 -0.707059
+    outer loop
+      vertex 13.6235 32.8901 0
+      vertex 12.3218 33.3996 0
+      vertex 12.5987 34.1502 0.799999
+    endloop
+  endfacet
+  facet normal 0.509819 -0.490126 -0.707009
+    outer loop
+      vertex 26.7293 -24.7083 0.799999
+      vertex 25.7387 -25.7387 0.799999
+      vertex 26.1419 -24.1653 0
+    endloop
+  endfacet
+  facet normal -0.546678 0.448614 -0.707028
+    outer loop
+      vertex -27.9573 22.0397 0
+      vertex -28.5855 22.535 0.799999
+      vertex -27.6788 23.6399 0.799999
+    endloop
+  endfacet
+  facet normal -0.595593 0.381231 -0.707058
+    outer loop
+      vertex -29.6003 19.7783 0
+      vertex -31.0361 19.0189 0.799999
+      vertex -30.2655 20.2228 0.799999
+    endloop
+  endfacet
+  facet normal 0.151561 -0.69074 -0.707041
+    outer loop
+      vertex 8.49741 -35.3943 0.799999
+      vertex 6.94522 -34.916 0
+      vertex 8.31065 -34.6164 0
+    endloop
+  endfacet
+  facet normal -0.333342 -0.623682 -0.707039
+    outer loop
+      vertex -16.5253 -32.4326 0.799999
+      vertex -17.3949 -31.0609 0
+      vertex -16.1621 -31.7198 0
+    endloop
+  endfacet
+  facet normal -0.124334 -0.696171 -0.707027
+    outer loop
+      vertex -5.69421 -35.9519 0.799999
+      vertex -7.10129 -35.7006 0.799999
+      vertex -6.94522 -34.916 0
+    endloop
+  endfacet
+  facet normal -0.124291 0.696145 -0.70706
+    outer loop
+      vertex -5.56907 35.1617 0
+      vertex -6.94522 34.916 0
+      vertex -5.69421 35.9519 0.799999
+    endloop
+  endfacet
+  facet normal -0.707074 -0.0139034 -0.707002
+    outer loop
+      vertex -36.3719 -1.42906 0.799999
+      vertex -36.4 0 0.799999
+      vertex -35.5726 -1.39765 0
+    endloop
+  endfacet
+  facet normal -0.707038 -0.013861 -0.707039
+    outer loop
+      vertex -35.5726 -1.39765 0
+      vertex -36.4 0 0.799999
+      vertex -35.6 0 0
+    endloop
+  endfacet
+  facet normal -0.308621 0.63629 -0.707028
+    outer loop
+      vertex -14.9043 32.3299 0
+      vertex -16.5253 32.4326 0.799999
+      vertex -15.2392 33.0564 0.799999
+    endloop
+  endfacet
+  facet normal 0.490126 0.509819 -0.707009
+    outer loop
+      vertex 25.7387 25.7387 0.799999
+      vertex 24.1653 26.1419 0
+      vertex 24.7083 26.7293 0.799999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.85 0 0
+      vertex 35.6 0 0
+      vertex 35.5726 -1.39765 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.8285 -1.09339 0
+      vertex 35.5726 -1.39765 0
+      vertex 35.4903 -2.79314 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.6 0 0
+      vertex 27.85 0 0
+      vertex 35.5726 1.39765 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.7641 -2.18509 0
+      vertex 35.4903 -2.79314 0
+      vertex 35.3532 -4.18433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.8285 1.09339 0
+      vertex 35.5726 1.39765 0
+      vertex 27.85 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.657 -3.27342 0
+      vertex 35.3532 -4.18433 0
+      vertex 35.1617 -5.56907 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 35.5726 1.39765 0
+      vertex 27.8285 1.09339 0
+      vertex 35.4903 2.79314 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.5071 -4.3567 0
+      vertex 35.1617 -5.56907 0
+      vertex 34.916 -6.94522 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.7641 2.18509 0
+      vertex 35.4903 2.79314 0
+      vertex 27.8285 1.09339 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3149 -5.43326 0
+      vertex 34.916 -6.94522 0
+      vertex 34.6164 -8.31065 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 35.4903 2.79314 0
+      vertex 27.7641 2.18509 0
+      vertex 35.3532 4.18433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0805 -6.50145 0
+      vertex 34.6164 -8.31065 0
+      vertex 34.2634 -9.66328 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.657 3.27342 0
+      vertex 35.3532 4.18433 0
+      vertex 27.7641 2.18509 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8044 -7.55962 0
+      vertex 34.2634 -9.66328 0
+      vertex 33.8576 -11.001 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 35.3532 4.18433 0
+      vertex 27.657 3.27342 0
+      vertex 35.1617 5.56907 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.4869 -8.60612 0
+      vertex 33.8576 -11.001 0
+      vertex 33.3996 -12.3218 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.5071 4.3567 0
+      vertex 35.1617 5.56907 0
+      vertex 27.657 3.27342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1286 -9.63936 0
+      vertex 33.3996 -12.3218 0
+      vertex 32.8901 -13.6235 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 35.1617 5.56907 0
+      vertex 27.5071 4.3567 0
+      vertex 34.916 6.94522 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.73 -10.6577 0
+      vertex 32.8901 -13.6235 0
+      vertex 32.3299 -14.9043 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3149 5.43326 0
+      vertex 34.916 6.94522 0
+      vertex 27.5071 4.3567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.2918 -11.6597 0
+      vertex 32.3299 -14.9043 0
+      vertex 31.7198 -16.1621 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 34.916 6.94522 0
+      vertex 27.3149 5.43326 0
+      vertex 34.6164 8.31065 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8145 -12.6436 0
+      vertex 31.7198 -16.1621 0
+      vertex 31.0609 -17.3949 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0805 6.50145 0
+      vertex 34.6164 8.31065 0
+      vertex 27.3149 5.43326 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.299 -13.6081 0
+      vertex 31.0609 -17.3949 0
+      vertex 30.354 -18.6009 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 34.6164 8.31065 0
+      vertex 27.0805 6.50145 0
+      vertex 34.2634 9.66328 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.746 -14.5516 0
+      vertex 30.354 -18.6009 0
+      vertex 29.6003 -19.7783 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8044 7.55962 0
+      vertex 34.2634 9.66328 0
+      vertex 27.0805 6.50145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.1564 -15.4726 0
+      vertex 29.6003 -19.7783 0
+      vertex 28.801 -20.9252 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 34.2634 9.66328 0
+      vertex 26.8044 7.55962 0
+      vertex 33.8576 11.001 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.5311 -16.3698 0
+      vertex 28.801 -20.9252 0
+      vertex 27.9573 -22.0397 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.4869 8.60612 0
+      vertex 33.8576 11.001 0
+      vertex 26.8044 7.55962 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 33.8576 11.001 0
+      vertex 26.4869 8.60612 0
+      vertex 33.3996 12.3218 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.5726 -1.39765 0
+      vertex 27.8285 -1.09339 0
+      vertex 27.85 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.4903 -2.79314 0
+      vertex 27.7641 -2.18509 0
+      vertex 27.8285 -1.09339 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.3532 -4.18433 0
+      vertex 27.657 -3.27342 0
+      vertex 27.7641 -2.18509 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.1617 -5.56907 0
+      vertex 27.5071 -4.3567 0
+      vertex 27.657 -3.27342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 34.916 -6.94522 0
+      vertex 27.3149 -5.43326 0
+      vertex 27.5071 -4.3567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 34.6164 -8.31065 0
+      vertex 27.0805 -6.50145 0
+      vertex 27.3149 -5.43326 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.8711 -17.2418 0
+      vertex 27.9573 -22.0397 0
+      vertex 27.0705 -23.1203 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 34.2634 -9.66328 0
+      vertex 26.8044 -7.55962 0
+      vertex 27.0805 -6.50145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 33.8576 -11.001 0
+      vertex 26.4869 -8.60612 0
+      vertex 26.8044 -7.55962 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.1773 -18.0871 0
+      vertex 27.0705 -23.1203 0
+      vertex 26.1419 -24.1653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 33.3996 -12.3218 0
+      vertex 26.1286 -9.63936 0
+      vertex 26.4869 -8.60612 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.8901 -13.6235 0
+      vertex 25.73 -10.6577 0
+      vertex 26.1286 -9.63936 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.3299 -14.9043 0
+      vertex 25.2918 -11.6597 0
+      vertex 25.73 -10.6577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.4509 -18.9046 0
+      vertex 26.1419 -24.1653 0
+      vertex 25.173 -25.173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31.7198 -16.1621 0
+      vertex 24.8145 -12.6436 0
+      vertex 25.2918 -11.6597 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31.0609 -17.3949 0
+      vertex 24.299 -13.6081 0
+      vertex 24.8145 -12.6436 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.6929 -19.6929 0
+      vertex 25.173 -25.173 0
+      vertex 24.1653 -26.1419 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.354 -18.6009 0
+      vertex 23.746 -14.5516 0
+      vertex 24.299 -13.6081 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 29.6003 -19.7783 0
+      vertex 23.1564 -15.4726 0
+      vertex 23.746 -14.5516 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9046 -20.4509 0
+      vertex 24.1653 -26.1419 0
+      vertex 23.1203 -27.0705 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.801 -20.9252 0
+      vertex 22.5311 -16.3698 0
+      vertex 23.1564 -15.4726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.0871 -21.1773 0
+      vertex 23.1203 -27.0705 0
+      vertex 22.0397 -27.9573 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.9573 -22.0397 0
+      vertex 21.8711 -17.2418 0
+      vertex 22.5311 -16.3698 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0705 -23.1203 0
+      vertex 21.1773 -18.0871 0
+      vertex 21.8711 -17.2418 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.2418 -21.8711 0
+      vertex 22.0397 -27.9573 0
+      vertex 20.9252 -28.801 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1419 -24.1653 0
+      vertex 20.4509 -18.9046 0
+      vertex 21.1773 -18.0871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.3698 -22.5311 0
+      vertex 20.9252 -28.801 0
+      vertex 19.7783 -29.6003 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.173 -25.173 0
+      vertex 19.6929 -19.6929 0
+      vertex 20.4509 -18.9046 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.1653 -26.1419 0
+      vertex 18.9046 -20.4509 0
+      vertex 19.6929 -19.6929 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4726 -23.1564 0
+      vertex 19.7783 -29.6003 0
+      vertex 18.6009 -30.354 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.1203 -27.0705 0
+      vertex 18.0871 -21.1773 0
+      vertex 18.9046 -20.4509 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.5516 -23.746 0
+      vertex 18.6009 -30.354 0
+      vertex 17.3949 -31.0609 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.0397 -27.9573 0
+      vertex 17.2418 -21.8711 0
+      vertex 18.0871 -21.1773 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.9252 -28.801 0
+      vertex 16.3698 -22.5311 0
+      vertex 17.2418 -21.8711 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6081 -24.299 0
+      vertex 17.3949 -31.0609 0
+      vertex 16.1621 -31.7198 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.7783 -29.6003 0
+      vertex 15.4726 -23.1564 0
+      vertex 16.3698 -22.5311 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6436 -24.8145 0
+      vertex 16.1621 -31.7198 0
+      vertex 14.9043 -32.3299 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6009 -30.354 0
+      vertex 14.5516 -23.746 0
+      vertex 15.4726 -23.1564 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.6597 -25.2918 0
+      vertex 14.9043 -32.3299 0
+      vertex 13.6235 -32.8901 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.3949 -31.0609 0
+      vertex 13.6081 -24.299 0
+      vertex 14.5516 -23.746 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.1621 -31.7198 0
+      vertex 12.6436 -24.8145 0
+      vertex 13.6081 -24.299 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6577 -25.73 0
+      vertex 13.6235 -32.8901 0
+      vertex 12.3218 -33.3996 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.9043 -32.3299 0
+      vertex 11.6597 -25.2918 0
+      vertex 12.6436 -24.8145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.63936 -26.1286 0
+      vertex 12.3218 -33.3996 0
+      vertex 11.001 -33.8576 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6235 -32.8901 0
+      vertex 10.6577 -25.73 0
+      vertex 11.6597 -25.2918 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.60612 -26.4869 0
+      vertex 11.001 -33.8576 0
+      vertex 9.66328 -34.2634 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.3218 -33.3996 0
+      vertex 9.63936 -26.1286 0
+      vertex 10.6577 -25.73 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.001 -33.8576 0
+      vertex 8.60612 -26.4869 0
+      vertex 9.63936 -26.1286 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.55962 -26.8044 0
+      vertex 9.66328 -34.2634 0
+      vertex 8.31065 -34.6164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.66328 -34.2634 0
+      vertex 7.55962 -26.8044 0
+      vertex 8.60612 -26.4869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.50145 -27.0805 0
+      vertex 8.31065 -34.6164 0
+      vertex 6.94522 -34.916 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.31065 -34.6164 0
+      vertex 6.50145 -27.0805 0
+      vertex 7.55962 -26.8044 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.43326 -27.3149 0
+      vertex 6.94522 -34.916 0
+      vertex 5.56907 -35.1617 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.94522 -34.916 0
+      vertex 5.43326 -27.3149 0
+      vertex 6.50145 -27.0805 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.56907 -35.1617 0
+      vertex 4.3567 -27.5071 0
+      vertex 5.43326 -27.3149 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.18433 -35.3532 0
+      vertex 4.3567 -27.5071 0
+      vertex 5.56907 -35.1617 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.18433 -35.3532 0
+      vertex 3.27342 -27.657 0
+      vertex 4.3567 -27.5071 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.79314 -35.4903 0
+      vertex 3.27342 -27.657 0
+      vertex 4.18433 -35.3532 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.79314 -35.4903 0
+      vertex 2.18509 -27.7641 0
+      vertex 3.27342 -27.657 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.39765 -35.5726 0
+      vertex 2.18509 -27.7641 0
+      vertex 2.79314 -35.4903 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.39765 -35.5726 0
+      vertex 1.09339 -27.8285 0
+      vertex 2.18509 -27.7641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -35.6 0
+      vertex 1.09339 -27.8285 0
+      vertex 1.39765 -35.5726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -35.6 0
+      vertex 0 -27.85 0
+      vertex 1.09339 -27.8285 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -35.6 0
+      vertex -1.09339 -27.8285 0
+      vertex 0 -27.85 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.39765 -35.5726 0
+      vertex -1.09339 -27.8285 0
+      vertex 0 -35.6 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.39765 -35.5726 0
+      vertex -2.18509 -27.7641 0
+      vertex -1.09339 -27.8285 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.79314 -35.4903 0
+      vertex -2.18509 -27.7641 0
+      vertex -1.39765 -35.5726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.79314 -35.4903 0
+      vertex -3.27342 -27.657 0
+      vertex -2.18509 -27.7641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.18433 -35.3532 0
+      vertex -3.27342 -27.657 0
+      vertex -2.79314 -35.4903 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.18433 -35.3532 0
+      vertex -4.3567 -27.5071 0
+      vertex -3.27342 -27.657 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.56907 -35.1617 0
+      vertex -4.3567 -27.5071 0
+      vertex -4.18433 -35.3532 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -4.3567 -27.5071 0
+      vertex -5.56907 -35.1617 0
+      vertex -5.43326 -27.3149 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.94522 -34.916 0
+      vertex -5.43326 -27.3149 0
+      vertex -5.56907 -35.1617 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.43326 -27.3149 0
+      vertex -6.94522 -34.916 0
+      vertex -6.50145 -27.0805 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.31065 -34.6164 0
+      vertex -6.50145 -27.0805 0
+      vertex -6.94522 -34.916 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -6.50145 -27.0805 0
+      vertex -8.31065 -34.6164 0
+      vertex -7.55962 -26.8044 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.66328 -34.2634 0
+      vertex -7.55962 -26.8044 0
+      vertex -8.31065 -34.6164 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -7.55962 -26.8044 0
+      vertex -9.66328 -34.2634 0
+      vertex -8.60612 -26.4869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.001 -33.8576 0
+      vertex -8.60612 -26.4869 0
+      vertex -9.66328 -34.2634 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.60612 -26.4869 0
+      vertex -11.001 -33.8576 0
+      vertex -9.63936 -26.1286 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.3218 -33.3996 0
+      vertex -9.63936 -26.1286 0
+      vertex -11.001 -33.8576 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.63936 -26.1286 0
+      vertex -12.3218 -33.3996 0
+      vertex -10.6577 -25.73 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.6235 -32.8901 0
+      vertex -10.6577 -25.73 0
+      vertex -12.3218 -33.3996 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -10.6577 -25.73 0
+      vertex -13.6235 -32.8901 0
+      vertex -11.6597 -25.2918 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.9043 -32.3299 0
+      vertex -11.6597 -25.2918 0
+      vertex -13.6235 -32.8901 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -11.6597 -25.2918 0
+      vertex -14.9043 -32.3299 0
+      vertex -12.6436 -24.8145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.1621 -31.7198 0
+      vertex -12.6436 -24.8145 0
+      vertex -14.9043 -32.3299 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -12.6436 -24.8145 0
+      vertex -16.1621 -31.7198 0
+      vertex -13.6081 -24.299 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3949 -31.0609 0
+      vertex -13.6081 -24.299 0
+      vertex -16.1621 -31.7198 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.6081 -24.299 0
+      vertex -17.3949 -31.0609 0
+      vertex -14.5516 -23.746 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6009 -30.354 0
+      vertex -14.5516 -23.746 0
+      vertex -17.3949 -31.0609 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.5516 -23.746 0
+      vertex -18.6009 -30.354 0
+      vertex -15.4726 -23.1564 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.7783 -29.6003 0
+      vertex -15.4726 -23.1564 0
+      vertex -18.6009 -30.354 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.4726 -23.1564 0
+      vertex -19.7783 -29.6003 0
+      vertex -16.3698 -22.5311 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.9252 -28.801 0
+      vertex -16.3698 -22.5311 0
+      vertex -19.7783 -29.6003 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.3698 -22.5311 0
+      vertex -20.9252 -28.801 0
+      vertex -17.2418 -21.8711 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.0397 -27.9573 0
+      vertex -17.2418 -21.8711 0
+      vertex -20.9252 -28.801 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -17.2418 -21.8711 0
+      vertex -22.0397 -27.9573 0
+      vertex -18.0871 -21.1773 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.1203 -27.0705 0
+      vertex -18.0871 -21.1773 0
+      vertex -22.0397 -27.9573 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.0871 -21.1773 0
+      vertex -23.1203 -27.0705 0
+      vertex -18.9046 -20.4509 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.1653 -26.1419 0
+      vertex -18.9046 -20.4509 0
+      vertex -23.1203 -27.0705 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.9046 -20.4509 0
+      vertex -24.1653 -26.1419 0
+      vertex -19.6929 -19.6929 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.173 -25.173 0
+      vertex -19.6929 -19.6929 0
+      vertex -24.1653 -26.1419 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.6929 -19.6929 0
+      vertex -25.173 -25.173 0
+      vertex -20.4509 -18.9046 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.1419 -24.1653 0
+      vertex -20.4509 -18.9046 0
+      vertex -25.173 -25.173 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -20.4509 -18.9046 0
+      vertex -26.1419 -24.1653 0
+      vertex -21.1773 -18.0871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0705 -23.1203 0
+      vertex -21.1773 -18.0871 0
+      vertex -26.1419 -24.1653 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -21.1773 -18.0871 0
+      vertex -27.0705 -23.1203 0
+      vertex -21.8711 -17.2418 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.9573 -22.0397 0
+      vertex -21.8711 -17.2418 0
+      vertex -27.0705 -23.1203 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -21.8711 -17.2418 0
+      vertex -27.9573 -22.0397 0
+      vertex -22.5311 -16.3698 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.801 -20.9252 0
+      vertex -22.5311 -16.3698 0
+      vertex -27.9573 -22.0397 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -22.5311 -16.3698 0
+      vertex -28.801 -20.9252 0
+      vertex -23.1564 -15.4726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.6003 -19.7783 0
+      vertex -23.1564 -15.4726 0
+      vertex -28.801 -20.9252 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.1564 -15.4726 0
+      vertex -29.6003 -19.7783 0
+      vertex -23.746 -14.5516 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.354 -18.6009 0
+      vertex -23.746 -14.5516 0
+      vertex -29.6003 -19.7783 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.746 -14.5516 0
+      vertex -30.354 -18.6009 0
+      vertex -24.299 -13.6081 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.0609 -17.3949 0
+      vertex -24.299 -13.6081 0
+      vertex -30.354 -18.6009 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.299 -13.6081 0
+      vertex -31.0609 -17.3949 0
+      vertex -24.8145 -12.6436 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.7198 -16.1621 0
+      vertex -24.8145 -12.6436 0
+      vertex -31.0609 -17.3949 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.8145 -12.6436 0
+      vertex -31.7198 -16.1621 0
+      vertex -25.2918 -11.6597 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.3299 -14.9043 0
+      vertex -25.2918 -11.6597 0
+      vertex -31.7198 -16.1621 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.2918 -11.6597 0
+      vertex -32.3299 -14.9043 0
+      vertex -25.73 -10.6577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.8901 -13.6235 0
+      vertex -25.73 -10.6577 0
+      vertex -32.3299 -14.9043 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.73 -10.6577 0
+      vertex -32.8901 -13.6235 0
+      vertex -26.1286 -9.63936 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.1286 -9.63936 0
+      vertex -33.3996 -12.3218 0
+      vertex -26.4869 -8.60612 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.3996 -12.3218 0
+      vertex -26.1286 -9.63936 0
+      vertex -32.8901 -13.6235 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1286 9.63936 0
+      vertex 33.3996 12.3218 0
+      vertex 26.4869 8.60612 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 33.3996 12.3218 0
+      vertex 26.1286 9.63936 0
+      vertex 32.8901 13.6235 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.73 10.6577 0
+      vertex 32.8901 13.6235 0
+      vertex 26.1286 9.63936 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 32.8901 13.6235 0
+      vertex 25.73 10.6577 0
+      vertex 32.3299 14.9043 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.2918 11.6597 0
+      vertex 32.3299 14.9043 0
+      vertex 25.73 10.6577 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 32.3299 14.9043 0
+      vertex 25.2918 11.6597 0
+      vertex 31.7198 16.1621 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8145 12.6436 0
+      vertex 31.7198 16.1621 0
+      vertex 25.2918 11.6597 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 31.7198 16.1621 0
+      vertex 24.8145 12.6436 0
+      vertex 31.0609 17.3949 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.299 13.6081 0
+      vertex 31.0609 17.3949 0
+      vertex 24.8145 12.6436 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 31.0609 17.3949 0
+      vertex 24.299 13.6081 0
+      vertex 30.354 18.6009 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.746 14.5516 0
+      vertex 30.354 18.6009 0
+      vertex 24.299 13.6081 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 30.354 18.6009 0
+      vertex 23.746 14.5516 0
+      vertex 29.6003 19.7783 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.1564 15.4726 0
+      vertex 29.6003 19.7783 0
+      vertex 23.746 14.5516 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 29.6003 19.7783 0
+      vertex 23.1564 15.4726 0
+      vertex 28.801 20.9252 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.5311 16.3698 0
+      vertex 28.801 20.9252 0
+      vertex 23.1564 15.4726 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.801 20.9252 0
+      vertex 22.5311 16.3698 0
+      vertex 27.9573 22.0397 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.8711 17.2418 0
+      vertex 27.9573 22.0397 0
+      vertex 22.5311 16.3698 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 27.9573 22.0397 0
+      vertex 21.8711 17.2418 0
+      vertex 27.0705 23.1203 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.1773 18.0871 0
+      vertex 27.0705 23.1203 0
+      vertex 21.8711 17.2418 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 27.0705 23.1203 0
+      vertex 21.1773 18.0871 0
+      vertex 26.1419 24.1653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.4509 18.9046 0
+      vertex 26.1419 24.1653 0
+      vertex 21.1773 18.0871 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 26.1419 24.1653 0
+      vertex 20.4509 18.9046 0
+      vertex 25.173 25.173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.6929 19.6929 0
+      vertex 25.173 25.173 0
+      vertex 20.4509 18.9046 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 25.173 25.173 0
+      vertex 19.6929 19.6929 0
+      vertex 24.1653 26.1419 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9046 20.4509 0
+      vertex 24.1653 26.1419 0
+      vertex 19.6929 19.6929 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 24.1653 26.1419 0
+      vertex 18.9046 20.4509 0
+      vertex 23.1203 27.0705 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.0871 21.1773 0
+      vertex 23.1203 27.0705 0
+      vertex 18.9046 20.4509 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 23.1203 27.0705 0
+      vertex 18.0871 21.1773 0
+      vertex 22.0397 27.9573 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.2418 21.8711 0
+      vertex 22.0397 27.9573 0
+      vertex 18.0871 21.1773 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 22.0397 27.9573 0
+      vertex 17.2418 21.8711 0
+      vertex 20.9252 28.801 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.3698 22.5311 0
+      vertex 20.9252 28.801 0
+      vertex 17.2418 21.8711 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.9252 28.801 0
+      vertex 16.3698 22.5311 0
+      vertex 19.7783 29.6003 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4726 23.1564 0
+      vertex 19.7783 29.6003 0
+      vertex 16.3698 22.5311 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.7783 29.6003 0
+      vertex 15.4726 23.1564 0
+      vertex 18.6009 30.354 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.5516 23.746 0
+      vertex 18.6009 30.354 0
+      vertex 15.4726 23.1564 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 18.6009 30.354 0
+      vertex 14.5516 23.746 0
+      vertex 17.3949 31.0609 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6081 24.299 0
+      vertex 17.3949 31.0609 0
+      vertex 14.5516 23.746 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.3949 31.0609 0
+      vertex 13.6081 24.299 0
+      vertex 16.1621 31.7198 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6436 24.8145 0
+      vertex 16.1621 31.7198 0
+      vertex 13.6081 24.299 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 16.1621 31.7198 0
+      vertex 12.6436 24.8145 0
+      vertex 14.9043 32.3299 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.6597 25.2918 0
+      vertex 14.9043 32.3299 0
+      vertex 12.6436 24.8145 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14.9043 32.3299 0
+      vertex 11.6597 25.2918 0
+      vertex 13.6235 32.8901 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6577 25.73 0
+      vertex 13.6235 32.8901 0
+      vertex 11.6597 25.2918 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 13.6235 32.8901 0
+      vertex 10.6577 25.73 0
+      vertex 12.3218 33.3996 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.63936 26.1286 0
+      vertex 12.3218 33.3996 0
+      vertex 10.6577 25.73 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 12.3218 33.3996 0
+      vertex 9.63936 26.1286 0
+      vertex 11.001 33.8576 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.60612 26.4869 0
+      vertex 11.001 33.8576 0
+      vertex 9.63936 26.1286 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.001 33.8576 0
+      vertex 8.60612 26.4869 0
+      vertex 9.66328 34.2634 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.55962 26.8044 0
+      vertex 9.66328 34.2634 0
+      vertex 8.60612 26.4869 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 9.66328 34.2634 0
+      vertex 7.55962 26.8044 0
+      vertex 8.31065 34.6164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.50145 27.0805 0
+      vertex 8.31065 34.6164 0
+      vertex 7.55962 26.8044 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 8.31065 34.6164 0
+      vertex 6.50145 27.0805 0
+      vertex 6.94522 34.916 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.43326 27.3149 0
+      vertex 6.94522 34.916 0
+      vertex 6.50145 27.0805 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 6.94522 34.916 0
+      vertex 5.43326 27.3149 0
+      vertex 5.56907 35.1617 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.3567 27.5071 0
+      vertex 5.56907 35.1617 0
+      vertex 5.43326 27.3149 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.3567 27.5071 0
+      vertex 4.18433 35.3532 0
+      vertex 5.56907 35.1617 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.27342 27.657 0
+      vertex 4.18433 35.3532 0
+      vertex 4.3567 27.5071 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.27342 27.657 0
+      vertex 2.79314 35.4903 0
+      vertex 4.18433 35.3532 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.18509 27.7641 0
+      vertex 2.79314 35.4903 0
+      vertex 3.27342 27.657 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.18509 27.7641 0
+      vertex 1.39765 35.5726 0
+      vertex 2.79314 35.4903 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.09339 27.8285 0
+      vertex 1.39765 35.5726 0
+      vertex 2.18509 27.7641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 27.85 0
+      vertex 1.39765 35.5726 0
+      vertex 1.09339 27.8285 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 27.85 0
+      vertex 0 35.6 0
+      vertex 1.39765 35.5726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.09339 27.8285 0
+      vertex 0 35.6 0
+      vertex 0 27.85 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.09339 27.8285 0
+      vertex -1.39765 35.5726 0
+      vertex 0 35.6 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.18509 27.7641 0
+      vertex -1.39765 35.5726 0
+      vertex -1.09339 27.8285 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.18509 27.7641 0
+      vertex -2.79314 35.4903 0
+      vertex -1.39765 35.5726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.27342 27.657 0
+      vertex -2.79314 35.4903 0
+      vertex -2.18509 27.7641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.27342 27.657 0
+      vertex -4.18433 35.3532 0
+      vertex -2.79314 35.4903 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.3567 27.5071 0
+      vertex -4.18433 35.3532 0
+      vertex -3.27342 27.657 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.56907 35.1617 0
+      vertex -4.3567 27.5071 0
+      vertex -5.43326 27.3149 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.3567 27.5071 0
+      vertex -5.56907 35.1617 0
+      vertex -4.18433 35.3532 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.94522 34.916 0
+      vertex -5.43326 27.3149 0
+      vertex -6.50145 27.0805 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.43326 27.3149 0
+      vertex -6.94522 34.916 0
+      vertex -5.56907 35.1617 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.31065 34.6164 0
+      vertex -6.50145 27.0805 0
+      vertex -7.55962 26.8044 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.50145 27.0805 0
+      vertex -8.31065 34.6164 0
+      vertex -6.94522 34.916 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.66328 34.2634 0
+      vertex -7.55962 26.8044 0
+      vertex -8.60612 26.4869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.001 33.8576 0
+      vertex -8.60612 26.4869 0
+      vertex -9.63936 26.1286 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.55962 26.8044 0
+      vertex -9.66328 34.2634 0
+      vertex -8.31065 34.6164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.3218 33.3996 0
+      vertex -9.63936 26.1286 0
+      vertex -10.6577 25.73 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.60612 26.4869 0
+      vertex -11.001 33.8576 0
+      vertex -9.66328 34.2634 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.6235 32.8901 0
+      vertex -10.6577 25.73 0
+      vertex -11.6597 25.2918 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.63936 26.1286 0
+      vertex -12.3218 33.3996 0
+      vertex -11.001 33.8576 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.9043 32.3299 0
+      vertex -11.6597 25.2918 0
+      vertex -12.6436 24.8145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.1621 31.7198 0
+      vertex -12.6436 24.8145 0
+      vertex -13.6081 24.299 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6577 25.73 0
+      vertex -13.6235 32.8901 0
+      vertex -12.3218 33.3996 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3949 31.0609 0
+      vertex -13.6081 24.299 0
+      vertex -14.5516 23.746 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.6597 25.2918 0
+      vertex -14.9043 32.3299 0
+      vertex -13.6235 32.8901 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6009 30.354 0
+      vertex -14.5516 23.746 0
+      vertex -15.4726 23.1564 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.6436 24.8145 0
+      vertex -16.1621 31.7198 0
+      vertex -14.9043 32.3299 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.7783 29.6003 0
+      vertex -15.4726 23.1564 0
+      vertex -16.3698 22.5311 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.9252 28.801 0
+      vertex -16.3698 22.5311 0
+      vertex -17.2418 21.8711 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.6081 24.299 0
+      vertex -17.3949 31.0609 0
+      vertex -16.1621 31.7198 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.0397 27.9573 0
+      vertex -17.2418 21.8711 0
+      vertex -18.0871 21.1773 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.5516 23.746 0
+      vertex -18.6009 30.354 0
+      vertex -17.3949 31.0609 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.1203 27.0705 0
+      vertex -18.0871 21.1773 0
+      vertex -18.9046 20.4509 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.1653 26.1419 0
+      vertex -18.9046 20.4509 0
+      vertex -19.6929 19.6929 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.4726 23.1564 0
+      vertex -19.7783 29.6003 0
+      vertex -18.6009 30.354 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.173 25.173 0
+      vertex -19.6929 19.6929 0
+      vertex -20.4509 18.9046 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.3698 22.5311 0
+      vertex -20.9252 28.801 0
+      vertex -19.7783 29.6003 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.1419 24.1653 0
+      vertex -20.4509 18.9046 0
+      vertex -21.1773 18.0871 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0705 23.1203 0
+      vertex -21.1773 18.0871 0
+      vertex -21.8711 17.2418 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.2418 21.8711 0
+      vertex -22.0397 27.9573 0
+      vertex -20.9252 28.801 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.9573 22.0397 0
+      vertex -21.8711 17.2418 0
+      vertex -22.5311 16.3698 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.0871 21.1773 0
+      vertex -23.1203 27.0705 0
+      vertex -22.0397 27.9573 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.801 20.9252 0
+      vertex -22.5311 16.3698 0
+      vertex -23.1564 15.4726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.6003 19.7783 0
+      vertex -23.1564 15.4726 0
+      vertex -23.746 14.5516 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9046 20.4509 0
+      vertex -24.1653 26.1419 0
+      vertex -23.1203 27.0705 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.354 18.6009 0
+      vertex -23.746 14.5516 0
+      vertex -24.299 13.6081 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.0609 17.3949 0
+      vertex -24.299 13.6081 0
+      vertex -24.8145 12.6436 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.6929 19.6929 0
+      vertex -25.173 25.173 0
+      vertex -24.1653 26.1419 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.7198 16.1621 0
+      vertex -24.8145 12.6436 0
+      vertex -25.2918 11.6597 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.3299 14.9043 0
+      vertex -25.2918 11.6597 0
+      vertex -25.73 10.6577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.8901 13.6235 0
+      vertex -25.73 10.6577 0
+      vertex -26.1286 9.63936 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.4509 18.9046 0
+      vertex -26.1419 24.1653 0
+      vertex -25.173 25.173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.3996 12.3218 0
+      vertex -26.1286 9.63936 0
+      vertex -26.4869 8.60612 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.8576 11.001 0
+      vertex -26.4869 8.60612 0
+      vertex -26.8044 7.55962 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.1773 18.0871 0
+      vertex -27.0705 23.1203 0
+      vertex -26.1419 24.1653 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -34.2634 9.66328 0
+      vertex -26.8044 7.55962 0
+      vertex -27.0805 6.50145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -34.6164 8.31065 0
+      vertex -27.0805 6.50145 0
+      vertex -27.3149 5.43326 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -34.916 6.94522 0
+      vertex -27.3149 5.43326 0
+      vertex -27.5071 4.3567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.1617 5.56907 0
+      vertex -27.5071 4.3567 0
+      vertex -27.657 3.27342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.3532 4.18433 0
+      vertex -27.657 3.27342 0
+      vertex -27.7641 2.18509 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.4903 2.79314 0
+      vertex -27.7641 2.18509 0
+      vertex -27.8285 1.09339 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.8711 17.2418 0
+      vertex -27.9573 22.0397 0
+      vertex -27.0705 23.1203 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.5726 1.39765 0
+      vertex -27.8285 1.09339 0
+      vertex -27.85 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.8576 -11.001 0
+      vertex -26.4869 -8.60612 0
+      vertex -33.3996 -12.3218 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.4869 -8.60612 0
+      vertex -33.8576 -11.001 0
+      vertex -26.8044 -7.55962 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5311 16.3698 0
+      vertex -28.801 20.9252 0
+      vertex -27.9573 22.0397 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -34.2634 -9.66328 0
+      vertex -26.8044 -7.55962 0
+      vertex -33.8576 -11.001 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.1564 15.4726 0
+      vertex -29.6003 19.7783 0
+      vertex -28.801 20.9252 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.8044 -7.55962 0
+      vertex -34.2634 -9.66328 0
+      vertex -27.0805 -6.50145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.746 14.5516 0
+      vertex -30.354 18.6009 0
+      vertex -29.6003 19.7783 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -34.6164 -8.31065 0
+      vertex -27.0805 -6.50145 0
+      vertex -34.2634 -9.66328 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.299 13.6081 0
+      vertex -31.0609 17.3949 0
+      vertex -30.354 18.6009 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.0805 -6.50145 0
+      vertex -34.6164 -8.31065 0
+      vertex -27.3149 -5.43326 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.8145 12.6436 0
+      vertex -31.7198 16.1621 0
+      vertex -31.0609 17.3949 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -34.916 -6.94522 0
+      vertex -27.3149 -5.43326 0
+      vertex -34.6164 -8.31065 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.2918 11.6597 0
+      vertex -32.3299 14.9043 0
+      vertex -31.7198 16.1621 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.3149 -5.43326 0
+      vertex -34.916 -6.94522 0
+      vertex -27.5071 -4.3567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.73 10.6577 0
+      vertex -32.8901 13.6235 0
+      vertex -32.3299 14.9043 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.1617 -5.56907 0
+      vertex -27.5071 -4.3567 0
+      vertex -34.916 -6.94522 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.1286 9.63936 0
+      vertex -33.3996 12.3218 0
+      vertex -32.8901 13.6235 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.5071 -4.3567 0
+      vertex -35.1617 -5.56907 0
+      vertex -27.657 -3.27342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.4869 8.60612 0
+      vertex -33.8576 11.001 0
+      vertex -33.3996 12.3218 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.3532 -4.18433 0
+      vertex -27.657 -3.27342 0
+      vertex -35.1617 -5.56907 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.8044 7.55962 0
+      vertex -34.2634 9.66328 0
+      vertex -33.8576 11.001 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.657 -3.27342 0
+      vertex -35.3532 -4.18433 0
+      vertex -27.7641 -2.18509 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0805 6.50145 0
+      vertex -34.6164 8.31065 0
+      vertex -34.2634 9.66328 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.4903 -2.79314 0
+      vertex -27.7641 -2.18509 0
+      vertex -35.3532 -4.18433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.3149 5.43326 0
+      vertex -34.916 6.94522 0
+      vertex -34.6164 8.31065 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.7641 -2.18509 0
+      vertex -35.4903 -2.79314 0
+      vertex -27.8285 -1.09339 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.5071 4.3567 0
+      vertex -35.1617 5.56907 0
+      vertex -34.916 6.94522 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.5726 -1.39765 0
+      vertex -27.8285 -1.09339 0
+      vertex -35.4903 -2.79314 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.657 3.27342 0
+      vertex -35.3532 4.18433 0
+      vertex -35.1617 5.56907 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.8285 -1.09339 0
+      vertex -35.5726 -1.39765 0
+      vertex -27.85 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.7641 2.18509 0
+      vertex -35.4903 2.79314 0
+      vertex -35.3532 4.18433 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.6 0 0
+      vertex -27.85 0 0
+      vertex -35.5726 -1.39765 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.8285 1.09339 0
+      vertex -35.5726 1.39765 0
+      vertex -35.4903 2.79314 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.85 0 0
+      vertex -35.6 0 0
+      vertex -35.5726 1.39765 0
+    endloop
+  endfacet
+  facet normal 0.124291 -0.696145 -0.70706
+    outer loop
+      vertex 5.69421 -35.9519 0.799999
+      vertex 5.56907 -35.1617 0
+      vertex 6.94522 -34.916 0
+    endloop
+  endfacet
+  facet normal -0.563844 0.426841 -0.707027
+    outer loop
+      vertex -27.9573 22.0397 0
+      vertex -29.4482 21.3954 0.799999
+      vertex -28.5855 22.535 0.799999
+    endloop
+  endfacet
+  facet normal 0.205274 -0.676711 -0.707054
+    outer loop
+      vertex 9.88043 -35.0334 0.799999
+      vertex 9.66328 -34.2634 0
+      vertex 11.2482 -34.6185 0.799999
+    endloop
+  endfacet
+  facet normal -0.283382 0.647904 -0.707047
+    outer loop
+      vertex -13.6235 32.8901 0
+      vertex -14.9043 32.3299 0
+      vertex -13.9297 33.6292 0.799999
+    endloop
+  endfacet
+  facet normal -0.668125 0.231679 -0.70706
+    outer loop
+      vertex -33.8576 11.001 0
+      vertex -34.6185 11.2482 0.799999
+      vertex -33.3996 12.3218 0
+    endloop
+  endfacet
+  facet normal 0.308627 -0.636275 -0.707039
+    outer loop
+      vertex 16.5253 -32.4326 0.799999
+      vertex 14.9043 -32.3299 0
+      vertex 16.1621 -31.7198 0
+    endloop
+  endfacet
+  facet normal 0.0416115 -0.705986 -0.707003
+    outer loop
+      vertex 1.42906 -36.3719 0.799999
+      vertex 1.39765 -35.5726 0
+      vertex 2.85591 -36.2878 0.799999
+    endloop
+  endfacet
+  facet normal -0.610088 0.357612 -0.707041
+    outer loop
+      vertex -31.0609 17.3949 0
+      vertex -31.7589 17.7858 0.799999
+      vertex -31.0361 19.0189 0.799999
+    endloop
+  endfacet
+  facet normal -0.381266 0.595599 -0.707035
+    outer loop
+      vertex -18.6009 30.354 0
+      vertex -19.7783 29.6003 0
+      vertex -19.0189 31.0361 0.799999
+    endloop
+  endfacet
+  facet normal 0.357612 -0.610088 -0.707041
+    outer loop
+      vertex 17.7858 -31.7589 0.799999
+      vertex 17.3949 -31.0609 0
+      vertex 19.0189 -31.0361 0.799999
+    endloop
+  endfacet
+  facet normal 0.0968726 0.700488 -0.707059
+    outer loop
+      vertex 5.56907 35.1617 0
+      vertex 4.18433 35.3532 0
+      vertex 4.27836 36.1477 0.799999
+    endloop
+  endfacet
+  facet normal 0.0968714 0.700487 -0.70706
+    outer loop
+      vertex 5.56907 35.1617 0
+      vertex 4.27836 36.1477 0.799999
+      vertex 5.69421 35.9519 0.799999
+    endloop
+  endfacet
+  facet normal -0.668125 -0.231679 -0.70706
+    outer loop
+      vertex -33.3996 -12.3218 0
+      vertex -34.6185 -11.2482 0.799999
+      vertex -33.8576 -11.001 0
+    endloop
+  endfacet
+  facet normal -0.528618 0.469789 -0.707008
+    outer loop
+      vertex -26.1419 24.1653 0
+      vertex -27.6788 23.6399 0.799999
+      vertex -26.7293 24.7083 0.799999
+    endloop
+  endfacet
+  facet normal 0.426842 0.563844 -0.707027
+    outer loop
+      vertex 22.0397 27.9573 0
+      vertex 20.9252 28.801 0
+      vertex 21.3954 29.4482 0.799999
+    endloop
+  endfacet
+  facet normal -0.0968714 0.700487 -0.70706
+    outer loop
+      vertex -5.56907 35.1617 0
+      vertex -5.69421 35.9519 0.799999
+      vertex -4.27836 36.1477 0.799999
+    endloop
+  endfacet
+  facet normal 0.231679 0.668125 -0.70706
+    outer loop
+      vertex 12.3218 33.3996 0
+      vertex 11.001 33.8576 0
+      vertex 11.2482 34.6185 0.799999
+    endloop
+  endfacet
+  facet normal 0.404357 0.580141 -0.707059
+    outer loop
+      vertex 21.3954 29.4482 0.799999
+      vertex 19.7783 29.6003 0
+      vertex 20.2228 30.2655 0.799999
+    endloop
+  endfacet
+  facet normal 0.546678 0.448614 -0.707028
+    outer loop
+      vertex 27.9573 22.0397 0
+      vertex 27.6788 23.6399 0.799999
+      vertex 28.5855 22.535 0.799999
+    endloop
+  endfacet
+  facet normal 0.283382 0.647904 -0.707047
+    outer loop
+      vertex 14.9043 32.3299 0
+      vertex 13.6235 32.8901 0
+      vertex 13.9297 33.6292 0.799999
+    endloop
+  endfacet
+  facet normal -0.563844 0.426842 -0.707027
+    outer loop
+      vertex -28.801 20.9252 0
+      vertex -29.4482 21.3954 0.799999
+      vertex -27.9573 22.0397 0
+    endloop
+  endfacet
+  facet normal -0.308621 -0.63629 -0.707028
+    outer loop
+      vertex -15.2392 -33.0564 0.799999
+      vertex -16.5253 -32.4326 0.799999
+      vertex -14.9043 -32.3299 0
+    endloop
+  endfacet
+  facet normal -0.426841 0.563844 -0.707027
+    outer loop
+      vertex -22.0397 27.9573 0
+      vertex -22.535 28.5855 0.799999
+      vertex -21.3954 29.4482 0.799999
+    endloop
+  endfacet
+  facet normal 0.308621 -0.63629 -0.707028
+    outer loop
+      vertex 15.2392 -33.0564 0.799999
+      vertex 14.9043 -32.3299 0
+      vertex 16.5253 -32.4326 0.799999
+    endloop
+  endfacet
+  facet normal -0.404346 -0.580188 -0.707027
+    outer loop
+      vertex -19.7783 -29.6003 0
+      vertex -21.3954 -29.4482 0.799999
+      vertex -20.9252 -28.801 0
+    endloop
+  endfacet
+  facet normal -0.684259 0.178558 -0.707041
+    outer loop
+      vertex -34.6164 8.31065 0
+      vertex -35.3943 8.49741 0.799999
+      vertex -35.0334 9.88043 0.799999
+    endloop
+  endfacet
+  facet normal -0.178558 -0.684259 -0.707041
+    outer loop
+      vertex -8.49741 -35.3943 0.799999
+      vertex -9.88043 -35.0334 0.799999
+      vertex -8.31065 -34.6164 0
+    endloop
+  endfacet
+  facet normal -0.404357 -0.580141 -0.707059
+    outer loop
+      vertex -20.2228 -30.2655 0.799999
+      vertex -21.3954 -29.4482 0.799999
+      vertex -19.7783 -29.6003 0
+    endloop
+  endfacet
+  facet normal -0.257748 0.658508 -0.707059
+    outer loop
+      vertex -12.3218 33.3996 0
+      vertex -13.6235 32.8901 0
+      vertex -12.5987 34.1502 0.799999
+    endloop
+  endfacet
+  facet normal -0.0968714 -0.700487 -0.70706
+    outer loop
+      vertex -4.27836 -36.1477 0.799999
+      vertex -5.69421 -35.9519 0.799999
+      vertex -5.56907 -35.1617 0
+    endloop
+  endfacet
+  facet normal 0.0968726 -0.700488 -0.707059
+    outer loop
+      vertex 4.27836 -36.1477 0.799999
+      vertex 4.18433 -35.3532 0
+      vertex 5.56907 -35.1617 0
+    endloop
+  endfacet
+  facet normal 0.580188 -0.404346 -0.707027
+    outer loop
+      vertex 29.4482 -21.3954 0.799999
+      vertex 28.801 -20.9252 0
+      vertex 29.6003 -19.7783 0
+    endloop
+  endfacet
+  facet normal 0.595599 0.381266 -0.707035
+    outer loop
+      vertex 30.354 18.6009 0
+      vertex 29.6003 19.7783 0
+      vertex 31.0361 19.0189 0.799999
+    endloop
+  endfacet
+  facet normal 0.580188 0.404346 -0.707027
+    outer loop
+      vertex 29.6003 19.7783 0
+      vertex 28.801 20.9252 0
+      vertex 29.4482 21.3954 0.799999
+    endloop
+  endfacet
+  facet normal 0.333342 -0.623682 -0.707039
+    outer loop
+      vertex 16.5253 -32.4326 0.799999
+      vertex 16.1621 -31.7198 0
+      vertex 17.3949 -31.0609 0
+    endloop
+  endfacet
+  facet normal 0.563844 0.426842 -0.707027
+    outer loop
+      vertex 28.801 20.9252 0
+      vertex 27.9573 22.0397 0
+      vertex 29.4482 21.3954 0.799999
+    endloop
+  endfacet
+  facet normal 0.636275 0.308627 -0.707039
+    outer loop
+      vertex 32.3299 14.9043 0
+      vertex 31.7198 16.1621 0
+      vertex 32.4326 16.5253 0.799999
+    endloop
+  endfacet
+  facet normal 0.357612 0.610088 -0.707041
+    outer loop
+      vertex 19.0189 31.0361 0.799999
+      vertex 17.3949 31.0609 0
+      vertex 17.7858 31.7589 0.799999
+    endloop
+  endfacet
+  facet normal 0.684259 0.178558 -0.707041
+    outer loop
+      vertex 35.3943 8.49741 0.799999
+      vertex 34.6164 8.31065 0
+      vertex 35.0334 9.88043 0.799999
+    endloop
+  endfacet
+  facet normal -0.124291 -0.696145 -0.70706
+    outer loop
+      vertex -5.69421 -35.9519 0.799999
+      vertex -6.94522 -34.916 0
+      vertex -5.56907 -35.1617 0
+    endloop
+  endfacet
+  facet normal 0.623682 0.333342 -0.707039
+    outer loop
+      vertex 31.7198 16.1621 0
+      vertex 31.0609 17.3949 0
+      vertex 32.4326 16.5253 0.799999
+    endloop
+  endfacet
+  facet normal 0.684259 -0.178558 -0.707041
+    outer loop
+      vertex 35.0334 -9.88043 0.799999
+      vertex 34.6164 -8.31065 0
+      vertex 35.3943 -8.49741 0.799999
+    endloop
+  endfacet
+  facet normal 0.178558 0.684259 -0.707041
+    outer loop
+      vertex 9.88043 35.0334 0.799999
+      vertex 8.31065 34.6164 0
+      vertex 8.49741 35.3943 0.799999
+    endloop
+  endfacet
+  facet normal -0.0968726 0.700488 -0.707059
+    outer loop
+      vertex -4.18433 35.3532 0
+      vertex -5.56907 35.1617 0
+      vertex -4.27836 36.1477 0.799999
+    endloop
+  endfacet
+  facet normal 0.151548 0.690758 -0.707027
+    outer loop
+      vertex 8.49741 35.3943 0.799999
+      vertex 6.94522 34.916 0
+      vertex 7.10129 35.7006 0.799999
+    endloop
+  endfacet
+  facet normal -0.381266 -0.595599 -0.707035
+    outer loop
+      vertex -19.0189 -31.0361 0.799999
+      vertex -19.7783 -29.6003 0
+      vertex -18.6009 -30.354 0
+    endloop
+  endfacet
+  facet normal 0.333339 -0.623681 -0.707041
+    outer loop
+      vertex 17.7858 -31.7589 0.799999
+      vertex 16.5253 -32.4326 0.799999
+      vertex 17.3949 -31.0609 0
+    endloop
+  endfacet
+  facet normal -0.703784 -0.0693171 -0.707024
+    outer loop
+      vertex -36.1477 -4.27836 0.799999
+      vertex -36.2878 -2.85591 0.799999
+      vertex -35.4903 -2.79314 0
+    endloop
+  endfacet
+  facet normal 0.448614 0.546678 -0.707028
+    outer loop
+      vertex 23.6399 27.6788 0.799999
+      vertex 22.0397 27.9573 0
+      vertex 22.535 28.5855 0.799999
+    endloop
+  endfacet
+  facet normal 0.426842 -0.563844 -0.707027
+    outer loop
+      vertex 21.3954 -29.4482 0.799999
+      vertex 20.9252 -28.801 0
+      vertex 22.0397 -27.9573 0
+    endloop
+  endfacet
+  facet normal -0.308627 0.636275 -0.707039
+    outer loop
+      vertex -16.1621 31.7198 0
+      vertex -16.5253 32.4326 0.799999
+      vertex -14.9043 32.3299 0
+    endloop
+  endfacet
+  facet normal 0.178569 -0.684242 -0.707054
+    outer loop
+      vertex 9.88043 -35.0334 0.799999
+      vertex 8.31065 -34.6164 0
+      vertex 9.66328 -34.2634 0
+    endloop
+  endfacet
+  facet normal -0.647912 -0.283409 -0.707028
+    outer loop
+      vertex -33.0564 -15.2392 0.799999
+      vertex -33.6292 -13.9297 0.799999
+      vertex -32.3299 -14.9043 0
+    endloop
+  endfacet
+  facet normal -0.448617 -0.546657 -0.707042
+    outer loop
+      vertex -22.0397 -27.9573 0
+      vertex -23.6399 -27.6788 0.799999
+      vertex -23.1203 -27.0705 0
+    endloop
+  endfacet
+  facet normal -0.469737 -0.528618 -0.707043
+    outer loop
+      vertex -23.6399 -27.6788 0.799999
+      vertex -24.1653 -26.1419 0
+      vertex -23.1203 -27.0705 0
+    endloop
+  endfacet
+  facet normal -0.563844 -0.426841 -0.707027
+    outer loop
+      vertex -28.5855 -22.535 0.799999
+      vertex -29.4482 -21.3954 0.799999
+      vertex -27.9573 -22.0397 0
+    endloop
+  endfacet
+  facet normal 0.690758 0.151548 -0.707027
+    outer loop
+      vertex 35.7006 7.10129 0.799999
+      vertex 34.916 6.94522 0
+      vertex 35.3943 8.49741 0.799999
+    endloop
+  endfacet
+  facet normal 0.469789 0.528618 -0.707008
+    outer loop
+      vertex 24.1653 26.1419 0
+      vertex 23.6399 27.6788 0.799999
+      vertex 24.7083 26.7293 0.799999
+    endloop
+  endfacet
+  facet normal -0.151548 -0.690758 -0.707027
+    outer loop
+      vertex -7.10129 -35.7006 0.799999
+      vertex -8.49741 -35.3943 0.799999
+      vertex -6.94522 -34.916 0
+    endloop
+  endfacet
+  facet normal -0.623681 0.333339 -0.707041
+    outer loop
+      vertex -31.0609 17.3949 0
+      vertex -32.4326 16.5253 0.799999
+      vertex -31.7589 17.7858 0.799999
+    endloop
+  endfacet
+  facet normal 0.623682 -0.333342 -0.707039
+    outer loop
+      vertex 32.4326 -16.5253 0.799999
+      vertex 31.0609 -17.3949 0
+      vertex 31.7198 -16.1621 0
+    endloop
+  endfacet
+  facet normal 0.668125 0.231679 -0.70706
+    outer loop
+      vertex 33.8576 11.001 0
+      vertex 33.3996 12.3218 0
+      vertex 34.6185 11.2482 0.799999
+    endloop
+  endfacet
+  facet normal 0.676702 0.205279 -0.707061
+    outer loop
+      vertex 34.2634 9.66328 0
+      vertex 33.8576 11.001 0
+      vertex 34.6185 11.2482 0.799999
+    endloop
+  endfacet
+  facet normal -0.705986 -0.0416115 -0.707003
+    outer loop
+      vertex -36.2878 -2.85591 0.799999
+      vertex -36.3719 -1.42906 0.799999
+      vertex -35.5726 -1.39765 0
+    endloop
+  endfacet
+  facet normal -0.357609 0.610096 -0.707035
+    outer loop
+      vertex -18.6009 30.354 0
+      vertex -19.0189 31.0361 0.799999
+      vertex -17.3949 31.0609 0
+    endloop
+  endfacet
+  facet normal 0.283409 -0.647912 -0.707028
+    outer loop
+      vertex 15.2392 -33.0564 0.799999
+      vertex 13.9297 -33.6292 0.799999
+      vertex 14.9043 -32.3299 0
+    endloop
+  endfacet
+  facet normal 0.257748 -0.658508 -0.707059
+    outer loop
+      vertex 12.5987 -34.1502 0.799999
+      vertex 12.3218 -33.3996 0
+      vertex 13.6235 -32.8901 0
+    endloop
+  endfacet
+  facet normal 0.509759 0.490131 -0.707048
+    outer loop
+      vertex 26.1419 24.1653 0
+      vertex 25.173 25.173 0
+      vertex 25.7387 25.7387 0.799999
+    endloop
+  endfacet
+  facet normal -0.404357 0.580141 -0.707059
+    outer loop
+      vertex -19.7783 29.6003 0
+      vertex -21.3954 29.4482 0.799999
+      vertex -20.2228 30.2655 0.799999
+    endloop
+  endfacet
+  facet normal -0.0139034 -0.707074 -0.707002
+    outer loop
+      vertex 0 -36.4 0.799999
+      vertex -1.42906 -36.3719 0.799999
+      vertex -1.39765 -35.5726 0
+    endloop
+  endfacet
+  facet normal -0.69074 0.151561 -0.707041
+    outer loop
+      vertex -34.916 6.94522 0
+      vertex -35.3943 8.49741 0.799999
+      vertex -34.6164 8.31065 0
+    endloop
+  endfacet
+  facet normal -0.178558 0.684259 -0.707041
+    outer loop
+      vertex -8.31065 34.6164 0
+      vertex -9.88043 35.0334 0.799999
+      vertex -8.49741 35.3943 0.799999
+    endloop
+  endfacet
+  facet normal -0.151548 0.690758 -0.707027
+    outer loop
+      vertex -6.94522 34.916 0
+      vertex -8.49741 35.3943 0.799999
+      vertex -7.10129 35.7006 0.799999
+    endloop
+  endfacet
+  facet normal -0.509819 -0.490126 -0.707009
+    outer loop
+      vertex -25.7387 -25.7387 0.799999
+      vertex -26.7293 -24.7083 0.799999
+      vertex -26.1419 -24.1653 0
+    endloop
+  endfacet
+  facet normal -0.528618 -0.469789 -0.707008
+    outer loop
+      vertex -26.7293 -24.7083 0.799999
+      vertex -27.6788 -23.6399 0.799999
+      vertex -26.1419 -24.1653 0
+    endloop
+  endfacet
+  facet normal 0.404346 0.580188 -0.707027
+    outer loop
+      vertex 20.9252 28.801 0
+      vertex 19.7783 29.6003 0
+      vertex 21.3954 29.4482 0.799999
+    endloop
+  endfacet
+  facet normal 0.546657 -0.448617 -0.707042
+    outer loop
+      vertex 27.6788 -23.6399 0.799999
+      vertex 27.0705 -23.1203 0
+      vertex 27.9573 -22.0397 0
+    endloop
+  endfacet
+  facet normal -0.257766 0.658515 -0.707046
+    outer loop
+      vertex -13.6235 32.8901 0
+      vertex -13.9297 33.6292 0.799999
+      vertex -12.5987 34.1502 0.799999
+    endloop
+  endfacet
+  facet normal -0.333342 0.623682 -0.707039
+    outer loop
+      vertex -16.1621 31.7198 0
+      vertex -17.3949 31.0609 0
+      vertex -16.5253 32.4326 0.799999
+    endloop
+  endfacet
+  facet normal -0.684242 0.178569 -0.707054
+    outer loop
+      vertex -34.6164 8.31065 0
+      vertex -35.0334 9.88043 0.799999
+      vertex -34.2634 9.66328 0
+    endloop
+  endfacet
+  facet normal -0.623682 -0.333342 -0.707039
+    outer loop
+      vertex -31.0609 -17.3949 0
+      vertex -32.4326 -16.5253 0.799999
+      vertex -31.7198 -16.1621 0
+    endloop
+  endfacet
+  facet normal -0.0693171 0.703784 -0.707024
+    outer loop
+      vertex -2.79314 35.4903 0
+      vertex -4.27836 36.1477 0.799999
+      vertex -2.85591 36.2878 0.799999
+    endloop
+  endfacet
+  facet normal 0.0416346 -0.705963 -0.707024
+    outer loop
+      vertex 2.85591 -36.2878 0.799999
+      vertex 1.39765 -35.5726 0
+      vertex 2.79314 -35.4903 0
+    endloop
+  endfacet
+  facet normal 0.469737 0.528618 -0.707043
+    outer loop
+      vertex 24.1653 26.1419 0
+      vertex 23.1203 27.0705 0
+      vertex 23.6399 27.6788 0.799999
+    endloop
+  endfacet
+  facet normal -0.703745 -0.0693532 -0.707059
+    outer loop
+      vertex -35.3532 -4.18433 0
+      vertex -36.1477 -4.27836 0.799999
+      vertex -35.4903 -2.79314 0
+    endloop
+  endfacet
+  facet normal -0.705963 -0.0416346 -0.707024
+    outer loop
+      vertex -35.4903 -2.79314 0
+      vertex -36.2878 -2.85591 0.799999
+      vertex -35.5726 -1.39765 0
+    endloop
+  endfacet
+  facet normal -0.205279 -0.676702 -0.707061
+    outer loop
+      vertex -9.66328 -34.2634 0
+      vertex -11.2482 -34.6185 0.799999
+      vertex -11.001 -33.8576 0
+    endloop
+  endfacet
+  facet normal -0.151561 0.69074 -0.707041
+    outer loop
+      vertex -8.31065 34.6164 0
+      vertex -8.49741 35.3943 0.799999
+      vertex -6.94522 34.916 0
+    endloop
+  endfacet
+  facet normal -0.490126 0.509819 -0.707009
+    outer loop
+      vertex -24.1653 26.1419 0
+      vertex -25.7387 25.7387 0.799999
+      vertex -24.7083 26.7293 0.799999
+    endloop
+  endfacet
+  facet normal -0.469789 0.528618 -0.707008
+    outer loop
+      vertex -24.1653 26.1419 0
+      vertex -24.7083 26.7293 0.799999
+      vertex -23.6399 27.6788 0.799999
+    endloop
+  endfacet
+  facet normal 0.448614 -0.546678 -0.707028
+    outer loop
+      vertex 22.535 -28.5855 0.799999
+      vertex 22.0397 -27.9573 0
+      vertex 23.6399 -27.6788 0.799999
+    endloop
+  endfacet
+  facet normal -0.357612 -0.610088 -0.707041
+    outer loop
+      vertex -17.7858 -31.7589 0.799999
+      vertex -19.0189 -31.0361 0.799999
+      vertex -17.3949 -31.0609 0
+    endloop
+  endfacet
+  facet normal -0.676702 -0.205279 -0.707061
+    outer loop
+      vertex -33.8576 -11.001 0
+      vertex -34.6185 -11.2482 0.799999
+      vertex -34.2634 -9.66328 0
+    endloop
+  endfacet
+  facet normal -0.610096 -0.357609 -0.707035
+    outer loop
+      vertex -31.0361 -19.0189 0.799999
+      vertex -31.0609 -17.3949 0
+      vertex -30.354 -18.6009 0
+    endloop
+  endfacet
+  facet normal -0.610088 -0.357612 -0.707041
+    outer loop
+      vertex -31.0361 -19.0189 0.799999
+      vertex -31.7589 -17.7858 0.799999
+      vertex -31.0609 -17.3949 0
+    endloop
+  endfacet
+  facet normal -0.636275 -0.308627 -0.707039
+    outer loop
+      vertex -31.7198 -16.1621 0
+      vertex -32.4326 -16.5253 0.799999
+      vertex -32.3299 -14.9043 0
+    endloop
+  endfacet
+  facet normal 0.528618 -0.469737 -0.707043
+    outer loop
+      vertex 27.6788 -23.6399 0.799999
+      vertex 26.1419 -24.1653 0
+      vertex 27.0705 -23.1203 0
+    endloop
+  endfacet
+  facet normal -0.013861 -0.707038 -0.707039
+    outer loop
+      vertex 0 -36.4 0.799999
+      vertex -1.39765 -35.5726 0
+      vertex 0 -35.6 0
+    endloop
+  endfacet
+  facet normal -0.546657 0.448617 -0.707042
+    outer loop
+      vertex -27.0705 23.1203 0
+      vertex -27.9573 22.0397 0
+      vertex -27.6788 23.6399 0.799999
+    endloop
+  endfacet
+  facet normal -0.528618 0.469737 -0.707043
+    outer loop
+      vertex -27.0705 23.1203 0
+      vertex -27.6788 23.6399 0.799999
+      vertex -26.1419 24.1653 0
+    endloop
+  endfacet
+  facet normal 0.333339 0.623681 -0.707041
+    outer loop
+      vertex 17.3949 31.0609 0
+      vertex 16.5253 32.4326 0.799999
+      vertex 17.7858 31.7589 0.799999
+    endloop
+  endfacet
+  facet normal -0.231679 -0.668125 -0.70706
+    outer loop
+      vertex -11.2482 -34.6185 0.799999
+      vertex -12.3218 -33.3996 0
+      vertex -11.001 -33.8576 0
+    endloop
+  endfacet
+  facet normal -0.283382 -0.647904 -0.707047
+    outer loop
+      vertex -13.9297 -33.6292 0.799999
+      vertex -14.9043 -32.3299 0
+      vertex -13.6235 -32.8901 0
+    endloop
+  endfacet
+  facet normal -0.151561 -0.69074 -0.707041
+    outer loop
+      vertex -6.94522 -34.916 0
+      vertex -8.49741 -35.3943 0.799999
+      vertex -8.31065 -34.6164 0
+    endloop
+  endfacet
+  facet normal -0.595599 -0.381266 -0.707035
+    outer loop
+      vertex -29.6003 -19.7783 0
+      vertex -31.0361 -19.0189 0.799999
+      vertex -30.354 -18.6009 0
+    endloop
+  endfacet
+  facet normal -0.610096 0.357609 -0.707035
+    outer loop
+      vertex -30.354 18.6009 0
+      vertex -31.0609 17.3949 0
+      vertex -31.0361 19.0189 0.799999
+    endloop
+  endfacet
+  facet normal -0.623682 0.333342 -0.707039
+    outer loop
+      vertex -31.7198 16.1621 0
+      vertex -32.4326 16.5253 0.799999
+      vertex -31.0609 17.3949 0
+    endloop
+  endfacet
+  facet normal 0.257766 -0.658515 -0.707046
+    outer loop
+      vertex 13.9297 -33.6292 0.799999
+      vertex 12.5987 -34.1502 0.799999
+      vertex 13.6235 -32.8901 0
+    endloop
+  endfacet
+  facet normal -0.257766 -0.658515 -0.707046
+    outer loop
+      vertex -12.5987 -34.1502 0.799999
+      vertex -13.9297 -33.6292 0.799999
+      vertex -13.6235 -32.8901 0
+    endloop
+  endfacet
+  facet normal -0.308627 -0.636275 -0.707039
+    outer loop
+      vertex -14.9043 -32.3299 0
+      vertex -16.5253 -32.4326 0.799999
+      vertex -16.1621 -31.7198 0
+    endloop
+  endfacet
+  facet normal -0.658515 -0.257766 -0.707046
+    outer loop
+      vertex -33.6292 -13.9297 0.799999
+      vertex -34.1502 -12.5987 0.799999
+      vertex -32.8901 -13.6235 0
+    endloop
+  endfacet
+  facet normal -0.647904 -0.283382 -0.707047
+    outer loop
+      vertex -32.3299 -14.9043 0
+      vertex -33.6292 -13.9297 0.799999
+      vertex -32.8901 -13.6235 0
+    endloop
+  endfacet
+  facet normal -0.69074 -0.151561 -0.707041
+    outer loop
+      vertex -34.6164 -8.31065 0
+      vertex -35.3943 -8.49741 0.799999
+      vertex -34.916 -6.94522 0
+    endloop
+  endfacet
+  facet normal -0.690758 -0.151548 -0.707027
+    outer loop
+      vertex -35.3943 -8.49741 0.799999
+      vertex -35.7006 -7.10129 0.799999
+      vertex -34.916 -6.94522 0
+    endloop
+  endfacet
+  facet normal -0.0968726 -0.700488 -0.707059
+    outer loop
+      vertex -4.27836 -36.1477 0.799999
+      vertex -5.56907 -35.1617 0
+      vertex -4.18433 -35.3532 0
+    endloop
+  endfacet
+  facet normal -0.0416115 -0.705986 -0.707003
+    outer loop
+      vertex -1.42906 -36.3719 0.799999
+      vertex -2.85591 -36.2878 0.799999
+      vertex -1.39765 -35.5726 0
+    endloop
+  endfacet
+  facet normal 0.124334 -0.696171 -0.707027
+    outer loop
+      vertex 7.10129 -35.7006 0.799999
+      vertex 5.69421 -35.9519 0.799999
+      vertex 6.94522 -34.916 0
+    endloop
+  endfacet
+  facet normal 0.676711 0.205274 0.707054
+    outer loop
+      vertex 34.6185 11.2482 58.2
+      vertex 34.2634 9.66328 59
+      vertex 35.0334 9.88043 58.2
+    endloop
+  endfacet
+  facet normal -0.490132 0.509759 0.707048
+    outer loop
+      vertex -24.1653 26.1419 59
+      vertex -25.7387 25.7387 58.2
+      vertex -25.173 25.173 59
+    endloop
+  endfacet
+  facet normal 0.707039 -0.013861 0.707039
+    outer loop
+      vertex 35.6 0 59
+      vertex 35.5726 -1.39765 59
+      vertex 36.4 0 58.2
+    endloop
+  endfacet
+  facet normal -0.676711 -0.205274 0.707054
+    outer loop
+      vertex -34.2634 -9.66328 59
+      vertex -35.0334 -9.88043 58.2
+      vertex -34.6185 -11.2482 58.2
+    endloop
+  endfacet
+  facet normal 0.707039 0.013861 0.707039
+    outer loop
+      vertex 36.4 0 58.2
+      vertex 35.5726 1.39765 59
+      vertex 35.6 0 59
+    endloop
+  endfacet
+  facet normal 0.707075 0.0139034 0.707002
+    outer loop
+      vertex 36.3719 1.42906 58.2
+      vertex 35.5726 1.39765 59
+      vertex 36.4 0 58.2
+    endloop
+  endfacet
+  facet normal 0.490132 -0.509759 0.707048
+    outer loop
+      vertex 25.173 -25.173 59
+      vertex 24.1653 -26.1419 59
+      vertex 25.7387 -25.7387 58.2
+    endloop
+  endfacet
+  facet normal 0.647913 -0.283409 0.707028
+    outer loop
+      vertex 33.6292 -13.9297 58.2
+      vertex 32.3299 -14.9043 59
+      vertex 33.0564 -15.2392 58.2
+    endloop
+  endfacet
+  facet normal -0.658509 0.257748 0.707059
+    outer loop
+      vertex -32.8901 13.6235 59
+      vertex -34.1502 12.5987 58.2
+      vertex -33.3996 12.3218 59
+    endloop
+  endfacet
+  facet normal -0.700487 -0.0968714 0.70706
+    outer loop
+      vertex -35.1617 -5.56907 59
+      vertex -36.1477 -4.27836 58.2
+      vertex -35.9519 -5.69421 58.2
+    endloop
+  endfacet
+  facet normal -0.528619 -0.46979 0.707008
+    outer loop
+      vertex -26.1419 -24.1653 59
+      vertex -27.6788 -23.6399 58.2
+      vertex -26.7293 -24.7083 58.2
+    endloop
+  endfacet
+  facet normal 0.509759 0.490132 0.707048
+    outer loop
+      vertex 25.7387 25.7387 58.2
+      vertex 25.173 25.173 59
+      vertex 26.1419 24.1653 59
+    endloop
+  endfacet
+  facet normal 0.700487 -0.0968714 0.70706
+    outer loop
+      vertex 36.1477 -4.27836 58.2
+      vertex 35.1617 -5.56907 59
+      vertex 35.9519 -5.69421 58.2
+    endloop
+  endfacet
+  facet normal -0.0139034 0.707075 0.707002
+    outer loop
+      vertex 0 36.4 58.2
+      vertex -1.42906 36.3719 58.2
+      vertex -1.39765 35.5726 59
+    endloop
+  endfacet
+  facet normal 0.283409 -0.647913 0.707028
+    outer loop
+      vertex 14.9043 -32.3299 59
+      vertex 13.9297 -33.6292 58.2
+      vertex 15.2392 -33.0564 58.2
+    endloop
+  endfacet
+  facet normal 0.690758 0.151548 0.707026
+    outer loop
+      vertex 35.3943 8.49741 58.2
+      vertex 34.916 6.94522 59
+      vertex 35.7006 7.10129 58.2
+    endloop
+  endfacet
+  facet normal 0.23168 0.668126 0.707059
+    outer loop
+      vertex 12.5987 34.1502 58.2
+      vertex 11.2482 34.6185 58.2
+      vertex 12.3218 33.3996 59
+    endloop
+  endfacet
+  facet normal -0.595599 -0.381266 0.707034
+    outer loop
+      vertex -30.354 -18.6009 59
+      vertex -31.0361 -19.0189 58.2
+      vertex -29.6003 -19.7783 59
+    endloop
+  endfacet
+  facet normal -0.205274 -0.676711 0.707054
+    outer loop
+      vertex -9.66328 -34.2634 59
+      vertex -11.2482 -34.6185 58.2
+      vertex -9.88043 -35.0334 58.2
+    endloop
+  endfacet
+  facet normal 0.546658 -0.448617 0.707042
+    outer loop
+      vertex 27.9573 -22.0397 59
+      vertex 27.0705 -23.1203 59
+      vertex 27.6788 -23.6399 58.2
+    endloop
+  endfacet
+  facet normal 0.257766 0.658516 0.707046
+    outer loop
+      vertex 13.9297 33.6292 58.2
+      vertex 12.5987 34.1502 58.2
+      vertex 13.6235 32.8901 59
+    endloop
+  endfacet
+  facet normal 0.546658 0.448617 0.707042
+    outer loop
+      vertex 27.6788 23.6399 58.2
+      vertex 27.0705 23.1203 59
+      vertex 27.9573 22.0397 59
+    endloop
+  endfacet
+  facet normal 0.333342 -0.623682 0.707038
+    outer loop
+      vertex 17.3949 -31.0609 59
+      vertex 16.1621 -31.7198 59
+      vertex 16.5253 -32.4326 58.2
+    endloop
+  endfacet
+  facet normal -0.696172 -0.124334 0.707026
+    outer loop
+      vertex -34.916 -6.94522 59
+      vertex -35.9519 -5.69421 58.2
+      vertex -35.7006 -7.10129 58.2
+    endloop
+  endfacet
+  facet normal 0.35761 -0.610096 0.707034
+    outer loop
+      vertex 18.6009 -30.354 59
+      vertex 17.3949 -31.0609 59
+      vertex 19.0189 -31.0361 58.2
+    endloop
+  endfacet
+  facet normal 0.647913 0.283409 0.707028
+    outer loop
+      vertex 33.0564 15.2392 58.2
+      vertex 32.3299 14.9043 59
+      vertex 33.6292 13.9297 58.2
+    endloop
+  endfacet
+  facet normal -0.703746 -0.0693532 0.707059
+    outer loop
+      vertex -35.4903 -2.79314 59
+      vertex -36.1477 -4.27836 58.2
+      vertex -35.3532 -4.18433 59
+    endloop
+  endfacet
+  facet normal -0.705986 0.0416115 0.707002
+    outer loop
+      vertex -36.2878 2.85591 58.2
+      vertex -36.3719 1.42906 58.2
+      vertex -35.5726 1.39765 59
+    endloop
+  endfacet
+  facet normal 0.0139034 -0.707075 0.707002
+    outer loop
+      vertex 1.39765 -35.5726 59
+      vertex 0 -36.4 58.2
+      vertex 1.42906 -36.3719 58.2
+    endloop
+  endfacet
+  facet normal -0.528619 0.46979 0.707008
+    outer loop
+      vertex -26.7293 24.7083 58.2
+      vertex -27.6788 23.6399 58.2
+      vertex -26.1419 24.1653 59
+    endloop
+  endfacet
+  facet normal -0.658516 0.257766 0.707046
+    outer loop
+      vertex -33.6292 13.9297 58.2
+      vertex -34.1502 12.5987 58.2
+      vertex -32.8901 13.6235 59
+    endloop
+  endfacet
+  facet normal -0.231679 0.668125 0.70706
+    outer loop
+      vertex -11.2482 34.6185 58.2
+      vertex -12.3218 33.3996 59
+      vertex -11.001 33.8576 59
+    endloop
+  endfacet
+  facet normal 0.333339 -0.623682 0.70704
+    outer loop
+      vertex 17.3949 -31.0609 59
+      vertex 16.5253 -32.4326 58.2
+      vertex 17.7858 -31.7589 58.2
+    endloop
+  endfacet
+  facet normal -0.668125 0.231679 0.70706
+    outer loop
+      vertex -33.3996 12.3218 59
+      vertex -34.6185 11.2482 58.2
+      vertex -33.8576 11.001 59
+    endloop
+  endfacet
+  facet normal 0.283382 -0.647904 0.707047
+    outer loop
+      vertex 14.9043 -32.3299 59
+      vertex 13.6235 -32.8901 59
+      vertex 13.9297 -33.6292 58.2
+    endloop
+  endfacet
+  facet normal 0.580141 -0.404357 0.707058
+    outer loop
+      vertex 29.6003 -19.7783 59
+      vertex 29.4482 -21.3954 58.2
+      vertex 30.2655 -20.2228 58.2
+    endloop
+  endfacet
+  facet normal -0.0693172 0.703784 0.707024
+    outer loop
+      vertex -2.85591 36.2878 58.2
+      vertex -4.27836 36.1477 58.2
+      vertex -2.79314 35.4903 59
+    endloop
+  endfacet
+  facet normal 0.610088 -0.357612 0.70704
+    outer loop
+      vertex 31.0609 -17.3949 59
+      vertex 31.0361 -19.0189 58.2
+      vertex 31.7589 -17.7858 58.2
+    endloop
+  endfacet
+  facet normal -0.308627 -0.636275 0.707038
+    outer loop
+      vertex -16.1621 -31.7198 59
+      vertex -16.5253 -32.4326 58.2
+      vertex -14.9043 -32.3299 59
+    endloop
+  endfacet
+  facet normal 0.546679 -0.448614 0.707028
+    outer loop
+      vertex 27.9573 -22.0397 59
+      vertex 27.6788 -23.6399 58.2
+      vertex 28.5855 -22.535 58.2
+    endloop
+  endfacet
+  facet normal 0.676703 0.205279 0.70706
+    outer loop
+      vertex 34.6185 11.2482 58.2
+      vertex 33.8576 11.001 59
+      vertex 34.2634 9.66328 59
+    endloop
+  endfacet
+  facet normal 0.257748 0.658509 0.707059
+    outer loop
+      vertex 12.5987 34.1502 58.2
+      vertex 12.3218 33.3996 59
+      vertex 13.6235 32.8901 59
+    endloop
+  endfacet
+  facet normal 0.684259 0.178558 0.707041
+    outer loop
+      vertex 35.0334 9.88043 58.2
+      vertex 34.6164 8.31065 59
+      vertex 35.3943 8.49741 58.2
+    endloop
+  endfacet
+  facet normal 0.0968727 -0.700488 0.707059
+    outer loop
+      vertex 5.56907 -35.1617 59
+      vertex 4.18433 -35.3532 59
+      vertex 4.27836 -36.1477 58.2
+    endloop
+  endfacet
+  facet normal -0.448614 0.546679 0.707028
+    outer loop
+      vertex -22.535 28.5855 58.2
+      vertex -23.6399 27.6788 58.2
+      vertex -22.0397 27.9573 59
+    endloop
+  endfacet
+  facet normal 0.0968714 0.700487 0.70706
+    outer loop
+      vertex 5.69421 35.9519 58.2
+      vertex 4.27836 36.1477 58.2
+      vertex 5.56907 35.1617 59
+    endloop
+  endfacet
+  facet normal -0.63629 -0.308621 0.707027
+    outer loop
+      vertex -32.3299 -14.9043 59
+      vertex -33.0564 -15.2392 58.2
+      vertex -32.4326 -16.5253 58.2
+    endloop
+  endfacet
+  facet normal -0.469737 -0.528619 0.707043
+    outer loop
+      vertex -23.1203 -27.0705 59
+      vertex -24.1653 -26.1419 59
+      vertex -23.6399 -27.6788 58.2
+    endloop
+  endfacet
+  facet normal -0.509819 -0.490127 0.707008
+    outer loop
+      vertex -26.1419 -24.1653 59
+      vertex -26.7293 -24.7083 58.2
+      vertex -25.7387 -25.7387 58.2
+    endloop
+  endfacet
+  facet normal 0.703784 0.0693172 0.707024
+    outer loop
+      vertex 36.1477 4.27836 58.2
+      vertex 35.4903 2.79314 59
+      vertex 36.2878 2.85591 58.2
+    endloop
+  endfacet
+  facet normal 0.333339 0.623682 0.70704
+    outer loop
+      vertex 17.7858 31.7589 58.2
+      vertex 16.5253 32.4326 58.2
+      vertex 17.3949 31.0609 59
+    endloop
+  endfacet
+  facet normal 0.308627 -0.636275 0.707038
+    outer loop
+      vertex 16.1621 -31.7198 59
+      vertex 14.9043 -32.3299 59
+      vertex 16.5253 -32.4326 58.2
+    endloop
+  endfacet
+  facet normal -0.684259 0.178558 0.707041
+    outer loop
+      vertex -35.0334 9.88043 58.2
+      vertex -35.3943 8.49741 58.2
+      vertex -34.6164 8.31065 59
+    endloop
+  endfacet
+  facet normal -0.705963 -0.0416347 0.707024
+    outer loop
+      vertex -35.5726 -1.39765 59
+      vertex -36.2878 -2.85591 58.2
+      vertex -35.4903 -2.79314 59
+    endloop
+  endfacet
+  facet normal -0.0693172 -0.703784 0.707024
+    outer loop
+      vertex -2.79314 -35.4903 59
+      vertex -4.27836 -36.1477 58.2
+      vertex -2.85591 -36.2878 58.2
+    endloop
+  endfacet
+  facet normal 0.658509 0.257748 0.707059
+    outer loop
+      vertex 34.1502 12.5987 58.2
+      vertex 32.8901 13.6235 59
+      vertex 33.3996 12.3218 59
+    endloop
+  endfacet
+  facet normal -0.528619 -0.469737 0.707043
+    outer loop
+      vertex -27.0705 -23.1203 59
+      vertex -27.6788 -23.6399 58.2
+      vertex -26.1419 -24.1653 59
+    endloop
+  endfacet
+  facet normal -0.124291 0.696145 0.70706
+    outer loop
+      vertex -5.69421 35.9519 58.2
+      vertex -6.94522 34.916 59
+      vertex -5.56907 35.1617 59
+    endloop
+  endfacet
+  facet normal -0.0968727 0.700488 0.707059
+    outer loop
+      vertex -4.27836 36.1477 58.2
+      vertex -5.56907 35.1617 59
+      vertex -4.18433 35.3532 59
+    endloop
+  endfacet
+  facet normal 0.580188 -0.404346 0.707026
+    outer loop
+      vertex 29.6003 -19.7783 59
+      vertex 28.801 -20.9252 59
+      vertex 29.4482 -21.3954 58.2
+    endloop
+  endfacet
+  facet normal -0.151548 0.690758 0.707026
+    outer loop
+      vertex -7.10129 35.7006 58.2
+      vertex -8.49741 35.3943 58.2
+      vertex -6.94522 34.916 59
+    endloop
+  endfacet
+  facet normal -0.707075 -0.0139034 0.707002
+    outer loop
+      vertex -35.5726 -1.39765 59
+      vertex -36.4 0 58.2
+      vertex -36.3719 -1.42906 58.2
+    endloop
+  endfacet
+  facet normal 0.623682 0.333342 0.707038
+    outer loop
+      vertex 32.4326 16.5253 58.2
+      vertex 31.0609 17.3949 59
+      vertex 31.7198 16.1621 59
+    endloop
+  endfacet
+  facet normal -0.381231 0.595594 0.707058
+    outer loop
+      vertex -19.0189 31.0361 58.2
+      vertex -20.2228 30.2655 58.2
+      vertex -19.7783 29.6003 59
+    endloop
+  endfacet
+  facet normal 0.124291 0.696145 0.70706
+    outer loop
+      vertex 5.69421 35.9519 58.2
+      vertex 5.56907 35.1617 59
+      vertex 6.94522 34.916 59
+    endloop
+  endfacet
+  facet normal -0.690758 -0.151548 0.707026
+    outer loop
+      vertex -34.916 -6.94522 59
+      vertex -35.7006 -7.10129 58.2
+      vertex -35.3943 -8.49741 58.2
+    endloop
+  endfacet
+  facet normal 0.705986 0.0416115 0.707002
+    outer loop
+      vertex 36.2878 2.85591 58.2
+      vertex 35.5726 1.39765 59
+      vertex 36.3719 1.42906 58.2
+    endloop
+  endfacet
+  facet normal 0.013861 -0.707039 0.707039
+    outer loop
+      vertex 0 -35.6 59
+      vertex 0 -36.4 58.2
+      vertex 1.39765 -35.5726 59
+    endloop
+  endfacet
+  facet normal 0.178558 -0.684259 0.707041
+    outer loop
+      vertex 9.88043 -35.0334 58.2
+      vertex 8.31065 -34.6164 59
+      vertex 8.49741 -35.3943 58.2
+    endloop
+  endfacet
+  facet normal 0.668126 0.23168 0.707059
+    outer loop
+      vertex 34.1502 12.5987 58.2
+      vertex 33.3996 12.3218 59
+      vertex 34.6185 11.2482 58.2
+    endloop
+  endfacet
+  facet normal -0.696172 0.124334 0.707026
+    outer loop
+      vertex -35.7006 7.10129 58.2
+      vertex -35.9519 5.69421 58.2
+      vertex -34.916 6.94522 59
+    endloop
+  endfacet
+  facet normal 0.333342 0.623682 0.707038
+    outer loop
+      vertex 16.5253 32.4326 58.2
+      vertex 16.1621 31.7198 59
+      vertex 17.3949 31.0609 59
+    endloop
+  endfacet
+  facet normal -0.151548 -0.690758 0.707026
+    outer loop
+      vertex -6.94522 -34.916 59
+      vertex -8.49741 -35.3943 58.2
+      vertex -7.10129 -35.7006 58.2
+    endloop
+  endfacet
+  facet normal 0.205279 0.676703 0.70706
+    outer loop
+      vertex 11.2482 34.6185 58.2
+      vertex 9.66328 34.2634 59
+      vertex 11.001 33.8576 59
+    endloop
+  endfacet
+  facet normal -0.257766 0.658516 0.707046
+    outer loop
+      vertex -12.5987 34.1502 58.2
+      vertex -13.9297 33.6292 58.2
+      vertex -13.6235 32.8901 59
+    endloop
+  endfacet
+  facet normal -0.703746 0.0693532 0.707059
+    outer loop
+      vertex -35.3532 4.18433 59
+      vertex -36.1477 4.27836 58.2
+      vertex -35.4903 2.79314 59
+    endloop
+  endfacet
+  facet normal 0.563844 0.426842 0.707026
+    outer loop
+      vertex 29.4482 21.3954 58.2
+      vertex 27.9573 22.0397 59
+      vertex 28.801 20.9252 59
+    endloop
+  endfacet
+  facet normal 0.705986 -0.0416115 0.707002
+    outer loop
+      vertex 36.3719 -1.42906 58.2
+      vertex 35.5726 -1.39765 59
+      vertex 36.2878 -2.85591 58.2
+    endloop
+  endfacet
+  facet normal 0.381231 -0.595594 0.707058
+    outer loop
+      vertex 19.7783 -29.6003 59
+      vertex 19.0189 -31.0361 58.2
+      vertex 20.2228 -30.2655 58.2
+    endloop
+  endfacet
+  facet normal 0.610096 -0.35761 0.707034
+    outer loop
+      vertex 31.0609 -17.3949 59
+      vertex 30.354 -18.6009 59
+      vertex 31.0361 -19.0189 58.2
+    endloop
+  endfacet
+  facet normal -0.283409 -0.647913 0.707028
+    outer loop
+      vertex -14.9043 -32.3299 59
+      vertex -15.2392 -33.0564 58.2
+      vertex -13.9297 -33.6292 58.2
+    endloop
+  endfacet
+  facet normal 0.205274 -0.676711 0.707054
+    outer loop
+      vertex 11.2482 -34.6185 58.2
+      vertex 9.66328 -34.2634 59
+      vertex 9.88043 -35.0334 58.2
+    endloop
+  endfacet
+  facet normal -0.151561 0.690741 0.707041
+    outer loop
+      vertex -6.94522 34.916 59
+      vertex -8.49741 35.3943 58.2
+      vertex -8.31065 34.6164 59
+    endloop
+  endfacet
+  facet normal -0.333339 0.623682 0.70704
+    outer loop
+      vertex -16.5253 32.4326 58.2
+      vertex -17.7858 31.7589 58.2
+      vertex -17.3949 31.0609 59
+    endloop
+  endfacet
+  facet normal 0.151548 0.690758 0.707026
+    outer loop
+      vertex 7.10129 35.7006 58.2
+      vertex 6.94522 34.916 59
+      vertex 8.49741 35.3943 58.2
+    endloop
+  endfacet
+  facet normal 0.703746 -0.0693532 0.707059
+    outer loop
+      vertex 35.4903 -2.79314 59
+      vertex 35.3532 -4.18433 59
+      vertex 36.1477 -4.27836 58.2
+    endloop
+  endfacet
+  facet normal 0.658509 -0.257748 0.707059
+    outer loop
+      vertex 33.3996 -12.3218 59
+      vertex 32.8901 -13.6235 59
+      vertex 34.1502 -12.5987 58.2
+    endloop
+  endfacet
+  facet normal 0.703784 -0.0693172 0.707024
+    outer loop
+      vertex 36.2878 -2.85591 58.2
+      vertex 35.4903 -2.79314 59
+      vertex 36.1477 -4.27836 58.2
+    endloop
+  endfacet
+  facet normal -0.0139034 -0.707075 0.707002
+    outer loop
+      vertex -1.39765 -35.5726 59
+      vertex -1.42906 -36.3719 58.2
+      vertex 0 -36.4 58.2
+    endloop
+  endfacet
+  facet normal -0.707039 -0.013861 0.707039
+    outer loop
+      vertex -35.6 0 59
+      vertex -36.4 0 58.2
+      vertex -35.5726 -1.39765 59
+    endloop
+  endfacet
+  facet normal 0.580188 0.404346 0.707026
+    outer loop
+      vertex 29.4482 21.3954 58.2
+      vertex 28.801 20.9252 59
+      vertex 29.6003 19.7783 59
+    endloop
+  endfacet
+  facet normal -0.636275 -0.308627 0.707038
+    outer loop
+      vertex -32.3299 -14.9043 59
+      vertex -32.4326 -16.5253 58.2
+      vertex -31.7198 -16.1621 59
+    endloop
+  endfacet
+  facet normal -0.0968714 0.700487 0.70706
+    outer loop
+      vertex -4.27836 36.1477 58.2
+      vertex -5.69421 35.9519 58.2
+      vertex -5.56907 35.1617 59
+    endloop
+  endfacet
+  facet normal -0.0416115 0.705986 0.707002
+    outer loop
+      vertex -1.42906 36.3719 58.2
+      vertex -2.85591 36.2878 58.2
+      vertex -1.39765 35.5726 59
+    endloop
+  endfacet
+  facet normal -0.357612 -0.610088 0.70704
+    outer loop
+      vertex -17.3949 -31.0609 59
+      vertex -19.0189 -31.0361 58.2
+      vertex -17.7858 -31.7589 58.2
+    endloop
+  endfacet
+  facet normal 0.700488 0.0968727 0.707059
+    outer loop
+      vertex 36.1477 4.27836 58.2
+      vertex 35.1617 5.56907 59
+      vertex 35.3532 4.18433 59
+    endloop
+  endfacet
+  facet normal -0.490127 0.509819 0.707008
+    outer loop
+      vertex -24.7083 26.7293 58.2
+      vertex -25.7387 25.7387 58.2
+      vertex -24.1653 26.1419 59
+    endloop
+  endfacet
+  facet normal 0.580141 0.404357 0.707058
+    outer loop
+      vertex 30.2655 20.2228 58.2
+      vertex 29.4482 21.3954 58.2
+      vertex 29.6003 19.7783 59
+    endloop
+  endfacet
+  facet normal 0.404357 -0.580141 0.707058
+    outer loop
+      vertex 21.3954 -29.4482 58.2
+      vertex 19.7783 -29.6003 59
+      vertex 20.2228 -30.2655 58.2
+    endloop
+  endfacet
+  facet normal 0.707075 -0.0139034 0.707002
+    outer loop
+      vertex 36.4 0 58.2
+      vertex 35.5726 -1.39765 59
+      vertex 36.3719 -1.42906 58.2
+    endloop
+  endfacet
+  facet normal -0.23168 -0.668126 0.707059
+    outer loop
+      vertex -12.3218 -33.3996 59
+      vertex -12.5987 -34.1502 58.2
+      vertex -11.2482 -34.6185 58.2
+    endloop
+  endfacet
+  facet normal -0.676703 0.205279 0.70706
+    outer loop
+      vertex -33.8576 11.001 59
+      vertex -34.6185 11.2482 58.2
+      vertex -34.2634 9.66328 59
+    endloop
+  endfacet
+  facet normal -0.580141 -0.404357 0.707058
+    outer loop
+      vertex -29.6003 -19.7783 59
+      vertex -30.2655 -20.2228 58.2
+      vertex -29.4482 -21.3954 58.2
+    endloop
+  endfacet
+  facet normal 0.381266 -0.595599 0.707034
+    outer loop
+      vertex 19.7783 -29.6003 59
+      vertex 18.6009 -30.354 59
+      vertex 19.0189 -31.0361 58.2
+    endloop
+  endfacet
+  facet normal -0.563844 -0.426841 0.707027
+    outer loop
+      vertex -27.9573 -22.0397 59
+      vertex -29.4482 -21.3954 58.2
+      vertex -28.5855 -22.535 58.2
+    endloop
+  endfacet
+  facet normal 0.595594 -0.381231 0.707058
+    outer loop
+      vertex 31.0361 -19.0189 58.2
+      vertex 29.6003 -19.7783 59
+      vertex 30.2655 -20.2228 58.2
+    endloop
+  endfacet
+  facet normal 0.205274 0.676711 0.707054
+    outer loop
+      vertex 9.88043 35.0334 58.2
+      vertex 9.66328 34.2634 59
+      vertex 11.2482 34.6185 58.2
+    endloop
+  endfacet
+  facet normal -0.595594 -0.381231 0.707058
+    outer loop
+      vertex -29.6003 -19.7783 59
+      vertex -31.0361 -19.0189 58.2
+      vertex -30.2655 -20.2228 58.2
+    endloop
+  endfacet
+  facet normal 0.357612 0.610088 0.70704
+    outer loop
+      vertex 17.7858 31.7589 58.2
+      vertex 17.3949 31.0609 59
+      vertex 19.0189 31.0361 58.2
+    endloop
+  endfacet
+  facet normal 0.404346 0.580188 0.707026
+    outer loop
+      vertex 21.3954 29.4482 58.2
+      vertex 19.7783 29.6003 59
+      vertex 20.9252 28.801 59
+    endloop
+  endfacet
+  facet normal 0.124291 -0.696145 0.70706
+    outer loop
+      vertex 6.94522 -34.916 59
+      vertex 5.56907 -35.1617 59
+      vertex 5.69421 -35.9519 58.2
+    endloop
+  endfacet
+  facet normal 0.205279 -0.676703 0.70706
+    outer loop
+      vertex 11.001 -33.8576 59
+      vertex 9.66328 -34.2634 59
+      vertex 11.2482 -34.6185 58.2
+    endloop
+  endfacet
+  facet normal -0.013861 -0.707039 0.707039
+    outer loop
+      vertex 0 -35.6 59
+      vertex -1.39765 -35.5726 59
+      vertex 0 -36.4 58.2
+    endloop
+  endfacet
+  facet normal 0.0416347 -0.705963 0.707024
+    outer loop
+      vertex 2.79314 -35.4903 59
+      vertex 1.39765 -35.5726 59
+      vertex 2.85591 -36.2878 58.2
+    endloop
+  endfacet
+  facet normal 0.668126 -0.23168 0.707059
+    outer loop
+      vertex 34.6185 -11.2482 58.2
+      vertex 33.3996 -12.3218 59
+      vertex 34.1502 -12.5987 58.2
+    endloop
+  endfacet
+  facet normal -0.696145 -0.124291 0.70706
+    outer loop
+      vertex -35.1617 -5.56907 59
+      vertex -35.9519 -5.69421 58.2
+      vertex -34.916 -6.94522 59
+    endloop
+  endfacet
+  facet normal 0.684243 -0.178569 0.707054
+    outer loop
+      vertex 34.6164 -8.31065 59
+      vertex 34.2634 -9.66328 59
+      vertex 35.0334 -9.88043 58.2
+    endloop
+  endfacet
+  facet normal -0.0693532 0.703746 0.707059
+    outer loop
+      vertex -2.79314 35.4903 59
+      vertex -4.27836 36.1477 58.2
+      vertex -4.18433 35.3532 59
+    endloop
+  endfacet
+  facet normal -0.700488 -0.0968727 0.707059
+    outer loop
+      vertex -35.3532 -4.18433 59
+      vertex -36.1477 -4.27836 58.2
+      vertex -35.1617 -5.56907 59
+    endloop
+  endfacet
+  facet normal 0.610096 0.35761 0.707034
+    outer loop
+      vertex 31.0361 19.0189 58.2
+      vertex 30.354 18.6009 59
+      vertex 31.0609 17.3949 59
+    endloop
+  endfacet
+  facet normal 0.668125 -0.231679 0.70706
+    outer loop
+      vertex 33.8576 -11.001 59
+      vertex 33.3996 -12.3218 59
+      vertex 34.6185 -11.2482 58.2
+    endloop
+  endfacet
+  facet normal 0.448614 0.546679 0.707028
+    outer loop
+      vertex 22.535 28.5855 58.2
+      vertex 22.0397 27.9573 59
+      vertex 23.6399 27.6788 58.2
+    endloop
+  endfacet
+  facet normal 0.658516 0.257766 0.707046
+    outer loop
+      vertex 33.6292 13.9297 58.2
+      vertex 32.8901 13.6235 59
+      vertex 34.1502 12.5987 58.2
+    endloop
+  endfacet
+  facet normal 0.647904 0.283382 0.707047
+    outer loop
+      vertex 33.6292 13.9297 58.2
+      vertex 32.3299 14.9043 59
+      vertex 32.8901 13.6235 59
+    endloop
+  endfacet
+  facet normal 0.490127 0.509819 0.707008
+    outer loop
+      vertex 24.7083 26.7293 58.2
+      vertex 24.1653 26.1419 59
+      vertex 25.7387 25.7387 58.2
+    endloop
+  endfacet
+  facet normal -0.0416347 0.705963 0.707024
+    outer loop
+      vertex -1.39765 35.5726 59
+      vertex -2.85591 36.2878 58.2
+      vertex -2.79314 35.4903 59
+    endloop
+  endfacet
+  facet normal -0.647913 -0.283409 0.707028
+    outer loop
+      vertex -32.3299 -14.9043 59
+      vertex -33.6292 -13.9297 58.2
+      vertex -33.0564 -15.2392 58.2
+    endloop
+  endfacet
+  facet normal 0.595599 0.381266 0.707034
+    outer loop
+      vertex 31.0361 19.0189 58.2
+      vertex 29.6003 19.7783 59
+      vertex 30.354 18.6009 59
+    endloop
+  endfacet
+  facet normal -0.333342 0.623682 0.707038
+    outer loop
+      vertex -16.5253 32.4326 58.2
+      vertex -17.3949 31.0609 59
+      vertex -16.1621 31.7198 59
+    endloop
+  endfacet
+  facet normal -0.705986 -0.0416115 0.707002
+    outer loop
+      vertex -35.5726 -1.39765 59
+      vertex -36.3719 -1.42906 58.2
+      vertex -36.2878 -2.85591 58.2
+    endloop
+  endfacet
+  facet normal 0.668125 0.231679 0.70706
+    outer loop
+      vertex 34.6185 11.2482 58.2
+      vertex 33.3996 12.3218 59
+      vertex 33.8576 11.001 59
+    endloop
+  endfacet
+  facet normal 0.563844 -0.426841 0.707027
+    outer loop
+      vertex 29.4482 -21.3954 58.2
+      vertex 27.9573 -22.0397 59
+      vertex 28.5855 -22.535 58.2
+    endloop
+  endfacet
+  facet normal -0.257748 0.658509 0.707059
+    outer loop
+      vertex -12.5987 34.1502 58.2
+      vertex -13.6235 32.8901 59
+      vertex -12.3218 33.3996 59
+    endloop
+  endfacet
+  facet normal 0.404357 0.580141 0.707058
+    outer loop
+      vertex 20.2228 30.2655 58.2
+      vertex 19.7783 29.6003 59
+      vertex 21.3954 29.4482 58.2
+    endloop
+  endfacet
+  facet normal 0.696145 0.124291 0.70706
+    outer loop
+      vertex 35.9519 5.69421 58.2
+      vertex 34.916 6.94522 59
+      vertex 35.1617 5.56907 59
+    endloop
+  endfacet
+  facet normal -0.658516 -0.257766 0.707046
+    outer loop
+      vertex -32.8901 -13.6235 59
+      vertex -34.1502 -12.5987 58.2
+      vertex -33.6292 -13.9297 58.2
+    endloop
+  endfacet
+  facet normal -0.668126 -0.23168 0.707059
+    outer loop
+      vertex -33.3996 -12.3218 59
+      vertex -34.6185 -11.2482 58.2
+      vertex -34.1502 -12.5987 58.2
+    endloop
+  endfacet
+  facet normal -0.610088 0.357612 0.70704
+    outer loop
+      vertex -31.0361 19.0189 58.2
+      vertex -31.7589 17.7858 58.2
+      vertex -31.0609 17.3949 59
+    endloop
+  endfacet
+  facet normal 0.658516 -0.257766 0.707046
+    outer loop
+      vertex 34.1502 -12.5987 58.2
+      vertex 32.8901 -13.6235 59
+      vertex 33.6292 -13.9297 58.2
+    endloop
+  endfacet
+  facet normal 0.178558 0.684259 0.707041
+    outer loop
+      vertex 8.49741 35.3943 58.2
+      vertex 8.31065 34.6164 59
+      vertex 9.88043 35.0334 58.2
+    endloop
+  endfacet
+  facet normal 0.696172 0.124334 0.707026
+    outer loop
+      vertex 35.7006 7.10129 58.2
+      vertex 34.916 6.94522 59
+      vertex 35.9519 5.69421 58.2
+    endloop
+  endfacet
+  facet normal -0.546658 0.448617 0.707042
+    outer loop
+      vertex -27.6788 23.6399 58.2
+      vertex -27.9573 22.0397 59
+      vertex -27.0705 23.1203 59
+    endloop
+  endfacet
+  facet normal -0.546679 -0.448614 0.707028
+    outer loop
+      vertex -27.9573 -22.0397 59
+      vertex -28.5855 -22.535 58.2
+      vertex -27.6788 -23.6399 58.2
+    endloop
+  endfacet
+  facet normal 0.46979 -0.528619 0.707008
+    outer loop
+      vertex 24.1653 -26.1419 59
+      vertex 23.6399 -27.6788 58.2
+      vertex 24.7083 -26.7293 58.2
+    endloop
+  endfacet
+  facet normal -0.124291 -0.696145 0.70706
+    outer loop
+      vertex -5.56907 -35.1617 59
+      vertex -6.94522 -34.916 59
+      vertex -5.69421 -35.9519 58.2
+    endloop
+  endfacet
+  facet normal -0.308621 0.63629 0.707027
+    outer loop
+      vertex -15.2392 33.0564 58.2
+      vertex -16.5253 32.4326 58.2
+      vertex -14.9043 32.3299 59
+    endloop
+  endfacet
+  facet normal 0.636275 0.308627 0.707038
+    outer loop
+      vertex 32.4326 16.5253 58.2
+      vertex 31.7198 16.1621 59
+      vertex 32.3299 14.9043 59
+    endloop
+  endfacet
+  facet normal -0.623682 -0.333339 0.70704
+    outer loop
+      vertex -31.0609 -17.3949 59
+      vertex -32.4326 -16.5253 58.2
+      vertex -31.7589 -17.7858 58.2
+    endloop
+  endfacet
+  facet normal -0.595594 0.381231 0.707058
+    outer loop
+      vertex -30.2655 20.2228 58.2
+      vertex -31.0361 19.0189 58.2
+      vertex -29.6003 19.7783 59
+    endloop
+  endfacet
+  facet normal -0.404357 0.580141 0.707058
+    outer loop
+      vertex -20.2228 30.2655 58.2
+      vertex -21.3954 29.4482 58.2
+      vertex -19.7783 29.6003 59
+    endloop
+  endfacet
+  facet normal 0.705963 0.0416347 0.707024
+    outer loop
+      vertex 36.2878 2.85591 58.2
+      vertex 35.4903 2.79314 59
+      vertex 35.5726 1.39765 59
+    endloop
+  endfacet
+  facet normal 0.448617 -0.546658 0.707042
+    outer loop
+      vertex 23.1203 -27.0705 59
+      vertex 22.0397 -27.9573 59
+      vertex 23.6399 -27.6788 58.2
+    endloop
+  endfacet
+  facet normal 0.63629 0.308621 0.707027
+    outer loop
+      vertex 32.4326 16.5253 58.2
+      vertex 32.3299 14.9043 59
+      vertex 33.0564 15.2392 58.2
+    endloop
+  endfacet
+  facet normal -0.623682 0.333339 0.70704
+    outer loop
+      vertex -31.7589 17.7858 58.2
+      vertex -32.4326 16.5253 58.2
+      vertex -31.0609 17.3949 59
+    endloop
+  endfacet
+  facet normal -0.205274 0.676711 0.707054
+    outer loop
+      vertex -9.88043 35.0334 58.2
+      vertex -11.2482 34.6185 58.2
+      vertex -9.66328 34.2634 59
+    endloop
+  endfacet
+  facet normal 0.690741 -0.151561 0.707041
+    outer loop
+      vertex 34.916 -6.94522 59
+      vertex 34.6164 -8.31065 59
+      vertex 35.3943 -8.49741 58.2
+    endloop
+  endfacet
+  facet normal 0.690741 0.151561 0.707041
+    outer loop
+      vertex 35.3943 8.49741 58.2
+      vertex 34.6164 8.31065 59
+      vertex 34.916 6.94522 59
+    endloop
+  endfacet
+  facet normal -0.231679 -0.668125 0.70706
+    outer loop
+      vertex -11.001 -33.8576 59
+      vertex -12.3218 -33.3996 59
+      vertex -11.2482 -34.6185 58.2
+    endloop
+  endfacet
+  facet normal -0.509819 0.490127 0.707008
+    outer loop
+      vertex -25.7387 25.7387 58.2
+      vertex -26.7293 24.7083 58.2
+      vertex -26.1419 24.1653 59
+    endloop
+  endfacet
+  facet normal 0.703746 0.0693532 0.707059
+    outer loop
+      vertex 36.1477 4.27836 58.2
+      vertex 35.3532 4.18433 59
+      vertex 35.4903 2.79314 59
+    endloop
+  endfacet
+  facet normal 0.151548 -0.690758 0.707026
+    outer loop
+      vertex 8.49741 -35.3943 58.2
+      vertex 6.94522 -34.916 59
+      vertex 7.10129 -35.7006 58.2
+    endloop
+  endfacet
+  facet normal -0.623682 0.333342 0.707038
+    outer loop
+      vertex -31.0609 17.3949 59
+      vertex -32.4326 16.5253 58.2
+      vertex -31.7198 16.1621 59
+    endloop
+  endfacet
+  facet normal -0.703784 -0.0693172 0.707024
+    outer loop
+      vertex -35.4903 -2.79314 59
+      vertex -36.2878 -2.85591 58.2
+      vertex -36.1477 -4.27836 58.2
+    endloop
+  endfacet
+  facet normal 0.231679 0.668125 0.70706
+    outer loop
+      vertex 11.2482 34.6185 58.2
+      vertex 11.001 33.8576 59
+      vertex 12.3218 33.3996 59
+    endloop
+  endfacet
+  facet normal 0.676711 -0.205274 0.707054
+    outer loop
+      vertex 35.0334 -9.88043 58.2
+      vertex 34.2634 -9.66328 59
+      vertex 34.6185 -11.2482 58.2
+    endloop
+  endfacet
+  facet normal 0.0968727 0.700488 0.707059
+    outer loop
+      vertex 4.27836 36.1477 58.2
+      vertex 4.18433 35.3532 59
+      vertex 5.56907 35.1617 59
+    endloop
+  endfacet
+  facet normal 0.705963 -0.0416347 0.707024
+    outer loop
+      vertex 35.5726 -1.39765 59
+      vertex 35.4903 -2.79314 59
+      vertex 36.2878 -2.85591 58.2
+    endloop
+  endfacet
+  facet normal -0.546679 0.448614 0.707028
+    outer loop
+      vertex -27.6788 23.6399 58.2
+      vertex -28.5855 22.535 58.2
+      vertex -27.9573 22.0397 59
+    endloop
+  endfacet
+  facet normal 0.404346 -0.580188 0.707026
+    outer loop
+      vertex 20.9252 -28.801 59
+      vertex 19.7783 -29.6003 59
+      vertex 21.3954 -29.4482 58.2
+    endloop
+  endfacet
+  facet normal 0.595599 -0.381266 0.707034
+    outer loop
+      vertex 30.354 -18.6009 59
+      vertex 29.6003 -19.7783 59
+      vertex 31.0361 -19.0189 58.2
+    endloop
+  endfacet
+  facet normal -0.705963 0.0416347 0.707024
+    outer loop
+      vertex -35.4903 2.79314 59
+      vertex -36.2878 2.85591 58.2
+      vertex -35.5726 1.39765 59
+    endloop
+  endfacet
+  facet normal -0.35761 -0.610096 0.707034
+    outer loop
+      vertex -18.6009 -30.354 59
+      vertex -19.0189 -31.0361 58.2
+      vertex -17.3949 -31.0609 59
+    endloop
+  endfacet
+  facet normal 0.700488 -0.0968727 0.707059
+    outer loop
+      vertex 35.3532 -4.18433 59
+      vertex 35.1617 -5.56907 59
+      vertex 36.1477 -4.27836 58.2
+    endloop
+  endfacet
+  facet normal 0.426841 -0.563844 0.707027
+    outer loop
+      vertex 22.0397 -27.9573 59
+      vertex 21.3954 -29.4482 58.2
+      vertex 22.535 -28.5855 58.2
+    endloop
+  endfacet
+  facet normal -0.283409 0.647913 0.707028
+    outer loop
+      vertex -13.9297 33.6292 58.2
+      vertex -15.2392 33.0564 58.2
+      vertex -14.9043 32.3299 59
+    endloop
+  endfacet
+  facet normal 0.700487 0.0968714 0.70706
+    outer loop
+      vertex 35.9519 5.69421 58.2
+      vertex 35.1617 5.56907 59
+      vertex 36.1477 4.27836 58.2
+    endloop
+  endfacet
+  facet normal -0.283382 0.647904 0.707047
+    outer loop
+      vertex -13.9297 33.6292 58.2
+      vertex -14.9043 32.3299 59
+      vertex -13.6235 32.8901 59
+    endloop
+  endfacet
+  facet normal 0.178569 0.684243 0.707054
+    outer loop
+      vertex 9.88043 35.0334 58.2
+      vertex 8.31065 34.6164 59
+      vertex 9.66328 34.2634 59
+    endloop
+  endfacet
+  facet normal -0.580188 0.404346 0.707026
+    outer loop
+      vertex -29.4482 21.3954 58.2
+      vertex -29.6003 19.7783 59
+      vertex -28.801 20.9252 59
+    endloop
+  endfacet
+  facet normal -0.610096 -0.35761 0.707034
+    outer loop
+      vertex -30.354 -18.6009 59
+      vertex -31.0609 -17.3949 59
+      vertex -31.0361 -19.0189 58.2
+    endloop
+  endfacet
+  facet normal 0.426842 0.563844 0.707026
+    outer loop
+      vertex 21.3954 29.4482 58.2
+      vertex 20.9252 28.801 59
+      vertex 22.0397 27.9573 59
+    endloop
+  endfacet
+  facet normal 0.426842 -0.563844 0.707026
+    outer loop
+      vertex 22.0397 -27.9573 59
+      vertex 20.9252 -28.801 59
+      vertex 21.3954 -29.4482 58.2
+    endloop
+  endfacet
+  facet normal -0.404346 0.580188 0.707026
+    outer loop
+      vertex -19.7783 29.6003 59
+      vertex -21.3954 29.4482 58.2
+      vertex -20.9252 28.801 59
+    endloop
+  endfacet
+  facet normal 0.0416115 -0.705986 0.707002
+    outer loop
+      vertex 2.85591 -36.2878 58.2
+      vertex 1.39765 -35.5726 59
+      vertex 1.42906 -36.3719 58.2
+    endloop
+  endfacet
+  facet normal 0.178569 -0.684243 0.707054
+    outer loop
+      vertex 9.66328 -34.2634 59
+      vertex 8.31065 -34.6164 59
+      vertex 9.88043 -35.0334 58.2
+    endloop
+  endfacet
+  facet normal 0.0968714 -0.700487 0.70706
+    outer loop
+      vertex 5.56907 -35.1617 59
+      vertex 4.27836 -36.1477 58.2
+      vertex 5.69421 -35.9519 58.2
+    endloop
+  endfacet
+  facet normal 0.636275 -0.308627 0.707038
+    outer loop
+      vertex 32.3299 -14.9043 59
+      vertex 31.7198 -16.1621 59
+      vertex 32.4326 -16.5253 58.2
+    endloop
+  endfacet
+  facet normal 0.490127 -0.509819 0.707008
+    outer loop
+      vertex 25.7387 -25.7387 58.2
+      vertex 24.1653 -26.1419 59
+      vertex 24.7083 -26.7293 58.2
+    endloop
+  endfacet
+  facet normal -0.013861 0.707039 0.707039
+    outer loop
+      vertex 0 36.4 58.2
+      vertex -1.39765 35.5726 59
+      vertex 0 35.6 59
+    endloop
+  endfacet
+  facet normal 0.151561 0.690741 0.707041
+    outer loop
+      vertex 8.49741 35.3943 58.2
+      vertex 6.94522 34.916 59
+      vertex 8.31065 34.6164 59
+    endloop
+  endfacet
+  facet normal 0.623682 0.333339 0.70704
+    outer loop
+      vertex 31.7589 17.7858 58.2
+      vertex 31.0609 17.3949 59
+      vertex 32.4326 16.5253 58.2
+    endloop
+  endfacet
+  facet normal 0.563844 0.426841 0.707027
+    outer loop
+      vertex 28.5855 22.535 58.2
+      vertex 27.9573 22.0397 59
+      vertex 29.4482 21.3954 58.2
+    endloop
+  endfacet
+  facet normal 0.546679 0.448614 0.707028
+    outer loop
+      vertex 28.5855 22.535 58.2
+      vertex 27.6788 23.6399 58.2
+      vertex 27.9573 22.0397 59
+    endloop
+  endfacet
+  facet normal 0.684243 0.178569 0.707054
+    outer loop
+      vertex 35.0334 9.88043 58.2
+      vertex 34.2634 9.66328 59
+      vertex 34.6164 8.31065 59
+    endloop
+  endfacet
+  facet normal 0.63629 -0.308621 0.707027
+    outer loop
+      vertex 33.0564 -15.2392 58.2
+      vertex 32.3299 -14.9043 59
+      vertex 32.4326 -16.5253 58.2
+    endloop
+  endfacet
+  facet normal -0.0693532 -0.703746 0.707059
+    outer loop
+      vertex -4.18433 -35.3532 59
+      vertex -4.27836 -36.1477 58.2
+      vertex -2.79314 -35.4903 59
+    endloop
+  endfacet
+  facet normal 0.528619 0.46979 0.707008
+    outer loop
+      vertex 26.7293 24.7083 58.2
+      vertex 26.1419 24.1653 59
+      vertex 27.6788 23.6399 58.2
+    endloop
+  endfacet
+  facet normal -0.46979 0.528619 0.707008
+    outer loop
+      vertex -23.6399 27.6788 58.2
+      vertex -24.7083 26.7293 58.2
+      vertex -24.1653 26.1419 59
+    endloop
+  endfacet
+  facet normal -0.676711 0.205274 0.707054
+    outer loop
+      vertex -34.6185 11.2482 58.2
+      vertex -35.0334 9.88043 58.2
+      vertex -34.2634 9.66328 59
+    endloop
+  endfacet
+  facet normal 0.595594 0.381231 0.707058
+    outer loop
+      vertex 30.2655 20.2228 58.2
+      vertex 29.6003 19.7783 59
+      vertex 31.0361 19.0189 58.2
+    endloop
+  endfacet
+  facet normal -0.647904 -0.283382 0.707047
+    outer loop
+      vertex -32.8901 -13.6235 59
+      vertex -33.6292 -13.9297 58.2
+      vertex -32.3299 -14.9043 59
+    endloop
+  endfacet
+  facet normal -0.658509 -0.257748 0.707059
+    outer loop
+      vertex -33.3996 -12.3218 59
+      vertex -34.1502 -12.5987 58.2
+      vertex -32.8901 -13.6235 59
+    endloop
+  endfacet
+  facet normal -0.707039 0.013861 0.707039
+    outer loop
+      vertex -35.5726 1.39765 59
+      vertex -36.4 0 58.2
+      vertex -35.6 0 59
+    endloop
+  endfacet
+  facet normal 0.528619 -0.469737 0.707043
+    outer loop
+      vertex 27.0705 -23.1203 59
+      vertex 26.1419 -24.1653 59
+      vertex 27.6788 -23.6399 58.2
+    endloop
+  endfacet
+  facet normal -0.509759 -0.490132 0.707048
+    outer loop
+      vertex -25.173 -25.173 59
+      vertex -26.1419 -24.1653 59
+      vertex -25.7387 -25.7387 58.2
+    endloop
+  endfacet
+  facet normal 0.623682 -0.333339 0.70704
+    outer loop
+      vertex 32.4326 -16.5253 58.2
+      vertex 31.0609 -17.3949 59
+      vertex 31.7589 -17.7858 58.2
+    endloop
+  endfacet
+  facet normal -0.700488 0.0968727 0.707059
+    outer loop
+      vertex -35.1617 5.56907 59
+      vertex -36.1477 4.27836 58.2
+      vertex -35.3532 4.18433 59
+    endloop
+  endfacet
+  facet normal 0.124334 0.696172 0.707026
+    outer loop
+      vertex 7.10129 35.7006 58.2
+      vertex 5.69421 35.9519 58.2
+      vertex 6.94522 34.916 59
+    endloop
+  endfacet
+  facet normal -0.490127 -0.509819 0.707008
+    outer loop
+      vertex -24.1653 -26.1419 59
+      vertex -25.7387 -25.7387 58.2
+      vertex -24.7083 -26.7293 58.2
+    endloop
+  endfacet
+  facet normal -0.684243 -0.178569 0.707054
+    outer loop
+      vertex -34.6164 -8.31065 59
+      vertex -35.0334 -9.88043 58.2
+      vertex -34.2634 -9.66328 59
+    endloop
+  endfacet
+  facet normal -0.580188 -0.404346 0.707026
+    outer loop
+      vertex -28.801 -20.9252 59
+      vertex -29.6003 -19.7783 59
+      vertex -29.4482 -21.3954 58.2
+    endloop
+  endfacet
+  facet normal 0.35761 0.610096 0.707034
+    outer loop
+      vertex 19.0189 31.0361 58.2
+      vertex 17.3949 31.0609 59
+      vertex 18.6009 30.354 59
+    endloop
+  endfacet
+  facet normal 0.381266 0.595599 0.707034
+    outer loop
+      vertex 19.0189 31.0361 58.2
+      vertex 18.6009 30.354 59
+      vertex 19.7783 29.6003 59
+    endloop
+  endfacet
+  facet normal 0.46979 0.528619 0.707008
+    outer loop
+      vertex 24.7083 26.7293 58.2
+      vertex 23.6399 27.6788 58.2
+      vertex 24.1653 26.1419 59
+    endloop
+  endfacet
+  facet normal -0.205279 -0.676703 0.70706
+    outer loop
+      vertex -11.001 -33.8576 59
+      vertex -11.2482 -34.6185 58.2
+      vertex -9.66328 -34.2634 59
+    endloop
+  endfacet
+  facet normal 0.426841 0.563844 0.707027
+    outer loop
+      vertex 22.535 28.5855 58.2
+      vertex 21.3954 29.4482 58.2
+      vertex 22.0397 27.9573 59
+    endloop
+  endfacet
+  facet normal 0.448617 0.546658 0.707042
+    outer loop
+      vertex 23.6399 27.6788 58.2
+      vertex 22.0397 27.9573 59
+      vertex 23.1203 27.0705 59
+    endloop
+  endfacet
+  facet normal 0.381231 0.595594 0.707058
+    outer loop
+      vertex 20.2228 30.2655 58.2
+      vertex 19.0189 31.0361 58.2
+      vertex 19.7783 29.6003 59
+    endloop
+  endfacet
+  facet normal -0.178569 0.684243 0.707054
+    outer loop
+      vertex -8.31065 34.6164 59
+      vertex -9.88043 35.0334 58.2
+      vertex -9.66328 34.2634 59
+    endloop
+  endfacet
+  facet normal -0.610096 0.35761 0.707034
+    outer loop
+      vertex -31.0361 19.0189 58.2
+      vertex -31.0609 17.3949 59
+      vertex -30.354 18.6009 59
+    endloop
+  endfacet
+  facet normal -0.700487 0.0968714 0.70706
+    outer loop
+      vertex -35.9519 5.69421 58.2
+      vertex -36.1477 4.27836 58.2
+      vertex -35.1617 5.56907 59
+    endloop
+  endfacet
+  facet normal -0.308621 -0.63629 0.707027
+    outer loop
+      vertex -14.9043 -32.3299 59
+      vertex -16.5253 -32.4326 58.2
+      vertex -15.2392 -33.0564 58.2
+    endloop
+  endfacet
+  facet normal -0.563844 0.426841 0.707027
+    outer loop
+      vertex -28.5855 22.535 58.2
+      vertex -29.4482 21.3954 58.2
+      vertex -27.9573 22.0397 59
+    endloop
+  endfacet
+  facet normal -0.668126 0.23168 0.707059
+    outer loop
+      vertex -34.1502 12.5987 58.2
+      vertex -34.6185 11.2482 58.2
+      vertex -33.3996 12.3218 59
+    endloop
+  endfacet
+  facet normal -0.684243 0.178569 0.707054
+    outer loop
+      vertex -34.2634 9.66328 59
+      vertex -35.0334 9.88043 58.2
+      vertex -34.6164 8.31065 59
+    endloop
+  endfacet
+  facet normal -0.707075 0.0139034 0.707002
+    outer loop
+      vertex -36.3719 1.42906 58.2
+      vertex -36.4 0 58.2
+      vertex -35.5726 1.39765 59
+    endloop
+  endfacet
+  facet normal 0.647904 -0.283382 0.707047
+    outer loop
+      vertex 32.8901 -13.6235 59
+      vertex 32.3299 -14.9043 59
+      vertex 33.6292 -13.9297 58.2
+    endloop
+  endfacet
+  facet normal -0.580141 0.404357 0.707058
+    outer loop
+      vertex -29.4482 21.3954 58.2
+      vertex -30.2655 20.2228 58.2
+      vertex -29.6003 19.7783 59
+    endloop
+  endfacet
+  facet normal 0.610088 0.357612 0.70704
+    outer loop
+      vertex 31.7589 17.7858 58.2
+      vertex 31.0361 19.0189 58.2
+      vertex 31.0609 17.3949 59
+    endloop
+  endfacet
+  facet normal -0.404357 -0.580141 0.707058
+    outer loop
+      vertex -19.7783 -29.6003 59
+      vertex -21.3954 -29.4482 58.2
+      vertex -20.2228 -30.2655 58.2
+    endloop
+  endfacet
+  facet normal -0.690741 0.151561 0.707041
+    outer loop
+      vertex -34.6164 8.31065 59
+      vertex -35.3943 8.49741 58.2
+      vertex -34.916 6.94522 59
+    endloop
+  endfacet
+  facet normal -0.448614 -0.546679 0.707028
+    outer loop
+      vertex -22.0397 -27.9573 59
+      vertex -23.6399 -27.6788 58.2
+      vertex -22.535 -28.5855 58.2
+    endloop
+  endfacet
+  facet normal -0.381266 0.595599 0.707034
+    outer loop
+      vertex -19.0189 31.0361 58.2
+      vertex -19.7783 29.6003 59
+      vertex -18.6009 30.354 59
+    endloop
+  endfacet
+  facet normal -0.308627 0.636275 0.707038
+    outer loop
+      vertex -14.9043 32.3299 59
+      vertex -16.5253 32.4326 58.2
+      vertex -16.1621 31.7198 59
+    endloop
+  endfacet
+  facet normal 0.283382 0.647904 0.707047
+    outer loop
+      vertex 13.9297 33.6292 58.2
+      vertex 13.6235 32.8901 59
+      vertex 14.9043 32.3299 59
+    endloop
+  endfacet
+  facet normal -0.623682 -0.333342 0.707038
+    outer loop
+      vertex -31.7198 -16.1621 59
+      vertex -32.4326 -16.5253 58.2
+      vertex -31.0609 -17.3949 59
+    endloop
+  endfacet
+  facet normal -0.426841 0.563844 0.707027
+    outer loop
+      vertex -21.3954 29.4482 58.2
+      vertex -22.535 28.5855 58.2
+      vertex -22.0397 27.9573 59
+    endloop
+  endfacet
+  facet normal 0.308621 0.63629 0.707027
+    outer loop
+      vertex 15.2392 33.0564 58.2
+      vertex 14.9043 32.3299 59
+      vertex 16.5253 32.4326 58.2
+    endloop
+  endfacet
+  facet normal -0.283382 -0.647904 0.707047
+    outer loop
+      vertex -13.6235 -32.8901 59
+      vertex -14.9043 -32.3299 59
+      vertex -13.9297 -33.6292 58.2
+    endloop
+  endfacet
+  facet normal 0.563844 -0.426842 0.707026
+    outer loop
+      vertex 28.801 -20.9252 59
+      vertex 27.9573 -22.0397 59
+      vertex 29.4482 -21.3954 58.2
+    endloop
+  endfacet
+  facet normal -0.647913 0.283409 0.707028
+    outer loop
+      vertex -33.0564 15.2392 58.2
+      vertex -33.6292 13.9297 58.2
+      vertex -32.3299 14.9043 59
+    endloop
+  endfacet
+  facet normal -0.469737 0.528619 0.707043
+    outer loop
+      vertex -23.6399 27.6788 58.2
+      vertex -24.1653 26.1419 59
+      vertex -23.1203 27.0705 59
+    endloop
+  endfacet
+  facet normal -0.690741 -0.151561 0.707041
+    outer loop
+      vertex -34.916 -6.94522 59
+      vertex -35.3943 -8.49741 58.2
+      vertex -34.6164 -8.31065 59
+    endloop
+  endfacet
+  facet normal -0.684259 -0.178558 0.707041
+    outer loop
+      vertex -34.6164 -8.31065 59
+      vertex -35.3943 -8.49741 58.2
+      vertex -35.0334 -9.88043 58.2
+    endloop
+  endfacet
+  facet normal 0.690758 -0.151548 0.707026
+    outer loop
+      vertex 35.7006 -7.10129 58.2
+      vertex 34.916 -6.94522 59
+      vertex 35.3943 -8.49741 58.2
+    endloop
+  endfacet
+  facet normal 0.469737 -0.528619 0.707043
+    outer loop
+      vertex 24.1653 -26.1419 59
+      vertex 23.1203 -27.0705 59
+      vertex 23.6399 -27.6788 58.2
+    endloop
+  endfacet
+  facet normal -0.636275 0.308627 0.707038
+    outer loop
+      vertex -31.7198 16.1621 59
+      vertex -32.4326 16.5253 58.2
+      vertex -32.3299 14.9043 59
+    endloop
+  endfacet
+  facet normal 0.696145 -0.124291 0.70706
+    outer loop
+      vertex 35.1617 -5.56907 59
+      vertex 34.916 -6.94522 59
+      vertex 35.9519 -5.69421 58.2
+    endloop
+  endfacet
+  facet normal -0.690758 0.151548 0.707026
+    outer loop
+      vertex -35.3943 8.49741 58.2
+      vertex -35.7006 7.10129 58.2
+      vertex -34.916 6.94522 59
+    endloop
+  endfacet
+  facet normal 0.696172 -0.124334 0.707026
+    outer loop
+      vertex 35.9519 -5.69421 58.2
+      vertex 34.916 -6.94522 59
+      vertex 35.7006 -7.10129 58.2
+    endloop
+  endfacet
+  facet normal -0.333339 -0.623682 0.70704
+    outer loop
+      vertex -17.3949 -31.0609 59
+      vertex -17.7858 -31.7589 58.2
+      vertex -16.5253 -32.4326 58.2
+    endloop
+  endfacet
+  facet normal -0.0968714 -0.700487 0.70706
+    outer loop
+      vertex -5.56907 -35.1617 59
+      vertex -5.69421 -35.9519 58.2
+      vertex -4.27836 -36.1477 58.2
+    endloop
+  endfacet
+  facet normal -0.257748 -0.658509 0.707059
+    outer loop
+      vertex -12.3218 -33.3996 59
+      vertex -13.6235 -32.8901 59
+      vertex -12.5987 -34.1502 58.2
+    endloop
+  endfacet
+  facet normal -0.257766 -0.658516 0.707046
+    outer loop
+      vertex -13.6235 -32.8901 59
+      vertex -13.9297 -33.6292 58.2
+      vertex -12.5987 -34.1502 58.2
+    endloop
+  endfacet
+  facet normal 0.469737 0.528619 0.707043
+    outer loop
+      vertex 23.6399 27.6788 58.2
+      vertex 23.1203 27.0705 59
+      vertex 24.1653 26.1419 59
+    endloop
+  endfacet
+  facet normal 0.623682 -0.333342 0.707038
+    outer loop
+      vertex 31.7198 -16.1621 59
+      vertex 31.0609 -17.3949 59
+      vertex 32.4326 -16.5253 58.2
+    endloop
+  endfacet
+  facet normal -0.668125 -0.231679 0.70706
+    outer loop
+      vertex -33.8576 -11.001 59
+      vertex -34.6185 -11.2482 58.2
+      vertex -33.3996 -12.3218 59
+    endloop
+  endfacet
+  facet normal -0.703784 0.0693172 0.707024
+    outer loop
+      vertex -36.1477 4.27836 58.2
+      vertex -36.2878 2.85591 58.2
+      vertex -35.4903 2.79314 59
+    endloop
+  endfacet
+  facet normal 0.448614 -0.546679 0.707028
+    outer loop
+      vertex 23.6399 -27.6788 58.2
+      vertex 22.0397 -27.9573 59
+      vertex 22.535 -28.5855 58.2
+    endloop
+  endfacet
+  facet normal 0.257766 -0.658516 0.707046
+    outer loop
+      vertex 13.6235 -32.8901 59
+      vertex 12.5987 -34.1502 58.2
+      vertex 13.9297 -33.6292 58.2
+    endloop
+  endfacet
+  facet normal -0.178558 -0.684259 0.707041
+    outer loop
+      vertex -8.31065 -34.6164 59
+      vertex -9.88043 -35.0334 58.2
+      vertex -8.49741 -35.3943 58.2
+    endloop
+  endfacet
+  facet normal 0.231679 -0.668125 0.70706
+    outer loop
+      vertex 12.3218 -33.3996 59
+      vertex 11.001 -33.8576 59
+      vertex 11.2482 -34.6185 58.2
+    endloop
+  endfacet
+  facet normal 0.124334 -0.696172 0.707026
+    outer loop
+      vertex 6.94522 -34.916 59
+      vertex 5.69421 -35.9519 58.2
+      vertex 7.10129 -35.7006 58.2
+    endloop
+  endfacet
+  facet normal -0.357612 0.610088 0.70704
+    outer loop
+      vertex -17.7858 31.7589 58.2
+      vertex -19.0189 31.0361 58.2
+      vertex -17.3949 31.0609 59
+    endloop
+  endfacet
+  facet normal -0.178558 0.684259 0.707041
+    outer loop
+      vertex -8.49741 35.3943 58.2
+      vertex -9.88043 35.0334 58.2
+      vertex -8.31065 34.6164 59
+    endloop
+  endfacet
+  facet normal 0.308621 -0.63629 0.707027
+    outer loop
+      vertex 16.5253 -32.4326 58.2
+      vertex 14.9043 -32.3299 59
+      vertex 15.2392 -33.0564 58.2
+    endloop
+  endfacet
+  facet normal 0.357612 -0.610088 0.70704
+    outer loop
+      vertex 19.0189 -31.0361 58.2
+      vertex 17.3949 -31.0609 59
+      vertex 17.7858 -31.7589 58.2
+    endloop
+  endfacet
+  facet normal -0.46979 -0.528619 0.707008
+    outer loop
+      vertex -24.1653 -26.1419 59
+      vertex -24.7083 -26.7293 58.2
+      vertex -23.6399 -27.6788 58.2
+    endloop
+  endfacet
+  facet normal -0.563844 -0.426842 0.707026
+    outer loop
+      vertex -28.801 -20.9252 59
+      vertex -29.4482 -21.3954 58.2
+      vertex -27.9573 -22.0397 59
+    endloop
+  endfacet
+  facet normal 0.257748 -0.658509 0.707059
+    outer loop
+      vertex 13.6235 -32.8901 59
+      vertex 12.3218 -33.3996 59
+      vertex 12.5987 -34.1502 58.2
+    endloop
+  endfacet
+  facet normal 0.23168 -0.668126 0.707059
+    outer loop
+      vertex 12.3218 -33.3996 59
+      vertex 11.2482 -34.6185 58.2
+      vertex 12.5987 -34.1502 58.2
+    endloop
+  endfacet
+  facet normal 0.684259 -0.178558 0.707041
+    outer loop
+      vertex 35.3943 -8.49741 58.2
+      vertex 34.6164 -8.31065 59
+      vertex 35.0334 -9.88043 58.2
+    endloop
+  endfacet
+  facet normal -0.63629 0.308621 0.707027
+    outer loop
+      vertex -32.4326 16.5253 58.2
+      vertex -33.0564 15.2392 58.2
+      vertex -32.3299 14.9043 59
+    endloop
+  endfacet
+  facet normal -0.528619 0.469737 0.707043
+    outer loop
+      vertex -26.1419 24.1653 59
+      vertex -27.6788 23.6399 58.2
+      vertex -27.0705 23.1203 59
+    endloop
+  endfacet
+  facet normal 0.676703 -0.205279 0.70706
+    outer loop
+      vertex 34.2634 -9.66328 59
+      vertex 33.8576 -11.001 59
+      vertex 34.6185 -11.2482 58.2
+    endloop
+  endfacet
+  facet normal -0.124334 0.696172 0.707026
+    outer loop
+      vertex -5.69421 35.9519 58.2
+      vertex -7.10129 35.7006 58.2
+      vertex -6.94522 34.916 59
+    endloop
+  endfacet
+  facet normal -0.509759 0.490132 0.707048
+    outer loop
+      vertex -25.7387 25.7387 58.2
+      vertex -26.1419 24.1653 59
+      vertex -25.173 25.173 59
+    endloop
+  endfacet
+  facet normal -0.381231 -0.595594 0.707058
+    outer loop
+      vertex -19.7783 -29.6003 59
+      vertex -20.2228 -30.2655 58.2
+      vertex -19.0189 -31.0361 58.2
+    endloop
+  endfacet
+  facet normal 0.509819 0.490127 0.707008
+    outer loop
+      vertex 26.7293 24.7083 58.2
+      vertex 25.7387 25.7387 58.2
+      vertex 26.1419 24.1653 59
+    endloop
+  endfacet
+  facet normal 0.528619 0.469737 0.707043
+    outer loop
+      vertex 27.6788 23.6399 58.2
+      vertex 26.1419 24.1653 59
+      vertex 27.0705 23.1203 59
+    endloop
+  endfacet
+  facet normal 0.013861 0.707039 0.707039
+    outer loop
+      vertex 0 36.4 58.2
+      vertex 0 35.6 59
+      vertex 1.39765 35.5726 59
+    endloop
+  endfacet
+  facet normal -0.151561 -0.690741 0.707041
+    outer loop
+      vertex -8.31065 -34.6164 59
+      vertex -8.49741 -35.3943 58.2
+      vertex -6.94522 -34.916 59
+    endloop
+  endfacet
+  facet normal -0.178569 -0.684243 0.707054
+    outer loop
+      vertex -9.66328 -34.2634 59
+      vertex -9.88043 -35.0334 58.2
+      vertex -8.31065 -34.6164 59
+    endloop
+  endfacet
+  facet normal 0.308627 0.636275 0.707038
+    outer loop
+      vertex 16.5253 32.4326 58.2
+      vertex 14.9043 32.3299 59
+      vertex 16.1621 31.7198 59
+    endloop
+  endfacet
+  facet normal 0.0139034 0.707075 0.707002
+    outer loop
+      vertex 1.42906 36.3719 58.2
+      vertex 0 36.4 58.2
+      vertex 1.39765 35.5726 59
+    endloop
+  endfacet
+  facet normal -0.0968727 -0.700488 0.707059
+    outer loop
+      vertex -4.18433 -35.3532 59
+      vertex -5.56907 -35.1617 59
+      vertex -4.27836 -36.1477 58.2
+    endloop
+  endfacet
+  facet normal -0.610088 -0.357612 0.70704
+    outer loop
+      vertex -31.0609 -17.3949 59
+      vertex -31.7589 -17.7858 58.2
+      vertex -31.0361 -19.0189 58.2
+    endloop
+  endfacet
+  facet normal -0.0416115 -0.705986 0.707002
+    outer loop
+      vertex -1.39765 -35.5726 59
+      vertex -2.85591 -36.2878 58.2
+      vertex -1.42906 -36.3719 58.2
+    endloop
+  endfacet
+  facet normal -0.696145 0.124291 0.70706
+    outer loop
+      vertex -34.916 6.94522 59
+      vertex -35.9519 5.69421 58.2
+      vertex -35.1617 5.56907 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.85 0 59
+      vertex 35.6 0 59
+      vertex 35.5726 1.39765 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.8285 1.09339 59
+      vertex 35.5726 1.39765 59
+      vertex 35.4903 2.79314 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.6 0 59
+      vertex 27.85 0 59
+      vertex 35.5726 -1.39765 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.7641 2.18509 59
+      vertex 35.4903 2.79314 59
+      vertex 35.3532 4.18433 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.8285 -1.09339 59
+      vertex 35.5726 -1.39765 59
+      vertex 27.85 0 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.657 3.27342 59
+      vertex 35.3532 4.18433 59
+      vertex 35.1617 5.56907 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.5726 -1.39765 59
+      vertex 27.8285 -1.09339 59
+      vertex 35.4903 -2.79314 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.5071 4.3567 59
+      vertex 35.1617 5.56907 59
+      vertex 34.916 6.94522 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.7641 -2.18509 59
+      vertex 35.4903 -2.79314 59
+      vertex 27.8285 -1.09339 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.3149 5.43326 59
+      vertex 34.916 6.94522 59
+      vertex 34.6164 8.31065 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.4903 -2.79314 59
+      vertex 27.7641 -2.18509 59
+      vertex 35.3532 -4.18433 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.0805 6.50145 59
+      vertex 34.6164 8.31065 59
+      vertex 34.2634 9.66328 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.657 -3.27342 59
+      vertex 35.3532 -4.18433 59
+      vertex 27.7641 -2.18509 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.8044 7.55962 59
+      vertex 34.2634 9.66328 59
+      vertex 33.8576 11.001 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.3532 -4.18433 59
+      vertex 27.657 -3.27342 59
+      vertex 35.1617 -5.56907 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.4869 8.60612 59
+      vertex 33.8576 11.001 59
+      vertex 33.3996 12.3218 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.5071 -4.3567 59
+      vertex 35.1617 -5.56907 59
+      vertex 27.657 -3.27342 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.1286 9.63936 59
+      vertex 33.3996 12.3218 59
+      vertex 32.8901 13.6235 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.1617 -5.56907 59
+      vertex 27.5071 -4.3567 59
+      vertex 34.916 -6.94522 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.73 10.6577 59
+      vertex 32.8901 13.6235 59
+      vertex 32.3299 14.9043 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.3149 -5.43326 59
+      vertex 34.916 -6.94522 59
+      vertex 27.5071 -4.3567 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.2918 11.6597 59
+      vertex 32.3299 14.9043 59
+      vertex 31.7198 16.1621 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.916 -6.94522 59
+      vertex 27.3149 -5.43326 59
+      vertex 34.6164 -8.31065 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8145 12.6436 59
+      vertex 31.7198 16.1621 59
+      vertex 31.0609 17.3949 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.0805 -6.50145 59
+      vertex 34.6164 -8.31065 59
+      vertex 27.3149 -5.43326 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.299 13.6081 59
+      vertex 31.0609 17.3949 59
+      vertex 30.354 18.6009 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.6164 -8.31065 59
+      vertex 27.0805 -6.50145 59
+      vertex 34.2634 -9.66328 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.746 14.5516 59
+      vertex 30.354 18.6009 59
+      vertex 29.6003 19.7783 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.8044 -7.55962 59
+      vertex 34.2634 -9.66328 59
+      vertex 27.0805 -6.50145 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.1564 15.4726 59
+      vertex 29.6003 19.7783 59
+      vertex 28.801 20.9252 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.2634 -9.66328 59
+      vertex 26.8044 -7.55962 59
+      vertex 33.8576 -11.001 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.5311 16.3698 59
+      vertex 28.801 20.9252 59
+      vertex 27.9573 22.0397 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.4869 -8.60612 59
+      vertex 33.8576 -11.001 59
+      vertex 26.8044 -7.55962 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.8576 -11.001 59
+      vertex 26.4869 -8.60612 59
+      vertex 33.3996 -12.3218 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.5726 1.39765 59
+      vertex 27.8285 1.09339 59
+      vertex 27.85 0 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.4903 2.79314 59
+      vertex 27.7641 2.18509 59
+      vertex 27.8285 1.09339 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.3532 4.18433 59
+      vertex 27.657 3.27342 59
+      vertex 27.7641 2.18509 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.1617 5.56907 59
+      vertex 27.5071 4.3567 59
+      vertex 27.657 3.27342 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.916 6.94522 59
+      vertex 27.3149 5.43326 59
+      vertex 27.5071 4.3567 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.6164 8.31065 59
+      vertex 27.0805 6.50145 59
+      vertex 27.3149 5.43326 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.8711 17.2418 59
+      vertex 27.9573 22.0397 59
+      vertex 27.0705 23.1203 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.2634 9.66328 59
+      vertex 26.8044 7.55962 59
+      vertex 27.0805 6.50145 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.8576 11.001 59
+      vertex 26.4869 8.60612 59
+      vertex 26.8044 7.55962 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.1773 18.0871 59
+      vertex 27.0705 23.1203 59
+      vertex 26.1419 24.1653 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.3996 12.3218 59
+      vertex 26.1286 9.63936 59
+      vertex 26.4869 8.60612 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 32.8901 13.6235 59
+      vertex 25.73 10.6577 59
+      vertex 26.1286 9.63936 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 32.3299 14.9043 59
+      vertex 25.2918 11.6597 59
+      vertex 25.73 10.6577 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.4509 18.9046 59
+      vertex 26.1419 24.1653 59
+      vertex 25.173 25.173 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.7198 16.1621 59
+      vertex 24.8145 12.6436 59
+      vertex 25.2918 11.6597 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.0609 17.3949 59
+      vertex 24.299 13.6081 59
+      vertex 24.8145 12.6436 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.6929 19.6929 59
+      vertex 25.173 25.173 59
+      vertex 24.1653 26.1419 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.354 18.6009 59
+      vertex 23.746 14.5516 59
+      vertex 24.299 13.6081 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.6003 19.7783 59
+      vertex 23.1564 15.4726 59
+      vertex 23.746 14.5516 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.9046 20.4509 59
+      vertex 24.1653 26.1419 59
+      vertex 23.1203 27.0705 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.801 20.9252 59
+      vertex 22.5311 16.3698 59
+      vertex 23.1564 15.4726 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0871 21.1773 59
+      vertex 23.1203 27.0705 59
+      vertex 22.0397 27.9573 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.9573 22.0397 59
+      vertex 21.8711 17.2418 59
+      vertex 22.5311 16.3698 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.0705 23.1203 59
+      vertex 21.1773 18.0871 59
+      vertex 21.8711 17.2418 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.2418 21.8711 59
+      vertex 22.0397 27.9573 59
+      vertex 20.9252 28.801 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.1419 24.1653 59
+      vertex 20.4509 18.9046 59
+      vertex 21.1773 18.0871 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.3698 22.5311 59
+      vertex 20.9252 28.801 59
+      vertex 19.7783 29.6003 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.173 25.173 59
+      vertex 19.6929 19.6929 59
+      vertex 20.4509 18.9046 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.1653 26.1419 59
+      vertex 18.9046 20.4509 59
+      vertex 19.6929 19.6929 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4726 23.1564 59
+      vertex 19.7783 29.6003 59
+      vertex 18.6009 30.354 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.1203 27.0705 59
+      vertex 18.0871 21.1773 59
+      vertex 18.9046 20.4509 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.5516 23.746 59
+      vertex 18.6009 30.354 59
+      vertex 17.3949 31.0609 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.0397 27.9573 59
+      vertex 17.2418 21.8711 59
+      vertex 18.0871 21.1773 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.9252 28.801 59
+      vertex 16.3698 22.5311 59
+      vertex 17.2418 21.8711 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6081 24.299 59
+      vertex 17.3949 31.0609 59
+      vertex 16.1621 31.7198 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.7783 29.6003 59
+      vertex 15.4726 23.1564 59
+      vertex 16.3698 22.5311 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.6436 24.8145 59
+      vertex 16.1621 31.7198 59
+      vertex 14.9043 32.3299 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.6009 30.354 59
+      vertex 14.5516 23.746 59
+      vertex 15.4726 23.1564 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.6597 25.2918 59
+      vertex 14.9043 32.3299 59
+      vertex 13.6235 32.8901 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.3949 31.0609 59
+      vertex 13.6081 24.299 59
+      vertex 14.5516 23.746 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.1621 31.7198 59
+      vertex 12.6436 24.8145 59
+      vertex 13.6081 24.299 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.6577 25.73 59
+      vertex 13.6235 32.8901 59
+      vertex 12.3218 33.3996 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.9043 32.3299 59
+      vertex 11.6597 25.2918 59
+      vertex 12.6436 24.8145 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.63936 26.1286 59
+      vertex 12.3218 33.3996 59
+      vertex 11.001 33.8576 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6235 32.8901 59
+      vertex 10.6577 25.73 59
+      vertex 11.6597 25.2918 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.60612 26.4869 59
+      vertex 11.001 33.8576 59
+      vertex 9.66328 34.2634 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3218 33.3996 59
+      vertex 9.63936 26.1286 59
+      vertex 10.6577 25.73 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.001 33.8576 59
+      vertex 8.60612 26.4869 59
+      vertex 9.63936 26.1286 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.55962 26.8044 59
+      vertex 9.66328 34.2634 59
+      vertex 8.31065 34.6164 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.66328 34.2634 59
+      vertex 7.55962 26.8044 59
+      vertex 8.60612 26.4869 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.50145 27.0805 59
+      vertex 8.31065 34.6164 59
+      vertex 6.94522 34.916 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.31065 34.6164 59
+      vertex 6.50145 27.0805 59
+      vertex 7.55962 26.8044 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.43326 27.3149 59
+      vertex 6.94522 34.916 59
+      vertex 5.56907 35.1617 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.94522 34.916 59
+      vertex 5.43326 27.3149 59
+      vertex 6.50145 27.0805 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.56907 35.1617 59
+      vertex 4.3567 27.5071 59
+      vertex 5.43326 27.3149 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.18433 35.3532 59
+      vertex 4.3567 27.5071 59
+      vertex 5.56907 35.1617 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.18433 35.3532 59
+      vertex 3.27342 27.657 59
+      vertex 4.3567 27.5071 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.79314 35.4903 59
+      vertex 3.27342 27.657 59
+      vertex 4.18433 35.3532 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.79314 35.4903 59
+      vertex 2.18509 27.7641 59
+      vertex 3.27342 27.657 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.39765 35.5726 59
+      vertex 2.18509 27.7641 59
+      vertex 2.79314 35.4903 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.39765 35.5726 59
+      vertex 1.09339 27.8285 59
+      vertex 2.18509 27.7641 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 35.6 59
+      vertex 1.09339 27.8285 59
+      vertex 1.39765 35.5726 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 35.6 59
+      vertex 0 27.85 59
+      vertex 1.09339 27.8285 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 35.6 59
+      vertex -1.09339 27.8285 59
+      vertex 0 27.85 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.39765 35.5726 59
+      vertex -1.09339 27.8285 59
+      vertex 0 35.6 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.39765 35.5726 59
+      vertex -2.18509 27.7641 59
+      vertex -1.09339 27.8285 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.79314 35.4903 59
+      vertex -2.18509 27.7641 59
+      vertex -1.39765 35.5726 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.79314 35.4903 59
+      vertex -3.27342 27.657 59
+      vertex -2.18509 27.7641 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -4.18433 35.3532 59
+      vertex -3.27342 27.657 59
+      vertex -2.79314 35.4903 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.18433 35.3532 59
+      vertex -4.3567 27.5071 59
+      vertex -3.27342 27.657 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.56907 35.1617 59
+      vertex -4.3567 27.5071 59
+      vertex -4.18433 35.3532 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.3567 27.5071 59
+      vertex -5.56907 35.1617 59
+      vertex -5.43326 27.3149 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -6.94522 34.916 59
+      vertex -5.43326 27.3149 59
+      vertex -5.56907 35.1617 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.43326 27.3149 59
+      vertex -6.94522 34.916 59
+      vertex -6.50145 27.0805 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -8.31065 34.6164 59
+      vertex -6.50145 27.0805 59
+      vertex -6.94522 34.916 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.50145 27.0805 59
+      vertex -8.31065 34.6164 59
+      vertex -7.55962 26.8044 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.66328 34.2634 59
+      vertex -7.55962 26.8044 59
+      vertex -8.31065 34.6164 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.55962 26.8044 59
+      vertex -9.66328 34.2634 59
+      vertex -8.60612 26.4869 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.001 33.8576 59
+      vertex -8.60612 26.4869 59
+      vertex -9.66328 34.2634 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.60612 26.4869 59
+      vertex -11.001 33.8576 59
+      vertex -9.63936 26.1286 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.3218 33.3996 59
+      vertex -9.63936 26.1286 59
+      vertex -11.001 33.8576 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.63936 26.1286 59
+      vertex -12.3218 33.3996 59
+      vertex -10.6577 25.73 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.6235 32.8901 59
+      vertex -10.6577 25.73 59
+      vertex -12.3218 33.3996 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.6577 25.73 59
+      vertex -13.6235 32.8901 59
+      vertex -11.6597 25.2918 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.9043 32.3299 59
+      vertex -11.6597 25.2918 59
+      vertex -13.6235 32.8901 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.6597 25.2918 59
+      vertex -14.9043 32.3299 59
+      vertex -12.6436 24.8145 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.1621 31.7198 59
+      vertex -12.6436 24.8145 59
+      vertex -14.9043 32.3299 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.6436 24.8145 59
+      vertex -16.1621 31.7198 59
+      vertex -13.6081 24.299 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.3949 31.0609 59
+      vertex -13.6081 24.299 59
+      vertex -16.1621 31.7198 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.6081 24.299 59
+      vertex -17.3949 31.0609 59
+      vertex -14.5516 23.746 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.6009 30.354 59
+      vertex -14.5516 23.746 59
+      vertex -17.3949 31.0609 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.5516 23.746 59
+      vertex -18.6009 30.354 59
+      vertex -15.4726 23.1564 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.7783 29.6003 59
+      vertex -15.4726 23.1564 59
+      vertex -18.6009 30.354 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.4726 23.1564 59
+      vertex -19.7783 29.6003 59
+      vertex -16.3698 22.5311 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.9252 28.801 59
+      vertex -16.3698 22.5311 59
+      vertex -19.7783 29.6003 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.3698 22.5311 59
+      vertex -20.9252 28.801 59
+      vertex -17.2418 21.8711 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.0397 27.9573 59
+      vertex -17.2418 21.8711 59
+      vertex -20.9252 28.801 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.2418 21.8711 59
+      vertex -22.0397 27.9573 59
+      vertex -18.0871 21.1773 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.1203 27.0705 59
+      vertex -18.0871 21.1773 59
+      vertex -22.0397 27.9573 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0871 21.1773 59
+      vertex -23.1203 27.0705 59
+      vertex -18.9046 20.4509 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.1653 26.1419 59
+      vertex -18.9046 20.4509 59
+      vertex -23.1203 27.0705 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9046 20.4509 59
+      vertex -24.1653 26.1419 59
+      vertex -19.6929 19.6929 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -25.173 25.173 59
+      vertex -19.6929 19.6929 59
+      vertex -24.1653 26.1419 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.6929 19.6929 59
+      vertex -25.173 25.173 59
+      vertex -20.4509 18.9046 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -26.1419 24.1653 59
+      vertex -20.4509 18.9046 59
+      vertex -25.173 25.173 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.4509 18.9046 59
+      vertex -26.1419 24.1653 59
+      vertex -21.1773 18.0871 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.0705 23.1203 59
+      vertex -21.1773 18.0871 59
+      vertex -26.1419 24.1653 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.1773 18.0871 59
+      vertex -27.0705 23.1203 59
+      vertex -21.8711 17.2418 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.9573 22.0397 59
+      vertex -21.8711 17.2418 59
+      vertex -27.0705 23.1203 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.8711 17.2418 59
+      vertex -27.9573 22.0397 59
+      vertex -22.5311 16.3698 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.801 20.9252 59
+      vertex -22.5311 16.3698 59
+      vertex -27.9573 22.0397 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5311 16.3698 59
+      vertex -28.801 20.9252 59
+      vertex -23.1564 15.4726 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -29.6003 19.7783 59
+      vertex -23.1564 15.4726 59
+      vertex -28.801 20.9252 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1564 15.4726 59
+      vertex -29.6003 19.7783 59
+      vertex -23.746 14.5516 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -30.354 18.6009 59
+      vertex -23.746 14.5516 59
+      vertex -29.6003 19.7783 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.746 14.5516 59
+      vertex -30.354 18.6009 59
+      vertex -24.299 13.6081 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.0609 17.3949 59
+      vertex -24.299 13.6081 59
+      vertex -30.354 18.6009 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.299 13.6081 59
+      vertex -31.0609 17.3949 59
+      vertex -24.8145 12.6436 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.7198 16.1621 59
+      vertex -24.8145 12.6436 59
+      vertex -31.0609 17.3949 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8145 12.6436 59
+      vertex -31.7198 16.1621 59
+      vertex -25.2918 11.6597 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -32.3299 14.9043 59
+      vertex -25.2918 11.6597 59
+      vertex -31.7198 16.1621 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.2918 11.6597 59
+      vertex -32.3299 14.9043 59
+      vertex -25.73 10.6577 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -32.8901 13.6235 59
+      vertex -25.73 10.6577 59
+      vertex -32.3299 14.9043 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.73 10.6577 59
+      vertex -32.8901 13.6235 59
+      vertex -26.1286 9.63936 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1286 9.63936 59
+      vertex -33.3996 12.3218 59
+      vertex -26.4869 8.60612 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -33.3996 12.3218 59
+      vertex -26.1286 9.63936 59
+      vertex -32.8901 13.6235 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.1286 -9.63936 59
+      vertex 33.3996 -12.3218 59
+      vertex 26.4869 -8.60612 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.3996 -12.3218 59
+      vertex 26.1286 -9.63936 59
+      vertex 32.8901 -13.6235 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.73 -10.6577 59
+      vertex 32.8901 -13.6235 59
+      vertex 26.1286 -9.63936 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 32.8901 -13.6235 59
+      vertex 25.73 -10.6577 59
+      vertex 32.3299 -14.9043 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.2918 -11.6597 59
+      vertex 32.3299 -14.9043 59
+      vertex 25.73 -10.6577 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 32.3299 -14.9043 59
+      vertex 25.2918 -11.6597 59
+      vertex 31.7198 -16.1621 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.8145 -12.6436 59
+      vertex 31.7198 -16.1621 59
+      vertex 25.2918 -11.6597 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.7198 -16.1621 59
+      vertex 24.8145 -12.6436 59
+      vertex 31.0609 -17.3949 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.299 -13.6081 59
+      vertex 31.0609 -17.3949 59
+      vertex 24.8145 -12.6436 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.0609 -17.3949 59
+      vertex 24.299 -13.6081 59
+      vertex 30.354 -18.6009 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.746 -14.5516 59
+      vertex 30.354 -18.6009 59
+      vertex 24.299 -13.6081 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.354 -18.6009 59
+      vertex 23.746 -14.5516 59
+      vertex 29.6003 -19.7783 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.1564 -15.4726 59
+      vertex 29.6003 -19.7783 59
+      vertex 23.746 -14.5516 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.6003 -19.7783 59
+      vertex 23.1564 -15.4726 59
+      vertex 28.801 -20.9252 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.5311 -16.3698 59
+      vertex 28.801 -20.9252 59
+      vertex 23.1564 -15.4726 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.801 -20.9252 59
+      vertex 22.5311 -16.3698 59
+      vertex 27.9573 -22.0397 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.8711 -17.2418 59
+      vertex 27.9573 -22.0397 59
+      vertex 22.5311 -16.3698 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.9573 -22.0397 59
+      vertex 21.8711 -17.2418 59
+      vertex 27.0705 -23.1203 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.1773 -18.0871 59
+      vertex 27.0705 -23.1203 59
+      vertex 21.8711 -17.2418 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.0705 -23.1203 59
+      vertex 21.1773 -18.0871 59
+      vertex 26.1419 -24.1653 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.4509 -18.9046 59
+      vertex 26.1419 -24.1653 59
+      vertex 21.1773 -18.0871 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.1419 -24.1653 59
+      vertex 20.4509 -18.9046 59
+      vertex 25.173 -25.173 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.6929 -19.6929 59
+      vertex 25.173 -25.173 59
+      vertex 20.4509 -18.9046 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.173 -25.173 59
+      vertex 19.6929 -19.6929 59
+      vertex 24.1653 -26.1419 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.9046 -20.4509 59
+      vertex 24.1653 -26.1419 59
+      vertex 19.6929 -19.6929 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.1653 -26.1419 59
+      vertex 18.9046 -20.4509 59
+      vertex 23.1203 -27.0705 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.0871 -21.1773 59
+      vertex 23.1203 -27.0705 59
+      vertex 18.9046 -20.4509 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.1203 -27.0705 59
+      vertex 18.0871 -21.1773 59
+      vertex 22.0397 -27.9573 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.2418 -21.8711 59
+      vertex 22.0397 -27.9573 59
+      vertex 18.0871 -21.1773 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.0397 -27.9573 59
+      vertex 17.2418 -21.8711 59
+      vertex 20.9252 -28.801 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.3698 -22.5311 59
+      vertex 20.9252 -28.801 59
+      vertex 17.2418 -21.8711 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.9252 -28.801 59
+      vertex 16.3698 -22.5311 59
+      vertex 19.7783 -29.6003 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.4726 -23.1564 59
+      vertex 19.7783 -29.6003 59
+      vertex 16.3698 -22.5311 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.7783 -29.6003 59
+      vertex 15.4726 -23.1564 59
+      vertex 18.6009 -30.354 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.5516 -23.746 59
+      vertex 18.6009 -30.354 59
+      vertex 15.4726 -23.1564 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.6009 -30.354 59
+      vertex 14.5516 -23.746 59
+      vertex 17.3949 -31.0609 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.6081 -24.299 59
+      vertex 17.3949 -31.0609 59
+      vertex 14.5516 -23.746 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.3949 -31.0609 59
+      vertex 13.6081 -24.299 59
+      vertex 16.1621 -31.7198 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.6436 -24.8145 59
+      vertex 16.1621 -31.7198 59
+      vertex 13.6081 -24.299 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.1621 -31.7198 59
+      vertex 12.6436 -24.8145 59
+      vertex 14.9043 -32.3299 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.6597 -25.2918 59
+      vertex 14.9043 -32.3299 59
+      vertex 12.6436 -24.8145 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.9043 -32.3299 59
+      vertex 11.6597 -25.2918 59
+      vertex 13.6235 -32.8901 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.6577 -25.73 59
+      vertex 13.6235 -32.8901 59
+      vertex 11.6597 -25.2918 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6235 -32.8901 59
+      vertex 10.6577 -25.73 59
+      vertex 12.3218 -33.3996 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.63936 -26.1286 59
+      vertex 12.3218 -33.3996 59
+      vertex 10.6577 -25.73 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3218 -33.3996 59
+      vertex 9.63936 -26.1286 59
+      vertex 11.001 -33.8576 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 8.60612 -26.4869 59
+      vertex 11.001 -33.8576 59
+      vertex 9.63936 -26.1286 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.001 -33.8576 59
+      vertex 8.60612 -26.4869 59
+      vertex 9.66328 -34.2634 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 7.55962 -26.8044 59
+      vertex 9.66328 -34.2634 59
+      vertex 8.60612 -26.4869 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.66328 -34.2634 59
+      vertex 7.55962 -26.8044 59
+      vertex 8.31065 -34.6164 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 6.50145 -27.0805 59
+      vertex 8.31065 -34.6164 59
+      vertex 7.55962 -26.8044 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.31065 -34.6164 59
+      vertex 6.50145 -27.0805 59
+      vertex 6.94522 -34.916 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.43326 -27.3149 59
+      vertex 6.94522 -34.916 59
+      vertex 6.50145 -27.0805 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.94522 -34.916 59
+      vertex 5.43326 -27.3149 59
+      vertex 5.56907 -35.1617 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.3567 -27.5071 59
+      vertex 5.56907 -35.1617 59
+      vertex 5.43326 -27.3149 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.3567 -27.5071 59
+      vertex 4.18433 -35.3532 59
+      vertex 5.56907 -35.1617 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.27342 -27.657 59
+      vertex 4.18433 -35.3532 59
+      vertex 4.3567 -27.5071 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.27342 -27.657 59
+      vertex 2.79314 -35.4903 59
+      vertex 4.18433 -35.3532 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.18509 -27.7641 59
+      vertex 2.79314 -35.4903 59
+      vertex 3.27342 -27.657 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.18509 -27.7641 59
+      vertex 1.39765 -35.5726 59
+      vertex 2.79314 -35.4903 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.09339 -27.8285 59
+      vertex 1.39765 -35.5726 59
+      vertex 2.18509 -27.7641 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 -27.85 59
+      vertex 1.39765 -35.5726 59
+      vertex 1.09339 -27.8285 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -27.85 59
+      vertex 0 -35.6 59
+      vertex 1.39765 -35.5726 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.09339 -27.8285 59
+      vertex 0 -35.6 59
+      vertex 0 -27.85 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.09339 -27.8285 59
+      vertex -1.39765 -35.5726 59
+      vertex 0 -35.6 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.18509 -27.7641 59
+      vertex -1.39765 -35.5726 59
+      vertex -1.09339 -27.8285 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.18509 -27.7641 59
+      vertex -2.79314 -35.4903 59
+      vertex -1.39765 -35.5726 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.27342 -27.657 59
+      vertex -2.79314 -35.4903 59
+      vertex -2.18509 -27.7641 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.27342 -27.657 59
+      vertex -4.18433 -35.3532 59
+      vertex -2.79314 -35.4903 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.3567 -27.5071 59
+      vertex -4.18433 -35.3532 59
+      vertex -3.27342 -27.657 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.56907 -35.1617 59
+      vertex -4.3567 -27.5071 59
+      vertex -5.43326 -27.3149 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.3567 -27.5071 59
+      vertex -5.56907 -35.1617 59
+      vertex -4.18433 -35.3532 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.94522 -34.916 59
+      vertex -5.43326 -27.3149 59
+      vertex -6.50145 -27.0805 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.43326 -27.3149 59
+      vertex -6.94522 -34.916 59
+      vertex -5.56907 -35.1617 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.31065 -34.6164 59
+      vertex -6.50145 -27.0805 59
+      vertex -7.55962 -26.8044 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.50145 -27.0805 59
+      vertex -8.31065 -34.6164 59
+      vertex -6.94522 -34.916 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.66328 -34.2634 59
+      vertex -7.55962 -26.8044 59
+      vertex -8.60612 -26.4869 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.001 -33.8576 59
+      vertex -8.60612 -26.4869 59
+      vertex -9.63936 -26.1286 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.55962 -26.8044 59
+      vertex -9.66328 -34.2634 59
+      vertex -8.31065 -34.6164 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.3218 -33.3996 59
+      vertex -9.63936 -26.1286 59
+      vertex -10.6577 -25.73 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.60612 -26.4869 59
+      vertex -11.001 -33.8576 59
+      vertex -9.66328 -34.2634 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.6235 -32.8901 59
+      vertex -10.6577 -25.73 59
+      vertex -11.6597 -25.2918 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.63936 -26.1286 59
+      vertex -12.3218 -33.3996 59
+      vertex -11.001 -33.8576 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.9043 -32.3299 59
+      vertex -11.6597 -25.2918 59
+      vertex -12.6436 -24.8145 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.1621 -31.7198 59
+      vertex -12.6436 -24.8145 59
+      vertex -13.6081 -24.299 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.6577 -25.73 59
+      vertex -13.6235 -32.8901 59
+      vertex -12.3218 -33.3996 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.3949 -31.0609 59
+      vertex -13.6081 -24.299 59
+      vertex -14.5516 -23.746 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.6597 -25.2918 59
+      vertex -14.9043 -32.3299 59
+      vertex -13.6235 -32.8901 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.6009 -30.354 59
+      vertex -14.5516 -23.746 59
+      vertex -15.4726 -23.1564 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.6436 -24.8145 59
+      vertex -16.1621 -31.7198 59
+      vertex -14.9043 -32.3299 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.7783 -29.6003 59
+      vertex -15.4726 -23.1564 59
+      vertex -16.3698 -22.5311 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.9252 -28.801 59
+      vertex -16.3698 -22.5311 59
+      vertex -17.2418 -21.8711 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.6081 -24.299 59
+      vertex -17.3949 -31.0609 59
+      vertex -16.1621 -31.7198 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.0397 -27.9573 59
+      vertex -17.2418 -21.8711 59
+      vertex -18.0871 -21.1773 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.5516 -23.746 59
+      vertex -18.6009 -30.354 59
+      vertex -17.3949 -31.0609 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1203 -27.0705 59
+      vertex -18.0871 -21.1773 59
+      vertex -18.9046 -20.4509 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.1653 -26.1419 59
+      vertex -18.9046 -20.4509 59
+      vertex -19.6929 -19.6929 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.4726 -23.1564 59
+      vertex -19.7783 -29.6003 59
+      vertex -18.6009 -30.354 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.173 -25.173 59
+      vertex -19.6929 -19.6929 59
+      vertex -20.4509 -18.9046 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.3698 -22.5311 59
+      vertex -20.9252 -28.801 59
+      vertex -19.7783 -29.6003 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1419 -24.1653 59
+      vertex -20.4509 -18.9046 59
+      vertex -21.1773 -18.0871 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0705 -23.1203 59
+      vertex -21.1773 -18.0871 59
+      vertex -21.8711 -17.2418 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.2418 -21.8711 59
+      vertex -22.0397 -27.9573 59
+      vertex -20.9252 -28.801 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.9573 -22.0397 59
+      vertex -21.8711 -17.2418 59
+      vertex -22.5311 -16.3698 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0871 -21.1773 59
+      vertex -23.1203 -27.0705 59
+      vertex -22.0397 -27.9573 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.801 -20.9252 59
+      vertex -22.5311 -16.3698 59
+      vertex -23.1564 -15.4726 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -29.6003 -19.7783 59
+      vertex -23.1564 -15.4726 59
+      vertex -23.746 -14.5516 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9046 -20.4509 59
+      vertex -24.1653 -26.1419 59
+      vertex -23.1203 -27.0705 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.354 -18.6009 59
+      vertex -23.746 -14.5516 59
+      vertex -24.299 -13.6081 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.0609 -17.3949 59
+      vertex -24.299 -13.6081 59
+      vertex -24.8145 -12.6436 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.6929 -19.6929 59
+      vertex -25.173 -25.173 59
+      vertex -24.1653 -26.1419 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.7198 -16.1621 59
+      vertex -24.8145 -12.6436 59
+      vertex -25.2918 -11.6597 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -32.3299 -14.9043 59
+      vertex -25.2918 -11.6597 59
+      vertex -25.73 -10.6577 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -32.8901 -13.6235 59
+      vertex -25.73 -10.6577 59
+      vertex -26.1286 -9.63936 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.4509 -18.9046 59
+      vertex -26.1419 -24.1653 59
+      vertex -25.173 -25.173 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.3996 -12.3218 59
+      vertex -26.1286 -9.63936 59
+      vertex -26.4869 -8.60612 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.8576 -11.001 59
+      vertex -26.4869 -8.60612 59
+      vertex -26.8044 -7.55962 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.1773 -18.0871 59
+      vertex -27.0705 -23.1203 59
+      vertex -26.1419 -24.1653 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.2634 -9.66328 59
+      vertex -26.8044 -7.55962 59
+      vertex -27.0805 -6.50145 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.6164 -8.31065 59
+      vertex -27.0805 -6.50145 59
+      vertex -27.3149 -5.43326 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.916 -6.94522 59
+      vertex -27.3149 -5.43326 59
+      vertex -27.5071 -4.3567 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.1617 -5.56907 59
+      vertex -27.5071 -4.3567 59
+      vertex -27.657 -3.27342 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.3532 -4.18433 59
+      vertex -27.657 -3.27342 59
+      vertex -27.7641 -2.18509 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.4903 -2.79314 59
+      vertex -27.7641 -2.18509 59
+      vertex -27.8285 -1.09339 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.8711 -17.2418 59
+      vertex -27.9573 -22.0397 59
+      vertex -27.0705 -23.1203 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.5726 -1.39765 59
+      vertex -27.8285 -1.09339 59
+      vertex -27.85 0 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -33.8576 11.001 59
+      vertex -26.4869 8.60612 59
+      vertex -33.3996 12.3218 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.4869 8.60612 59
+      vertex -33.8576 11.001 59
+      vertex -26.8044 7.55962 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5311 -16.3698 59
+      vertex -28.801 -20.9252 59
+      vertex -27.9573 -22.0397 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -34.2634 9.66328 59
+      vertex -26.8044 7.55962 59
+      vertex -33.8576 11.001 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1564 -15.4726 59
+      vertex -29.6003 -19.7783 59
+      vertex -28.801 -20.9252 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8044 7.55962 59
+      vertex -34.2634 9.66328 59
+      vertex -27.0805 6.50145 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.746 -14.5516 59
+      vertex -30.354 -18.6009 59
+      vertex -29.6003 -19.7783 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -34.6164 8.31065 59
+      vertex -27.0805 6.50145 59
+      vertex -34.2634 9.66328 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.299 -13.6081 59
+      vertex -31.0609 -17.3949 59
+      vertex -30.354 -18.6009 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0805 6.50145 59
+      vertex -34.6164 8.31065 59
+      vertex -27.3149 5.43326 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8145 -12.6436 59
+      vertex -31.7198 -16.1621 59
+      vertex -31.0609 -17.3949 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -34.916 6.94522 59
+      vertex -27.3149 5.43326 59
+      vertex -34.6164 8.31065 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.2918 -11.6597 59
+      vertex -32.3299 -14.9043 59
+      vertex -31.7198 -16.1621 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3149 5.43326 59
+      vertex -34.916 6.94522 59
+      vertex -27.5071 4.3567 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.73 -10.6577 59
+      vertex -32.8901 -13.6235 59
+      vertex -32.3299 -14.9043 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -35.1617 5.56907 59
+      vertex -27.5071 4.3567 59
+      vertex -34.916 6.94522 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1286 -9.63936 59
+      vertex -33.3996 -12.3218 59
+      vertex -32.8901 -13.6235 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.5071 4.3567 59
+      vertex -35.1617 5.56907 59
+      vertex -27.657 3.27342 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.4869 -8.60612 59
+      vertex -33.8576 -11.001 59
+      vertex -33.3996 -12.3218 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -35.3532 4.18433 59
+      vertex -27.657 3.27342 59
+      vertex -35.1617 5.56907 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8044 -7.55962 59
+      vertex -34.2634 -9.66328 59
+      vertex -33.8576 -11.001 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.657 3.27342 59
+      vertex -35.3532 4.18433 59
+      vertex -27.7641 2.18509 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0805 -6.50145 59
+      vertex -34.6164 -8.31065 59
+      vertex -34.2634 -9.66328 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -35.4903 2.79314 59
+      vertex -27.7641 2.18509 59
+      vertex -35.3532 4.18433 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3149 -5.43326 59
+      vertex -34.916 -6.94522 59
+      vertex -34.6164 -8.31065 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.7641 2.18509 59
+      vertex -35.4903 2.79314 59
+      vertex -27.8285 1.09339 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.5071 -4.3567 59
+      vertex -35.1617 -5.56907 59
+      vertex -34.916 -6.94522 59
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -35.5726 1.39765 59
+      vertex -27.8285 1.09339 59
+      vertex -35.4903 2.79314 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.657 -3.27342 59
+      vertex -35.3532 -4.18433 59
+      vertex -35.1617 -5.56907 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.8285 1.09339 59
+      vertex -35.5726 1.39765 59
+      vertex -27.85 0 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.7641 -2.18509 59
+      vertex -35.4903 -2.79314 59
+      vertex -35.3532 -4.18433 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.6 0 59
+      vertex -27.85 0 59
+      vertex -35.5726 1.39765 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.8285 -1.09339 59
+      vertex -35.5726 -1.39765 59
+      vertex -35.4903 -2.79314 59
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.85 0 59
+      vertex -35.6 0 59
+      vertex -35.5726 -1.39765 59
+    endloop
+  endfacet
+  facet normal 0.528619 -0.46979 0.707008
+    outer loop
+      vertex 27.6788 -23.6399 58.2
+      vertex 26.1419 -24.1653 59
+      vertex 26.7293 -24.7083 58.2
+    endloop
+  endfacet
+  facet normal -0.205279 0.676703 0.70706
+    outer loop
+      vertex -9.66328 34.2634 59
+      vertex -11.2482 34.6185 58.2
+      vertex -11.001 33.8576 59
+    endloop
+  endfacet
+  facet normal -0.595599 0.381266 0.707034
+    outer loop
+      vertex -29.6003 19.7783 59
+      vertex -31.0361 19.0189 58.2
+      vertex -30.354 18.6009 59
+    endloop
+  endfacet
+  facet normal -0.23168 0.668126 0.707059
+    outer loop
+      vertex -11.2482 34.6185 58.2
+      vertex -12.5987 34.1502 58.2
+      vertex -12.3218 33.3996 59
+    endloop
+  endfacet
+  facet normal -0.426842 -0.563844 0.707026
+    outer loop
+      vertex -20.9252 -28.801 59
+      vertex -22.0397 -27.9573 59
+      vertex -21.3954 -29.4482 58.2
+    endloop
+  endfacet
+  facet normal -0.676703 -0.205279 0.70706
+    outer loop
+      vertex -34.2634 -9.66328 59
+      vertex -34.6185 -11.2482 58.2
+      vertex -33.8576 -11.001 59
+    endloop
+  endfacet
+  facet normal -0.404346 -0.580188 0.707026
+    outer loop
+      vertex -20.9252 -28.801 59
+      vertex -21.3954 -29.4482 58.2
+      vertex -19.7783 -29.6003 59
+    endloop
+  endfacet
+  facet normal 0.0693172 0.703784 0.707024
+    outer loop
+      vertex 2.85591 36.2878 58.2
+      vertex 2.79314 35.4903 59
+      vertex 4.27836 36.1477 58.2
+    endloop
+  endfacet
+  facet normal -0.647904 0.283382 0.707047
+    outer loop
+      vertex -32.3299 14.9043 59
+      vertex -33.6292 13.9297 58.2
+      vertex -32.8901 13.6235 59
+    endloop
+  endfacet
+  facet normal -0.426841 -0.563844 0.707027
+    outer loop
+      vertex -22.0397 -27.9573 59
+      vertex -22.535 -28.5855 58.2
+      vertex -21.3954 -29.4482 58.2
+    endloop
+  endfacet
+  facet normal 0.283409 0.647913 0.707028
+    outer loop
+      vertex 15.2392 33.0564 58.2
+      vertex 13.9297 33.6292 58.2
+      vertex 14.9043 32.3299 59
+    endloop
+  endfacet
+  facet normal -0.448617 0.546658 0.707042
+    outer loop
+      vertex -22.0397 27.9573 59
+      vertex -23.6399 27.6788 58.2
+      vertex -23.1203 27.0705 59
+    endloop
+  endfacet
+  facet normal -0.333342 -0.623682 0.707038
+    outer loop
+      vertex -16.1621 -31.7198 59
+      vertex -17.3949 -31.0609 59
+      vertex -16.5253 -32.4326 58.2
+    endloop
+  endfacet
+  facet normal -0.563844 0.426842 0.707026
+    outer loop
+      vertex -27.9573 22.0397 59
+      vertex -29.4482 21.3954 58.2
+      vertex -28.801 20.9252 59
+    endloop
+  endfacet
+  facet normal 0.490132 0.509759 0.707048
+    outer loop
+      vertex 25.7387 25.7387 58.2
+      vertex 24.1653 26.1419 59
+      vertex 25.173 25.173 59
+    endloop
+  endfacet
+  facet normal 0.509819 -0.490127 0.707008
+    outer loop
+      vertex 26.1419 -24.1653 59
+      vertex 25.7387 -25.7387 58.2
+      vertex 26.7293 -24.7083 58.2
+    endloop
+  endfacet
+  facet normal -0.381266 -0.595599 0.707034
+    outer loop
+      vertex -18.6009 -30.354 59
+      vertex -19.7783 -29.6003 59
+      vertex -19.0189 -31.0361 58.2
+    endloop
+  endfacet
+  facet normal -0.490132 -0.509759 0.707048
+    outer loop
+      vertex -25.173 -25.173 59
+      vertex -25.7387 -25.7387 58.2
+      vertex -24.1653 -26.1419 59
+    endloop
+  endfacet
+  facet normal 0.509759 -0.490132 0.707048
+    outer loop
+      vertex 26.1419 -24.1653 59
+      vertex 25.173 -25.173 59
+      vertex 25.7387 -25.7387 58.2
+    endloop
+  endfacet
+  facet normal -0.426842 0.563844 0.707026
+    outer loop
+      vertex -21.3954 29.4482 58.2
+      vertex -22.0397 27.9573 59
+      vertex -20.9252 28.801 59
+    endloop
+  endfacet
+  facet normal -0.448617 -0.546658 0.707042
+    outer loop
+      vertex -23.1203 -27.0705 59
+      vertex -23.6399 -27.6788 58.2
+      vertex -22.0397 -27.9573 59
+    endloop
+  endfacet
+  facet normal 0.0693532 0.703746 0.707059
+    outer loop
+      vertex 4.27836 36.1477 58.2
+      vertex 2.79314 35.4903 59
+      vertex 4.18433 35.3532 59
+    endloop
+  endfacet
+  facet normal 0.151561 -0.690741 0.707041
+    outer loop
+      vertex 8.31065 -34.6164 59
+      vertex 6.94522 -34.916 59
+      vertex 8.49741 -35.3943 58.2
+    endloop
+  endfacet
+  facet normal 0.0693172 -0.703784 0.707024
+    outer loop
+      vertex 4.27836 -36.1477 58.2
+      vertex 2.79314 -35.4903 59
+      vertex 2.85591 -36.2878 58.2
+    endloop
+  endfacet
+  facet normal 0.0693532 -0.703746 0.707059
+    outer loop
+      vertex 4.18433 -35.3532 59
+      vertex 2.79314 -35.4903 59
+      vertex 4.27836 -36.1477 58.2
+    endloop
+  endfacet
+  facet normal -0.124334 -0.696172 0.707026
+    outer loop
+      vertex -6.94522 -34.916 59
+      vertex -7.10129 -35.7006 58.2
+      vertex -5.69421 -35.9519 58.2
+    endloop
+  endfacet
+  facet normal 0.0416347 0.705963 0.707024
+    outer loop
+      vertex 2.85591 36.2878 58.2
+      vertex 1.39765 35.5726 59
+      vertex 2.79314 35.4903 59
+    endloop
+  endfacet
+  facet normal 0.0416115 0.705986 0.707002
+    outer loop
+      vertex 1.42906 36.3719 58.2
+      vertex 1.39765 35.5726 59
+      vertex 2.85591 36.2878 58.2
+    endloop
+  endfacet
+  facet normal -0.35761 0.610096 0.707034
+    outer loop
+      vertex -17.3949 31.0609 59
+      vertex -19.0189 31.0361 58.2
+      vertex -18.6009 30.354 59
+    endloop
+  endfacet
+  facet normal -0.0416347 -0.705963 0.707024
+    outer loop
+      vertex -2.79314 -35.4903 59
+      vertex -2.85591 -36.2878 58.2
+      vertex -1.39765 -35.5726 59
+    endloop
+  endfacet
+  facet normal -0.546658 -0.448617 0.707042
+    outer loop
+      vertex -27.0705 -23.1203 59
+      vertex -27.9573 -22.0397 59
+      vertex -27.6788 -23.6399 58.2
+    endloop
+  endfacet
+  facet normal -0.998265 -0.0588882 0
+    outer loop
+      vertex 27.8285 1.09339 0.599999
+      vertex 27.7641 2.18509 58.4
+      vertex 27.7641 2.18509 0.599999
+    endloop
+  endfacet
+  facet normal -0.998265 -0.0588882 0
+    outer loop
+      vertex 27.7641 2.18509 58.4
+      vertex 27.8285 1.09339 0.599999
+      vertex 27.8285 1.09339 58.4
+    endloop
+  endfacet
+  facet normal -0.999807 -0.0196598 0
+    outer loop
+      vertex 27.85 0 0.599999
+      vertex 27.8285 1.09339 58.4
+      vertex 27.8285 1.09339 0.599999
+    endloop
+  endfacet
+  facet normal -0.999807 -0.0196598 0
+    outer loop
+      vertex 27.8285 1.09339 58.4
+      vertex 27.85 0 0.599999
+      vertex 27.85 0 58.4
+    endloop
+  endfacet
+  facet normal -0.995193 -0.0979346 0
+    outer loop
+      vertex 27.7641 2.18509 0.599999
+      vertex 27.657 3.27342 58.4
+      vertex 27.657 3.27342 0.599999
+    endloop
+  endfacet
+  facet normal -0.995193 -0.0979346 0
+    outer loop
+      vertex 27.657 3.27342 58.4
+      vertex 27.7641 2.18509 0.599999
+      vertex 27.7641 2.18509 58.4
+    endloop
+  endfacet
+  facet normal -0.916216 0.400685 0
+    outer loop
+      vertex 25.2918 -11.6597 0.599999
+      vertex 25.73 -10.6577 58.4
+      vertex 25.73 -10.6577 0.599999
+    endloop
+  endfacet
+  facet normal -0.916216 0.400685 0
+    outer loop
+      vertex 25.73 -10.6577 58.4
+      vertex 25.2918 -11.6597 0.599999
+      vertex 25.2918 -11.6597 58.4
+    endloop
+  endfacet
+  facet normal 0.899722 -0.436464 0
+    outer loop
+      vertex -25.2918 11.6597 58.4
+      vertex -24.8145 12.6436 0.599999
+      vertex -24.8145 12.6436 58.4
+    endloop
+  endfacet
+  facet normal 0.899722 -0.436464 0
+    outer loop
+      vertex -24.8145 12.6436 0.599999
+      vertex -25.2918 11.6597 58.4
+      vertex -25.2918 11.6597 0.599999
+    endloop
+  endfacet
+  facet normal -0.990561 -0.13707 0
+    outer loop
+      vertex 27.657 3.27342 0.599999
+      vertex 27.5071 4.3567 58.4
+      vertex 27.5071 4.3567 0.599999
+    endloop
+  endfacet
+  facet normal -0.990561 -0.13707 0
+    outer loop
+      vertex 27.5071 4.3567 58.4
+      vertex 27.657 3.27342 0.599999
+      vertex 27.657 3.27342 58.4
+    endloop
+  endfacet
+  facet normal 0.74753 -0.664228 0
+    outer loop
+      vertex -21.1773 18.0871 58.4
+      vertex -20.4509 18.9046 0.599999
+      vertex -20.4509 18.9046 58.4
+    endloop
+  endfacet
+  facet normal 0.74753 -0.664228 0
+    outer loop
+      vertex -20.4509 18.9046 0.599999
+      vertex -21.1773 18.0871 58.4
+      vertex -21.1773 18.0871 0.599999
+    endloop
+  endfacet
+  facet normal 0.931206 0.364494 0
+    outer loop
+      vertex -25.73 -10.6577 58.4
+      vertex -26.1286 -9.63936 0.599999
+      vertex -26.1286 -9.63936 58.4
+    endloop
+  endfacet
+  facet normal 0.931206 0.364494 0
+    outer loop
+      vertex -26.1286 -9.63936 0.599999
+      vertex -25.73 -10.6577 58.4
+      vertex -25.73 -10.6577 0.599999
+    endloop
+  endfacet
+  facet normal -0.13707 0.990561 0
+    outer loop
+      vertex 4.3567 -27.5071 0.599999
+      vertex 3.27342 -27.657 58.4
+      vertex 4.3567 -27.5071 58.4
+    endloop
+  endfacet
+  facet normal -0.13707 0.990561 0
+    outer loop
+      vertex 3.27342 -27.657 58.4
+      vertex 4.3567 -27.5071 0.599999
+      vertex 3.27342 -27.657 0.599999
+    endloop
+  endfacet
+  facet normal -0.505661 0.862732 0
+    outer loop
+      vertex 14.5516 -23.746 0.599999
+      vertex 13.6081 -24.299 58.4
+      vertex 14.5516 -23.746 58.4
+    endloop
+  endfacet
+  facet normal -0.505661 0.862732 0
+    outer loop
+      vertex 13.6081 -24.299 58.4
+      vertex 14.5516 -23.746 0.599999
+      vertex 13.6081 -24.299 0.599999
+    endloop
+  endfacet
+  facet normal 0.820407 0.57178 0
+    outer loop
+      vertex -22.5311 -16.3698 58.4
+      vertex -23.1564 -15.4726 0.599999
+      vertex -23.1564 -15.4726 58.4
+    endloop
+  endfacet
+  facet normal 0.820407 0.57178 0
+    outer loop
+      vertex -23.1564 -15.4726 0.599999
+      vertex -22.5311 -16.3698 58.4
+      vertex -22.5311 -16.3698 0.599999
+    endloop
+  endfacet
+  facet normal -0.899722 -0.436464 0
+    outer loop
+      vertex 25.2918 11.6597 0.599999
+      vertex 24.8145 12.6436 58.4
+      vertex 24.8145 12.6436 0.599999
+    endloop
+  endfacet
+  facet normal -0.899722 -0.436464 0
+    outer loop
+      vertex 24.8145 12.6436 58.4
+      vertex 25.2918 11.6597 0.599999
+      vertex 25.2918 11.6597 58.4
+    endloop
+  endfacet
+  facet normal 0.998265 -0.0588882 0
+    outer loop
+      vertex -27.8285 1.09339 58.4
+      vertex -27.7641 2.18509 0.599999
+      vertex -27.7641 2.18509 58.4
+    endloop
+  endfacet
+  facet normal 0.998265 -0.0588882 0
+    outer loop
+      vertex -27.7641 2.18509 0.599999
+      vertex -27.8285 1.09339 58.4
+      vertex -27.8285 1.09339 0.599999
+    endloop
+  endfacet
+  facet normal -0.97676 0.214337 0
+    outer loop
+      vertex 27.0805 -6.50145 0.599999
+      vertex 27.3149 -5.43326 58.4
+      vertex 27.3149 -5.43326 0.599999
+    endloop
+  endfacet
+  facet normal -0.97676 0.214337 0
+    outer loop
+      vertex 27.3149 -5.43326 58.4
+      vertex 27.0805 -6.50145 0.599999
+      vertex 27.0805 -6.50145 58.4
+    endloop
+  endfacet
+  facet normal -0.881935 0.471371 0
+    outer loop
+      vertex 24.299 -13.6081 0.599999
+      vertex 24.8145 -12.6436 58.4
+      vertex 24.8145 -12.6436 0.599999
+    endloop
+  endfacet
+  facet normal -0.881935 0.471371 0
+    outer loop
+      vertex 24.8145 -12.6436 58.4
+      vertex 24.299 -13.6081 0.599999
+      vertex 24.299 -13.6081 58.4
+    endloop
+  endfacet
+  facet normal -0.797359 0.603506 0
+    outer loop
+      vertex 21.8711 -17.2418 0.599999
+      vertex 22.5311 -16.3698 58.4
+      vertex 22.5311 -16.3698 0.599999
+    endloop
+  endfacet
+  facet normal -0.797359 0.603506 0
+    outer loop
+      vertex 22.5311 -16.3698 58.4
+      vertex 21.8711 -17.2418 0.599999
+      vertex 21.8711 -17.2418 58.4
+    endloop
+  endfacet
+  facet normal -0.364494 0.931206 0
+    outer loop
+      vertex 10.6577 -25.73 0.599999
+      vertex 9.63936 -26.1286 58.4
+      vertex 10.6577 -25.73 58.4
+    endloop
+  endfacet
+  facet normal -0.364494 0.931206 0
+    outer loop
+      vertex 9.63936 -26.1286 58.4
+      vertex 10.6577 -25.73 0.599999
+      vertex 9.63936 -26.1286 0.599999
+    endloop
+  endfacet
+  facet normal -0.634437 -0.772974 0
+    outer loop
+      vertex 17.2418 21.8711 0.599999
+      vertex 18.0871 21.1773 58.4
+      vertex 17.2418 21.8711 58.4
+    endloop
+  endfacet
+  facet normal -0.634437 -0.772974 -0
+    outer loop
+      vertex 18.0871 21.1773 58.4
+      vertex 17.2418 21.8711 0.599999
+      vertex 18.0871 21.1773 0.599999
+    endloop
+  endfacet
+  facet normal -0.74753 0.664228 0
+    outer loop
+      vertex 20.4509 -18.9046 0.599999
+      vertex 21.1773 -18.0871 58.4
+      vertex 21.1773 -18.0871 0.599999
+    endloop
+  endfacet
+  facet normal -0.74753 0.664228 0
+    outer loop
+      vertex 21.1773 -18.0871 58.4
+      vertex 20.4509 -18.9046 0.599999
+      vertex 20.4509 -18.9046 58.4
+    endloop
+  endfacet
+  facet normal -0.364494 -0.931206 0
+    outer loop
+      vertex 9.63936 26.1286 0.599999
+      vertex 10.6577 25.73 58.4
+      vertex 9.63936 26.1286 58.4
+    endloop
+  endfacet
+  facet normal -0.364494 -0.931206 -0
+    outer loop
+      vertex 10.6577 25.73 58.4
+      vertex 9.63936 26.1286 0.599999
+      vertex 10.6577 25.73 0.599999
+    endloop
+  endfacet
+  facet normal -0.820407 -0.57178 0
+    outer loop
+      vertex 23.1564 15.4726 0.599999
+      vertex 22.5311 16.3698 58.4
+      vertex 22.5311 16.3698 0.599999
+    endloop
+  endfacet
+  facet normal -0.820407 -0.57178 0
+    outer loop
+      vertex 22.5311 16.3698 58.4
+      vertex 23.1564 15.4726 0.599999
+      vertex 23.1564 15.4726 58.4
+    endloop
+  endfacet
+  facet normal 0.881935 0.471371 0
+    outer loop
+      vertex -24.299 -13.6081 58.4
+      vertex -24.8145 -12.6436 0.599999
+      vertex -24.8145 -12.6436 58.4
+    endloop
+  endfacet
+  facet normal 0.881935 0.471371 0
+    outer loop
+      vertex -24.8145 -12.6436 0.599999
+      vertex -24.299 -13.6081 58.4
+      vertex -24.299 -13.6081 0.599999
+    endloop
+  endfacet
+  facet normal 0.603506 0.797359 -0
+    outer loop
+      vertex -16.3698 -22.5311 0.599999
+      vertex -17.2418 -21.8711 58.4
+      vertex -16.3698 -22.5311 58.4
+    endloop
+  endfacet
+  facet normal 0.603506 0.797359 0
+    outer loop
+      vertex -17.2418 -21.8711 58.4
+      vertex -16.3698 -22.5311 0.599999
+      vertex -17.2418 -21.8711 0.599999
+    endloop
+  endfacet
+  facet normal 0.772974 -0.634437 0
+    outer loop
+      vertex -21.8711 17.2418 58.4
+      vertex -21.1773 18.0871 0.599999
+      vertex -21.1773 18.0871 58.4
+    endloop
+  endfacet
+  facet normal 0.772974 -0.634437 0
+    outer loop
+      vertex -21.1773 18.0871 0.599999
+      vertex -21.8711 17.2418 58.4
+      vertex -21.8711 17.2418 0.599999
+    endloop
+  endfacet
+  facet normal 0.400685 -0.916216 0
+    outer loop
+      vertex -11.6597 25.2918 0.599999
+      vertex -10.6577 25.73 58.4
+      vertex -11.6597 25.2918 58.4
+    endloop
+  endfacet
+  facet normal 0.400685 -0.916216 0
+    outer loop
+      vertex -10.6577 25.73 58.4
+      vertex -11.6597 25.2918 0.599999
+      vertex -10.6577 25.73 0.599999
+    endloop
+  endfacet
+  facet normal 0.25247 0.967605 -0
+    outer loop
+      vertex -6.50145 -27.0805 0.599999
+      vertex -7.55962 -26.8044 58.4
+      vertex -6.50145 -27.0805 58.4
+    endloop
+  endfacet
+  facet normal 0.25247 0.967605 0
+    outer loop
+      vertex -7.55962 -26.8044 58.4
+      vertex -6.50145 -27.0805 0.599999
+      vertex -7.55962 -26.8044 0.599999
+    endloop
+  endfacet
+  facet normal 0.772974 0.634437 0
+    outer loop
+      vertex -21.1773 -18.0871 58.4
+      vertex -21.8711 -17.2418 0.599999
+      vertex -21.8711 -17.2418 58.4
+    endloop
+  endfacet
+  facet normal 0.772974 0.634437 0
+    outer loop
+      vertex -21.8711 -17.2418 0.599999
+      vertex -21.1773 -18.0871 58.4
+      vertex -21.1773 -18.0871 0.599999
+    endloop
+  endfacet
+  facet normal -0.0979346 -0.995193 0
+    outer loop
+      vertex 2.18509 27.7641 0.599999
+      vertex 3.27342 27.657 58.4
+      vertex 2.18509 27.7641 58.4
+    endloop
+  endfacet
+  facet normal -0.0979346 -0.995193 -0
+    outer loop
+      vertex 3.27342 27.657 58.4
+      vertex 2.18509 27.7641 0.599999
+      vertex 3.27342 27.657 0.599999
+    endloop
+  endfacet
+  facet normal -0.664228 0.74753 0
+    outer loop
+      vertex 18.9046 -20.4509 0.599999
+      vertex 18.0871 -21.1773 58.4
+      vertex 18.9046 -20.4509 58.4
+    endloop
+  endfacet
+  facet normal -0.664228 0.74753 0
+    outer loop
+      vertex 18.0871 -21.1773 58.4
+      vertex 18.9046 -20.4509 0.599999
+      vertex 18.0871 -21.1773 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.85 0 0.599999
+      vertex 28.45 0 0.599999
+      vertex 28.4281 -1.11694 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.8285 -1.09339 0.599999
+      vertex 28.4281 -1.11694 0.599999
+      vertex 28.3623 -2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.45 0 0.599999
+      vertex 27.85 0 0.599999
+      vertex 28.4281 1.11694 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.7641 -2.18509 0.599999
+      vertex 28.3623 -2.23216 0.599999
+      vertex 28.2528 -3.34394 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.8285 1.09339 0.599999
+      vertex 28.4281 1.11694 0.599999
+      vertex 27.85 0 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.657 -3.27342 0.599999
+      vertex 28.2528 -3.34394 0.599999
+      vertex 28.0997 -4.45056 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.4281 1.11694 0.599999
+      vertex 27.8285 1.09339 0.599999
+      vertex 28.3623 2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.5071 -4.3567 0.599999
+      vertex 28.0997 -4.45056 0.599999
+      vertex 27.9033 -5.55032 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.7641 2.18509 0.599999
+      vertex 28.3623 2.23216 0.599999
+      vertex 27.8285 1.09339 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.3623 2.23216 0.599999
+      vertex 27.7641 2.18509 0.599999
+      vertex 28.2528 3.34394 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.4281 -1.11694 0.599999
+      vertex 27.8285 -1.09339 0.599999
+      vertex 27.85 0 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.3623 -2.23216 0.599999
+      vertex 27.7641 -2.18509 0.599999
+      vertex 27.8285 -1.09339 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3149 -5.43326 0.599999
+      vertex 27.9033 -5.55032 0.599999
+      vertex 27.6639 -6.64152 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.2528 -3.34394 0.599999
+      vertex 27.657 -3.27342 0.599999
+      vertex 27.7641 -2.18509 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.0997 -4.45056 0.599999
+      vertex 27.5071 -4.3567 0.599999
+      vertex 27.657 -3.27342 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0805 -6.50145 0.599999
+      vertex 27.6639 -6.64152 0.599999
+      vertex 27.3819 -7.72248 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.9033 -5.55032 0.599999
+      vertex 27.3149 -5.43326 0.599999
+      vertex 27.5071 -4.3567 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.6639 -6.64152 0.599999
+      vertex 27.0805 -6.50145 0.599999
+      vertex 27.3149 -5.43326 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8044 -7.55962 0.599999
+      vertex 27.3819 -7.72248 0.599999
+      vertex 27.0576 -8.79153 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3819 -7.72248 0.599999
+      vertex 26.8044 -7.55962 0.599999
+      vertex 27.0805 -6.50145 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.4869 -8.60612 0.599999
+      vertex 27.0576 -8.79153 0.599999
+      vertex 26.6915 -9.84703 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0576 -8.79153 0.599999
+      vertex 26.4869 -8.60612 0.599999
+      vertex 26.8044 -7.55962 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1286 -9.63936 0.599999
+      vertex 26.6915 -9.84703 0.599999
+      vertex 26.2844 -10.8873 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6915 -9.84703 0.599999
+      vertex 26.1286 -9.63936 0.599999
+      vertex 26.4869 -8.60612 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.73 -10.6577 0.599999
+      vertex 26.2844 -10.8873 0.599999
+      vertex 25.8367 -11.9109 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.2844 -10.8873 0.599999
+      vertex 25.73 -10.6577 0.599999
+      vertex 26.1286 -9.63936 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.2918 -11.6597 0.599999
+      vertex 25.8367 -11.9109 0.599999
+      vertex 25.3491 -12.916 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.8367 -11.9109 0.599999
+      vertex 25.2918 -11.6597 0.599999
+      vertex 25.73 -10.6577 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8145 -12.6436 0.599999
+      vertex 25.3491 -12.916 0.599999
+      vertex 24.8225 -13.9013 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.3491 -12.916 0.599999
+      vertex 24.8145 -12.6436 0.599999
+      vertex 25.2918 -11.6597 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8225 -13.9013 0.599999
+      vertex 24.299 -13.6081 0.599999
+      vertex 24.8145 -12.6436 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.2576 -14.8651 0.599999
+      vertex 24.299 -13.6081 0.599999
+      vertex 24.8225 -13.9013 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.2576 -14.8651 0.599999
+      vertex 23.746 -14.5516 0.599999
+      vertex 24.299 -13.6081 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.6553 -15.806 0.599999
+      vertex 23.746 -14.5516 0.599999
+      vertex 24.2576 -14.8651 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.6553 -15.806 0.599999
+      vertex 23.1564 -15.4726 0.599999
+      vertex 23.746 -14.5516 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.0165 -16.7225 0.599999
+      vertex 23.1564 -15.4726 0.599999
+      vertex 23.6553 -15.806 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.0165 -16.7225 0.599999
+      vertex 22.5311 -16.3698 0.599999
+      vertex 23.1564 -15.4726 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.3423 -17.6132 0.599999
+      vertex 22.5311 -16.3698 0.599999
+      vertex 23.0165 -16.7225 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.3423 -17.6132 0.599999
+      vertex 21.8711 -17.2418 0.599999
+      vertex 22.5311 -16.3698 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.6335 -18.4768 0.599999
+      vertex 21.8711 -17.2418 0.599999
+      vertex 22.3423 -17.6132 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.6335 -18.4768 0.599999
+      vertex 21.1773 -18.0871 0.599999
+      vertex 21.8711 -17.2418 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.8915 -19.3119 0.599999
+      vertex 21.1773 -18.0871 0.599999
+      vertex 21.6335 -18.4768 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.8915 -19.3119 0.599999
+      vertex 20.4509 -18.9046 0.599999
+      vertex 21.1773 -18.0871 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1172 -20.1172 0.599999
+      vertex 20.4509 -18.9046 0.599999
+      vertex 20.8915 -19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.1172 -20.1172 0.599999
+      vertex 19.6929 -19.6929 0.599999
+      vertex 20.4509 -18.9046 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3119 -20.8915 0.599999
+      vertex 19.6929 -19.6929 0.599999
+      vertex 20.1172 -20.1172 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3119 -20.8915 0.599999
+      vertex 18.9046 -20.4509 0.599999
+      vertex 19.6929 -19.6929 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.4768 -21.6335 0.599999
+      vertex 18.9046 -20.4509 0.599999
+      vertex 19.3119 -20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.4768 -21.6335 0.599999
+      vertex 18.0871 -21.1773 0.599999
+      vertex 18.9046 -20.4509 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.6132 -22.3423 0.599999
+      vertex 18.0871 -21.1773 0.599999
+      vertex 18.4768 -21.6335 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.6132 -22.3423 0.599999
+      vertex 17.2418 -21.8711 0.599999
+      vertex 18.0871 -21.1773 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.7225 -23.0165 0.599999
+      vertex 17.2418 -21.8711 0.599999
+      vertex 17.6132 -22.3423 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.7225 -23.0165 0.599999
+      vertex 16.3698 -22.5311 0.599999
+      vertex 17.2418 -21.8711 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.806 -23.6553 0.599999
+      vertex 16.3698 -22.5311 0.599999
+      vertex 16.7225 -23.0165 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.806 -23.6553 0.599999
+      vertex 15.4726 -23.1564 0.599999
+      vertex 16.3698 -22.5311 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8651 -24.2576 0.599999
+      vertex 15.4726 -23.1564 0.599999
+      vertex 15.806 -23.6553 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8651 -24.2576 0.599999
+      vertex 14.5516 -23.746 0.599999
+      vertex 15.4726 -23.1564 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.9013 -24.8225 0.599999
+      vertex 14.5516 -23.746 0.599999
+      vertex 14.8651 -24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.9013 -24.8225 0.599999
+      vertex 13.6081 -24.299 0.599999
+      vertex 14.5516 -23.746 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.916 -25.3491 0.599999
+      vertex 13.6081 -24.299 0.599999
+      vertex 13.9013 -24.8225 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.916 -25.3491 0.599999
+      vertex 12.6436 -24.8145 0.599999
+      vertex 13.6081 -24.299 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.9109 -25.8367 0.599999
+      vertex 12.6436 -24.8145 0.599999
+      vertex 12.916 -25.3491 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.9109 -25.8367 0.599999
+      vertex 11.6597 -25.2918 0.599999
+      vertex 12.6436 -24.8145 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.8873 -26.2844 0.599999
+      vertex 11.6597 -25.2918 0.599999
+      vertex 11.9109 -25.8367 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.8873 -26.2844 0.599999
+      vertex 10.6577 -25.73 0.599999
+      vertex 11.6597 -25.2918 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.84703 -26.6915 0.599999
+      vertex 10.6577 -25.73 0.599999
+      vertex 10.8873 -26.2844 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.84703 -26.6915 0.599999
+      vertex 9.63936 -26.1286 0.599999
+      vertex 10.6577 -25.73 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.79153 -27.0576 0.599999
+      vertex 9.63936 -26.1286 0.599999
+      vertex 9.84703 -26.6915 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.79153 -27.0576 0.599999
+      vertex 8.60612 -26.4869 0.599999
+      vertex 9.63936 -26.1286 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.72248 -27.3819 0.599999
+      vertex 8.60612 -26.4869 0.599999
+      vertex 8.79153 -27.0576 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.72248 -27.3819 0.599999
+      vertex 7.55962 -26.8044 0.599999
+      vertex 8.60612 -26.4869 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.64152 -27.6639 0.599999
+      vertex 7.55962 -26.8044 0.599999
+      vertex 7.72248 -27.3819 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.64152 -27.6639 0.599999
+      vertex 6.50145 -27.0805 0.599999
+      vertex 7.55962 -26.8044 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.55032 -27.9033 0.599999
+      vertex 6.50145 -27.0805 0.599999
+      vertex 6.64152 -27.6639 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.55032 -27.9033 0.599999
+      vertex 5.43326 -27.3149 0.599999
+      vertex 6.50145 -27.0805 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.45056 -28.0997 0.599999
+      vertex 5.43326 -27.3149 0.599999
+      vertex 5.55032 -27.9033 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.45056 -28.0997 0.599999
+      vertex 4.3567 -27.5071 0.599999
+      vertex 5.43326 -27.3149 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.34394 -28.2528 0.599999
+      vertex 4.3567 -27.5071 0.599999
+      vertex 4.45056 -28.0997 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.34394 -28.2528 0.599999
+      vertex 3.27342 -27.657 0.599999
+      vertex 4.3567 -27.5071 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.23216 -28.3623 0.599999
+      vertex 3.27342 -27.657 0.599999
+      vertex 3.34394 -28.2528 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.23216 -28.3623 0.599999
+      vertex 2.18509 -27.7641 0.599999
+      vertex 3.27342 -27.657 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.11694 -28.4281 0.599999
+      vertex 2.18509 -27.7641 0.599999
+      vertex 2.23216 -28.3623 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.11694 -28.4281 0.599999
+      vertex 1.09339 -27.8285 0.599999
+      vertex 2.18509 -27.7641 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -28.45 0.599999
+      vertex 1.09339 -27.8285 0.599999
+      vertex 1.11694 -28.4281 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -28.45 0.599999
+      vertex 0 -27.85 0.599999
+      vertex 1.09339 -27.8285 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -28.45 0.599999
+      vertex -1.09339 -27.8285 0.599999
+      vertex 0 -27.85 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.11694 -28.4281 0.599999
+      vertex -1.09339 -27.8285 0.599999
+      vertex 0 -28.45 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.11694 -28.4281 0.599999
+      vertex -2.18509 -27.7641 0.599999
+      vertex -1.09339 -27.8285 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.23216 -28.3623 0.599999
+      vertex -2.18509 -27.7641 0.599999
+      vertex -1.11694 -28.4281 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.23216 -28.3623 0.599999
+      vertex -3.27342 -27.657 0.599999
+      vertex -2.18509 -27.7641 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.34394 -28.2528 0.599999
+      vertex -3.27342 -27.657 0.599999
+      vertex -2.23216 -28.3623 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.34394 -28.2528 0.599999
+      vertex -4.3567 -27.5071 0.599999
+      vertex -3.27342 -27.657 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.45056 -28.0997 0.599999
+      vertex -4.3567 -27.5071 0.599999
+      vertex -3.34394 -28.2528 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.45056 -28.0997 0.599999
+      vertex -5.43326 -27.3149 0.599999
+      vertex -4.3567 -27.5071 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.55032 -27.9033 0.599999
+      vertex -5.43326 -27.3149 0.599999
+      vertex -4.45056 -28.0997 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.55032 -27.9033 0.599999
+      vertex -6.50145 -27.0805 0.599999
+      vertex -5.43326 -27.3149 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.64152 -27.6639 0.599999
+      vertex -6.50145 -27.0805 0.599999
+      vertex -5.55032 -27.9033 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.64152 -27.6639 0.599999
+      vertex -7.55962 -26.8044 0.599999
+      vertex -6.50145 -27.0805 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.72248 -27.3819 0.599999
+      vertex -7.55962 -26.8044 0.599999
+      vertex -6.64152 -27.6639 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.72248 -27.3819 0.599999
+      vertex -8.60612 -26.4869 0.599999
+      vertex -7.55962 -26.8044 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.79153 -27.0576 0.599999
+      vertex -8.60612 -26.4869 0.599999
+      vertex -7.72248 -27.3819 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.79153 -27.0576 0.599999
+      vertex -9.63936 -26.1286 0.599999
+      vertex -8.60612 -26.4869 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.84703 -26.6915 0.599999
+      vertex -9.63936 -26.1286 0.599999
+      vertex -8.79153 -27.0576 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.84703 -26.6915 0.599999
+      vertex -10.6577 -25.73 0.599999
+      vertex -9.63936 -26.1286 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.8873 -26.2844 0.599999
+      vertex -10.6577 -25.73 0.599999
+      vertex -9.84703 -26.6915 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.8873 -26.2844 0.599999
+      vertex -11.6597 -25.2918 0.599999
+      vertex -10.6577 -25.73 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.9109 -25.8367 0.599999
+      vertex -11.6597 -25.2918 0.599999
+      vertex -10.8873 -26.2844 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.9109 -25.8367 0.599999
+      vertex -12.6436 -24.8145 0.599999
+      vertex -11.6597 -25.2918 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.916 -25.3491 0.599999
+      vertex -12.6436 -24.8145 0.599999
+      vertex -11.9109 -25.8367 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.916 -25.3491 0.599999
+      vertex -13.6081 -24.299 0.599999
+      vertex -12.6436 -24.8145 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.9013 -24.8225 0.599999
+      vertex -13.6081 -24.299 0.599999
+      vertex -12.916 -25.3491 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.9013 -24.8225 0.599999
+      vertex -14.5516 -23.746 0.599999
+      vertex -13.6081 -24.299 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8651 -24.2576 0.599999
+      vertex -14.5516 -23.746 0.599999
+      vertex -13.9013 -24.8225 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8651 -24.2576 0.599999
+      vertex -15.4726 -23.1564 0.599999
+      vertex -14.5516 -23.746 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.806 -23.6553 0.599999
+      vertex -15.4726 -23.1564 0.599999
+      vertex -14.8651 -24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.806 -23.6553 0.599999
+      vertex -16.3698 -22.5311 0.599999
+      vertex -15.4726 -23.1564 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.7225 -23.0165 0.599999
+      vertex -16.3698 -22.5311 0.599999
+      vertex -15.806 -23.6553 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.7225 -23.0165 0.599999
+      vertex -17.2418 -21.8711 0.599999
+      vertex -16.3698 -22.5311 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.6132 -22.3423 0.599999
+      vertex -17.2418 -21.8711 0.599999
+      vertex -16.7225 -23.0165 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.6132 -22.3423 0.599999
+      vertex -18.0871 -21.1773 0.599999
+      vertex -17.2418 -21.8711 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.4768 -21.6335 0.599999
+      vertex -18.0871 -21.1773 0.599999
+      vertex -17.6132 -22.3423 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.4768 -21.6335 0.599999
+      vertex -18.9046 -20.4509 0.599999
+      vertex -18.0871 -21.1773 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3119 -20.8915 0.599999
+      vertex -18.9046 -20.4509 0.599999
+      vertex -18.4768 -21.6335 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3119 -20.8915 0.599999
+      vertex -19.6929 -19.6929 0.599999
+      vertex -18.9046 -20.4509 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1172 -20.1172 0.599999
+      vertex -19.6929 -19.6929 0.599999
+      vertex -19.3119 -20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1172 -20.1172 0.599999
+      vertex -20.4509 -18.9046 0.599999
+      vertex -19.6929 -19.6929 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.8915 -19.3119 0.599999
+      vertex -20.4509 -18.9046 0.599999
+      vertex -20.1172 -20.1172 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.8915 -19.3119 0.599999
+      vertex -21.1773 -18.0871 0.599999
+      vertex -20.4509 -18.9046 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.6335 -18.4768 0.599999
+      vertex -21.1773 -18.0871 0.599999
+      vertex -20.8915 -19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.6335 -18.4768 0.599999
+      vertex -21.8711 -17.2418 0.599999
+      vertex -21.1773 -18.0871 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.3423 -17.6132 0.599999
+      vertex -21.8711 -17.2418 0.599999
+      vertex -21.6335 -18.4768 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.3423 -17.6132 0.599999
+      vertex -22.5311 -16.3698 0.599999
+      vertex -21.8711 -17.2418 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.0165 -16.7225 0.599999
+      vertex -22.5311 -16.3698 0.599999
+      vertex -22.3423 -17.6132 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.0165 -16.7225 0.599999
+      vertex -23.1564 -15.4726 0.599999
+      vertex -22.5311 -16.3698 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.6553 -15.806 0.599999
+      vertex -23.1564 -15.4726 0.599999
+      vertex -23.0165 -16.7225 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.6553 -15.806 0.599999
+      vertex -23.746 -14.5516 0.599999
+      vertex -23.1564 -15.4726 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.2576 -14.8651 0.599999
+      vertex -23.746 -14.5516 0.599999
+      vertex -23.6553 -15.806 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.2576 -14.8651 0.599999
+      vertex -24.299 -13.6081 0.599999
+      vertex -23.746 -14.5516 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.8225 -13.9013 0.599999
+      vertex -24.299 -13.6081 0.599999
+      vertex -24.2576 -14.8651 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.299 -13.6081 0.599999
+      vertex -24.8225 -13.9013 0.599999
+      vertex -24.8145 -12.6436 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.3491 -12.916 0.599999
+      vertex -24.8145 -12.6436 0.599999
+      vertex -24.8225 -13.9013 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.8145 -12.6436 0.599999
+      vertex -25.3491 -12.916 0.599999
+      vertex -25.2918 -11.6597 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.8367 -11.9109 0.599999
+      vertex -25.2918 -11.6597 0.599999
+      vertex -25.3491 -12.916 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.2918 -11.6597 0.599999
+      vertex -25.8367 -11.9109 0.599999
+      vertex -25.73 -10.6577 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.2844 -10.8873 0.599999
+      vertex -25.73 -10.6577 0.599999
+      vertex -25.8367 -11.9109 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.73 -10.6577 0.599999
+      vertex -26.2844 -10.8873 0.599999
+      vertex -26.1286 -9.63936 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.6915 -9.84703 0.599999
+      vertex -26.1286 -9.63936 0.599999
+      vertex -26.2844 -10.8873 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.1286 -9.63936 0.599999
+      vertex -26.6915 -9.84703 0.599999
+      vertex -26.4869 -8.60612 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0576 -8.79153 0.599999
+      vertex -26.4869 -8.60612 0.599999
+      vertex -26.6915 -9.84703 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.4869 -8.60612 0.599999
+      vertex -27.0576 -8.79153 0.599999
+      vertex -26.8044 -7.55962 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.3819 -7.72248 0.599999
+      vertex -26.8044 -7.55962 0.599999
+      vertex -27.0576 -8.79153 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.8044 -7.55962 0.599999
+      vertex -27.3819 -7.72248 0.599999
+      vertex -27.0805 -6.50145 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6639 -6.64152 0.599999
+      vertex -27.0805 -6.50145 0.599999
+      vertex -27.3819 -7.72248 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.0805 -6.50145 0.599999
+      vertex -27.6639 -6.64152 0.599999
+      vertex -27.3149 -5.43326 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.9033 -5.55032 0.599999
+      vertex -27.3149 -5.43326 0.599999
+      vertex -27.6639 -6.64152 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.3149 -5.43326 0.599999
+      vertex -27.9033 -5.55032 0.599999
+      vertex -27.5071 -4.3567 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.0997 -4.45056 0.599999
+      vertex -27.5071 -4.3567 0.599999
+      vertex -27.9033 -5.55032 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.5071 -4.3567 0.599999
+      vertex -28.0997 -4.45056 0.599999
+      vertex -27.657 -3.27342 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.657 -3.27342 0.599999
+      vertex -28.2528 -3.34394 0.599999
+      vertex -27.7641 -2.18509 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.2528 -3.34394 0.599999
+      vertex -27.657 -3.27342 0.599999
+      vertex -28.0997 -4.45056 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.657 3.27342 0.599999
+      vertex 28.2528 3.34394 0.599999
+      vertex 27.7641 2.18509 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.2528 3.34394 0.599999
+      vertex 27.657 3.27342 0.599999
+      vertex 28.0997 4.45056 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.5071 4.3567 0.599999
+      vertex 28.0997 4.45056 0.599999
+      vertex 27.657 3.27342 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 28.0997 4.45056 0.599999
+      vertex 27.5071 4.3567 0.599999
+      vertex 27.9033 5.55032 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.3149 5.43326 0.599999
+      vertex 27.9033 5.55032 0.599999
+      vertex 27.5071 4.3567 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 27.9033 5.55032 0.599999
+      vertex 27.3149 5.43326 0.599999
+      vertex 27.6639 6.64152 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 27.0805 6.50145 0.599999
+      vertex 27.6639 6.64152 0.599999
+      vertex 27.3149 5.43326 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 27.6639 6.64152 0.599999
+      vertex 27.0805 6.50145 0.599999
+      vertex 27.3819 7.72248 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8044 7.55962 0.599999
+      vertex 27.3819 7.72248 0.599999
+      vertex 27.0805 6.50145 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 27.3819 7.72248 0.599999
+      vertex 26.8044 7.55962 0.599999
+      vertex 27.0576 8.79153 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.4869 8.60612 0.599999
+      vertex 27.0576 8.79153 0.599999
+      vertex 26.8044 7.55962 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 27.0576 8.79153 0.599999
+      vertex 26.4869 8.60612 0.599999
+      vertex 26.6915 9.84703 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1286 9.63936 0.599999
+      vertex 26.6915 9.84703 0.599999
+      vertex 26.4869 8.60612 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 26.6915 9.84703 0.599999
+      vertex 26.1286 9.63936 0.599999
+      vertex 26.2844 10.8873 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.73 10.6577 0.599999
+      vertex 26.2844 10.8873 0.599999
+      vertex 26.1286 9.63936 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 26.2844 10.8873 0.599999
+      vertex 25.73 10.6577 0.599999
+      vertex 25.8367 11.9109 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.2918 11.6597 0.599999
+      vertex 25.8367 11.9109 0.599999
+      vertex 25.73 10.6577 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 25.8367 11.9109 0.599999
+      vertex 25.2918 11.6597 0.599999
+      vertex 25.3491 12.916 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8145 12.6436 0.599999
+      vertex 25.3491 12.916 0.599999
+      vertex 25.2918 11.6597 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 25.3491 12.916 0.599999
+      vertex 24.8145 12.6436 0.599999
+      vertex 24.8225 13.9013 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.299 13.6081 0.599999
+      vertex 24.8225 13.9013 0.599999
+      vertex 24.8145 12.6436 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.299 13.6081 0.599999
+      vertex 24.2576 14.8651 0.599999
+      vertex 24.8225 13.9013 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.746 14.5516 0.599999
+      vertex 24.2576 14.8651 0.599999
+      vertex 24.299 13.6081 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.746 14.5516 0.599999
+      vertex 23.6553 15.806 0.599999
+      vertex 24.2576 14.8651 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.1564 15.4726 0.599999
+      vertex 23.6553 15.806 0.599999
+      vertex 23.746 14.5516 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.1564 15.4726 0.599999
+      vertex 23.0165 16.7225 0.599999
+      vertex 23.6553 15.806 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.5311 16.3698 0.599999
+      vertex 23.0165 16.7225 0.599999
+      vertex 23.1564 15.4726 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.5311 16.3698 0.599999
+      vertex 22.3423 17.6132 0.599999
+      vertex 23.0165 16.7225 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.8711 17.2418 0.599999
+      vertex 22.3423 17.6132 0.599999
+      vertex 22.5311 16.3698 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.8711 17.2418 0.599999
+      vertex 21.6335 18.4768 0.599999
+      vertex 22.3423 17.6132 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.1773 18.0871 0.599999
+      vertex 21.6335 18.4768 0.599999
+      vertex 21.8711 17.2418 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.1773 18.0871 0.599999
+      vertex 20.8915 19.3119 0.599999
+      vertex 21.6335 18.4768 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.4509 18.9046 0.599999
+      vertex 20.8915 19.3119 0.599999
+      vertex 21.1773 18.0871 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.4509 18.9046 0.599999
+      vertex 20.1172 20.1172 0.599999
+      vertex 20.8915 19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.6929 19.6929 0.599999
+      vertex 20.1172 20.1172 0.599999
+      vertex 20.4509 18.9046 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.6929 19.6929 0.599999
+      vertex 19.3119 20.8915 0.599999
+      vertex 20.1172 20.1172 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9046 20.4509 0.599999
+      vertex 19.3119 20.8915 0.599999
+      vertex 19.6929 19.6929 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9046 20.4509 0.599999
+      vertex 18.4768 21.6335 0.599999
+      vertex 19.3119 20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.0871 21.1773 0.599999
+      vertex 18.4768 21.6335 0.599999
+      vertex 18.9046 20.4509 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.0871 21.1773 0.599999
+      vertex 17.6132 22.3423 0.599999
+      vertex 18.4768 21.6335 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.2418 21.8711 0.599999
+      vertex 17.6132 22.3423 0.599999
+      vertex 18.0871 21.1773 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.2418 21.8711 0.599999
+      vertex 16.7225 23.0165 0.599999
+      vertex 17.6132 22.3423 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.3698 22.5311 0.599999
+      vertex 16.7225 23.0165 0.599999
+      vertex 17.2418 21.8711 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.3698 22.5311 0.599999
+      vertex 15.806 23.6553 0.599999
+      vertex 16.7225 23.0165 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4726 23.1564 0.599999
+      vertex 15.806 23.6553 0.599999
+      vertex 16.3698 22.5311 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4726 23.1564 0.599999
+      vertex 14.8651 24.2576 0.599999
+      vertex 15.806 23.6553 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.5516 23.746 0.599999
+      vertex 14.8651 24.2576 0.599999
+      vertex 15.4726 23.1564 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.5516 23.746 0.599999
+      vertex 13.9013 24.8225 0.599999
+      vertex 14.8651 24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6081 24.299 0.599999
+      vertex 13.9013 24.8225 0.599999
+      vertex 14.5516 23.746 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6081 24.299 0.599999
+      vertex 12.916 25.3491 0.599999
+      vertex 13.9013 24.8225 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6436 24.8145 0.599999
+      vertex 12.916 25.3491 0.599999
+      vertex 13.6081 24.299 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6436 24.8145 0.599999
+      vertex 11.9109 25.8367 0.599999
+      vertex 12.916 25.3491 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.6597 25.2918 0.599999
+      vertex 11.9109 25.8367 0.599999
+      vertex 12.6436 24.8145 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.6597 25.2918 0.599999
+      vertex 10.8873 26.2844 0.599999
+      vertex 11.9109 25.8367 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6577 25.73 0.599999
+      vertex 10.8873 26.2844 0.599999
+      vertex 11.6597 25.2918 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6577 25.73 0.599999
+      vertex 9.84703 26.6915 0.599999
+      vertex 10.8873 26.2844 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.63936 26.1286 0.599999
+      vertex 9.84703 26.6915 0.599999
+      vertex 10.6577 25.73 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.63936 26.1286 0.599999
+      vertex 8.79153 27.0576 0.599999
+      vertex 9.84703 26.6915 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.60612 26.4869 0.599999
+      vertex 8.79153 27.0576 0.599999
+      vertex 9.63936 26.1286 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.60612 26.4869 0.599999
+      vertex 7.72248 27.3819 0.599999
+      vertex 8.79153 27.0576 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.55962 26.8044 0.599999
+      vertex 7.72248 27.3819 0.599999
+      vertex 8.60612 26.4869 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.55962 26.8044 0.599999
+      vertex 6.64152 27.6639 0.599999
+      vertex 7.72248 27.3819 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.50145 27.0805 0.599999
+      vertex 6.64152 27.6639 0.599999
+      vertex 7.55962 26.8044 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.50145 27.0805 0.599999
+      vertex 5.55032 27.9033 0.599999
+      vertex 6.64152 27.6639 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.43326 27.3149 0.599999
+      vertex 5.55032 27.9033 0.599999
+      vertex 6.50145 27.0805 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.43326 27.3149 0.599999
+      vertex 4.45056 28.0997 0.599999
+      vertex 5.55032 27.9033 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.3567 27.5071 0.599999
+      vertex 4.45056 28.0997 0.599999
+      vertex 5.43326 27.3149 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.3567 27.5071 0.599999
+      vertex 3.34394 28.2528 0.599999
+      vertex 4.45056 28.0997 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.27342 27.657 0.599999
+      vertex 3.34394 28.2528 0.599999
+      vertex 4.3567 27.5071 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.27342 27.657 0.599999
+      vertex 2.23216 28.3623 0.599999
+      vertex 3.34394 28.2528 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.18509 27.7641 0.599999
+      vertex 2.23216 28.3623 0.599999
+      vertex 3.27342 27.657 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.18509 27.7641 0.599999
+      vertex 1.11694 28.4281 0.599999
+      vertex 2.23216 28.3623 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.09339 27.8285 0.599999
+      vertex 1.11694 28.4281 0.599999
+      vertex 2.18509 27.7641 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 27.85 0.599999
+      vertex 1.11694 28.4281 0.599999
+      vertex 1.09339 27.8285 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 27.85 0.599999
+      vertex 0 28.45 0.599999
+      vertex 1.11694 28.4281 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.09339 27.8285 0.599999
+      vertex 0 28.45 0.599999
+      vertex 0 27.85 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.09339 27.8285 0.599999
+      vertex -1.11694 28.4281 0.599999
+      vertex 0 28.45 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.18509 27.7641 0.599999
+      vertex -1.11694 28.4281 0.599999
+      vertex -1.09339 27.8285 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.18509 27.7641 0.599999
+      vertex -2.23216 28.3623 0.599999
+      vertex -1.11694 28.4281 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.27342 27.657 0.599999
+      vertex -2.23216 28.3623 0.599999
+      vertex -2.18509 27.7641 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.27342 27.657 0.599999
+      vertex -3.34394 28.2528 0.599999
+      vertex -2.23216 28.3623 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.3567 27.5071 0.599999
+      vertex -3.34394 28.2528 0.599999
+      vertex -3.27342 27.657 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.3567 27.5071 0.599999
+      vertex -4.45056 28.0997 0.599999
+      vertex -3.34394 28.2528 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.43326 27.3149 0.599999
+      vertex -4.45056 28.0997 0.599999
+      vertex -4.3567 27.5071 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.43326 27.3149 0.599999
+      vertex -5.55032 27.9033 0.599999
+      vertex -4.45056 28.0997 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.50145 27.0805 0.599999
+      vertex -5.55032 27.9033 0.599999
+      vertex -5.43326 27.3149 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.50145 27.0805 0.599999
+      vertex -6.64152 27.6639 0.599999
+      vertex -5.55032 27.9033 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.55962 26.8044 0.599999
+      vertex -6.64152 27.6639 0.599999
+      vertex -6.50145 27.0805 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.55962 26.8044 0.599999
+      vertex -7.72248 27.3819 0.599999
+      vertex -6.64152 27.6639 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.60612 26.4869 0.599999
+      vertex -7.72248 27.3819 0.599999
+      vertex -7.55962 26.8044 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.60612 26.4869 0.599999
+      vertex -8.79153 27.0576 0.599999
+      vertex -7.72248 27.3819 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.63936 26.1286 0.599999
+      vertex -8.79153 27.0576 0.599999
+      vertex -8.60612 26.4869 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.63936 26.1286 0.599999
+      vertex -9.84703 26.6915 0.599999
+      vertex -8.79153 27.0576 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6577 25.73 0.599999
+      vertex -9.84703 26.6915 0.599999
+      vertex -9.63936 26.1286 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6577 25.73 0.599999
+      vertex -10.8873 26.2844 0.599999
+      vertex -9.84703 26.6915 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.6597 25.2918 0.599999
+      vertex -10.8873 26.2844 0.599999
+      vertex -10.6577 25.73 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.6597 25.2918 0.599999
+      vertex -11.9109 25.8367 0.599999
+      vertex -10.8873 26.2844 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.6436 24.8145 0.599999
+      vertex -11.9109 25.8367 0.599999
+      vertex -11.6597 25.2918 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.6436 24.8145 0.599999
+      vertex -12.916 25.3491 0.599999
+      vertex -11.9109 25.8367 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.6081 24.299 0.599999
+      vertex -12.916 25.3491 0.599999
+      vertex -12.6436 24.8145 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.6081 24.299 0.599999
+      vertex -13.9013 24.8225 0.599999
+      vertex -12.916 25.3491 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.5516 23.746 0.599999
+      vertex -13.9013 24.8225 0.599999
+      vertex -13.6081 24.299 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.5516 23.746 0.599999
+      vertex -14.8651 24.2576 0.599999
+      vertex -13.9013 24.8225 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.4726 23.1564 0.599999
+      vertex -14.8651 24.2576 0.599999
+      vertex -14.5516 23.746 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.4726 23.1564 0.599999
+      vertex -15.806 23.6553 0.599999
+      vertex -14.8651 24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.3698 22.5311 0.599999
+      vertex -15.806 23.6553 0.599999
+      vertex -15.4726 23.1564 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.3698 22.5311 0.599999
+      vertex -16.7225 23.0165 0.599999
+      vertex -15.806 23.6553 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.2418 21.8711 0.599999
+      vertex -16.7225 23.0165 0.599999
+      vertex -16.3698 22.5311 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.2418 21.8711 0.599999
+      vertex -17.6132 22.3423 0.599999
+      vertex -16.7225 23.0165 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.0871 21.1773 0.599999
+      vertex -17.6132 22.3423 0.599999
+      vertex -17.2418 21.8711 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.0871 21.1773 0.599999
+      vertex -18.4768 21.6335 0.599999
+      vertex -17.6132 22.3423 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9046 20.4509 0.599999
+      vertex -18.4768 21.6335 0.599999
+      vertex -18.0871 21.1773 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9046 20.4509 0.599999
+      vertex -19.3119 20.8915 0.599999
+      vertex -18.4768 21.6335 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.6929 19.6929 0.599999
+      vertex -19.3119 20.8915 0.599999
+      vertex -18.9046 20.4509 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.6929 19.6929 0.599999
+      vertex -20.1172 20.1172 0.599999
+      vertex -19.3119 20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.4509 18.9046 0.599999
+      vertex -20.1172 20.1172 0.599999
+      vertex -19.6929 19.6929 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.4509 18.9046 0.599999
+      vertex -20.8915 19.3119 0.599999
+      vertex -20.1172 20.1172 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.1773 18.0871 0.599999
+      vertex -20.8915 19.3119 0.599999
+      vertex -20.4509 18.9046 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.1773 18.0871 0.599999
+      vertex -21.6335 18.4768 0.599999
+      vertex -20.8915 19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.8711 17.2418 0.599999
+      vertex -21.6335 18.4768 0.599999
+      vertex -21.1773 18.0871 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.8711 17.2418 0.599999
+      vertex -22.3423 17.6132 0.599999
+      vertex -21.6335 18.4768 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5311 16.3698 0.599999
+      vertex -22.3423 17.6132 0.599999
+      vertex -21.8711 17.2418 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5311 16.3698 0.599999
+      vertex -23.0165 16.7225 0.599999
+      vertex -22.3423 17.6132 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.1564 15.4726 0.599999
+      vertex -23.0165 16.7225 0.599999
+      vertex -22.5311 16.3698 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.1564 15.4726 0.599999
+      vertex -23.6553 15.806 0.599999
+      vertex -23.0165 16.7225 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.746 14.5516 0.599999
+      vertex -23.6553 15.806 0.599999
+      vertex -23.1564 15.4726 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.746 14.5516 0.599999
+      vertex -24.2576 14.8651 0.599999
+      vertex -23.6553 15.806 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.299 13.6081 0.599999
+      vertex -24.2576 14.8651 0.599999
+      vertex -23.746 14.5516 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.8225 13.9013 0.599999
+      vertex -24.299 13.6081 0.599999
+      vertex -24.8145 12.6436 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.299 13.6081 0.599999
+      vertex -24.8225 13.9013 0.599999
+      vertex -24.2576 14.8651 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.3491 12.916 0.599999
+      vertex -24.8145 12.6436 0.599999
+      vertex -25.2918 11.6597 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.8145 12.6436 0.599999
+      vertex -25.3491 12.916 0.599999
+      vertex -24.8225 13.9013 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.8367 11.9109 0.599999
+      vertex -25.2918 11.6597 0.599999
+      vertex -25.73 10.6577 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.2918 11.6597 0.599999
+      vertex -25.8367 11.9109 0.599999
+      vertex -25.3491 12.916 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.2844 10.8873 0.599999
+      vertex -25.73 10.6577 0.599999
+      vertex -26.1286 9.63936 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.73 10.6577 0.599999
+      vertex -26.2844 10.8873 0.599999
+      vertex -25.8367 11.9109 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.6915 9.84703 0.599999
+      vertex -26.1286 9.63936 0.599999
+      vertex -26.4869 8.60612 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.1286 9.63936 0.599999
+      vertex -26.6915 9.84703 0.599999
+      vertex -26.2844 10.8873 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0576 8.79153 0.599999
+      vertex -26.4869 8.60612 0.599999
+      vertex -26.8044 7.55962 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.4869 8.60612 0.599999
+      vertex -27.0576 8.79153 0.599999
+      vertex -26.6915 9.84703 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.3819 7.72248 0.599999
+      vertex -26.8044 7.55962 0.599999
+      vertex -27.0805 6.50145 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6639 6.64152 0.599999
+      vertex -27.0805 6.50145 0.599999
+      vertex -27.3149 5.43326 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.8044 7.55962 0.599999
+      vertex -27.3819 7.72248 0.599999
+      vertex -27.0576 8.79153 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.9033 5.55032 0.599999
+      vertex -27.3149 5.43326 0.599999
+      vertex -27.5071 4.3567 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.0997 4.45056 0.599999
+      vertex -27.5071 4.3567 0.599999
+      vertex -27.657 3.27342 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0805 6.50145 0.599999
+      vertex -27.6639 6.64152 0.599999
+      vertex -27.3819 7.72248 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.2528 3.34394 0.599999
+      vertex -27.657 3.27342 0.599999
+      vertex -27.7641 2.18509 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.3623 2.23216 0.599999
+      vertex -27.7641 2.18509 0.599999
+      vertex -27.8285 1.09339 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.3149 5.43326 0.599999
+      vertex -27.9033 5.55032 0.599999
+      vertex -27.6639 6.64152 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.4281 1.11694 0.599999
+      vertex -27.8285 1.09339 0.599999
+      vertex -27.85 0 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.3623 -2.23216 0.599999
+      vertex -27.7641 -2.18509 0.599999
+      vertex -28.2528 -3.34394 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.7641 -2.18509 0.599999
+      vertex -28.3623 -2.23216 0.599999
+      vertex -27.8285 -1.09339 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.5071 4.3567 0.599999
+      vertex -28.0997 4.45056 0.599999
+      vertex -27.9033 5.55032 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.4281 -1.11694 0.599999
+      vertex -27.8285 -1.09339 0.599999
+      vertex -28.3623 -2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.657 3.27342 0.599999
+      vertex -28.2528 3.34394 0.599999
+      vertex -28.0997 4.45056 0.599999
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.8285 -1.09339 0.599999
+      vertex -28.4281 -1.11694 0.599999
+      vertex -27.85 0 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.7641 2.18509 0.599999
+      vertex -28.3623 2.23216 0.599999
+      vertex -28.2528 3.34394 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.45 0 0.599999
+      vertex -27.85 0 0.599999
+      vertex -28.4281 -1.11694 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.8285 1.09339 0.599999
+      vertex -28.4281 1.11694 0.599999
+      vertex -28.3623 2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.85 0 0.599999
+      vertex -28.45 0 0.599999
+      vertex -28.4281 1.11694 0.599999
+    endloop
+  endfacet
+  facet normal 0.603506 -0.797359 0
+    outer loop
+      vertex -17.2418 21.8711 0.599999
+      vertex -16.3698 22.5311 58.4
+      vertex -17.2418 21.8711 58.4
+    endloop
+  endfacet
+  facet normal 0.603506 -0.797359 0
+    outer loop
+      vertex -16.3698 22.5311 58.4
+      vertex -17.2418 21.8711 0.599999
+      vertex -16.3698 22.5311 0.599999
+    endloop
+  endfacet
+  facet normal 0.0196598 0.999807 -0
+    outer loop
+      vertex 0 -27.85 0.599999
+      vertex -1.09339 -27.8285 58.4
+      vertex 0 -27.85 58.4
+    endloop
+  endfacet
+  facet normal 0.0196598 0.999807 0
+    outer loop
+      vertex -1.09339 -27.8285 58.4
+      vertex 0 -27.85 0.599999
+      vertex -1.09339 -27.8285 0.599999
+    endloop
+  endfacet
+  facet normal -0.327633 0.944805 0
+    outer loop
+      vertex 9.63936 -26.1286 0.599999
+      vertex 8.60612 -26.4869 58.4
+      vertex 9.63936 -26.1286 58.4
+    endloop
+  endfacet
+  facet normal -0.327633 0.944805 0
+    outer loop
+      vertex 8.60612 -26.4869 58.4
+      vertex 9.63936 -26.1286 0.599999
+      vertex 8.60612 -26.4869 0.599999
+    endloop
+  endfacet
+  facet normal -0.400685 -0.916216 0
+    outer loop
+      vertex 10.6577 25.73 0.599999
+      vertex 11.6597 25.2918 58.4
+      vertex 10.6577 25.73 58.4
+    endloop
+  endfacet
+  facet normal -0.400685 -0.916216 -0
+    outer loop
+      vertex 11.6597 25.2918 58.4
+      vertex 10.6577 25.73 0.599999
+      vertex 11.6597 25.2918 0.599999
+    endloop
+  endfacet
+  facet normal -0.881935 -0.471371 0
+    outer loop
+      vertex 24.8145 12.6436 0.599999
+      vertex 24.299 13.6081 58.4
+      vertex 24.299 13.6081 0.599999
+    endloop
+  endfacet
+  facet normal -0.881935 -0.471371 0
+    outer loop
+      vertex 24.299 13.6081 58.4
+      vertex 24.8145 12.6436 0.599999
+      vertex 24.8145 12.6436 58.4
+    endloop
+  endfacet
+  facet normal -0.995193 0.0979346 0
+    outer loop
+      vertex 27.657 -3.27342 0.599999
+      vertex 27.7641 -2.18509 58.4
+      vertex 27.7641 -2.18509 0.599999
+    endloop
+  endfacet
+  facet normal -0.995193 0.0979346 0
+    outer loop
+      vertex 27.7641 -2.18509 58.4
+      vertex 27.657 -3.27342 0.599999
+      vertex 27.657 -3.27342 58.4
+    endloop
+  endfacet
+  facet normal -0.290325 -0.956928 0
+    outer loop
+      vertex 7.55962 26.8044 0.599999
+      vertex 8.60612 26.4869 58.4
+      vertex 7.55962 26.8044 58.4
+    endloop
+  endfacet
+  facet normal -0.290325 -0.956928 -0
+    outer loop
+      vertex 8.60612 26.4869 58.4
+      vertex 7.55962 26.8044 0.599999
+      vertex 8.60612 26.4869 0.599999
+    endloop
+  endfacet
+  facet normal 0.0979346 -0.995193 0
+    outer loop
+      vertex -3.27342 27.657 0.599999
+      vertex -2.18509 27.7641 58.4
+      vertex -3.27342 27.657 58.4
+    endloop
+  endfacet
+  facet normal 0.0979346 -0.995193 0
+    outer loop
+      vertex -2.18509 27.7641 58.4
+      vertex -3.27342 27.657 0.599999
+      vertex -2.18509 27.7641 0.599999
+    endloop
+  endfacet
+  facet normal -0.984434 0.175753 0
+    outer loop
+      vertex 27.3149 -5.43326 0.599999
+      vertex 27.5071 -4.3567 58.4
+      vertex 27.5071 -4.3567 0.599999
+    endloop
+  endfacet
+  facet normal -0.984434 0.175753 0
+    outer loop
+      vertex 27.5071 -4.3567 58.4
+      vertex 27.3149 -5.43326 0.599999
+      vertex 27.3149 -5.43326 58.4
+    endloop
+  endfacet
+  facet normal -0.400685 0.916216 0
+    outer loop
+      vertex 11.6597 -25.2918 0.599999
+      vertex 10.6577 -25.73 58.4
+      vertex 11.6597 -25.2918 58.4
+    endloop
+  endfacet
+  facet normal -0.400685 0.916216 0
+    outer loop
+      vertex 10.6577 -25.73 58.4
+      vertex 11.6597 -25.2918 0.599999
+      vertex 10.6577 -25.73 0.599999
+    endloop
+  endfacet
+  facet normal 0.327633 0.944805 -0
+    outer loop
+      vertex -8.60612 -26.4869 0.599999
+      vertex -9.63936 -26.1286 58.4
+      vertex -8.60612 -26.4869 58.4
+    endloop
+  endfacet
+  facet normal 0.327633 0.944805 0
+    outer loop
+      vertex -9.63936 -26.1286 58.4
+      vertex -8.60612 -26.4869 0.599999
+      vertex -9.63936 -26.1286 0.599999
+    endloop
+  endfacet
+  facet normal 0.944805 0.327633 0
+    outer loop
+      vertex -26.1286 -9.63936 58.4
+      vertex -26.4869 -8.60612 0.599999
+      vertex -26.4869 -8.60612 58.4
+    endloop
+  endfacet
+  facet normal 0.944805 0.327633 0
+    outer loop
+      vertex -26.4869 -8.60612 0.599999
+      vertex -26.1286 -9.63936 58.4
+      vertex -26.1286 -9.63936 0.599999
+    endloop
+  endfacet
+  facet normal -0.25247 0.967605 0
+    outer loop
+      vertex 7.55962 -26.8044 0.599999
+      vertex 6.50145 -27.0805 58.4
+      vertex 7.55962 -26.8044 58.4
+    endloop
+  endfacet
+  facet normal -0.25247 0.967605 0
+    outer loop
+      vertex 6.50145 -27.0805 58.4
+      vertex 7.55962 -26.8044 0.599999
+      vertex 6.50145 -27.0805 0.599999
+    endloop
+  endfacet
+  facet normal -0.984434 -0.175753 0
+    outer loop
+      vertex 27.5071 4.3567 0.599999
+      vertex 27.3149 5.43326 58.4
+      vertex 27.3149 5.43326 0.599999
+    endloop
+  endfacet
+  facet normal -0.984434 -0.175753 0
+    outer loop
+      vertex 27.3149 5.43326 58.4
+      vertex 27.5071 4.3567 0.599999
+      vertex 27.5071 4.3567 58.4
+    endloop
+  endfacet
+  facet normal -0.97676 -0.214337 0
+    outer loop
+      vertex 27.3149 5.43326 0.599999
+      vertex 27.0805 6.50145 58.4
+      vertex 27.0805 6.50145 0.599999
+    endloop
+  endfacet
+  facet normal -0.97676 -0.214337 0
+    outer loop
+      vertex 27.0805 6.50145 58.4
+      vertex 27.3149 5.43326 0.599999
+      vertex 27.3149 5.43326 58.4
+    endloop
+  endfacet
+  facet normal -0.693118 -0.720824 0
+    outer loop
+      vertex 18.9046 20.4509 0.599999
+      vertex 19.6929 19.6929 58.4
+      vertex 18.9046 20.4509 58.4
+    endloop
+  endfacet
+  facet normal -0.693118 -0.720824 -0
+    outer loop
+      vertex 19.6929 19.6929 58.4
+      vertex 18.9046 20.4509 0.599999
+      vertex 19.6929 19.6929 0.599999
+    endloop
+  endfacet
+  facet normal -0.956928 -0.290325 0
+    outer loop
+      vertex 26.8044 7.55962 0.599999
+      vertex 26.4869 8.60612 58.4
+      vertex 26.4869 8.60612 0.599999
+    endloop
+  endfacet
+  facet normal -0.956928 -0.290325 0
+    outer loop
+      vertex 26.4869 8.60612 58.4
+      vertex 26.8044 7.55962 0.599999
+      vertex 26.8044 7.55962 58.4
+    endloop
+  endfacet
+  facet normal 0.0588882 -0.998265 0
+    outer loop
+      vertex -2.18509 27.7641 0.599999
+      vertex -1.09339 27.8285 58.4
+      vertex -2.18509 27.7641 58.4
+    endloop
+  endfacet
+  facet normal 0.0588882 -0.998265 0
+    outer loop
+      vertex -1.09339 27.8285 58.4
+      vertex -2.18509 27.7641 0.599999
+      vertex -1.09339 27.8285 0.599999
+    endloop
+  endfacet
+  facet normal 0.214337 0.97676 -0
+    outer loop
+      vertex -5.43326 -27.3149 0.599999
+      vertex -6.50145 -27.0805 58.4
+      vertex -5.43326 -27.3149 58.4
+    endloop
+  endfacet
+  facet normal 0.214337 0.97676 0
+    outer loop
+      vertex -6.50145 -27.0805 58.4
+      vertex -5.43326 -27.3149 0.599999
+      vertex -6.50145 -27.0805 0.599999
+    endloop
+  endfacet
+  facet normal -0.0588882 0.998265 0
+    outer loop
+      vertex 2.18509 -27.7641 0.599999
+      vertex 1.09339 -27.8285 58.4
+      vertex 2.18509 -27.7641 58.4
+    endloop
+  endfacet
+  facet normal -0.0588882 0.998265 0
+    outer loop
+      vertex 1.09339 -27.8285 58.4
+      vertex 2.18509 -27.7641 0.599999
+      vertex 1.09339 -27.8285 0.599999
+    endloop
+  endfacet
+  facet normal -0.899722 0.436464 0
+    outer loop
+      vertex 24.8145 -12.6436 0.599999
+      vertex 25.2918 -11.6597 58.4
+      vertex 25.2918 -11.6597 0.599999
+    endloop
+  endfacet
+  facet normal -0.899722 0.436464 0
+    outer loop
+      vertex 25.2918 -11.6597 58.4
+      vertex 24.8145 -12.6436 0.599999
+      vertex 24.8145 -12.6436 58.4
+    endloop
+  endfacet
+  facet normal 0.995193 0.0979346 0
+    outer loop
+      vertex -27.657 -3.27342 58.4
+      vertex -27.7641 -2.18509 0.599999
+      vertex -27.7641 -2.18509 58.4
+    endloop
+  endfacet
+  facet normal 0.995193 0.0979346 0
+    outer loop
+      vertex -27.7641 -2.18509 0.599999
+      vertex -27.657 -3.27342 58.4
+      vertex -27.657 -3.27342 0.599999
+    endloop
+  endfacet
+  facet normal -0.436464 0.899722 0
+    outer loop
+      vertex 12.6436 -24.8145 0.599999
+      vertex 11.6597 -25.2918 58.4
+      vertex 12.6436 -24.8145 58.4
+    endloop
+  endfacet
+  facet normal -0.436464 0.899722 0
+    outer loop
+      vertex 11.6597 -25.2918 58.4
+      vertex 12.6436 -24.8145 0.599999
+      vertex 11.6597 -25.2918 0.599999
+    endloop
+  endfacet
+  facet normal 0.327633 -0.944805 0
+    outer loop
+      vertex -9.63936 26.1286 0.599999
+      vertex -8.60612 26.4869 58.4
+      vertex -9.63936 26.1286 58.4
+    endloop
+  endfacet
+  facet normal 0.327633 -0.944805 0
+    outer loop
+      vertex -8.60612 26.4869 58.4
+      vertex -9.63936 26.1286 0.599999
+      vertex -8.60612 26.4869 0.599999
+    endloop
+  endfacet
+  facet normal -0.820407 0.57178 0
+    outer loop
+      vertex 22.5311 -16.3698 0.599999
+      vertex 23.1564 -15.4726 58.4
+      vertex 23.1564 -15.4726 0.599999
+    endloop
+  endfacet
+  facet normal -0.820407 0.57178 0
+    outer loop
+      vertex 23.1564 -15.4726 58.4
+      vertex 22.5311 -16.3698 0.599999
+      vertex 22.5311 -16.3698 58.4
+    endloop
+  endfacet
+  facet normal -0.175753 0.984434 0
+    outer loop
+      vertex 5.43326 -27.3149 0.599999
+      vertex 4.3567 -27.5071 58.4
+      vertex 5.43326 -27.3149 58.4
+    endloop
+  endfacet
+  facet normal -0.175753 0.984434 0
+    outer loop
+      vertex 4.3567 -27.5071 58.4
+      vertex 5.43326 -27.3149 0.599999
+      vertex 4.3567 -27.5071 0.599999
+    endloop
+  endfacet
+  facet normal 0.175753 0.984434 -0
+    outer loop
+      vertex -4.3567 -27.5071 0.599999
+      vertex -5.43326 -27.3149 58.4
+      vertex -4.3567 -27.5071 58.4
+    endloop
+  endfacet
+  facet normal 0.175753 0.984434 0
+    outer loop
+      vertex -5.43326 -27.3149 58.4
+      vertex -4.3567 -27.5071 0.599999
+      vertex -5.43326 -27.3149 0.599999
+    endloop
+  endfacet
+  facet normal -0.57178 -0.820407 0
+    outer loop
+      vertex 15.4726 23.1564 0.599999
+      vertex 16.3698 22.5311 58.4
+      vertex 15.4726 23.1564 58.4
+    endloop
+  endfacet
+  facet normal -0.57178 -0.820407 -0
+    outer loop
+      vertex 16.3698 22.5311 58.4
+      vertex 15.4726 23.1564 0.599999
+      vertex 16.3698 22.5311 0.599999
+    endloop
+  endfacet
+  facet normal -0.25247 -0.967605 0
+    outer loop
+      vertex 6.50145 27.0805 0.599999
+      vertex 7.55962 26.8044 58.4
+      vertex 6.50145 27.0805 58.4
+    endloop
+  endfacet
+  facet normal -0.25247 -0.967605 -0
+    outer loop
+      vertex 7.55962 26.8044 58.4
+      vertex 6.50145 27.0805 0.599999
+      vertex 7.55962 26.8044 0.599999
+    endloop
+  endfacet
+  facet normal -0.13707 -0.990561 0
+    outer loop
+      vertex 3.27342 27.657 0.599999
+      vertex 4.3567 27.5071 58.4
+      vertex 3.27342 27.657 58.4
+    endloop
+  endfacet
+  facet normal -0.13707 -0.990561 -0
+    outer loop
+      vertex 4.3567 27.5071 58.4
+      vertex 3.27342 27.657 0.599999
+      vertex 4.3567 27.5071 0.599999
+    endloop
+  endfacet
+  facet normal 0.13707 -0.990561 0
+    outer loop
+      vertex -4.3567 27.5071 0.599999
+      vertex -3.27342 27.657 58.4
+      vertex -4.3567 27.5071 58.4
+    endloop
+  endfacet
+  facet normal 0.13707 -0.990561 0
+    outer loop
+      vertex -3.27342 27.657 58.4
+      vertex -4.3567 27.5071 0.599999
+      vertex -3.27342 27.657 0.599999
+    endloop
+  endfacet
+  facet normal -0.0979346 0.995193 0
+    outer loop
+      vertex 3.27342 -27.657 0.599999
+      vertex 2.18509 -27.7641 58.4
+      vertex 3.27342 -27.657 58.4
+    endloop
+  endfacet
+  facet normal -0.0979346 0.995193 0
+    outer loop
+      vertex 2.18509 -27.7641 58.4
+      vertex 3.27342 -27.657 0.599999
+      vertex 2.18509 -27.7641 0.599999
+    endloop
+  endfacet
+  facet normal -0.990561 0.13707 0
+    outer loop
+      vertex 27.5071 -4.3567 0.599999
+      vertex 27.657 -3.27342 58.4
+      vertex 27.657 -3.27342 0.599999
+    endloop
+  endfacet
+  facet normal -0.990561 0.13707 0
+    outer loop
+      vertex 27.657 -3.27342 58.4
+      vertex 27.5071 -4.3567 0.599999
+      vertex 27.5071 -4.3567 58.4
+    endloop
+  endfacet
+  facet normal -0.842205 0.539157 0
+    outer loop
+      vertex 23.1564 -15.4726 0.599999
+      vertex 23.746 -14.5516 58.4
+      vertex 23.746 -14.5516 0.599999
+    endloop
+  endfacet
+  facet normal -0.842205 0.539157 0
+    outer loop
+      vertex 23.746 -14.5516 58.4
+      vertex 23.1564 -15.4726 0.599999
+      vertex 23.1564 -15.4726 58.4
+    endloop
+  endfacet
+  facet normal -0.664228 -0.74753 0
+    outer loop
+      vertex 18.0871 21.1773 0.599999
+      vertex 18.9046 20.4509 58.4
+      vertex 18.0871 21.1773 58.4
+    endloop
+  endfacet
+  facet normal -0.664228 -0.74753 -0
+    outer loop
+      vertex 18.9046 20.4509 58.4
+      vertex 18.0871 21.1773 0.599999
+      vertex 18.9046 20.4509 0.599999
+    endloop
+  endfacet
+  facet normal 0.364494 0.931206 -0
+    outer loop
+      vertex -9.63936 -26.1286 0.599999
+      vertex -10.6577 -25.73 58.4
+      vertex -9.63936 -26.1286 58.4
+    endloop
+  endfacet
+  facet normal 0.364494 0.931206 0
+    outer loop
+      vertex -10.6577 -25.73 58.4
+      vertex -9.63936 -26.1286 0.599999
+      vertex -10.6577 -25.73 0.599999
+    endloop
+  endfacet
+  facet normal -0.998265 0.0588882 0
+    outer loop
+      vertex 27.7641 -2.18509 0.599999
+      vertex 27.8285 -1.09339 58.4
+      vertex 27.8285 -1.09339 0.599999
+    endloop
+  endfacet
+  facet normal -0.998265 0.0588882 0
+    outer loop
+      vertex 27.8285 -1.09339 58.4
+      vertex 27.7641 -2.18509 0.599999
+      vertex 27.7641 -2.18509 58.4
+    endloop
+  endfacet
+  facet normal -0.999807 0.0196598 0
+    outer loop
+      vertex 27.8285 -1.09339 0.599999
+      vertex 27.85 0 58.4
+      vertex 27.85 0 0.599999
+    endloop
+  endfacet
+  facet normal -0.999807 0.0196598 0
+    outer loop
+      vertex 27.85 0 58.4
+      vertex 27.8285 -1.09339 0.599999
+      vertex 27.8285 -1.09339 58.4
+    endloop
+  endfacet
+  facet normal -0.720824 0.693118 0
+    outer loop
+      vertex 19.6929 -19.6929 0.599999
+      vertex 20.4509 -18.9046 58.4
+      vertex 20.4509 -18.9046 0.599999
+    endloop
+  endfacet
+  facet normal -0.720824 0.693118 0
+    outer loop
+      vertex 20.4509 -18.9046 58.4
+      vertex 19.6929 -19.6929 0.599999
+      vertex 19.6929 -19.6929 58.4
+    endloop
+  endfacet
+  facet normal 0.436464 0.899722 -0
+    outer loop
+      vertex -11.6597 -25.2918 0.599999
+      vertex -12.6436 -24.8145 58.4
+      vertex -11.6597 -25.2918 58.4
+    endloop
+  endfacet
+  facet normal 0.436464 0.899722 0
+    outer loop
+      vertex -12.6436 -24.8145 58.4
+      vertex -11.6597 -25.2918 0.599999
+      vertex -12.6436 -24.8145 0.599999
+    endloop
+  endfacet
+  facet normal -0.797359 -0.603506 0
+    outer loop
+      vertex 22.5311 16.3698 0.599999
+      vertex 21.8711 17.2418 58.4
+      vertex 21.8711 17.2418 0.599999
+    endloop
+  endfacet
+  facet normal -0.797359 -0.603506 0
+    outer loop
+      vertex 21.8711 17.2418 58.4
+      vertex 22.5311 16.3698 0.599999
+      vertex 22.5311 16.3698 58.4
+    endloop
+  endfacet
+  facet normal -0.967605 -0.25247 0
+    outer loop
+      vertex 27.0805 6.50145 0.599999
+      vertex 26.8044 7.55962 58.4
+      vertex 26.8044 7.55962 0.599999
+    endloop
+  endfacet
+  facet normal -0.967605 -0.25247 0
+    outer loop
+      vertex 26.8044 7.55962 58.4
+      vertex 27.0805 6.50145 0.599999
+      vertex 27.0805 6.50145 58.4
+    endloop
+  endfacet
+  facet normal 0.990561 0.13707 0
+    outer loop
+      vertex -27.5071 -4.3567 58.4
+      vertex -27.657 -3.27342 0.599999
+      vertex -27.657 -3.27342 58.4
+    endloop
+  endfacet
+  facet normal 0.990561 0.13707 0
+    outer loop
+      vertex -27.657 -3.27342 0.599999
+      vertex -27.5071 -4.3567 58.4
+      vertex -27.5071 -4.3567 0.599999
+    endloop
+  endfacet
+  facet normal 0.995193 -0.0979346 0
+    outer loop
+      vertex -27.7641 2.18509 58.4
+      vertex -27.657 3.27342 0.599999
+      vertex -27.657 3.27342 58.4
+    endloop
+  endfacet
+  facet normal 0.995193 -0.0979346 0
+    outer loop
+      vertex -27.657 3.27342 0.599999
+      vertex -27.7641 2.18509 58.4
+      vertex -27.7641 2.18509 0.599999
+    endloop
+  endfacet
+  facet normal -0.772974 0.634437 0
+    outer loop
+      vertex 21.1773 -18.0871 0.599999
+      vertex 21.8711 -17.2418 58.4
+      vertex 21.8711 -17.2418 0.599999
+    endloop
+  endfacet
+  facet normal -0.772974 0.634437 0
+    outer loop
+      vertex 21.8711 -17.2418 58.4
+      vertex 21.1773 -18.0871 0.599999
+      vertex 21.1773 -18.0871 58.4
+    endloop
+  endfacet
+  facet normal 0.634437 0.772974 -0
+    outer loop
+      vertex -17.2418 -21.8711 0.599999
+      vertex -18.0871 -21.1773 58.4
+      vertex -17.2418 -21.8711 58.4
+    endloop
+  endfacet
+  facet normal 0.634437 0.772974 0
+    outer loop
+      vertex -18.0871 -21.1773 58.4
+      vertex -17.2418 -21.8711 0.599999
+      vertex -18.0871 -21.1773 0.599999
+    endloop
+  endfacet
+  facet normal -0.57178 0.820407 0
+    outer loop
+      vertex 16.3698 -22.5311 0.599999
+      vertex 15.4726 -23.1564 58.4
+      vertex 16.3698 -22.5311 58.4
+    endloop
+  endfacet
+  facet normal -0.57178 0.820407 0
+    outer loop
+      vertex 15.4726 -23.1564 58.4
+      vertex 16.3698 -22.5311 0.599999
+      vertex 15.4726 -23.1564 0.599999
+    endloop
+  endfacet
+  facet normal 0.944805 -0.327633 0
+    outer loop
+      vertex -26.4869 8.60612 58.4
+      vertex -26.1286 9.63936 0.599999
+      vertex -26.1286 9.63936 58.4
+    endloop
+  endfacet
+  facet normal 0.944805 -0.327633 0
+    outer loop
+      vertex -26.1286 9.63936 0.599999
+      vertex -26.4869 8.60612 58.4
+      vertex -26.4869 8.60612 0.599999
+    endloop
+  endfacet
+  facet normal 0.634437 -0.772974 0
+    outer loop
+      vertex -18.0871 21.1773 0.599999
+      vertex -17.2418 21.8711 58.4
+      vertex -18.0871 21.1773 58.4
+    endloop
+  endfacet
+  facet normal 0.634437 -0.772974 0
+    outer loop
+      vertex -17.2418 21.8711 58.4
+      vertex -18.0871 21.1773 0.599999
+      vertex -17.2418 21.8711 0.599999
+    endloop
+  endfacet
+  facet normal -0.603506 0.797359 0
+    outer loop
+      vertex 17.2418 -21.8711 0.599999
+      vertex 16.3698 -22.5311 58.4
+      vertex 17.2418 -21.8711 58.4
+    endloop
+  endfacet
+  facet normal -0.603506 0.797359 0
+    outer loop
+      vertex 16.3698 -22.5311 58.4
+      vertex 17.2418 -21.8711 0.599999
+      vertex 16.3698 -22.5311 0.599999
+    endloop
+  endfacet
+  facet normal -0.327633 -0.944805 0
+    outer loop
+      vertex 8.60612 26.4869 0.599999
+      vertex 9.63936 26.1286 58.4
+      vertex 8.60612 26.4869 58.4
+    endloop
+  endfacet
+  facet normal -0.327633 -0.944805 -0
+    outer loop
+      vertex 9.63936 26.1286 58.4
+      vertex 8.60612 26.4869 0.599999
+      vertex 9.63936 26.1286 0.599999
+    endloop
+  endfacet
+  facet normal 0.797359 0.603506 0
+    outer loop
+      vertex -21.8711 -17.2418 58.4
+      vertex -22.5311 -16.3698 0.599999
+      vertex -22.5311 -16.3698 58.4
+    endloop
+  endfacet
+  facet normal 0.797359 0.603506 0
+    outer loop
+      vertex -22.5311 -16.3698 0.599999
+      vertex -21.8711 -17.2418 58.4
+      vertex -21.8711 -17.2418 0.599999
+    endloop
+  endfacet
+  facet normal 0.471371 -0.881935 0
+    outer loop
+      vertex -13.6081 24.299 0.599999
+      vertex -12.6436 24.8145 58.4
+      vertex -13.6081 24.299 58.4
+    endloop
+  endfacet
+  facet normal 0.471371 -0.881935 0
+    outer loop
+      vertex -12.6436 24.8145 58.4
+      vertex -13.6081 24.299 0.599999
+      vertex -12.6436 24.8145 0.599999
+    endloop
+  endfacet
+  facet normal 0.505661 -0.862732 0
+    outer loop
+      vertex -14.5516 23.746 0.599999
+      vertex -13.6081 24.299 58.4
+      vertex -14.5516 23.746 58.4
+    endloop
+  endfacet
+  facet normal 0.505661 -0.862732 0
+    outer loop
+      vertex -13.6081 24.299 58.4
+      vertex -14.5516 23.746 0.599999
+      vertex -13.6081 24.299 0.599999
+    endloop
+  endfacet
+  facet normal 0.0979346 0.995193 -0
+    outer loop
+      vertex -2.18509 -27.7641 0.599999
+      vertex -3.27342 -27.657 58.4
+      vertex -2.18509 -27.7641 58.4
+    endloop
+  endfacet
+  facet normal 0.0979346 0.995193 0
+    outer loop
+      vertex -3.27342 -27.657 58.4
+      vertex -2.18509 -27.7641 0.599999
+      vertex -3.27342 -27.657 0.599999
+    endloop
+  endfacet
+  facet normal -0.603506 -0.797359 0
+    outer loop
+      vertex 16.3698 22.5311 0.599999
+      vertex 17.2418 21.8711 58.4
+      vertex 16.3698 22.5311 58.4
+    endloop
+  endfacet
+  facet normal -0.603506 -0.797359 -0
+    outer loop
+      vertex 17.2418 21.8711 58.4
+      vertex 16.3698 22.5311 0.599999
+      vertex 17.2418 21.8711 0.599999
+    endloop
+  endfacet
+  facet normal -0.539157 -0.842205 0
+    outer loop
+      vertex 14.5516 23.746 0.599999
+      vertex 15.4726 23.1564 58.4
+      vertex 14.5516 23.746 58.4
+    endloop
+  endfacet
+  facet normal -0.539157 -0.842205 -0
+    outer loop
+      vertex 15.4726 23.1564 58.4
+      vertex 14.5516 23.746 0.599999
+      vertex 15.4726 23.1564 0.599999
+    endloop
+  endfacet
+  facet normal -0.0196598 0.999807 0
+    outer loop
+      vertex 1.09339 -27.8285 0.599999
+      vertex 0 -27.85 58.4
+      vertex 1.09339 -27.8285 58.4
+    endloop
+  endfacet
+  facet normal -0.0196598 0.999807 0
+    outer loop
+      vertex 0 -27.85 58.4
+      vertex 1.09339 -27.8285 0.599999
+      vertex 0 -27.85 0.599999
+    endloop
+  endfacet
+  facet normal 0.999807 0.0196598 0
+    outer loop
+      vertex -27.8285 -1.09339 58.4
+      vertex -27.85 0 0.599999
+      vertex -27.85 0 58.4
+    endloop
+  endfacet
+  facet normal 0.999807 0.0196598 0
+    outer loop
+      vertex -27.85 0 0.599999
+      vertex -27.8285 -1.09339 58.4
+      vertex -27.8285 -1.09339 0.599999
+    endloop
+  endfacet
+  facet normal 0.931206 -0.364494 0
+    outer loop
+      vertex -26.1286 9.63936 58.4
+      vertex -25.73 10.6577 0.599999
+      vertex -25.73 10.6577 58.4
+    endloop
+  endfacet
+  facet normal 0.931206 -0.364494 0
+    outer loop
+      vertex -25.73 10.6577 0.599999
+      vertex -26.1286 9.63936 58.4
+      vertex -26.1286 9.63936 0.599999
+    endloop
+  endfacet
+  facet normal 0.664228 0.74753 -0
+    outer loop
+      vertex -18.0871 -21.1773 0.599999
+      vertex -18.9046 -20.4509 58.4
+      vertex -18.0871 -21.1773 58.4
+    endloop
+  endfacet
+  facet normal 0.664228 0.74753 0
+    outer loop
+      vertex -18.9046 -20.4509 58.4
+      vertex -18.0871 -21.1773 0.599999
+      vertex -18.9046 -20.4509 0.599999
+    endloop
+  endfacet
+  facet normal 0.97676 0.214337 0
+    outer loop
+      vertex -27.0805 -6.50145 58.4
+      vertex -27.3149 -5.43326 0.599999
+      vertex -27.3149 -5.43326 58.4
+    endloop
+  endfacet
+  facet normal 0.97676 0.214337 0
+    outer loop
+      vertex -27.3149 -5.43326 0.599999
+      vertex -27.0805 -6.50145 58.4
+      vertex -27.0805 -6.50145 0.599999
+    endloop
+  endfacet
+  facet normal 0.720824 -0.693118 0
+    outer loop
+      vertex -20.4509 18.9046 58.4
+      vertex -19.6929 19.6929 0.599999
+      vertex -19.6929 19.6929 58.4
+    endloop
+  endfacet
+  facet normal 0.720824 -0.693118 0
+    outer loop
+      vertex -19.6929 19.6929 0.599999
+      vertex -20.4509 18.9046 58.4
+      vertex -20.4509 18.9046 0.599999
+    endloop
+  endfacet
+  facet normal 0.214337 -0.97676 0
+    outer loop
+      vertex -6.50145 27.0805 0.599999
+      vertex -5.43326 27.3149 58.4
+      vertex -6.50145 27.0805 58.4
+    endloop
+  endfacet
+  facet normal 0.214337 -0.97676 0
+    outer loop
+      vertex -5.43326 27.3149 58.4
+      vertex -6.50145 27.0805 0.599999
+      vertex -5.43326 27.3149 0.599999
+    endloop
+  endfacet
+  facet normal -0.956928 0.290325 0
+    outer loop
+      vertex 26.4869 -8.60612 0.599999
+      vertex 26.8044 -7.55962 58.4
+      vertex 26.8044 -7.55962 0.599999
+    endloop
+  endfacet
+  facet normal -0.956928 0.290325 0
+    outer loop
+      vertex 26.8044 -7.55962 58.4
+      vertex 26.4869 -8.60612 0.599999
+      vertex 26.4869 -8.60612 58.4
+    endloop
+  endfacet
+  facet normal -0.862732 -0.505661 0
+    outer loop
+      vertex 24.299 13.6081 0.599999
+      vertex 23.746 14.5516 58.4
+      vertex 23.746 14.5516 0.599999
+    endloop
+  endfacet
+  facet normal -0.862732 -0.505661 0
+    outer loop
+      vertex 23.746 14.5516 58.4
+      vertex 24.299 13.6081 0.599999
+      vertex 24.299 13.6081 58.4
+    endloop
+  endfacet
+  facet normal 0.720824 0.693118 0
+    outer loop
+      vertex -19.6929 -19.6929 58.4
+      vertex -20.4509 -18.9046 0.599999
+      vertex -20.4509 -18.9046 58.4
+    endloop
+  endfacet
+  facet normal 0.720824 0.693118 0
+    outer loop
+      vertex -20.4509 -18.9046 0.599999
+      vertex -19.6929 -19.6929 58.4
+      vertex -19.6929 -19.6929 0.599999
+    endloop
+  endfacet
+  facet normal 0.693118 -0.720824 0
+    outer loop
+      vertex -19.6929 19.6929 0.599999
+      vertex -18.9046 20.4509 58.4
+      vertex -19.6929 19.6929 58.4
+    endloop
+  endfacet
+  facet normal 0.693118 -0.720824 0
+    outer loop
+      vertex -18.9046 20.4509 58.4
+      vertex -19.6929 19.6929 0.599999
+      vertex -18.9046 20.4509 0.599999
+    endloop
+  endfacet
+  facet normal 0.664228 -0.74753 0
+    outer loop
+      vertex -18.9046 20.4509 0.599999
+      vertex -18.0871 21.1773 58.4
+      vertex -18.9046 20.4509 58.4
+    endloop
+  endfacet
+  facet normal 0.664228 -0.74753 0
+    outer loop
+      vertex -18.0871 21.1773 58.4
+      vertex -18.9046 20.4509 0.599999
+      vertex -18.0871 21.1773 0.599999
+    endloop
+  endfacet
+  facet normal 0.175753 -0.984434 0
+    outer loop
+      vertex -5.43326 27.3149 0.599999
+      vertex -4.3567 27.5071 58.4
+      vertex -5.43326 27.3149 58.4
+    endloop
+  endfacet
+  facet normal 0.175753 -0.984434 0
+    outer loop
+      vertex -4.3567 27.5071 58.4
+      vertex -5.43326 27.3149 0.599999
+      vertex -4.3567 27.5071 0.599999
+    endloop
+  endfacet
+  facet normal -0.471371 -0.881935 0
+    outer loop
+      vertex 12.6436 24.8145 0.599999
+      vertex 13.6081 24.299 58.4
+      vertex 12.6436 24.8145 58.4
+    endloop
+  endfacet
+  facet normal -0.471371 -0.881935 -0
+    outer loop
+      vertex 13.6081 24.299 58.4
+      vertex 12.6436 24.8145 0.599999
+      vertex 13.6081 24.299 0.599999
+    endloop
+  endfacet
+  facet normal -0.944805 0.327633 0
+    outer loop
+      vertex 26.1286 -9.63936 0.599999
+      vertex 26.4869 -8.60612 58.4
+      vertex 26.4869 -8.60612 0.599999
+    endloop
+  endfacet
+  facet normal -0.944805 0.327633 0
+    outer loop
+      vertex 26.4869 -8.60612 58.4
+      vertex 26.1286 -9.63936 0.599999
+      vertex 26.1286 -9.63936 58.4
+    endloop
+  endfacet
+  facet normal -0.931206 -0.364494 0
+    outer loop
+      vertex 26.1286 9.63936 0.599999
+      vertex 25.73 10.6577 58.4
+      vertex 25.73 10.6577 0.599999
+    endloop
+  endfacet
+  facet normal -0.931206 -0.364494 0
+    outer loop
+      vertex 25.73 10.6577 58.4
+      vertex 26.1286 9.63936 0.599999
+      vertex 26.1286 9.63936 58.4
+    endloop
+  endfacet
+  facet normal -0.931206 0.364494 0
+    outer loop
+      vertex 25.73 -10.6577 0.599999
+      vertex 26.1286 -9.63936 58.4
+      vertex 26.1286 -9.63936 0.599999
+    endloop
+  endfacet
+  facet normal -0.931206 0.364494 0
+    outer loop
+      vertex 26.1286 -9.63936 58.4
+      vertex 25.73 -10.6577 0.599999
+      vertex 25.73 -10.6577 58.4
+    endloop
+  endfacet
+  facet normal -0.539157 0.842205 0
+    outer loop
+      vertex 15.4726 -23.1564 0.599999
+      vertex 14.5516 -23.746 58.4
+      vertex 15.4726 -23.1564 58.4
+    endloop
+  endfacet
+  facet normal -0.539157 0.842205 0
+    outer loop
+      vertex 14.5516 -23.746 58.4
+      vertex 15.4726 -23.1564 0.599999
+      vertex 14.5516 -23.746 0.599999
+    endloop
+  endfacet
+  facet normal -0.720824 -0.693118 0
+    outer loop
+      vertex 20.4509 18.9046 0.599999
+      vertex 19.6929 19.6929 58.4
+      vertex 19.6929 19.6929 0.599999
+    endloop
+  endfacet
+  facet normal -0.720824 -0.693118 0
+    outer loop
+      vertex 19.6929 19.6929 58.4
+      vertex 20.4509 18.9046 0.599999
+      vertex 20.4509 18.9046 58.4
+    endloop
+  endfacet
+  facet normal -0.505661 -0.862732 0
+    outer loop
+      vertex 13.6081 24.299 0.599999
+      vertex 14.5516 23.746 58.4
+      vertex 13.6081 24.299 58.4
+    endloop
+  endfacet
+  facet normal -0.505661 -0.862732 -0
+    outer loop
+      vertex 14.5516 23.746 58.4
+      vertex 13.6081 24.299 0.599999
+      vertex 14.5516 23.746 0.599999
+    endloop
+  endfacet
+  facet normal -0.175753 -0.984434 0
+    outer loop
+      vertex 4.3567 27.5071 0.599999
+      vertex 5.43326 27.3149 58.4
+      vertex 4.3567 27.5071 58.4
+    endloop
+  endfacet
+  facet normal -0.175753 -0.984434 -0
+    outer loop
+      vertex 5.43326 27.3149 58.4
+      vertex 4.3567 27.5071 0.599999
+      vertex 5.43326 27.3149 0.599999
+    endloop
+  endfacet
+  facet normal 0.97676 -0.214337 0
+    outer loop
+      vertex -27.3149 5.43326 58.4
+      vertex -27.0805 6.50145 0.599999
+      vertex -27.0805 6.50145 58.4
+    endloop
+  endfacet
+  facet normal 0.97676 -0.214337 0
+    outer loop
+      vertex -27.0805 6.50145 0.599999
+      vertex -27.3149 5.43326 58.4
+      vertex -27.3149 5.43326 0.599999
+    endloop
+  endfacet
+  facet normal 0.984434 0.175753 0
+    outer loop
+      vertex -27.3149 -5.43326 58.4
+      vertex -27.5071 -4.3567 0.599999
+      vertex -27.5071 -4.3567 58.4
+    endloop
+  endfacet
+  facet normal 0.984434 0.175753 0
+    outer loop
+      vertex -27.5071 -4.3567 0.599999
+      vertex -27.3149 -5.43326 58.4
+      vertex -27.3149 -5.43326 0.599999
+    endloop
+  endfacet
+  facet normal -0.916216 -0.400685 0
+    outer loop
+      vertex 25.73 10.6577 0.599999
+      vertex 25.2918 11.6597 58.4
+      vertex 25.2918 11.6597 0.599999
+    endloop
+  endfacet
+  facet normal -0.916216 -0.400685 0
+    outer loop
+      vertex 25.2918 11.6597 58.4
+      vertex 25.73 10.6577 0.599999
+      vertex 25.73 10.6577 58.4
+    endloop
+  endfacet
+  facet normal -0.214337 0.97676 0
+    outer loop
+      vertex 6.50145 -27.0805 0.599999
+      vertex 5.43326 -27.3149 58.4
+      vertex 6.50145 -27.0805 58.4
+    endloop
+  endfacet
+  facet normal -0.214337 0.97676 0
+    outer loop
+      vertex 5.43326 -27.3149 58.4
+      vertex 6.50145 -27.0805 0.599999
+      vertex 5.43326 -27.3149 0.599999
+    endloop
+  endfacet
+  facet normal 0.916216 0.400685 0
+    outer loop
+      vertex -25.2918 -11.6597 58.4
+      vertex -25.73 -10.6577 0.599999
+      vertex -25.73 -10.6577 58.4
+    endloop
+  endfacet
+  facet normal 0.916216 0.400685 0
+    outer loop
+      vertex -25.73 -10.6577 0.599999
+      vertex -25.2918 -11.6597 58.4
+      vertex -25.2918 -11.6597 0.599999
+    endloop
+  endfacet
+  facet normal -0.862732 0.505661 0
+    outer loop
+      vertex 23.746 -14.5516 0.599999
+      vertex 24.299 -13.6081 58.4
+      vertex 24.299 -13.6081 0.599999
+    endloop
+  endfacet
+  facet normal -0.862732 0.505661 0
+    outer loop
+      vertex 24.299 -13.6081 58.4
+      vertex 23.746 -14.5516 0.599999
+      vertex 23.746 -14.5516 58.4
+    endloop
+  endfacet
+  facet normal 0.57178 -0.820407 0
+    outer loop
+      vertex -16.3698 22.5311 0.599999
+      vertex -15.4726 23.1564 58.4
+      vertex -16.3698 22.5311 58.4
+    endloop
+  endfacet
+  facet normal 0.57178 -0.820407 0
+    outer loop
+      vertex -15.4726 23.1564 58.4
+      vertex -16.3698 22.5311 0.599999
+      vertex -15.4726 23.1564 0.599999
+    endloop
+  endfacet
+  facet normal -0.944805 -0.327633 0
+    outer loop
+      vertex 26.4869 8.60612 0.599999
+      vertex 26.1286 9.63936 58.4
+      vertex 26.1286 9.63936 0.599999
+    endloop
+  endfacet
+  facet normal -0.944805 -0.327633 0
+    outer loop
+      vertex 26.1286 9.63936 58.4
+      vertex 26.4869 8.60612 0.599999
+      vertex 26.4869 8.60612 58.4
+    endloop
+  endfacet
+  facet normal 0.967605 -0.25247 0
+    outer loop
+      vertex -27.0805 6.50145 58.4
+      vertex -26.8044 7.55962 0.599999
+      vertex -26.8044 7.55962 58.4
+    endloop
+  endfacet
+  facet normal 0.967605 -0.25247 0
+    outer loop
+      vertex -26.8044 7.55962 0.599999
+      vertex -27.0805 6.50145 58.4
+      vertex -27.0805 6.50145 0.599999
+    endloop
+  endfacet
+  facet normal -0.842205 -0.539157 0
+    outer loop
+      vertex 23.746 14.5516 0.599999
+      vertex 23.1564 15.4726 58.4
+      vertex 23.1564 15.4726 0.599999
+    endloop
+  endfacet
+  facet normal -0.842205 -0.539157 0
+    outer loop
+      vertex 23.1564 15.4726 58.4
+      vertex 23.746 14.5516 0.599999
+      vertex 23.746 14.5516 58.4
+    endloop
+  endfacet
+  facet normal 0.13707 0.990561 -0
+    outer loop
+      vertex -3.27342 -27.657 0.599999
+      vertex -4.3567 -27.5071 58.4
+      vertex -3.27342 -27.657 58.4
+    endloop
+  endfacet
+  facet normal 0.13707 0.990561 0
+    outer loop
+      vertex -4.3567 -27.5071 58.4
+      vertex -3.27342 -27.657 0.599999
+      vertex -4.3567 -27.5071 0.599999
+    endloop
+  endfacet
+  facet normal -0.436464 -0.899722 0
+    outer loop
+      vertex 11.6597 25.2918 0.599999
+      vertex 12.6436 24.8145 58.4
+      vertex 11.6597 25.2918 58.4
+    endloop
+  endfacet
+  facet normal -0.436464 -0.899722 -0
+    outer loop
+      vertex 12.6436 24.8145 58.4
+      vertex 11.6597 25.2918 0.599999
+      vertex 12.6436 24.8145 0.599999
+    endloop
+  endfacet
+  facet normal -0.0196598 -0.999807 0
+    outer loop
+      vertex 0 27.85 0.599999
+      vertex 1.09339 27.8285 58.4
+      vertex 0 27.85 58.4
+    endloop
+  endfacet
+  facet normal -0.0196598 -0.999807 -0
+    outer loop
+      vertex 1.09339 27.8285 58.4
+      vertex 0 27.85 0.599999
+      vertex 1.09339 27.8285 0.599999
+    endloop
+  endfacet
+  facet normal 0.0196598 -0.999807 0
+    outer loop
+      vertex -1.09339 27.8285 0.599999
+      vertex 0 27.85 58.4
+      vertex -1.09339 27.8285 58.4
+    endloop
+  endfacet
+  facet normal 0.0196598 -0.999807 0
+    outer loop
+      vertex 0 27.85 58.4
+      vertex -1.09339 27.8285 0.599999
+      vertex 0 27.85 0.599999
+    endloop
+  endfacet
+  facet normal 0.842205 0.539157 0
+    outer loop
+      vertex -23.1564 -15.4726 58.4
+      vertex -23.746 -14.5516 0.599999
+      vertex -23.746 -14.5516 58.4
+    endloop
+  endfacet
+  facet normal 0.842205 0.539157 0
+    outer loop
+      vertex -23.746 -14.5516 0.599999
+      vertex -23.1564 -15.4726 58.4
+      vertex -23.1564 -15.4726 0.599999
+    endloop
+  endfacet
+  facet normal -0.634437 0.772974 0
+    outer loop
+      vertex 18.0871 -21.1773 0.599999
+      vertex 17.2418 -21.8711 58.4
+      vertex 18.0871 -21.1773 58.4
+    endloop
+  endfacet
+  facet normal -0.634437 0.772974 0
+    outer loop
+      vertex 17.2418 -21.8711 58.4
+      vertex 18.0871 -21.1773 0.599999
+      vertex 17.2418 -21.8711 0.599999
+    endloop
+  endfacet
+  facet normal 0.881935 -0.471371 0
+    outer loop
+      vertex -24.8145 12.6436 58.4
+      vertex -24.299 13.6081 0.599999
+      vertex -24.299 13.6081 58.4
+    endloop
+  endfacet
+  facet normal 0.881935 -0.471371 0
+    outer loop
+      vertex -24.299 13.6081 0.599999
+      vertex -24.8145 12.6436 58.4
+      vertex -24.8145 12.6436 0.599999
+    endloop
+  endfacet
+  facet normal 0.0588882 0.998265 -0
+    outer loop
+      vertex -1.09339 -27.8285 0.599999
+      vertex -2.18509 -27.7641 58.4
+      vertex -1.09339 -27.8285 58.4
+    endloop
+  endfacet
+  facet normal 0.0588882 0.998265 0
+    outer loop
+      vertex -2.18509 -27.7641 58.4
+      vertex -1.09339 -27.8285 0.599999
+      vertex -2.18509 -27.7641 0.599999
+    endloop
+  endfacet
+  facet normal 0.998265 0.0588882 0
+    outer loop
+      vertex -27.7641 -2.18509 58.4
+      vertex -27.8285 -1.09339 0.599999
+      vertex -27.8285 -1.09339 58.4
+    endloop
+  endfacet
+  facet normal 0.998265 0.0588882 0
+    outer loop
+      vertex -27.8285 -1.09339 0.599999
+      vertex -27.7641 -2.18509 58.4
+      vertex -27.7641 -2.18509 0.599999
+    endloop
+  endfacet
+  facet normal 0.999807 -0.0196598 0
+    outer loop
+      vertex -27.85 0 58.4
+      vertex -27.8285 1.09339 0.599999
+      vertex -27.8285 1.09339 58.4
+    endloop
+  endfacet
+  facet normal 0.999807 -0.0196598 0
+    outer loop
+      vertex -27.8285 1.09339 0.599999
+      vertex -27.85 0 58.4
+      vertex -27.85 0 0.599999
+    endloop
+  endfacet
+  facet normal 0.25247 -0.967605 0
+    outer loop
+      vertex -7.55962 26.8044 0.599999
+      vertex -6.50145 27.0805 58.4
+      vertex -7.55962 26.8044 58.4
+    endloop
+  endfacet
+  facet normal 0.25247 -0.967605 0
+    outer loop
+      vertex -6.50145 27.0805 58.4
+      vertex -7.55962 26.8044 0.599999
+      vertex -6.50145 27.0805 0.599999
+    endloop
+  endfacet
+  facet normal 0.984434 -0.175753 0
+    outer loop
+      vertex -27.5071 4.3567 58.4
+      vertex -27.3149 5.43326 0.599999
+      vertex -27.3149 5.43326 58.4
+    endloop
+  endfacet
+  facet normal 0.984434 -0.175753 0
+    outer loop
+      vertex -27.3149 5.43326 0.599999
+      vertex -27.5071 4.3567 58.4
+      vertex -27.5071 4.3567 0.599999
+    endloop
+  endfacet
+  facet normal 0.990561 -0.13707 0
+    outer loop
+      vertex -27.657 3.27342 58.4
+      vertex -27.5071 4.3567 0.599999
+      vertex -27.5071 4.3567 58.4
+    endloop
+  endfacet
+  facet normal 0.990561 -0.13707 0
+    outer loop
+      vertex -27.5071 4.3567 0.599999
+      vertex -27.657 3.27342 58.4
+      vertex -27.657 3.27342 0.599999
+    endloop
+  endfacet
+  facet normal 0.74753 0.664228 0
+    outer loop
+      vertex -20.4509 -18.9046 58.4
+      vertex -21.1773 -18.0871 0.599999
+      vertex -21.1773 -18.0871 58.4
+    endloop
+  endfacet
+  facet normal 0.74753 0.664228 0
+    outer loop
+      vertex -21.1773 -18.0871 0.599999
+      vertex -20.4509 -18.9046 58.4
+      vertex -20.4509 -18.9046 0.599999
+    endloop
+  endfacet
+  facet normal 0.290325 -0.956928 0
+    outer loop
+      vertex -8.60612 26.4869 0.599999
+      vertex -7.55962 26.8044 58.4
+      vertex -8.60612 26.4869 58.4
+    endloop
+  endfacet
+  facet normal 0.290325 -0.956928 0
+    outer loop
+      vertex -7.55962 26.8044 58.4
+      vertex -8.60612 26.4869 0.599999
+      vertex -7.55962 26.8044 0.599999
+    endloop
+  endfacet
+  facet normal -0.290325 0.956928 0
+    outer loop
+      vertex 8.60612 -26.4869 0.599999
+      vertex 7.55962 -26.8044 58.4
+      vertex 8.60612 -26.4869 58.4
+    endloop
+  endfacet
+  facet normal -0.290325 0.956928 0
+    outer loop
+      vertex 7.55962 -26.8044 58.4
+      vertex 8.60612 -26.4869 0.599999
+      vertex 7.55962 -26.8044 0.599999
+    endloop
+  endfacet
+  facet normal 0.539157 0.842205 -0
+    outer loop
+      vertex -14.5516 -23.746 0.599999
+      vertex -15.4726 -23.1564 58.4
+      vertex -14.5516 -23.746 58.4
+    endloop
+  endfacet
+  facet normal 0.539157 0.842205 0
+    outer loop
+      vertex -15.4726 -23.1564 58.4
+      vertex -14.5516 -23.746 0.599999
+      vertex -15.4726 -23.1564 0.599999
+    endloop
+  endfacet
+  facet normal -0.693118 0.720824 0
+    outer loop
+      vertex 19.6929 -19.6929 0.599999
+      vertex 18.9046 -20.4509 58.4
+      vertex 19.6929 -19.6929 58.4
+    endloop
+  endfacet
+  facet normal -0.693118 0.720824 0
+    outer loop
+      vertex 18.9046 -20.4509 58.4
+      vertex 19.6929 -19.6929 0.599999
+      vertex 18.9046 -20.4509 0.599999
+    endloop
+  endfacet
+  facet normal 0.471371 0.881935 -0
+    outer loop
+      vertex -12.6436 -24.8145 0.599999
+      vertex -13.6081 -24.299 58.4
+      vertex -12.6436 -24.8145 58.4
+    endloop
+  endfacet
+  facet normal 0.471371 0.881935 0
+    outer loop
+      vertex -13.6081 -24.299 58.4
+      vertex -12.6436 -24.8145 0.599999
+      vertex -13.6081 -24.299 0.599999
+    endloop
+  endfacet
+  facet normal -0.0588882 -0.998265 0
+    outer loop
+      vertex 1.09339 27.8285 0.599999
+      vertex 2.18509 27.7641 58.4
+      vertex 1.09339 27.8285 58.4
+    endloop
+  endfacet
+  facet normal -0.0588882 -0.998265 -0
+    outer loop
+      vertex 2.18509 27.7641 58.4
+      vertex 1.09339 27.8285 0.599999
+      vertex 2.18509 27.7641 0.599999
+    endloop
+  endfacet
+  facet normal -0.471371 0.881935 0
+    outer loop
+      vertex 13.6081 -24.299 0.599999
+      vertex 12.6436 -24.8145 58.4
+      vertex 13.6081 -24.299 58.4
+    endloop
+  endfacet
+  facet normal -0.471371 0.881935 0
+    outer loop
+      vertex 12.6436 -24.8145 58.4
+      vertex 13.6081 -24.299 0.599999
+      vertex 12.6436 -24.8145 0.599999
+    endloop
+  endfacet
+  facet normal 0.539157 -0.842205 0
+    outer loop
+      vertex -15.4726 23.1564 0.599999
+      vertex -14.5516 23.746 58.4
+      vertex -15.4726 23.1564 58.4
+    endloop
+  endfacet
+  facet normal 0.539157 -0.842205 0
+    outer loop
+      vertex -14.5516 23.746 58.4
+      vertex -15.4726 23.1564 0.599999
+      vertex -14.5516 23.746 0.599999
+    endloop
+  endfacet
+  facet normal 0.820407 -0.57178 0
+    outer loop
+      vertex -23.1564 15.4726 58.4
+      vertex -22.5311 16.3698 0.599999
+      vertex -22.5311 16.3698 58.4
+    endloop
+  endfacet
+  facet normal 0.820407 -0.57178 0
+    outer loop
+      vertex -22.5311 16.3698 0.599999
+      vertex -23.1564 15.4726 58.4
+      vertex -23.1564 15.4726 0.599999
+    endloop
+  endfacet
+  facet normal -0.967605 0.25247 0
+    outer loop
+      vertex 26.8044 -7.55962 0.599999
+      vertex 27.0805 -6.50145 58.4
+      vertex 27.0805 -6.50145 0.599999
+    endloop
+  endfacet
+  facet normal -0.967605 0.25247 0
+    outer loop
+      vertex 27.0805 -6.50145 58.4
+      vertex 26.8044 -7.55962 0.599999
+      vertex 26.8044 -7.55962 58.4
+    endloop
+  endfacet
+  facet normal -0.74753 -0.664228 0
+    outer loop
+      vertex 21.1773 18.0871 0.599999
+      vertex 20.4509 18.9046 58.4
+      vertex 20.4509 18.9046 0.599999
+    endloop
+  endfacet
+  facet normal -0.74753 -0.664228 0
+    outer loop
+      vertex 20.4509 18.9046 58.4
+      vertex 21.1773 18.0871 0.599999
+      vertex 21.1773 18.0871 58.4
+    endloop
+  endfacet
+  facet normal 0.862732 -0.505661 0
+    outer loop
+      vertex -24.299 13.6081 58.4
+      vertex -23.746 14.5516 0.599999
+      vertex -23.746 14.5516 58.4
+    endloop
+  endfacet
+  facet normal 0.862732 -0.505661 0
+    outer loop
+      vertex -23.746 14.5516 0.599999
+      vertex -24.299 13.6081 58.4
+      vertex -24.299 13.6081 0.599999
+    endloop
+  endfacet
+  facet normal 0.364494 -0.931206 0
+    outer loop
+      vertex -10.6577 25.73 0.599999
+      vertex -9.63936 26.1286 58.4
+      vertex -10.6577 25.73 58.4
+    endloop
+  endfacet
+  facet normal 0.364494 -0.931206 0
+    outer loop
+      vertex -9.63936 26.1286 58.4
+      vertex -10.6577 25.73 0.599999
+      vertex -9.63936 26.1286 0.599999
+    endloop
+  endfacet
+  facet normal 0.797359 -0.603506 0
+    outer loop
+      vertex -22.5311 16.3698 58.4
+      vertex -21.8711 17.2418 0.599999
+      vertex -21.8711 17.2418 58.4
+    endloop
+  endfacet
+  facet normal 0.797359 -0.603506 0
+    outer loop
+      vertex -21.8711 17.2418 0.599999
+      vertex -22.5311 16.3698 58.4
+      vertex -22.5311 16.3698 0.599999
+    endloop
+  endfacet
+  facet normal 0.956928 0.290325 0
+    outer loop
+      vertex -26.4869 -8.60612 58.4
+      vertex -26.8044 -7.55962 0.599999
+      vertex -26.8044 -7.55962 58.4
+    endloop
+  endfacet
+  facet normal 0.956928 0.290325 0
+    outer loop
+      vertex -26.8044 -7.55962 0.599999
+      vertex -26.4869 -8.60612 58.4
+      vertex -26.4869 -8.60612 0.599999
+    endloop
+  endfacet
+  facet normal 0.956928 -0.290325 0
+    outer loop
+      vertex -26.8044 7.55962 58.4
+      vertex -26.4869 8.60612 0.599999
+      vertex -26.4869 8.60612 58.4
+    endloop
+  endfacet
+  facet normal 0.956928 -0.290325 0
+    outer loop
+      vertex -26.4869 8.60612 0.599999
+      vertex -26.8044 7.55962 58.4
+      vertex -26.8044 7.55962 0.599999
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.85 0 58.4
+      vertex 28.45 0 58.4
+      vertex 28.4281 1.11694 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.8285 1.09339 58.4
+      vertex 28.4281 1.11694 58.4
+      vertex 28.3623 2.23216 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.45 0 58.4
+      vertex 27.85 0 58.4
+      vertex 28.4281 -1.11694 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.7641 2.18509 58.4
+      vertex 28.3623 2.23216 58.4
+      vertex 28.2528 3.34394 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.8285 -1.09339 58.4
+      vertex 28.4281 -1.11694 58.4
+      vertex 27.85 0 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.657 3.27342 58.4
+      vertex 28.2528 3.34394 58.4
+      vertex 28.0997 4.45056 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.4281 -1.11694 58.4
+      vertex 27.8285 -1.09339 58.4
+      vertex 28.3623 -2.23216 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.5071 4.3567 58.4
+      vertex 28.0997 4.45056 58.4
+      vertex 27.9033 5.55032 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.7641 -2.18509 58.4
+      vertex 28.3623 -2.23216 58.4
+      vertex 27.8285 -1.09339 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.3623 -2.23216 58.4
+      vertex 27.7641 -2.18509 58.4
+      vertex 28.2528 -3.34394 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.4281 1.11694 58.4
+      vertex 27.8285 1.09339 58.4
+      vertex 27.85 0 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.3623 2.23216 58.4
+      vertex 27.7641 2.18509 58.4
+      vertex 27.8285 1.09339 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.3149 5.43326 58.4
+      vertex 27.9033 5.55032 58.4
+      vertex 27.6639 6.64152 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.2528 3.34394 58.4
+      vertex 27.657 3.27342 58.4
+      vertex 27.7641 2.18509 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.0997 4.45056 58.4
+      vertex 27.5071 4.3567 58.4
+      vertex 27.657 3.27342 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.0805 6.50145 58.4
+      vertex 27.6639 6.64152 58.4
+      vertex 27.3819 7.72248 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.9033 5.55032 58.4
+      vertex 27.3149 5.43326 58.4
+      vertex 27.5071 4.3567 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.6639 6.64152 58.4
+      vertex 27.0805 6.50145 58.4
+      vertex 27.3149 5.43326 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.8044 7.55962 58.4
+      vertex 27.3819 7.72248 58.4
+      vertex 27.0576 8.79153 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.3819 7.72248 58.4
+      vertex 26.8044 7.55962 58.4
+      vertex 27.0805 6.50145 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.4869 8.60612 58.4
+      vertex 27.0576 8.79153 58.4
+      vertex 26.6915 9.84703 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.0576 8.79153 58.4
+      vertex 26.4869 8.60612 58.4
+      vertex 26.8044 7.55962 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.1286 9.63936 58.4
+      vertex 26.6915 9.84703 58.4
+      vertex 26.2844 10.8873 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6915 9.84703 58.4
+      vertex 26.1286 9.63936 58.4
+      vertex 26.4869 8.60612 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.73 10.6577 58.4
+      vertex 26.2844 10.8873 58.4
+      vertex 25.8367 11.9109 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.2844 10.8873 58.4
+      vertex 25.73 10.6577 58.4
+      vertex 26.1286 9.63936 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.2918 11.6597 58.4
+      vertex 25.8367 11.9109 58.4
+      vertex 25.3491 12.916 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.8367 11.9109 58.4
+      vertex 25.2918 11.6597 58.4
+      vertex 25.73 10.6577 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8145 12.6436 58.4
+      vertex 25.3491 12.916 58.4
+      vertex 24.8225 13.9013 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.3491 12.916 58.4
+      vertex 24.8145 12.6436 58.4
+      vertex 25.2918 11.6597 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8225 13.9013 58.4
+      vertex 24.299 13.6081 58.4
+      vertex 24.8145 12.6436 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.2576 14.8651 58.4
+      vertex 24.299 13.6081 58.4
+      vertex 24.8225 13.9013 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.2576 14.8651 58.4
+      vertex 23.746 14.5516 58.4
+      vertex 24.299 13.6081 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.6553 15.806 58.4
+      vertex 23.746 14.5516 58.4
+      vertex 24.2576 14.8651 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.6553 15.806 58.4
+      vertex 23.1564 15.4726 58.4
+      vertex 23.746 14.5516 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.0165 16.7225 58.4
+      vertex 23.1564 15.4726 58.4
+      vertex 23.6553 15.806 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.0165 16.7225 58.4
+      vertex 22.5311 16.3698 58.4
+      vertex 23.1564 15.4726 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.3423 17.6132 58.4
+      vertex 22.5311 16.3698 58.4
+      vertex 23.0165 16.7225 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.3423 17.6132 58.4
+      vertex 21.8711 17.2418 58.4
+      vertex 22.5311 16.3698 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.6335 18.4768 58.4
+      vertex 21.8711 17.2418 58.4
+      vertex 22.3423 17.6132 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.6335 18.4768 58.4
+      vertex 21.1773 18.0871 58.4
+      vertex 21.8711 17.2418 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8915 19.3119 58.4
+      vertex 21.1773 18.0871 58.4
+      vertex 21.6335 18.4768 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.8915 19.3119 58.4
+      vertex 20.4509 18.9046 58.4
+      vertex 21.1773 18.0871 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1172 20.1172 58.4
+      vertex 20.4509 18.9046 58.4
+      vertex 20.8915 19.3119 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.1172 20.1172 58.4
+      vertex 19.6929 19.6929 58.4
+      vertex 20.4509 18.9046 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3119 20.8915 58.4
+      vertex 19.6929 19.6929 58.4
+      vertex 20.1172 20.1172 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3119 20.8915 58.4
+      vertex 18.9046 20.4509 58.4
+      vertex 19.6929 19.6929 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.4768 21.6335 58.4
+      vertex 18.9046 20.4509 58.4
+      vertex 19.3119 20.8915 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.4768 21.6335 58.4
+      vertex 18.0871 21.1773 58.4
+      vertex 18.9046 20.4509 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6132 22.3423 58.4
+      vertex 18.0871 21.1773 58.4
+      vertex 18.4768 21.6335 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6132 22.3423 58.4
+      vertex 17.2418 21.8711 58.4
+      vertex 18.0871 21.1773 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.7225 23.0165 58.4
+      vertex 17.2418 21.8711 58.4
+      vertex 17.6132 22.3423 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.7225 23.0165 58.4
+      vertex 16.3698 22.5311 58.4
+      vertex 17.2418 21.8711 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.806 23.6553 58.4
+      vertex 16.3698 22.5311 58.4
+      vertex 16.7225 23.0165 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.806 23.6553 58.4
+      vertex 15.4726 23.1564 58.4
+      vertex 16.3698 22.5311 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8651 24.2576 58.4
+      vertex 15.4726 23.1564 58.4
+      vertex 15.806 23.6553 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8651 24.2576 58.4
+      vertex 14.5516 23.746 58.4
+      vertex 15.4726 23.1564 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.9013 24.8225 58.4
+      vertex 14.5516 23.746 58.4
+      vertex 14.8651 24.2576 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.9013 24.8225 58.4
+      vertex 13.6081 24.299 58.4
+      vertex 14.5516 23.746 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.916 25.3491 58.4
+      vertex 13.6081 24.299 58.4
+      vertex 13.9013 24.8225 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.916 25.3491 58.4
+      vertex 12.6436 24.8145 58.4
+      vertex 13.6081 24.299 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.9109 25.8367 58.4
+      vertex 12.6436 24.8145 58.4
+      vertex 12.916 25.3491 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.9109 25.8367 58.4
+      vertex 11.6597 25.2918 58.4
+      vertex 12.6436 24.8145 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.8873 26.2844 58.4
+      vertex 11.6597 25.2918 58.4
+      vertex 11.9109 25.8367 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.8873 26.2844 58.4
+      vertex 10.6577 25.73 58.4
+      vertex 11.6597 25.2918 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.84703 26.6915 58.4
+      vertex 10.6577 25.73 58.4
+      vertex 10.8873 26.2844 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.84703 26.6915 58.4
+      vertex 9.63936 26.1286 58.4
+      vertex 10.6577 25.73 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.79153 27.0576 58.4
+      vertex 9.63936 26.1286 58.4
+      vertex 9.84703 26.6915 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.79153 27.0576 58.4
+      vertex 8.60612 26.4869 58.4
+      vertex 9.63936 26.1286 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.72248 27.3819 58.4
+      vertex 8.60612 26.4869 58.4
+      vertex 8.79153 27.0576 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.72248 27.3819 58.4
+      vertex 7.55962 26.8044 58.4
+      vertex 8.60612 26.4869 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.64152 27.6639 58.4
+      vertex 7.55962 26.8044 58.4
+      vertex 7.72248 27.3819 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.64152 27.6639 58.4
+      vertex 6.50145 27.0805 58.4
+      vertex 7.55962 26.8044 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.55032 27.9033 58.4
+      vertex 6.50145 27.0805 58.4
+      vertex 6.64152 27.6639 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.55032 27.9033 58.4
+      vertex 5.43326 27.3149 58.4
+      vertex 6.50145 27.0805 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.45056 28.0997 58.4
+      vertex 5.43326 27.3149 58.4
+      vertex 5.55032 27.9033 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.45056 28.0997 58.4
+      vertex 4.3567 27.5071 58.4
+      vertex 5.43326 27.3149 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.34394 28.2528 58.4
+      vertex 4.3567 27.5071 58.4
+      vertex 4.45056 28.0997 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.34394 28.2528 58.4
+      vertex 3.27342 27.657 58.4
+      vertex 4.3567 27.5071 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.23216 28.3623 58.4
+      vertex 3.27342 27.657 58.4
+      vertex 3.34394 28.2528 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.23216 28.3623 58.4
+      vertex 2.18509 27.7641 58.4
+      vertex 3.27342 27.657 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.11694 28.4281 58.4
+      vertex 2.18509 27.7641 58.4
+      vertex 2.23216 28.3623 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.11694 28.4281 58.4
+      vertex 1.09339 27.8285 58.4
+      vertex 2.18509 27.7641 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 28.45 58.4
+      vertex 1.09339 27.8285 58.4
+      vertex 1.11694 28.4281 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 28.45 58.4
+      vertex 0 27.85 58.4
+      vertex 1.09339 27.8285 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 28.45 58.4
+      vertex -1.09339 27.8285 58.4
+      vertex 0 27.85 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.11694 28.4281 58.4
+      vertex -1.09339 27.8285 58.4
+      vertex 0 28.45 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.11694 28.4281 58.4
+      vertex -2.18509 27.7641 58.4
+      vertex -1.09339 27.8285 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.23216 28.3623 58.4
+      vertex -2.18509 27.7641 58.4
+      vertex -1.11694 28.4281 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.23216 28.3623 58.4
+      vertex -3.27342 27.657 58.4
+      vertex -2.18509 27.7641 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3.34394 28.2528 58.4
+      vertex -3.27342 27.657 58.4
+      vertex -2.23216 28.3623 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.34394 28.2528 58.4
+      vertex -4.3567 27.5071 58.4
+      vertex -3.27342 27.657 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -4.45056 28.0997 58.4
+      vertex -4.3567 27.5071 58.4
+      vertex -3.34394 28.2528 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.45056 28.0997 58.4
+      vertex -5.43326 27.3149 58.4
+      vertex -4.3567 27.5071 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.55032 27.9033 58.4
+      vertex -5.43326 27.3149 58.4
+      vertex -4.45056 28.0997 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.55032 27.9033 58.4
+      vertex -6.50145 27.0805 58.4
+      vertex -5.43326 27.3149 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -6.64152 27.6639 58.4
+      vertex -6.50145 27.0805 58.4
+      vertex -5.55032 27.9033 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.64152 27.6639 58.4
+      vertex -7.55962 26.8044 58.4
+      vertex -6.50145 27.0805 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -7.72248 27.3819 58.4
+      vertex -7.55962 26.8044 58.4
+      vertex -6.64152 27.6639 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.72248 27.3819 58.4
+      vertex -8.60612 26.4869 58.4
+      vertex -7.55962 26.8044 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -8.79153 27.0576 58.4
+      vertex -8.60612 26.4869 58.4
+      vertex -7.72248 27.3819 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.79153 27.0576 58.4
+      vertex -9.63936 26.1286 58.4
+      vertex -8.60612 26.4869 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.84703 26.6915 58.4
+      vertex -9.63936 26.1286 58.4
+      vertex -8.79153 27.0576 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.84703 26.6915 58.4
+      vertex -10.6577 25.73 58.4
+      vertex -9.63936 26.1286 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.8873 26.2844 58.4
+      vertex -10.6577 25.73 58.4
+      vertex -9.84703 26.6915 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.8873 26.2844 58.4
+      vertex -11.6597 25.2918 58.4
+      vertex -10.6577 25.73 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.9109 25.8367 58.4
+      vertex -11.6597 25.2918 58.4
+      vertex -10.8873 26.2844 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.9109 25.8367 58.4
+      vertex -12.6436 24.8145 58.4
+      vertex -11.6597 25.2918 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.916 25.3491 58.4
+      vertex -12.6436 24.8145 58.4
+      vertex -11.9109 25.8367 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.916 25.3491 58.4
+      vertex -13.6081 24.299 58.4
+      vertex -12.6436 24.8145 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.9013 24.8225 58.4
+      vertex -13.6081 24.299 58.4
+      vertex -12.916 25.3491 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.9013 24.8225 58.4
+      vertex -14.5516 23.746 58.4
+      vertex -13.6081 24.299 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.8651 24.2576 58.4
+      vertex -14.5516 23.746 58.4
+      vertex -13.9013 24.8225 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8651 24.2576 58.4
+      vertex -15.4726 23.1564 58.4
+      vertex -14.5516 23.746 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.806 23.6553 58.4
+      vertex -15.4726 23.1564 58.4
+      vertex -14.8651 24.2576 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.806 23.6553 58.4
+      vertex -16.3698 22.5311 58.4
+      vertex -15.4726 23.1564 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.7225 23.0165 58.4
+      vertex -16.3698 22.5311 58.4
+      vertex -15.806 23.6553 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.7225 23.0165 58.4
+      vertex -17.2418 21.8711 58.4
+      vertex -16.3698 22.5311 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.6132 22.3423 58.4
+      vertex -17.2418 21.8711 58.4
+      vertex -16.7225 23.0165 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6132 22.3423 58.4
+      vertex -18.0871 21.1773 58.4
+      vertex -17.2418 21.8711 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.4768 21.6335 58.4
+      vertex -18.0871 21.1773 58.4
+      vertex -17.6132 22.3423 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4768 21.6335 58.4
+      vertex -18.9046 20.4509 58.4
+      vertex -18.0871 21.1773 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.3119 20.8915 58.4
+      vertex -18.9046 20.4509 58.4
+      vertex -18.4768 21.6335 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3119 20.8915 58.4
+      vertex -19.6929 19.6929 58.4
+      vertex -18.9046 20.4509 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.1172 20.1172 58.4
+      vertex -19.6929 19.6929 58.4
+      vertex -19.3119 20.8915 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.1172 20.1172 58.4
+      vertex -20.4509 18.9046 58.4
+      vertex -19.6929 19.6929 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.8915 19.3119 58.4
+      vertex -20.4509 18.9046 58.4
+      vertex -20.1172 20.1172 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.8915 19.3119 58.4
+      vertex -21.1773 18.0871 58.4
+      vertex -20.4509 18.9046 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.6335 18.4768 58.4
+      vertex -21.1773 18.0871 58.4
+      vertex -20.8915 19.3119 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.6335 18.4768 58.4
+      vertex -21.8711 17.2418 58.4
+      vertex -21.1773 18.0871 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.3423 17.6132 58.4
+      vertex -21.8711 17.2418 58.4
+      vertex -21.6335 18.4768 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.3423 17.6132 58.4
+      vertex -22.5311 16.3698 58.4
+      vertex -21.8711 17.2418 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.0165 16.7225 58.4
+      vertex -22.5311 16.3698 58.4
+      vertex -22.3423 17.6132 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0165 16.7225 58.4
+      vertex -23.1564 15.4726 58.4
+      vertex -22.5311 16.3698 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.6553 15.806 58.4
+      vertex -23.1564 15.4726 58.4
+      vertex -23.0165 16.7225 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.6553 15.806 58.4
+      vertex -23.746 14.5516 58.4
+      vertex -23.1564 15.4726 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.2576 14.8651 58.4
+      vertex -23.746 14.5516 58.4
+      vertex -23.6553 15.806 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.2576 14.8651 58.4
+      vertex -24.299 13.6081 58.4
+      vertex -23.746 14.5516 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.8225 13.9013 58.4
+      vertex -24.299 13.6081 58.4
+      vertex -24.2576 14.8651 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.299 13.6081 58.4
+      vertex -24.8225 13.9013 58.4
+      vertex -24.8145 12.6436 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -25.3491 12.916 58.4
+      vertex -24.8145 12.6436 58.4
+      vertex -24.8225 13.9013 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8145 12.6436 58.4
+      vertex -25.3491 12.916 58.4
+      vertex -25.2918 11.6597 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -25.8367 11.9109 58.4
+      vertex -25.2918 11.6597 58.4
+      vertex -25.3491 12.916 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.2918 11.6597 58.4
+      vertex -25.8367 11.9109 58.4
+      vertex -25.73 10.6577 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -26.2844 10.8873 58.4
+      vertex -25.73 10.6577 58.4
+      vertex -25.8367 11.9109 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.73 10.6577 58.4
+      vertex -26.2844 10.8873 58.4
+      vertex -26.1286 9.63936 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -26.6915 9.84703 58.4
+      vertex -26.1286 9.63936 58.4
+      vertex -26.2844 10.8873 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1286 9.63936 58.4
+      vertex -26.6915 9.84703 58.4
+      vertex -26.4869 8.60612 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.0576 8.79153 58.4
+      vertex -26.4869 8.60612 58.4
+      vertex -26.6915 9.84703 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.4869 8.60612 58.4
+      vertex -27.0576 8.79153 58.4
+      vertex -26.8044 7.55962 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.3819 7.72248 58.4
+      vertex -26.8044 7.55962 58.4
+      vertex -27.0576 8.79153 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8044 7.55962 58.4
+      vertex -27.3819 7.72248 58.4
+      vertex -27.0805 6.50145 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.6639 6.64152 58.4
+      vertex -27.0805 6.50145 58.4
+      vertex -27.3819 7.72248 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0805 6.50145 58.4
+      vertex -27.6639 6.64152 58.4
+      vertex -27.3149 5.43326 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -27.9033 5.55032 58.4
+      vertex -27.3149 5.43326 58.4
+      vertex -27.6639 6.64152 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3149 5.43326 58.4
+      vertex -27.9033 5.55032 58.4
+      vertex -27.5071 4.3567 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.0997 4.45056 58.4
+      vertex -27.5071 4.3567 58.4
+      vertex -27.9033 5.55032 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.5071 4.3567 58.4
+      vertex -28.0997 4.45056 58.4
+      vertex -27.657 3.27342 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.657 3.27342 58.4
+      vertex -28.2528 3.34394 58.4
+      vertex -27.7641 2.18509 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.2528 3.34394 58.4
+      vertex -27.657 3.27342 58.4
+      vertex -28.0997 4.45056 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.657 -3.27342 58.4
+      vertex 28.2528 -3.34394 58.4
+      vertex 27.7641 -2.18509 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.2528 -3.34394 58.4
+      vertex 27.657 -3.27342 58.4
+      vertex 28.0997 -4.45056 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.5071 -4.3567 58.4
+      vertex 28.0997 -4.45056 58.4
+      vertex 27.657 -3.27342 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.0997 -4.45056 58.4
+      vertex 27.5071 -4.3567 58.4
+      vertex 27.9033 -5.55032 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.3149 -5.43326 58.4
+      vertex 27.9033 -5.55032 58.4
+      vertex 27.5071 -4.3567 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.9033 -5.55032 58.4
+      vertex 27.3149 -5.43326 58.4
+      vertex 27.6639 -6.64152 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 27.0805 -6.50145 58.4
+      vertex 27.6639 -6.64152 58.4
+      vertex 27.3149 -5.43326 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.6639 -6.64152 58.4
+      vertex 27.0805 -6.50145 58.4
+      vertex 27.3819 -7.72248 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.8044 -7.55962 58.4
+      vertex 27.3819 -7.72248 58.4
+      vertex 27.0805 -6.50145 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.3819 -7.72248 58.4
+      vertex 26.8044 -7.55962 58.4
+      vertex 27.0576 -8.79153 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.4869 -8.60612 58.4
+      vertex 27.0576 -8.79153 58.4
+      vertex 26.8044 -7.55962 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 27.0576 -8.79153 58.4
+      vertex 26.4869 -8.60612 58.4
+      vertex 26.6915 -9.84703 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.1286 -9.63936 58.4
+      vertex 26.6915 -9.84703 58.4
+      vertex 26.4869 -8.60612 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6915 -9.84703 58.4
+      vertex 26.1286 -9.63936 58.4
+      vertex 26.2844 -10.8873 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.73 -10.6577 58.4
+      vertex 26.2844 -10.8873 58.4
+      vertex 26.1286 -9.63936 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.2844 -10.8873 58.4
+      vertex 25.73 -10.6577 58.4
+      vertex 25.8367 -11.9109 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 25.2918 -11.6597 58.4
+      vertex 25.8367 -11.9109 58.4
+      vertex 25.73 -10.6577 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.8367 -11.9109 58.4
+      vertex 25.2918 -11.6597 58.4
+      vertex 25.3491 -12.916 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.8145 -12.6436 58.4
+      vertex 25.3491 -12.916 58.4
+      vertex 25.2918 -11.6597 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.3491 -12.916 58.4
+      vertex 24.8145 -12.6436 58.4
+      vertex 24.8225 -13.9013 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.299 -13.6081 58.4
+      vertex 24.8225 -13.9013 58.4
+      vertex 24.8145 -12.6436 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.299 -13.6081 58.4
+      vertex 24.2576 -14.8651 58.4
+      vertex 24.8225 -13.9013 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.746 -14.5516 58.4
+      vertex 24.2576 -14.8651 58.4
+      vertex 24.299 -13.6081 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.746 -14.5516 58.4
+      vertex 23.6553 -15.806 58.4
+      vertex 24.2576 -14.8651 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.1564 -15.4726 58.4
+      vertex 23.6553 -15.806 58.4
+      vertex 23.746 -14.5516 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.1564 -15.4726 58.4
+      vertex 23.0165 -16.7225 58.4
+      vertex 23.6553 -15.806 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.5311 -16.3698 58.4
+      vertex 23.0165 -16.7225 58.4
+      vertex 23.1564 -15.4726 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.5311 -16.3698 58.4
+      vertex 22.3423 -17.6132 58.4
+      vertex 23.0165 -16.7225 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.8711 -17.2418 58.4
+      vertex 22.3423 -17.6132 58.4
+      vertex 22.5311 -16.3698 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.8711 -17.2418 58.4
+      vertex 21.6335 -18.4768 58.4
+      vertex 22.3423 -17.6132 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.1773 -18.0871 58.4
+      vertex 21.6335 -18.4768 58.4
+      vertex 21.8711 -17.2418 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.1773 -18.0871 58.4
+      vertex 20.8915 -19.3119 58.4
+      vertex 21.6335 -18.4768 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.4509 -18.9046 58.4
+      vertex 20.8915 -19.3119 58.4
+      vertex 21.1773 -18.0871 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.4509 -18.9046 58.4
+      vertex 20.1172 -20.1172 58.4
+      vertex 20.8915 -19.3119 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.6929 -19.6929 58.4
+      vertex 20.1172 -20.1172 58.4
+      vertex 20.4509 -18.9046 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.6929 -19.6929 58.4
+      vertex 19.3119 -20.8915 58.4
+      vertex 20.1172 -20.1172 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.9046 -20.4509 58.4
+      vertex 19.3119 -20.8915 58.4
+      vertex 19.6929 -19.6929 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.9046 -20.4509 58.4
+      vertex 18.4768 -21.6335 58.4
+      vertex 19.3119 -20.8915 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.0871 -21.1773 58.4
+      vertex 18.4768 -21.6335 58.4
+      vertex 18.9046 -20.4509 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0871 -21.1773 58.4
+      vertex 17.6132 -22.3423 58.4
+      vertex 18.4768 -21.6335 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.2418 -21.8711 58.4
+      vertex 17.6132 -22.3423 58.4
+      vertex 18.0871 -21.1773 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.2418 -21.8711 58.4
+      vertex 16.7225 -23.0165 58.4
+      vertex 17.6132 -22.3423 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.3698 -22.5311 58.4
+      vertex 16.7225 -23.0165 58.4
+      vertex 17.2418 -21.8711 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.3698 -22.5311 58.4
+      vertex 15.806 -23.6553 58.4
+      vertex 16.7225 -23.0165 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.4726 -23.1564 58.4
+      vertex 15.806 -23.6553 58.4
+      vertex 16.3698 -22.5311 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4726 -23.1564 58.4
+      vertex 14.8651 -24.2576 58.4
+      vertex 15.806 -23.6553 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.5516 -23.746 58.4
+      vertex 14.8651 -24.2576 58.4
+      vertex 15.4726 -23.1564 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.5516 -23.746 58.4
+      vertex 13.9013 -24.8225 58.4
+      vertex 14.8651 -24.2576 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.6081 -24.299 58.4
+      vertex 13.9013 -24.8225 58.4
+      vertex 14.5516 -23.746 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6081 -24.299 58.4
+      vertex 12.916 -25.3491 58.4
+      vertex 13.9013 -24.8225 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.6436 -24.8145 58.4
+      vertex 12.916 -25.3491 58.4
+      vertex 13.6081 -24.299 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.6436 -24.8145 58.4
+      vertex 11.9109 -25.8367 58.4
+      vertex 12.916 -25.3491 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.6597 -25.2918 58.4
+      vertex 11.9109 -25.8367 58.4
+      vertex 12.6436 -24.8145 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.6597 -25.2918 58.4
+      vertex 10.8873 -26.2844 58.4
+      vertex 11.9109 -25.8367 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.6577 -25.73 58.4
+      vertex 10.8873 -26.2844 58.4
+      vertex 11.6597 -25.2918 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.6577 -25.73 58.4
+      vertex 9.84703 -26.6915 58.4
+      vertex 10.8873 -26.2844 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.63936 -26.1286 58.4
+      vertex 9.84703 -26.6915 58.4
+      vertex 10.6577 -25.73 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.63936 -26.1286 58.4
+      vertex 8.79153 -27.0576 58.4
+      vertex 9.84703 -26.6915 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 8.60612 -26.4869 58.4
+      vertex 8.79153 -27.0576 58.4
+      vertex 9.63936 -26.1286 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.60612 -26.4869 58.4
+      vertex 7.72248 -27.3819 58.4
+      vertex 8.79153 -27.0576 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 7.55962 -26.8044 58.4
+      vertex 7.72248 -27.3819 58.4
+      vertex 8.60612 -26.4869 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.55962 -26.8044 58.4
+      vertex 6.64152 -27.6639 58.4
+      vertex 7.72248 -27.3819 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 6.50145 -27.0805 58.4
+      vertex 6.64152 -27.6639 58.4
+      vertex 7.55962 -26.8044 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.50145 -27.0805 58.4
+      vertex 5.55032 -27.9033 58.4
+      vertex 6.64152 -27.6639 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.43326 -27.3149 58.4
+      vertex 5.55032 -27.9033 58.4
+      vertex 6.50145 -27.0805 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.43326 -27.3149 58.4
+      vertex 4.45056 -28.0997 58.4
+      vertex 5.55032 -27.9033 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.3567 -27.5071 58.4
+      vertex 4.45056 -28.0997 58.4
+      vertex 5.43326 -27.3149 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.3567 -27.5071 58.4
+      vertex 3.34394 -28.2528 58.4
+      vertex 4.45056 -28.0997 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.27342 -27.657 58.4
+      vertex 3.34394 -28.2528 58.4
+      vertex 4.3567 -27.5071 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.27342 -27.657 58.4
+      vertex 2.23216 -28.3623 58.4
+      vertex 3.34394 -28.2528 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.18509 -27.7641 58.4
+      vertex 2.23216 -28.3623 58.4
+      vertex 3.27342 -27.657 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.18509 -27.7641 58.4
+      vertex 1.11694 -28.4281 58.4
+      vertex 2.23216 -28.3623 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.09339 -27.8285 58.4
+      vertex 1.11694 -28.4281 58.4
+      vertex 2.18509 -27.7641 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 -27.85 58.4
+      vertex 1.11694 -28.4281 58.4
+      vertex 1.09339 -27.8285 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -27.85 58.4
+      vertex 0 -28.45 58.4
+      vertex 1.11694 -28.4281 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.09339 -27.8285 58.4
+      vertex 0 -28.45 58.4
+      vertex 0 -27.85 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.09339 -27.8285 58.4
+      vertex -1.11694 -28.4281 58.4
+      vertex 0 -28.45 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.18509 -27.7641 58.4
+      vertex -1.11694 -28.4281 58.4
+      vertex -1.09339 -27.8285 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.18509 -27.7641 58.4
+      vertex -2.23216 -28.3623 58.4
+      vertex -1.11694 -28.4281 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.27342 -27.657 58.4
+      vertex -2.23216 -28.3623 58.4
+      vertex -2.18509 -27.7641 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.27342 -27.657 58.4
+      vertex -3.34394 -28.2528 58.4
+      vertex -2.23216 -28.3623 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.3567 -27.5071 58.4
+      vertex -3.34394 -28.2528 58.4
+      vertex -3.27342 -27.657 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.3567 -27.5071 58.4
+      vertex -4.45056 -28.0997 58.4
+      vertex -3.34394 -28.2528 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.43326 -27.3149 58.4
+      vertex -4.45056 -28.0997 58.4
+      vertex -4.3567 -27.5071 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.43326 -27.3149 58.4
+      vertex -5.55032 -27.9033 58.4
+      vertex -4.45056 -28.0997 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.50145 -27.0805 58.4
+      vertex -5.55032 -27.9033 58.4
+      vertex -5.43326 -27.3149 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.50145 -27.0805 58.4
+      vertex -6.64152 -27.6639 58.4
+      vertex -5.55032 -27.9033 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.55962 -26.8044 58.4
+      vertex -6.64152 -27.6639 58.4
+      vertex -6.50145 -27.0805 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.55962 -26.8044 58.4
+      vertex -7.72248 -27.3819 58.4
+      vertex -6.64152 -27.6639 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.60612 -26.4869 58.4
+      vertex -7.72248 -27.3819 58.4
+      vertex -7.55962 -26.8044 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.60612 -26.4869 58.4
+      vertex -8.79153 -27.0576 58.4
+      vertex -7.72248 -27.3819 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.63936 -26.1286 58.4
+      vertex -8.79153 -27.0576 58.4
+      vertex -8.60612 -26.4869 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.63936 -26.1286 58.4
+      vertex -9.84703 -26.6915 58.4
+      vertex -8.79153 -27.0576 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.6577 -25.73 58.4
+      vertex -9.84703 -26.6915 58.4
+      vertex -9.63936 -26.1286 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.6577 -25.73 58.4
+      vertex -10.8873 -26.2844 58.4
+      vertex -9.84703 -26.6915 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.6597 -25.2918 58.4
+      vertex -10.8873 -26.2844 58.4
+      vertex -10.6577 -25.73 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.6597 -25.2918 58.4
+      vertex -11.9109 -25.8367 58.4
+      vertex -10.8873 -26.2844 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.6436 -24.8145 58.4
+      vertex -11.9109 -25.8367 58.4
+      vertex -11.6597 -25.2918 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.6436 -24.8145 58.4
+      vertex -12.916 -25.3491 58.4
+      vertex -11.9109 -25.8367 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.6081 -24.299 58.4
+      vertex -12.916 -25.3491 58.4
+      vertex -12.6436 -24.8145 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.6081 -24.299 58.4
+      vertex -13.9013 -24.8225 58.4
+      vertex -12.916 -25.3491 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.5516 -23.746 58.4
+      vertex -13.9013 -24.8225 58.4
+      vertex -13.6081 -24.299 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.5516 -23.746 58.4
+      vertex -14.8651 -24.2576 58.4
+      vertex -13.9013 -24.8225 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.4726 -23.1564 58.4
+      vertex -14.8651 -24.2576 58.4
+      vertex -14.5516 -23.746 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.4726 -23.1564 58.4
+      vertex -15.806 -23.6553 58.4
+      vertex -14.8651 -24.2576 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.3698 -22.5311 58.4
+      vertex -15.806 -23.6553 58.4
+      vertex -15.4726 -23.1564 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.3698 -22.5311 58.4
+      vertex -16.7225 -23.0165 58.4
+      vertex -15.806 -23.6553 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.2418 -21.8711 58.4
+      vertex -16.7225 -23.0165 58.4
+      vertex -16.3698 -22.5311 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.2418 -21.8711 58.4
+      vertex -17.6132 -22.3423 58.4
+      vertex -16.7225 -23.0165 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0871 -21.1773 58.4
+      vertex -17.6132 -22.3423 58.4
+      vertex -17.2418 -21.8711 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0871 -21.1773 58.4
+      vertex -18.4768 -21.6335 58.4
+      vertex -17.6132 -22.3423 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9046 -20.4509 58.4
+      vertex -18.4768 -21.6335 58.4
+      vertex -18.0871 -21.1773 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9046 -20.4509 58.4
+      vertex -19.3119 -20.8915 58.4
+      vertex -18.4768 -21.6335 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.6929 -19.6929 58.4
+      vertex -19.3119 -20.8915 58.4
+      vertex -18.9046 -20.4509 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.6929 -19.6929 58.4
+      vertex -20.1172 -20.1172 58.4
+      vertex -19.3119 -20.8915 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.4509 -18.9046 58.4
+      vertex -20.1172 -20.1172 58.4
+      vertex -19.6929 -19.6929 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.4509 -18.9046 58.4
+      vertex -20.8915 -19.3119 58.4
+      vertex -20.1172 -20.1172 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.1773 -18.0871 58.4
+      vertex -20.8915 -19.3119 58.4
+      vertex -20.4509 -18.9046 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.1773 -18.0871 58.4
+      vertex -21.6335 -18.4768 58.4
+      vertex -20.8915 -19.3119 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.8711 -17.2418 58.4
+      vertex -21.6335 -18.4768 58.4
+      vertex -21.1773 -18.0871 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.8711 -17.2418 58.4
+      vertex -22.3423 -17.6132 58.4
+      vertex -21.6335 -18.4768 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5311 -16.3698 58.4
+      vertex -22.3423 -17.6132 58.4
+      vertex -21.8711 -17.2418 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5311 -16.3698 58.4
+      vertex -23.0165 -16.7225 58.4
+      vertex -22.3423 -17.6132 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1564 -15.4726 58.4
+      vertex -23.0165 -16.7225 58.4
+      vertex -22.5311 -16.3698 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1564 -15.4726 58.4
+      vertex -23.6553 -15.806 58.4
+      vertex -23.0165 -16.7225 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.746 -14.5516 58.4
+      vertex -23.6553 -15.806 58.4
+      vertex -23.1564 -15.4726 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.746 -14.5516 58.4
+      vertex -24.2576 -14.8651 58.4
+      vertex -23.6553 -15.806 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.299 -13.6081 58.4
+      vertex -24.2576 -14.8651 58.4
+      vertex -23.746 -14.5516 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8225 -13.9013 58.4
+      vertex -24.299 -13.6081 58.4
+      vertex -24.8145 -12.6436 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.299 -13.6081 58.4
+      vertex -24.8225 -13.9013 58.4
+      vertex -24.2576 -14.8651 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3491 -12.916 58.4
+      vertex -24.8145 -12.6436 58.4
+      vertex -25.2918 -11.6597 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8145 -12.6436 58.4
+      vertex -25.3491 -12.916 58.4
+      vertex -24.8225 -13.9013 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.8367 -11.9109 58.4
+      vertex -25.2918 -11.6597 58.4
+      vertex -25.73 -10.6577 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.2918 -11.6597 58.4
+      vertex -25.8367 -11.9109 58.4
+      vertex -25.3491 -12.916 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.2844 -10.8873 58.4
+      vertex -25.73 -10.6577 58.4
+      vertex -26.1286 -9.63936 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.73 -10.6577 58.4
+      vertex -26.2844 -10.8873 58.4
+      vertex -25.8367 -11.9109 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.6915 -9.84703 58.4
+      vertex -26.1286 -9.63936 58.4
+      vertex -26.4869 -8.60612 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1286 -9.63936 58.4
+      vertex -26.6915 -9.84703 58.4
+      vertex -26.2844 -10.8873 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0576 -8.79153 58.4
+      vertex -26.4869 -8.60612 58.4
+      vertex -26.8044 -7.55962 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.4869 -8.60612 58.4
+      vertex -27.0576 -8.79153 58.4
+      vertex -26.6915 -9.84703 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3819 -7.72248 58.4
+      vertex -26.8044 -7.55962 58.4
+      vertex -27.0805 -6.50145 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6639 -6.64152 58.4
+      vertex -27.0805 -6.50145 58.4
+      vertex -27.3149 -5.43326 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.8044 -7.55962 58.4
+      vertex -27.3819 -7.72248 58.4
+      vertex -27.0576 -8.79153 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.9033 -5.55032 58.4
+      vertex -27.3149 -5.43326 58.4
+      vertex -27.5071 -4.3567 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.0997 -4.45056 58.4
+      vertex -27.5071 -4.3567 58.4
+      vertex -27.657 -3.27342 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.0805 -6.50145 58.4
+      vertex -27.6639 -6.64152 58.4
+      vertex -27.3819 -7.72248 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.2528 -3.34394 58.4
+      vertex -27.657 -3.27342 58.4
+      vertex -27.7641 -2.18509 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.3623 -2.23216 58.4
+      vertex -27.7641 -2.18509 58.4
+      vertex -27.8285 -1.09339 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.3149 -5.43326 58.4
+      vertex -27.9033 -5.55032 58.4
+      vertex -27.6639 -6.64152 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.4281 -1.11694 58.4
+      vertex -27.8285 -1.09339 58.4
+      vertex -27.85 0 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.3623 2.23216 58.4
+      vertex -27.7641 2.18509 58.4
+      vertex -28.2528 3.34394 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.7641 2.18509 58.4
+      vertex -28.3623 2.23216 58.4
+      vertex -27.8285 1.09339 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.5071 -4.3567 58.4
+      vertex -28.0997 -4.45056 58.4
+      vertex -27.9033 -5.55032 58.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.4281 1.11694 58.4
+      vertex -27.8285 1.09339 58.4
+      vertex -28.3623 2.23216 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.657 -3.27342 58.4
+      vertex -28.2528 -3.34394 58.4
+      vertex -28.0997 -4.45056 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.8285 1.09339 58.4
+      vertex -28.4281 1.11694 58.4
+      vertex -27.85 0 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.7641 -2.18509 58.4
+      vertex -28.3623 -2.23216 58.4
+      vertex -28.2528 -3.34394 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.45 0 58.4
+      vertex -27.85 0 58.4
+      vertex -28.4281 1.11694 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.8285 -1.09339 58.4
+      vertex -28.4281 -1.11694 58.4
+      vertex -28.3623 -2.23216 58.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.85 0 58.4
+      vertex -28.45 0 58.4
+      vertex -28.4281 -1.11694 58.4
+    endloop
+  endfacet
+  facet normal 0.862732 0.505661 0
+    outer loop
+      vertex -23.746 -14.5516 58.4
+      vertex -24.299 -13.6081 0.599999
+      vertex -24.299 -13.6081 58.4
+    endloop
+  endfacet
+  facet normal 0.862732 0.505661 0
+    outer loop
+      vertex -24.299 -13.6081 0.599999
+      vertex -23.746 -14.5516 58.4
+      vertex -23.746 -14.5516 0.599999
+    endloop
+  endfacet
+  facet normal 0.436464 -0.899722 0
+    outer loop
+      vertex -12.6436 24.8145 0.599999
+      vertex -11.6597 25.2918 58.4
+      vertex -12.6436 24.8145 58.4
+    endloop
+  endfacet
+  facet normal 0.436464 -0.899722 0
+    outer loop
+      vertex -11.6597 25.2918 58.4
+      vertex -12.6436 24.8145 0.599999
+      vertex -11.6597 25.2918 0.599999
+    endloop
+  endfacet
+  facet normal -0.772974 -0.634437 0
+    outer loop
+      vertex 21.8711 17.2418 0.599999
+      vertex 21.1773 18.0871 58.4
+      vertex 21.1773 18.0871 0.599999
+    endloop
+  endfacet
+  facet normal -0.772974 -0.634437 0
+    outer loop
+      vertex 21.1773 18.0871 58.4
+      vertex 21.8711 17.2418 0.599999
+      vertex 21.8711 17.2418 58.4
+    endloop
+  endfacet
+  facet normal 0.57178 0.820407 -0
+    outer loop
+      vertex -15.4726 -23.1564 0.599999
+      vertex -16.3698 -22.5311 58.4
+      vertex -15.4726 -23.1564 58.4
+    endloop
+  endfacet
+  facet normal 0.57178 0.820407 0
+    outer loop
+      vertex -16.3698 -22.5311 58.4
+      vertex -15.4726 -23.1564 0.599999
+      vertex -16.3698 -22.5311 0.599999
+    endloop
+  endfacet
+  facet normal 0.290325 0.956928 -0
+    outer loop
+      vertex -7.55962 -26.8044 0.599999
+      vertex -8.60612 -26.4869 58.4
+      vertex -7.55962 -26.8044 58.4
+    endloop
+  endfacet
+  facet normal 0.290325 0.956928 0
+    outer loop
+      vertex -8.60612 -26.4869 58.4
+      vertex -7.55962 -26.8044 0.599999
+      vertex -8.60612 -26.4869 0.599999
+    endloop
+  endfacet
+  facet normal -0.214337 -0.97676 0
+    outer loop
+      vertex 5.43326 27.3149 0.599999
+      vertex 6.50145 27.0805 58.4
+      vertex 5.43326 27.3149 58.4
+    endloop
+  endfacet
+  facet normal -0.214337 -0.97676 -0
+    outer loop
+      vertex 6.50145 27.0805 58.4
+      vertex 5.43326 27.3149 0.599999
+      vertex 6.50145 27.0805 0.599999
+    endloop
+  endfacet
+  facet normal 0.967605 0.25247 0
+    outer loop
+      vertex -26.8044 -7.55962 58.4
+      vertex -27.0805 -6.50145 0.599999
+      vertex -27.0805 -6.50145 58.4
+    endloop
+  endfacet
+  facet normal 0.967605 0.25247 0
+    outer loop
+      vertex -27.0805 -6.50145 0.599999
+      vertex -26.8044 -7.55962 58.4
+      vertex -26.8044 -7.55962 0.599999
+    endloop
+  endfacet
+  facet normal 0.693118 0.720824 -0
+    outer loop
+      vertex -18.9046 -20.4509 0.599999
+      vertex -19.6929 -19.6929 58.4
+      vertex -18.9046 -20.4509 58.4
+    endloop
+  endfacet
+  facet normal 0.693118 0.720824 0
+    outer loop
+      vertex -19.6929 -19.6929 58.4
+      vertex -18.9046 -20.4509 0.599999
+      vertex -19.6929 -19.6929 0.599999
+    endloop
+  endfacet
+  facet normal 0.400685 0.916216 -0
+    outer loop
+      vertex -10.6577 -25.73 0.599999
+      vertex -11.6597 -25.2918 58.4
+      vertex -10.6577 -25.73 58.4
+    endloop
+  endfacet
+  facet normal 0.400685 0.916216 0
+    outer loop
+      vertex -11.6597 -25.2918 58.4
+      vertex -10.6577 -25.73 0.599999
+      vertex -11.6597 -25.2918 0.599999
+    endloop
+  endfacet
+  facet normal 0.899722 0.436464 0
+    outer loop
+      vertex -24.8145 -12.6436 58.4
+      vertex -25.2918 -11.6597 0.599999
+      vertex -25.2918 -11.6597 58.4
+    endloop
+  endfacet
+  facet normal 0.899722 0.436464 0
+    outer loop
+      vertex -25.2918 -11.6597 0.599999
+      vertex -24.8145 -12.6436 58.4
+      vertex -24.8145 -12.6436 0.599999
+    endloop
+  endfacet
+  facet normal 0.916216 -0.400685 0
+    outer loop
+      vertex -25.73 10.6577 58.4
+      vertex -25.2918 11.6597 0.599999
+      vertex -25.2918 11.6597 58.4
+    endloop
+  endfacet
+  facet normal 0.916216 -0.400685 0
+    outer loop
+      vertex -25.2918 11.6597 0.599999
+      vertex -25.73 10.6577 58.4
+      vertex -25.73 10.6577 0.599999
+    endloop
+  endfacet
+  facet normal 0.842205 -0.539157 0
+    outer loop
+      vertex -23.746 14.5516 58.4
+      vertex -23.1564 15.4726 0.599999
+      vertex -23.1564 15.4726 58.4
+    endloop
+  endfacet
+  facet normal 0.842205 -0.539157 0
+    outer loop
+      vertex -23.1564 15.4726 0.599999
+      vertex -23.746 14.5516 58.4
+      vertex -23.746 14.5516 0.599999
+    endloop
+  endfacet
+  facet normal 0.505661 0.862732 -0
+    outer loop
+      vertex -13.6081 -24.299 0.599999
+      vertex -14.5516 -23.746 58.4
+      vertex -13.6081 -24.299 58.4
+    endloop
+  endfacet
+  facet normal 0.505661 0.862732 0
+    outer loop
+      vertex -14.5516 -23.746 58.4
+      vertex -13.6081 -24.299 0.599999
+      vertex -14.5516 -23.746 0.599999
+    endloop
+  endfacet
+  facet normal -0.707038 -0.0139029 0.707039
+    outer loop
+      vertex 27.85 0 0
+      vertex 28.45 0 0.599999
+      vertex 27.8285 1.09339 0
+    endloop
+  endfacet
+  facet normal 0.528651 -0.469715 0.707033
+    outer loop
+      vertex -21.1773 18.0871 0
+      vertex -20.8915 19.3119 0.599999
+      vertex -21.6335 18.4768 0.599999
+    endloop
+  endfacet
+  facet normal -0.696168 -0.124325 0.707032
+    outer loop
+      vertex 28.0997 4.45056 0.599999
+      vertex 27.9033 5.55032 0.599999
+      vertex 27.5071 4.3567 0
+    endloop
+  endfacet
+  facet normal -0.509741 0.490148 0.70705
+    outer loop
+      vertex 20.8915 -19.3119 0.599999
+      vertex 20.4509 -18.9046 0
+      vertex 19.6929 -19.6929 0
+    endloop
+  endfacet
+  facet normal -0.333329 -0.623679 0.707048
+    outer loop
+      vertex 13.6081 24.299 0
+      vertex 13.9013 24.8225 0.599999
+      vertex 12.916 25.3491 0.599999
+    endloop
+  endfacet
+  facet normal -0.703793 0.0693171 0.707015
+    outer loop
+      vertex 28.2528 -3.34394 0.599999
+      vertex 28.3623 -2.23216 0.599999
+      vertex 27.657 -3.27342 0
+    endloop
+  endfacet
+  facet normal -0.580133 -0.404353 0.707067
+    outer loop
+      vertex 23.1564 15.4726 0
+      vertex 23.6553 15.806 0.599999
+      vertex 23.0165 16.7225 0.599999
+    endloop
+  endfacet
+  facet normal -0.595574 -0.381246 0.707067
+    outer loop
+      vertex 24.2576 14.8651 0.599999
+      vertex 23.6553 15.806 0.599999
+      vertex 23.1564 15.4726 0
+    endloop
+  endfacet
+  facet normal -0.676702 -0.205306 0.707053
+    outer loop
+      vertex 26.8044 7.55962 0
+      vertex 27.3819 7.72248 0.599999
+      vertex 26.4869 8.60612 0
+    endloop
+  endfacet
+  facet normal 0.178543 -0.684277 0.707027
+    outer loop
+      vertex -6.50145 27.0805 0
+      vertex -6.64152 27.6639 0.599999
+      vertex -7.55962 26.8044 0
+    endloop
+  endfacet
+  facet normal -0.469715 0.528651 0.707033
+    outer loop
+      vertex 18.4768 -21.6335 0.599999
+      vertex 19.3119 -20.8915 0.599999
+      vertex 18.0871 -21.1773 0
+    endloop
+  endfacet
+  facet normal -0.610094 -0.357587 0.707049
+    outer loop
+      vertex 24.299 13.6081 0
+      vertex 24.8225 13.9013 0.599999
+      vertex 24.2576 14.8651 0.599999
+    endloop
+  endfacet
+  facet normal -0.04165 -0.70591 0.707076
+    outer loop
+      vertex 2.23216 28.3623 0.599999
+      vertex 1.11694 28.4281 0.599999
+      vertex 1.09339 27.8285 0
+    endloop
+  endfacet
+  facet normal 0.04165 -0.70591 0.707076
+    outer loop
+      vertex -1.09339 27.8285 0
+      vertex -1.11694 28.4281 0.599999
+      vertex -2.23216 28.3623 0.599999
+    endloop
+  endfacet
+  facet normal -0.404353 0.580133 0.707067
+    outer loop
+      vertex 15.806 -23.6553 0.599999
+      vertex 16.7225 -23.0165 0.599999
+      vertex 15.4726 -23.1564 0
+    endloop
+  endfacet
+  facet normal 0.0138623 -0.707002 0.707076
+    outer loop
+      vertex -1.09339 27.8285 0
+      vertex 0 28.45 0.599999
+      vertex -1.11694 28.4281 0.599999
+    endloop
+  endfacet
+  facet normal -0.684259 -0.178509 0.707053
+    outer loop
+      vertex 27.6639 6.64152 0.599999
+      vertex 27.3819 7.72248 0.599999
+      vertex 26.8044 7.55962 0
+    endloop
+  endfacet
+  facet normal -0.205306 0.676702 0.707053
+    outer loop
+      vertex 7.72248 -27.3819 0.599999
+      vertex 8.60612 -26.4869 0
+      vertex 7.55962 -26.8044 0
+    endloop
+  endfacet
+  facet normal 0.705918 0.0416425 0.707068
+    outer loop
+      vertex -27.7641 -2.18509 0
+      vertex -27.8285 -1.09339 0
+      vertex -28.3623 -2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0.610094 0.357587 0.707049
+    outer loop
+      vertex -24.2576 -14.8651 0.599999
+      vertex -24.299 -13.6081 0
+      vertex -24.8225 -13.9013 0.599999
+    endloop
+  endfacet
+  facet normal 0.381274 -0.595579 0.707047
+    outer loop
+      vertex -14.5516 23.746 0
+      vertex -14.8651 24.2576 0.599999
+      vertex -15.4726 23.1564 0
+    endloop
+  endfacet
+  facet normal -0.64789 0.283339 0.707076
+    outer loop
+      vertex 26.2844 -10.8873 0.599999
+      vertex 25.73 -10.6577 0
+      vertex 25.2918 -11.6597 0
+    endloop
+  endfacet
+  facet normal -0.151576 -0.690751 0.707027
+    outer loop
+      vertex 6.50145 27.0805 0
+      vertex 6.64152 27.6639 0.599999
+      vertex 5.43326 27.3149 0
+    endloop
+  endfacet
+  facet normal -0.65849 0.257747 0.707077
+    outer loop
+      vertex 26.2844 -10.8873 0.599999
+      vertex 26.1286 -9.63936 0
+      vertex 25.73 -10.6577 0
+    endloop
+  endfacet
+  facet normal -0.580133 0.404353 0.707067
+    outer loop
+      vertex 23.6553 -15.806 0.599999
+      vertex 23.1564 -15.4726 0
+      vertex 23.0165 -16.7225 0.599999
+    endloop
+  endfacet
+  facet normal -0.580167 0.404345 0.707044
+    outer loop
+      vertex 23.0165 -16.7225 0.599999
+      vertex 23.1564 -15.4726 0
+      vertex 22.5311 -16.3698 0
+    endloop
+  endfacet
+  facet normal -0.563853 0.426799 0.707045
+    outer loop
+      vertex 23.0165 -16.7225 0.599999
+      vertex 22.5311 -16.3698 0
+      vertex 22.3423 -17.6132 0.599999
+    endloop
+  endfacet
+  facet normal 0.0139029 -0.707038 0.707039
+    outer loop
+      vertex 0 27.85 0
+      vertex 0 28.45 0.599999
+      vertex -1.09339 27.8285 0
+    endloop
+  endfacet
+  facet normal -0.0693171 0.703793 0.707015
+    outer loop
+      vertex 3.34394 -28.2528 0.599999
+      vertex 3.27342 -27.657 0
+      vertex 2.23216 -28.3623 0.599999
+    endloop
+  endfacet
+  facet normal 0.124325 -0.696168 0.707032
+    outer loop
+      vertex -4.3567 27.5071 0
+      vertex -4.45056 28.0997 0.599999
+      vertex -5.55032 27.9033 0.599999
+    endloop
+  endfacet
+  facet normal -0.610095 -0.357586 0.707048
+    outer loop
+      vertex 24.299 13.6081 0
+      vertex 24.2576 14.8651 0.599999
+      vertex 23.746 14.5516 0
+    endloop
+  endfacet
+  facet normal -0.357586 -0.610095 0.707048
+    outer loop
+      vertex 14.5516 23.746 0
+      vertex 14.8651 24.2576 0.599999
+      vertex 13.6081 24.299 0
+    endloop
+  endfacet
+  facet normal 0.563853 -0.426799 0.707045
+    outer loop
+      vertex -22.5311 16.3698 0
+      vertex -22.3423 17.6132 0.599999
+      vertex -23.0165 16.7225 0.599999
+    endloop
+  endfacet
+  facet normal 0.610094 -0.357587 0.707049
+    outer loop
+      vertex -24.299 13.6081 0
+      vertex -24.2576 14.8651 0.599999
+      vertex -24.8225 13.9013 0.599999
+    endloop
+  endfacet
+  facet normal 0.65855 -0.257718 0.707031
+    outer loop
+      vertex -26.1286 9.63936 0
+      vertex -26.2844 10.8873 0.599999
+      vertex -26.6915 9.84703 0.599999
+    endloop
+  endfacet
+  facet normal 0.703746 -0.069254 0.707069
+    outer loop
+      vertex -27.7641 2.18509 0
+      vertex -27.657 3.27342 0
+      vertex -28.3623 2.23216 0.599999
+    endloop
+  endfacet
+  facet normal -0.509741 -0.490148 0.70705
+    outer loop
+      vertex 20.4509 18.9046 0
+      vertex 20.8915 19.3119 0.599999
+      vertex 19.6929 19.6929 0
+    endloop
+  endfacet
+  facet normal 0.696168 0.124325 0.707032
+    outer loop
+      vertex -27.9033 -5.55032 0.599999
+      vertex -27.5071 -4.3567 0
+      vertex -28.0997 -4.45056 0.599999
+    endloop
+  endfacet
+  facet normal 0.580133 -0.404353 0.707067
+    outer loop
+      vertex -23.1564 15.4726 0
+      vertex -23.0165 16.7225 0.599999
+      vertex -23.6553 15.806 0.599999
+    endloop
+  endfacet
+  facet normal -0.610095 0.357586 0.707048
+    outer loop
+      vertex 24.2576 -14.8651 0.599999
+      vertex 24.299 -13.6081 0
+      vertex 23.746 -14.5516 0
+    endloop
+  endfacet
+  facet normal -0.528651 -0.469715 0.707033
+    outer loop
+      vertex 21.1773 18.0871 0
+      vertex 21.6335 18.4768 0.599999
+      vertex 20.8915 19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0.509742 -0.490119 0.707069
+    outer loop
+      vertex -19.6929 19.6929 0
+      vertex -20.1172 20.1172 0.599999
+      vertex -20.8915 19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0.357586 -0.610095 0.707048
+    outer loop
+      vertex -14.5516 23.746 0
+      vertex -13.6081 24.299 0
+      vertex -14.8651 24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0.580167 -0.404345 0.707044
+    outer loop
+      vertex -22.5311 16.3698 0
+      vertex -23.0165 16.7225 0.599999
+      vertex -23.1564 15.4726 0
+    endloop
+  endfacet
+  facet normal 0.700524 -0.0969357 0.707015
+    outer loop
+      vertex -27.657 3.27342 0
+      vertex -27.5071 4.3567 0
+      vertex -28.2528 3.34394 0.599999
+    endloop
+  endfacet
+  facet normal -0.509742 0.490119 0.707069
+    outer loop
+      vertex 20.1172 -20.1172 0.599999
+      vertex 20.8915 -19.3119 0.599999
+      vertex 19.6929 -19.6929 0
+    endloop
+  endfacet
+  facet normal -0.528651 0.469715 0.707033
+    outer loop
+      vertex 21.6335 -18.4768 0.599999
+      vertex 21.1773 -18.0871 0
+      vertex 20.8915 -19.3119 0.599999
+    endloop
+  endfacet
+  facet normal -0.70591 -0.04165 0.707076
+    outer loop
+      vertex 28.4281 1.11694 0.599999
+      vertex 28.3623 2.23216 0.599999
+      vertex 27.8285 1.09339 0
+    endloop
+  endfacet
+  facet normal 0.151576 0.690751 0.707027
+    outer loop
+      vertex -5.43326 -27.3149 0
+      vertex -6.50145 -27.0805 0
+      vertex -6.64152 -27.6639 0.599999
+    endloop
+  endfacet
+  facet normal 0.381246 -0.595574 0.707067
+    outer loop
+      vertex -15.4726 23.1564 0
+      vertex -14.8651 24.2576 0.599999
+      vertex -15.806 23.6553 0.599999
+    endloop
+  endfacet
+  facet normal -0.65849 -0.257747 0.707077
+    outer loop
+      vertex 26.1286 9.63936 0
+      vertex 26.2844 10.8873 0.599999
+      vertex 25.73 10.6577 0
+    endloop
+  endfacet
+  facet normal 0.448663 0.546634 0.707031
+    outer loop
+      vertex -17.2418 -21.8711 0
+      vertex -18.0871 -21.1773 0
+      vertex -18.4768 -21.6335 0.599999
+    endloop
+  endfacet
+  facet normal -0.426799 0.563853 0.707045
+    outer loop
+      vertex 16.7225 -23.0165 0.599999
+      vertex 17.6132 -22.3423 0.599999
+      vertex 16.3698 -22.5311 0
+    endloop
+  endfacet
+  facet normal 0.448661 0.546647 0.707022
+    outer loop
+      vertex -17.6132 -22.3423 0.599999
+      vertex -17.2418 -21.8711 0
+      vertex -18.4768 -21.6335 0.599999
+    endloop
+  endfacet
+  facet normal 0.668133 0.231742 0.707031
+    outer loop
+      vertex -26.6915 -9.84703 0.599999
+      vertex -26.1286 -9.63936 0
+      vertex -27.0576 -8.79153 0.599999
+    endloop
+  endfacet
+  facet normal 0.381246 0.595574 0.707067
+    outer loop
+      vertex -14.8651 -24.2576 0.599999
+      vertex -15.4726 -23.1564 0
+      vertex -15.806 -23.6553 0.599999
+    endloop
+  endfacet
+  facet normal -0.178543 0.684277 0.707027
+    outer loop
+      vertex 6.64152 -27.6639 0.599999
+      vertex 7.55962 -26.8044 0
+      vertex 6.50145 -27.0805 0
+    endloop
+  endfacet
+  facet normal -0.668107 0.231682 0.707076
+    outer loop
+      vertex 27.0576 -8.79153 0.599999
+      vertex 26.4869 -8.60612 0
+      vertex 26.1286 -9.63936 0
+    endloop
+  endfacet
+  facet normal -0.283339 -0.64789 0.707076
+    outer loop
+      vertex 11.6597 25.2918 0
+      vertex 10.8873 26.2844 0.599999
+      vertex 10.6577 25.73 0
+    endloop
+  endfacet
+  facet normal 0.690785 -0.151552 0.706999
+    outer loop
+      vertex -27.3149 5.43326 0
+      vertex -27.6639 6.64152 0.599999
+      vertex -27.9033 5.55032 0.599999
+    endloop
+  endfacet
+  facet normal -0.528627 0.469718 0.707049
+    outer loop
+      vertex 20.8915 -19.3119 0.599999
+      vertex 21.1773 -18.0871 0
+      vertex 20.4509 -18.9046 0
+    endloop
+  endfacet
+  facet normal -0.308661 -0.636249 0.707047
+    outer loop
+      vertex 12.916 25.3491 0.599999
+      vertex 11.9109 25.8367 0.599999
+      vertex 11.6597 25.2918 0
+    endloop
+  endfacet
+  facet normal 0.580133 0.404353 0.707067
+    outer loop
+      vertex -23.0165 -16.7225 0.599999
+      vertex -23.1564 -15.4726 0
+      vertex -23.6553 -15.806 0.599999
+    endloop
+  endfacet
+  facet normal 0.490119 -0.509742 0.707069
+    outer loop
+      vertex -19.6929 19.6929 0
+      vertex -19.3119 20.8915 0.599999
+      vertex -20.1172 20.1172 0.599999
+    endloop
+  endfacet
+  facet normal 0.528651 0.469715 0.707033
+    outer loop
+      vertex -20.8915 -19.3119 0.599999
+      vertex -21.1773 -18.0871 0
+      vertex -21.6335 -18.4768 0.599999
+    endloop
+  endfacet
+  facet normal -0.580167 -0.404345 0.707044
+    outer loop
+      vertex 23.1564 15.4726 0
+      vertex 23.0165 16.7225 0.599999
+      vertex 22.5311 16.3698 0
+    endloop
+  endfacet
+  facet normal 0.178509 -0.684259 0.707053
+    outer loop
+      vertex -7.55962 26.8044 0
+      vertex -6.64152 27.6639 0.599999
+      vertex -7.72248 27.3819 0.599999
+    endloop
+  endfacet
+  facet normal 0.124295 -0.696207 0.706998
+    outer loop
+      vertex -5.43326 27.3149 0
+      vertex -4.3567 27.5071 0
+      vertex -5.55032 27.9033 0.599999
+    endloop
+  endfacet
+  facet normal -0.63626 -0.308656 0.707039
+    outer loop
+      vertex 25.2918 11.6597 0
+      vertex 25.3491 12.916 0.599999
+      vertex 24.8145 12.6436 0
+    endloop
+  endfacet
+  facet normal -0.690751 -0.151576 0.707027
+    outer loop
+      vertex 27.3149 5.43326 0
+      vertex 27.6639 6.64152 0.599999
+      vertex 27.0805 6.50145 0
+    endloop
+  endfacet
+  facet normal -0.684259 0.178509 0.707053
+    outer loop
+      vertex 27.3819 -7.72248 0.599999
+      vertex 27.6639 -6.64152 0.599999
+      vertex 26.8044 -7.55962 0
+    endloop
+  endfacet
+  facet normal 0.580167 0.404345 0.707044
+    outer loop
+      vertex -23.0165 -16.7225 0.599999
+      vertex -22.5311 -16.3698 0
+      vertex -23.1564 -15.4726 0
+    endloop
+  endfacet
+  facet normal -0.707002 -0.0138623 0.707076
+    outer loop
+      vertex 28.45 0 0.599999
+      vertex 28.4281 1.11694 0.599999
+      vertex 27.8285 1.09339 0
+    endloop
+  endfacet
+  facet normal -0.707002 0.0138623 0.707076
+    outer loop
+      vertex 28.4281 -1.11694 0.599999
+      vertex 28.45 0 0.599999
+      vertex 27.8285 -1.09339 0
+    endloop
+  endfacet
+  facet normal -0.04165 0.70591 0.707076
+    outer loop
+      vertex 1.11694 -28.4281 0.599999
+      vertex 2.23216 -28.3623 0.599999
+      vertex 1.09339 -27.8285 0
+    endloop
+  endfacet
+  facet normal -0.700524 -0.0969357 0.707015
+    outer loop
+      vertex 27.657 3.27342 0
+      vertex 28.2528 3.34394 0.599999
+      vertex 27.5071 4.3567 0
+    endloop
+  endfacet
+  facet normal -0.696207 0.124295 0.706998
+    outer loop
+      vertex 27.9033 -5.55032 0.599999
+      vertex 27.5071 -4.3567 0
+      vertex 27.3149 -5.43326 0
+    endloop
+  endfacet
+  facet normal -0.469715 -0.528651 0.707033
+    outer loop
+      vertex 19.3119 20.8915 0.599999
+      vertex 18.4768 21.6335 0.599999
+      vertex 18.0871 21.1773 0
+    endloop
+  endfacet
+  facet normal -0.70591 0.04165 0.707076
+    outer loop
+      vertex 28.3623 -2.23216 0.599999
+      vertex 28.4281 -1.11694 0.599999
+      vertex 27.8285 -1.09339 0
+    endloop
+  endfacet
+  facet normal -0.528627 -0.469718 0.707049
+    outer loop
+      vertex 21.1773 18.0871 0
+      vertex 20.8915 19.3119 0.599999
+      vertex 20.4509 18.9046 0
+    endloop
+  endfacet
+  facet normal -0.257747 0.65849 0.707077
+    outer loop
+      vertex 10.8873 -26.2844 0.599999
+      vertex 10.6577 -25.73 0
+      vertex 9.63936 -26.1286 0
+    endloop
+  endfacet
+  facet normal 0.509741 -0.490148 0.70705
+    outer loop
+      vertex -20.4509 18.9046 0
+      vertex -19.6929 19.6929 0
+      vertex -20.8915 19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0.528627 -0.469718 0.707049
+    outer loop
+      vertex -20.4509 18.9046 0
+      vertex -20.8915 19.3119 0.599999
+      vertex -21.1773 18.0871 0
+    endloop
+  endfacet
+  facet normal 0.703793 -0.0693171 0.707015
+    outer loop
+      vertex -27.657 3.27342 0
+      vertex -28.2528 3.34394 0.599999
+      vertex -28.3623 2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0.70591 -0.04165 0.707076
+    outer loop
+      vertex -27.8285 1.09339 0
+      vertex -28.3623 2.23216 0.599999
+      vertex -28.4281 1.11694 0.599999
+    endloop
+  endfacet
+  facet normal 0.448663 -0.546634 0.707031
+    outer loop
+      vertex -18.0871 21.1773 0
+      vertex -17.2418 21.8711 0
+      vertex -18.4768 21.6335 0.599999
+    endloop
+  endfacet
+  facet normal -0.151552 -0.690785 0.706999
+    outer loop
+      vertex 6.64152 27.6639 0.599999
+      vertex 5.55032 27.9033 0.599999
+      vertex 5.43326 27.3149 0
+    endloop
+  endfacet
+  facet normal -0.381274 -0.595579 0.707047
+    outer loop
+      vertex 15.4726 23.1564 0
+      vertex 14.8651 24.2576 0.599999
+      vertex 14.5516 23.746 0
+    endloop
+  endfacet
+  facet normal -0.404353 -0.580133 0.707067
+    outer loop
+      vertex 16.7225 23.0165 0.599999
+      vertex 15.806 23.6553 0.599999
+      vertex 15.4726 23.1564 0
+    endloop
+  endfacet
+  facet normal -0.509742 -0.490119 0.707069
+    outer loop
+      vertex 20.8915 19.3119 0.599999
+      vertex 20.1172 20.1172 0.599999
+      vertex 19.6929 19.6929 0
+    endloop
+  endfacet
+  facet normal 0.64789 0.283339 0.707076
+    outer loop
+      vertex -25.2918 -11.6597 0
+      vertex -25.73 -10.6577 0
+      vertex -26.2844 -10.8873 0.599999
+    endloop
+  endfacet
+  facet normal 0.610095 0.357586 0.707048
+    outer loop
+      vertex -24.2576 -14.8651 0.599999
+      vertex -23.746 -14.5516 0
+      vertex -24.299 -13.6081 0
+    endloop
+  endfacet
+  facet normal 0.0416425 0.705918 0.707068
+    outer loop
+      vertex -1.09339 -27.8285 0
+      vertex -2.18509 -27.7641 0
+      vertex -2.23216 -28.3623 0.599999
+    endloop
+  endfacet
+  facet normal 0.705918 -0.0416425 0.707068
+    outer loop
+      vertex -27.8285 1.09339 0
+      vertex -27.7641 2.18509 0
+      vertex -28.3623 2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0.333329 0.623679 0.707048
+    outer loop
+      vertex -12.916 -25.3491 0.599999
+      vertex -13.6081 -24.299 0
+      vertex -13.9013 -24.8225 0.599999
+    endloop
+  endfacet
+  facet normal 0.0969149 0.700509 0.707032
+    outer loop
+      vertex -3.34394 -28.2528 0.599999
+      vertex -4.3567 -27.5071 0
+      vertex -4.45056 -28.0997 0.599999
+    endloop
+  endfacet
+  facet normal -0.563884 -0.426793 0.707023
+    outer loop
+      vertex 22.5311 16.3698 0
+      vertex 22.3423 17.6132 0.599999
+      vertex 21.8711 17.2418 0
+    endloop
+  endfacet
+  facet normal -0.0138623 -0.707002 0.707076
+    outer loop
+      vertex 1.09339 27.8285 0
+      vertex 1.11694 28.4281 0.599999
+      vertex 0 28.45 0.599999
+    endloop
+  endfacet
+  facet normal -0.0969149 0.700509 0.707032
+    outer loop
+      vertex 4.45056 -28.0997 0.599999
+      vertex 4.3567 -27.5071 0
+      vertex 3.34394 -28.2528 0.599999
+    endloop
+  endfacet
+  facet normal -0.668133 0.231742 0.707031
+    outer loop
+      vertex 26.6915 -9.84703 0.599999
+      vertex 27.0576 -8.79153 0.599999
+      vertex 26.1286 -9.63936 0
+    endloop
+  endfacet
+  facet normal -0.0416425 -0.705918 0.707068
+    outer loop
+      vertex 2.18509 27.7641 0
+      vertex 2.23216 28.3623 0.599999
+      vertex 1.09339 27.8285 0
+    endloop
+  endfacet
+  facet normal -0.0139029 0.707038 0.707039
+    outer loop
+      vertex 1.09339 -27.8285 0
+      vertex 0 -27.85 0
+      vertex 0 -28.45 0.599999
+    endloop
+  endfacet
+  facet normal 0.546634 -0.448663 0.707031
+    outer loop
+      vertex -21.1773 18.0871 0
+      vertex -21.6335 18.4768 0.599999
+      vertex -21.8711 17.2418 0
+    endloop
+  endfacet
+  facet normal -0.448661 0.546647 0.707022
+    outer loop
+      vertex 17.6132 -22.3423 0.599999
+      vertex 18.4768 -21.6335 0.599999
+      vertex 17.2418 -21.8711 0
+    endloop
+  endfacet
+  facet normal 0.65849 0.257747 0.707077
+    outer loop
+      vertex -25.73 -10.6577 0
+      vertex -26.1286 -9.63936 0
+      vertex -26.2844 -10.8873 0.599999
+    endloop
+  endfacet
+  facet normal -0.546634 -0.448663 0.707031
+    outer loop
+      vertex 21.8711 17.2418 0
+      vertex 21.6335 18.4768 0.599999
+      vertex 21.1773 18.0871 0
+    endloop
+  endfacet
+  facet normal -0.333342 -0.623682 0.707039
+    outer loop
+      vertex 13.6081 24.299 0
+      vertex 12.916 25.3491 0.599999
+      vertex 12.6436 24.8145 0
+    endloop
+  endfacet
+  facet normal 0.64789 -0.283339 0.707076
+    outer loop
+      vertex -25.73 10.6577 0
+      vertex -25.2918 11.6597 0
+      vertex -26.2844 10.8873 0.599999
+    endloop
+  endfacet
+  facet normal -0.448663 0.546634 0.707031
+    outer loop
+      vertex 18.4768 -21.6335 0.599999
+      vertex 18.0871 -21.1773 0
+      vertex 17.2418 -21.8711 0
+    endloop
+  endfacet
+  facet normal -0.069254 -0.703746 0.707069
+    outer loop
+      vertex 3.27342 27.657 0
+      vertex 2.23216 28.3623 0.599999
+      vertex 2.18509 27.7641 0
+    endloop
+  endfacet
+  facet normal 0.684259 0.178509 0.707053
+    outer loop
+      vertex -27.3819 -7.72248 0.599999
+      vertex -26.8044 -7.55962 0
+      vertex -27.6639 -6.64152 0.599999
+    endloop
+  endfacet
+  facet normal 0.490148 0.509741 0.70705
+    outer loop
+      vertex -19.3119 -20.8915 0.599999
+      vertex -18.9046 -20.4509 0
+      vertex -19.6929 -19.6929 0
+    endloop
+  endfacet
+  facet normal -0.0693171 -0.703793 0.707015
+    outer loop
+      vertex 3.27342 27.657 0
+      vertex 3.34394 28.2528 0.599999
+      vertex 2.23216 28.3623 0.599999
+    endloop
+  endfacet
+  facet normal 0.257718 0.65855 0.707031
+    outer loop
+      vertex -9.84703 -26.6915 0.599999
+      vertex -9.63936 -26.1286 0
+      vertex -10.8873 -26.2844 0.599999
+    endloop
+  endfacet
+  facet normal 0.676702 -0.205306 0.707053
+    outer loop
+      vertex -26.8044 7.55962 0
+      vertex -26.4869 8.60612 0
+      vertex -27.3819 7.72248 0.599999
+    endloop
+  endfacet
+  facet normal -0.610094 0.357587 0.707049
+    outer loop
+      vertex 24.8225 -13.9013 0.599999
+      vertex 24.299 -13.6081 0
+      vertex 24.2576 -14.8651 0.599999
+    endloop
+  endfacet
+  facet normal 0.546634 0.448663 0.707031
+    outer loop
+      vertex -21.6335 -18.4768 0.599999
+      vertex -21.1773 -18.0871 0
+      vertex -21.8711 -17.2418 0
+    endloop
+  endfacet
+  facet normal -0.257718 0.65855 0.707031
+    outer loop
+      vertex 9.84703 -26.6915 0.599999
+      vertex 10.8873 -26.2844 0.599999
+      vertex 9.63936 -26.1286 0
+    endloop
+  endfacet
+  facet normal -0.700509 -0.0969149 0.707032
+    outer loop
+      vertex 28.2528 3.34394 0.599999
+      vertex 28.0997 4.45056 0.599999
+      vertex 27.5071 4.3567 0
+    endloop
+  endfacet
+  facet normal -0.707038 0.0139029 0.707039
+    outer loop
+      vertex 28.45 0 0.599999
+      vertex 27.85 0 0
+      vertex 27.8285 -1.09339 0
+    endloop
+  endfacet
+  facet normal -0.690785 0.151552 0.706999
+    outer loop
+      vertex 27.6639 -6.64152 0.599999
+      vertex 27.9033 -5.55032 0.599999
+      vertex 27.3149 -5.43326 0
+    endloop
+  endfacet
+  facet normal -0.703793 -0.0693171 0.707015
+    outer loop
+      vertex 28.3623 2.23216 0.599999
+      vertex 28.2528 3.34394 0.599999
+      vertex 27.657 3.27342 0
+    endloop
+  endfacet
+  facet normal 0.490148 -0.509741 0.70705
+    outer loop
+      vertex -18.9046 20.4509 0
+      vertex -19.3119 20.8915 0.599999
+      vertex -19.6929 19.6929 0
+    endloop
+  endfacet
+  facet normal -0.64789 -0.283339 0.707076
+    outer loop
+      vertex 25.73 10.6577 0
+      vertex 26.2844 10.8873 0.599999
+      vertex 25.2918 11.6597 0
+    endloop
+  endfacet
+  facet normal -0.595574 0.381246 0.707067
+    outer loop
+      vertex 23.6553 -15.806 0.599999
+      vertex 24.2576 -14.8651 0.599999
+      vertex 23.1564 -15.4726 0
+    endloop
+  endfacet
+  facet normal -0.623679 -0.333329 0.707048
+    outer loop
+      vertex 25.3491 12.916 0.599999
+      vertex 24.8225 13.9013 0.599999
+      vertex 24.299 13.6081 0
+    endloop
+  endfacet
+  facet normal 0.623682 0.333342 0.707039
+    outer loop
+      vertex -24.299 -13.6081 0
+      vertex -24.8145 -12.6436 0
+      vertex -25.3491 -12.916 0.599999
+    endloop
+  endfacet
+  facet normal 0.231742 -0.668133 0.707031
+    outer loop
+      vertex -9.63936 26.1286 0
+      vertex -8.79153 27.0576 0.599999
+      vertex -9.84703 26.6915 0.599999
+    endloop
+  endfacet
+  facet normal 0.469718 -0.528627 0.707049
+    outer loop
+      vertex -18.9046 20.4509 0
+      vertex -18.0871 21.1773 0
+      vertex -19.3119 20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0.595574 0.381246 0.707067
+    outer loop
+      vertex -23.6553 -15.806 0.599999
+      vertex -23.1564 -15.4726 0
+      vertex -24.2576 -14.8651 0.599999
+    endloop
+  endfacet
+  facet normal -0.448661 -0.546647 0.707022
+    outer loop
+      vertex 18.4768 21.6335 0.599999
+      vertex 17.6132 22.3423 0.599999
+      vertex 17.2418 21.8711 0
+    endloop
+  endfacet
+  facet normal -0.647904 -0.283379 0.707048
+    outer loop
+      vertex 26.2844 10.8873 0.599999
+      vertex 25.8367 11.9109 0.599999
+      vertex 25.2918 11.6597 0
+    endloop
+  endfacet
+  facet normal -0.205306 -0.676702 0.707053
+    outer loop
+      vertex 8.60612 26.4869 0
+      vertex 7.72248 27.3819 0.599999
+      vertex 7.55962 26.8044 0
+    endloop
+  endfacet
+  facet normal -0.563853 -0.426799 0.707045
+    outer loop
+      vertex 22.5311 16.3698 0
+      vertex 23.0165 16.7225 0.599999
+      vertex 22.3423 17.6132 0.599999
+    endloop
+  endfacet
+  facet normal 0.151552 0.690785 0.706999
+    outer loop
+      vertex -5.55032 -27.9033 0.599999
+      vertex -5.43326 -27.3149 0
+      vertex -6.64152 -27.6639 0.599999
+    endloop
+  endfacet
+  facet normal 0.0693171 0.703793 0.707015
+    outer loop
+      vertex -2.23216 -28.3623 0.599999
+      vertex -3.27342 -27.657 0
+      vertex -3.34394 -28.2528 0.599999
+    endloop
+  endfacet
+  facet normal -0.490119 0.509742 0.707069
+    outer loop
+      vertex 20.1172 -20.1172 0.599999
+      vertex 19.6929 -19.6929 0
+      vertex 19.3119 -20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0.696207 -0.124295 0.706998
+    outer loop
+      vertex -27.5071 4.3567 0
+      vertex -27.3149 5.43326 0
+      vertex -27.9033 5.55032 0.599999
+    endloop
+  endfacet
+  facet normal -0.647904 0.283379 0.707048
+    outer loop
+      vertex 25.8367 -11.9109 0.599999
+      vertex 26.2844 -10.8873 0.599999
+      vertex 25.2918 -11.6597 0
+    endloop
+  endfacet
+  facet normal -0.0416425 0.705918 0.707068
+    outer loop
+      vertex 2.23216 -28.3623 0.599999
+      vertex 2.18509 -27.7641 0
+      vertex 1.09339 -27.8285 0
+    endloop
+  endfacet
+  facet normal 0.257747 -0.65849 0.707077
+    outer loop
+      vertex -10.6577 25.73 0
+      vertex -9.63936 26.1286 0
+      vertex -10.8873 26.2844 0.599999
+    endloop
+  endfacet
+  facet normal -0.308656 -0.63626 0.707039
+    outer loop
+      vertex 12.6436 24.8145 0
+      vertex 12.916 25.3491 0.599999
+      vertex 11.6597 25.2918 0
+    endloop
+  endfacet
+  facet normal -0.546634 0.448663 0.707031
+    outer loop
+      vertex 21.6335 -18.4768 0.599999
+      vertex 21.8711 -17.2418 0
+      vertex 21.1773 -18.0871 0
+    endloop
+  endfacet
+  facet normal -0.333342 0.623682 0.707039
+    outer loop
+      vertex 12.916 -25.3491 0.599999
+      vertex 13.6081 -24.299 0
+      vertex 12.6436 -24.8145 0
+    endloop
+  endfacet
+  facet normal -0.308661 0.636249 0.707047
+    outer loop
+      vertex 11.9109 -25.8367 0.599999
+      vertex 12.916 -25.3491 0.599999
+      vertex 11.6597 -25.2918 0
+    endloop
+  endfacet
+  facet normal 0.70591 0.04165 0.707076
+    outer loop
+      vertex -28.3623 -2.23216 0.599999
+      vertex -27.8285 -1.09339 0
+      vertex -28.4281 -1.11694 0.599999
+    endloop
+  endfacet
+  facet normal -0.595579 -0.381274 0.707047
+    outer loop
+      vertex 23.746 14.5516 0
+      vertex 24.2576 14.8651 0.599999
+      vertex 23.1564 15.4726 0
+    endloop
+  endfacet
+  facet normal 0.178509 0.684259 0.707053
+    outer loop
+      vertex -6.64152 -27.6639 0.599999
+      vertex -7.55962 -26.8044 0
+      vertex -7.72248 -27.3819 0.599999
+    endloop
+  endfacet
+  facet normal 0.178543 0.684277 0.707027
+    outer loop
+      vertex -6.64152 -27.6639 0.599999
+      vertex -6.50145 -27.0805 0
+      vertex -7.55962 -26.8044 0
+    endloop
+  endfacet
+  facet normal 0.707038 -0.0139029 0.707039
+    outer loop
+      vertex -27.85 0 0
+      vertex -27.8285 1.09339 0
+      vertex -28.45 0 0.599999
+    endloop
+  endfacet
+  facet normal 0.707002 -0.0138623 0.707076
+    outer loop
+      vertex -27.8285 1.09339 0
+      vertex -28.4281 1.11694 0.599999
+      vertex -28.45 0 0.599999
+    endloop
+  endfacet
+  facet normal 0.684259 -0.178509 0.707053
+    outer loop
+      vertex -26.8044 7.55962 0
+      vertex -27.3819 7.72248 0.599999
+      vertex -27.6639 6.64152 0.599999
+    endloop
+  endfacet
+  facet normal -0.676702 0.205306 0.707053
+    outer loop
+      vertex 27.3819 -7.72248 0.599999
+      vertex 26.8044 -7.55962 0
+      vertex 26.4869 -8.60612 0
+    endloop
+  endfacet
+  facet normal -0.0969357 0.700524 0.707015
+    outer loop
+      vertex 3.34394 -28.2528 0.599999
+      vertex 4.3567 -27.5071 0
+      vertex 3.27342 -27.657 0
+    endloop
+  endfacet
+  facet normal 0.595574 -0.381246 0.707067
+    outer loop
+      vertex -23.1564 15.4726 0
+      vertex -23.6553 15.806 0.599999
+      vertex -24.2576 14.8651 0.599999
+    endloop
+  endfacet
+  facet normal -0.124295 -0.696207 0.706998
+    outer loop
+      vertex 5.43326 27.3149 0
+      vertex 5.55032 27.9033 0.599999
+      vertex 4.3567 27.5071 0
+    endloop
+  endfacet
+  facet normal -0.283339 0.64789 0.707076
+    outer loop
+      vertex 10.8873 -26.2844 0.599999
+      vertex 11.6597 -25.2918 0
+      vertex 10.6577 -25.73 0
+    endloop
+  endfacet
+  facet normal -0.684277 0.178543 0.707027
+    outer loop
+      vertex 27.6639 -6.64152 0.599999
+      vertex 27.0805 -6.50145 0
+      vertex 26.8044 -7.55962 0
+    endloop
+  endfacet
+  facet normal -0.178509 0.684259 0.707053
+    outer loop
+      vertex 7.72248 -27.3819 0.599999
+      vertex 7.55962 -26.8044 0
+      vertex 6.64152 -27.6639 0.599999
+    endloop
+  endfacet
+  facet normal -0.205275 0.676687 0.707076
+    outer loop
+      vertex 8.79153 -27.0576 0.599999
+      vertex 8.60612 -26.4869 0
+      vertex 7.72248 -27.3819 0.599999
+    endloop
+  endfacet
+  facet normal 0.623679 -0.333329 0.707048
+    outer loop
+      vertex -24.299 13.6081 0
+      vertex -24.8225 13.9013 0.599999
+      vertex -25.3491 12.916 0.599999
+    endloop
+  endfacet
+  facet normal 0.623679 0.333329 0.707048
+    outer loop
+      vertex -24.8225 -13.9013 0.599999
+      vertex -24.299 -13.6081 0
+      vertex -25.3491 -12.916 0.599999
+    endloop
+  endfacet
+  facet normal -0.676687 -0.205275 0.707076
+    outer loop
+      vertex 27.3819 7.72248 0.599999
+      vertex 27.0576 8.79153 0.599999
+      vertex 26.4869 8.60612 0
+    endloop
+  endfacet
+  facet normal 0.151552 -0.690785 0.706999
+    outer loop
+      vertex -5.43326 27.3149 0
+      vertex -5.55032 27.9033 0.599999
+      vertex -6.64152 27.6639 0.599999
+    endloop
+  endfacet
+  facet normal -0.283379 -0.647904 0.707048
+    outer loop
+      vertex 11.6597 25.2918 0
+      vertex 11.9109 25.8367 0.599999
+      vertex 10.8873 26.2844 0.599999
+    endloop
+  endfacet
+  facet normal -0.490119 -0.509742 0.707069
+    outer loop
+      vertex 19.6929 19.6929 0
+      vertex 20.1172 20.1172 0.599999
+      vertex 19.3119 20.8915 0.599999
+    endloop
+  endfacet
+  facet normal -0.0139029 -0.707038 0.707039
+    outer loop
+      vertex 1.09339 27.8285 0
+      vertex 0 28.45 0.599999
+      vertex 0 27.85 0
+    endloop
+  endfacet
+  facet normal -0.490148 -0.509741 0.70705
+    outer loop
+      vertex 19.6929 19.6929 0
+      vertex 19.3119 20.8915 0.599999
+      vertex 18.9046 20.4509 0
+    endloop
+  endfacet
+  facet normal -0.490148 0.509741 0.70705
+    outer loop
+      vertex 19.3119 -20.8915 0.599999
+      vertex 19.6929 -19.6929 0
+      vertex 18.9046 -20.4509 0
+    endloop
+  endfacet
+  facet normal -0.690751 0.151576 0.707027
+    outer loop
+      vertex 27.6639 -6.64152 0.599999
+      vertex 27.3149 -5.43326 0
+      vertex 27.0805 -6.50145 0
+    endloop
+  endfacet
+  facet normal 0.623682 -0.333342 0.707039
+    outer loop
+      vertex -24.8145 12.6436 0
+      vertex -24.299 13.6081 0
+      vertex -25.3491 12.916 0.599999
+    endloop
+  endfacet
+  facet normal 0.308656 -0.63626 0.707039
+    outer loop
+      vertex -12.6436 24.8145 0
+      vertex -11.6597 25.2918 0
+      vertex -12.916 25.3491 0.599999
+    endloop
+  endfacet
+  facet normal 0.700524 0.0969357 0.707015
+    outer loop
+      vertex -27.5071 -4.3567 0
+      vertex -27.657 -3.27342 0
+      vertex -28.2528 -3.34394 0.599999
+    endloop
+  endfacet
+  facet normal 0.490119 0.509742 0.707069
+    outer loop
+      vertex -19.3119 -20.8915 0.599999
+      vertex -19.6929 -19.6929 0
+      vertex -20.1172 -20.1172 0.599999
+    endloop
+  endfacet
+  facet normal -0.668133 -0.231742 0.707031
+    outer loop
+      vertex 27.0576 8.79153 0.599999
+      vertex 26.6915 9.84703 0.599999
+      vertex 26.1286 9.63936 0
+    endloop
+  endfacet
+  facet normal -0.700509 0.0969149 0.707032
+    outer loop
+      vertex 28.0997 -4.45056 0.599999
+      vertex 28.2528 -3.34394 0.599999
+      vertex 27.5071 -4.3567 0
+    endloop
+  endfacet
+  facet normal -0.124295 0.696207 0.706998
+    outer loop
+      vertex 5.55032 -27.9033 0.599999
+      vertex 5.43326 -27.3149 0
+      vertex 4.3567 -27.5071 0
+    endloop
+  endfacet
+  facet normal 0.636249 -0.308661 0.707047
+    outer loop
+      vertex -25.2918 11.6597 0
+      vertex -25.3491 12.916 0.599999
+      vertex -25.8367 11.9109 0.599999
+    endloop
+  endfacet
+  facet normal 0.700509 -0.0969149 0.707032
+    outer loop
+      vertex -27.5071 4.3567 0
+      vertex -28.0997 4.45056 0.599999
+      vertex -28.2528 3.34394 0.599999
+    endloop
+  endfacet
+  facet normal -0.0138623 0.707002 0.707076
+    outer loop
+      vertex 1.11694 -28.4281 0.599999
+      vertex 1.09339 -27.8285 0
+      vertex 0 -28.45 0.599999
+    endloop
+  endfacet
+  facet normal -0.546647 -0.448661 0.707022
+    outer loop
+      vertex 21.8711 17.2418 0
+      vertex 22.3423 17.6132 0.599999
+      vertex 21.6335 18.4768 0.599999
+    endloop
+  endfacet
+  facet normal 0.04165 0.70591 0.707076
+    outer loop
+      vertex -1.11694 -28.4281 0.599999
+      vertex -1.09339 -27.8285 0
+      vertex -2.23216 -28.3623 0.599999
+    endloop
+  endfacet
+  facet normal -0.257718 -0.65855 0.707031
+    outer loop
+      vertex 10.8873 26.2844 0.599999
+      vertex 9.84703 26.6915 0.599999
+      vertex 9.63936 26.1286 0
+    endloop
+  endfacet
+  facet normal -0.469718 0.528627 0.707049
+    outer loop
+      vertex 19.3119 -20.8915 0.599999
+      vertex 18.9046 -20.4509 0
+      vertex 18.0871 -21.1773 0
+    endloop
+  endfacet
+  facet normal 0.647904 -0.283379 0.707048
+    outer loop
+      vertex -25.2918 11.6597 0
+      vertex -25.8367 11.9109 0.599999
+      vertex -26.2844 10.8873 0.599999
+    endloop
+  endfacet
+  facet normal -0.595579 0.381274 0.707047
+    outer loop
+      vertex 24.2576 -14.8651 0.599999
+      vertex 23.746 -14.5516 0
+      vertex 23.1564 -15.4726 0
+    endloop
+  endfacet
+  facet normal 0.404345 -0.580167 0.707044
+    outer loop
+      vertex -16.3698 22.5311 0
+      vertex -15.4726 23.1564 0
+      vertex -16.7225 23.0165 0.599999
+    endloop
+  endfacet
+  facet normal -0.546647 0.448661 0.707022
+    outer loop
+      vertex 22.3423 -17.6132 0.599999
+      vertex 21.8711 -17.2418 0
+      vertex 21.6335 -18.4768 0.599999
+    endloop
+  endfacet
+  facet normal -0.676687 0.205275 0.707076
+    outer loop
+      vertex 27.0576 -8.79153 0.599999
+      vertex 27.3819 -7.72248 0.599999
+      vertex 26.4869 -8.60612 0
+    endloop
+  endfacet
+  facet normal -0.705918 0.0416425 0.707068
+    outer loop
+      vertex 28.3623 -2.23216 0.599999
+      vertex 27.8285 -1.09339 0
+      vertex 27.7641 -2.18509 0
+    endloop
+  endfacet
+  facet normal -0.703746 0.069254 0.707069
+    outer loop
+      vertex 28.3623 -2.23216 0.599999
+      vertex 27.7641 -2.18509 0
+      vertex 27.657 -3.27342 0
+    endloop
+  endfacet
+  facet normal 0.668133 -0.231742 0.707031
+    outer loop
+      vertex -26.1286 9.63936 0
+      vertex -26.6915 9.84703 0.599999
+      vertex -27.0576 8.79153 0.599999
+    endloop
+  endfacet
+  facet normal -0.426793 0.563884 0.707023
+    outer loop
+      vertex 17.6132 -22.3423 0.599999
+      vertex 17.2418 -21.8711 0
+      vertex 16.3698 -22.5311 0
+    endloop
+  endfacet
+  facet normal 0.528627 0.469718 0.707049
+    outer loop
+      vertex -20.8915 -19.3119 0.599999
+      vertex -20.4509 -18.9046 0
+      vertex -21.1773 -18.0871 0
+    endloop
+  endfacet
+  facet normal -0.703746 -0.069254 0.707069
+    outer loop
+      vertex 27.7641 2.18509 0
+      vertex 28.3623 2.23216 0.599999
+      vertex 27.657 3.27342 0
+    endloop
+  endfacet
+  facet normal -0.705918 -0.0416425 0.707068
+    outer loop
+      vertex 27.8285 1.09339 0
+      vertex 28.3623 2.23216 0.599999
+      vertex 27.7641 2.18509 0
+    endloop
+  endfacet
+  facet normal 0.690751 -0.151576 0.707027
+    outer loop
+      vertex -27.3149 5.43326 0
+      vertex -27.0805 6.50145 0
+      vertex -27.6639 6.64152 0.599999
+    endloop
+  endfacet
+  facet normal -0.151552 0.690785 0.706999
+    outer loop
+      vertex 5.55032 -27.9033 0.599999
+      vertex 6.64152 -27.6639 0.599999
+      vertex 5.43326 -27.3149 0
+    endloop
+  endfacet
+  facet normal 0.205306 -0.676702 0.707053
+    outer loop
+      vertex -7.55962 26.8044 0
+      vertex -7.72248 27.3819 0.599999
+      vertex -8.60612 26.4869 0
+    endloop
+  endfacet
+  facet normal 0.205275 -0.676687 0.707076
+    outer loop
+      vertex -8.60612 26.4869 0
+      vertex -7.72248 27.3819 0.599999
+      vertex -8.79153 27.0576 0.599999
+    endloop
+  endfacet
+  facet normal -0.636249 -0.308661 0.707047
+    outer loop
+      vertex 25.8367 11.9109 0.599999
+      vertex 25.3491 12.916 0.599999
+      vertex 25.2918 11.6597 0
+    endloop
+  endfacet
+  facet normal -0.231742 0.668133 0.707031
+    outer loop
+      vertex 9.84703 -26.6915 0.599999
+      vertex 9.63936 -26.1286 0
+      vertex 8.79153 -27.0576 0.599999
+    endloop
+  endfacet
+  facet normal -0.283379 0.647904 0.707048
+    outer loop
+      vertex 11.9109 -25.8367 0.599999
+      vertex 11.6597 -25.2918 0
+      vertex 10.8873 -26.2844 0.599999
+    endloop
+  endfacet
+  facet normal -0.563884 0.426793 0.707023
+    outer loop
+      vertex 22.3423 -17.6132 0.599999
+      vertex 22.5311 -16.3698 0
+      vertex 21.8711 -17.2418 0
+    endloop
+  endfacet
+  facet normal -0.381246 -0.595574 0.707067
+    outer loop
+      vertex 15.4726 23.1564 0
+      vertex 15.806 23.6553 0.599999
+      vertex 14.8651 24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0.426793 -0.563884 0.707023
+    outer loop
+      vertex -17.2418 21.8711 0
+      vertex -16.3698 22.5311 0
+      vertex -17.6132 22.3423 0.599999
+    endloop
+  endfacet
+  facet normal 0.707002 0.0138623 0.707076
+    outer loop
+      vertex -28.4281 -1.11694 0.599999
+      vertex -27.8285 -1.09339 0
+      vertex -28.45 0 0.599999
+    endloop
+  endfacet
+  facet normal 0.707038 0.0139029 0.707039
+    outer loop
+      vertex -27.8285 -1.09339 0
+      vertex -27.85 0 0
+      vertex -28.45 0 0.599999
+    endloop
+  endfacet
+  facet normal -0.469718 -0.528627 0.707049
+    outer loop
+      vertex 18.9046 20.4509 0
+      vertex 19.3119 20.8915 0.599999
+      vertex 18.0871 21.1773 0
+    endloop
+  endfacet
+  facet normal 0.448661 -0.546647 0.707022
+    outer loop
+      vertex -17.2418 21.8711 0
+      vertex -17.6132 22.3423 0.599999
+      vertex -18.4768 21.6335 0.599999
+    endloop
+  endfacet
+  facet normal 0.308656 0.63626 0.707039
+    outer loop
+      vertex -11.6597 -25.2918 0
+      vertex -12.6436 -24.8145 0
+      vertex -12.916 -25.3491 0.599999
+    endloop
+  endfacet
+  facet normal -0.623682 0.333342 0.707039
+    outer loop
+      vertex 25.3491 -12.916 0.599999
+      vertex 24.8145 -12.6436 0
+      vertex 24.299 -13.6081 0
+    endloop
+  endfacet
+  facet normal -0.623679 0.333329 0.707048
+    outer loop
+      vertex 24.8225 -13.9013 0.599999
+      vertex 25.3491 -12.916 0.599999
+      vertex 24.299 -13.6081 0
+    endloop
+  endfacet
+  facet normal 0.426793 0.563884 0.707023
+    outer loop
+      vertex -16.3698 -22.5311 0
+      vertex -17.2418 -21.8711 0
+      vertex -17.6132 -22.3423 0.599999
+    endloop
+  endfacet
+  facet normal 0.595579 -0.381274 0.707047
+    outer loop
+      vertex -23.746 14.5516 0
+      vertex -23.1564 15.4726 0
+      vertex -24.2576 14.8651 0.599999
+    endloop
+  endfacet
+  facet normal -0.63626 0.308656 0.707039
+    outer loop
+      vertex 25.3491 -12.916 0.599999
+      vertex 25.2918 -11.6597 0
+      vertex 24.8145 -12.6436 0
+    endloop
+  endfacet
+  facet normal 0.257718 -0.65855 0.707031
+    outer loop
+      vertex -9.63936 26.1286 0
+      vertex -9.84703 26.6915 0.599999
+      vertex -10.8873 26.2844 0.599999
+    endloop
+  endfacet
+  facet normal -0.178509 -0.684259 0.707053
+    outer loop
+      vertex 7.55962 26.8044 0
+      vertex 7.72248 27.3819 0.599999
+      vertex 6.64152 27.6639 0.599999
+    endloop
+  endfacet
+  facet normal 0.333342 0.623682 0.707039
+    outer loop
+      vertex -12.916 -25.3491 0.599999
+      vertex -12.6436 -24.8145 0
+      vertex -13.6081 -24.299 0
+    endloop
+  endfacet
+  facet normal -0.668107 -0.231682 0.707076
+    outer loop
+      vertex 26.4869 8.60612 0
+      vertex 27.0576 8.79153 0.599999
+      vertex 26.1286 9.63936 0
+    endloop
+  endfacet
+  facet normal -0.65855 -0.257718 0.707031
+    outer loop
+      vertex 26.6915 9.84703 0.599999
+      vertex 26.2844 10.8873 0.599999
+      vertex 26.1286 9.63936 0
+    endloop
+  endfacet
+  facet normal 0.283339 -0.64789 0.707076
+    outer loop
+      vertex -10.6577 25.73 0
+      vertex -10.8873 26.2844 0.599999
+      vertex -11.6597 25.2918 0
+    endloop
+  endfacet
+  facet normal 0.684277 -0.178543 0.707027
+    outer loop
+      vertex -27.0805 6.50145 0
+      vertex -26.8044 7.55962 0
+      vertex -27.6639 6.64152 0.599999
+    endloop
+  endfacet
+  facet normal 0.696207 0.124295 0.706998
+    outer loop
+      vertex -27.3149 -5.43326 0
+      vertex -27.5071 -4.3567 0
+      vertex -27.9033 -5.55032 0.599999
+    endloop
+  endfacet
+  facet normal 0.0969357 0.700524 0.707015
+    outer loop
+      vertex -3.34394 -28.2528 0.599999
+      vertex -3.27342 -27.657 0
+      vertex -4.3567 -27.5071 0
+    endloop
+  endfacet
+  facet normal -0.636249 0.308661 0.707047
+    outer loop
+      vertex 25.3491 -12.916 0.599999
+      vertex 25.8367 -11.9109 0.599999
+      vertex 25.2918 -11.6597 0
+    endloop
+  endfacet
+  facet normal 0.283379 0.647904 0.707048
+    outer loop
+      vertex -10.8873 -26.2844 0.599999
+      vertex -11.6597 -25.2918 0
+      vertex -11.9109 -25.8367 0.599999
+    endloop
+  endfacet
+  facet normal 0.0139029 0.707038 0.707039
+    outer loop
+      vertex 0 -28.45 0.599999
+      vertex 0 -27.85 0
+      vertex -1.09339 -27.8285 0
+    endloop
+  endfacet
+  facet normal 0.426799 -0.563853 0.707045
+    outer loop
+      vertex -16.3698 22.5311 0
+      vertex -16.7225 23.0165 0.599999
+      vertex -17.6132 22.3423 0.599999
+    endloop
+  endfacet
+  facet normal -0.623682 -0.333342 0.707039
+    outer loop
+      vertex 24.8145 12.6436 0
+      vertex 25.3491 12.916 0.599999
+      vertex 24.299 13.6081 0
+    endloop
+  endfacet
+  facet normal -0.124325 0.696168 0.707032
+    outer loop
+      vertex 4.45056 -28.0997 0.599999
+      vertex 5.55032 -27.9033 0.599999
+      vertex 4.3567 -27.5071 0
+    endloop
+  endfacet
+  facet normal 0.404353 0.580133 0.707067
+    outer loop
+      vertex -15.806 -23.6553 0.599999
+      vertex -15.4726 -23.1564 0
+      vertex -16.7225 -23.0165 0.599999
+    endloop
+  endfacet
+  facet normal 0.469715 -0.528651 0.707033
+    outer loop
+      vertex -18.0871 21.1773 0
+      vertex -18.4768 21.6335 0.599999
+      vertex -19.3119 20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0.283379 -0.647904 0.707048
+    outer loop
+      vertex -11.6597 25.2918 0
+      vertex -10.8873 26.2844 0.599999
+      vertex -11.9109 25.8367 0.599999
+    endloop
+  endfacet
+  facet normal 0.703746 0.069254 0.707069
+    outer loop
+      vertex -27.657 -3.27342 0
+      vertex -27.7641 -2.18509 0
+      vertex -28.3623 -2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0.357587 0.610094 0.707049
+    outer loop
+      vertex -13.9013 -24.8225 0.599999
+      vertex -13.6081 -24.299 0
+      vertex -14.8651 -24.2576 0.599999
+    endloop
+  endfacet
+  facet normal -0.205275 -0.676687 0.707076
+    outer loop
+      vertex 8.60612 26.4869 0
+      vertex 8.79153 27.0576 0.599999
+      vertex 7.72248 27.3819 0.599999
+    endloop
+  endfacet
+  facet normal -0.696207 -0.124295 0.706998
+    outer loop
+      vertex 27.5071 4.3567 0
+      vertex 27.9033 5.55032 0.599999
+      vertex 27.3149 5.43326 0
+    endloop
+  endfacet
+  facet normal -0.690785 -0.151552 0.706999
+    outer loop
+      vertex 27.9033 5.55032 0.599999
+      vertex 27.6639 6.64152 0.599999
+      vertex 27.3149 5.43326 0
+    endloop
+  endfacet
+  facet normal 0.124325 0.696168 0.707032
+    outer loop
+      vertex -4.45056 -28.0997 0.599999
+      vertex -4.3567 -27.5071 0
+      vertex -5.55032 -27.9033 0.599999
+    endloop
+  endfacet
+  facet normal -0.124325 -0.696168 0.707032
+    outer loop
+      vertex 5.55032 27.9033 0.599999
+      vertex 4.45056 28.0997 0.599999
+      vertex 4.3567 27.5071 0
+    endloop
+  endfacet
+  facet normal -0.257747 -0.65849 0.707077
+    outer loop
+      vertex 10.6577 25.73 0
+      vertex 10.8873 26.2844 0.599999
+      vertex 9.63936 26.1286 0
+    endloop
+  endfacet
+  facet normal -0.426793 -0.563884 0.707023
+    outer loop
+      vertex 17.2418 21.8711 0
+      vertex 17.6132 22.3423 0.599999
+      vertex 16.3698 22.5311 0
+    endloop
+  endfacet
+  facet normal 0.696168 -0.124325 0.707032
+    outer loop
+      vertex -27.5071 4.3567 0
+      vertex -27.9033 5.55032 0.599999
+      vertex -28.0997 4.45056 0.599999
+    endloop
+  endfacet
+  facet normal 0.381274 0.595579 0.707047
+    outer loop
+      vertex -14.8651 -24.2576 0.599999
+      vertex -14.5516 -23.746 0
+      vertex -15.4726 -23.1564 0
+    endloop
+  endfacet
+  facet normal -0.231682 -0.668107 0.707076
+    outer loop
+      vertex 9.63936 26.1286 0
+      vertex 8.79153 27.0576 0.599999
+      vertex 8.60612 26.4869 0
+    endloop
+  endfacet
+  facet normal -0.308656 0.63626 0.707039
+    outer loop
+      vertex 12.916 -25.3491 0.599999
+      vertex 12.6436 -24.8145 0
+      vertex 11.6597 -25.2918 0
+    endloop
+  endfacet
+  facet normal 0.469715 0.528651 0.707033
+    outer loop
+      vertex -18.4768 -21.6335 0.599999
+      vertex -18.0871 -21.1773 0
+      vertex -19.3119 -20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0.563884 0.426793 0.707023
+    outer loop
+      vertex -22.3423 -17.6132 0.599999
+      vertex -21.8711 -17.2418 0
+      vertex -22.5311 -16.3698 0
+    endloop
+  endfacet
+  facet normal 0.65855 0.257718 0.707031
+    outer loop
+      vertex -26.2844 -10.8873 0.599999
+      vertex -26.1286 -9.63936 0
+      vertex -26.6915 -9.84703 0.599999
+    endloop
+  endfacet
+  facet normal 0.700509 0.0969149 0.707032
+    outer loop
+      vertex -28.0997 -4.45056 0.599999
+      vertex -27.5071 -4.3567 0
+      vertex -28.2528 -3.34394 0.599999
+    endloop
+  endfacet
+  facet normal -0.0969149 -0.700509 0.707032
+    outer loop
+      vertex 4.3567 27.5071 0
+      vertex 4.45056 28.0997 0.599999
+      vertex 3.34394 28.2528 0.599999
+    endloop
+  endfacet
+  facet normal -0.0969357 -0.700524 0.707015
+    outer loop
+      vertex 4.3567 27.5071 0
+      vertex 3.34394 28.2528 0.599999
+      vertex 3.27342 27.657 0
+    endloop
+  endfacet
+  facet normal -0.357587 -0.610094 0.707049
+    outer loop
+      vertex 14.8651 24.2576 0.599999
+      vertex 13.9013 24.8225 0.599999
+      vertex 13.6081 24.299 0
+    endloop
+  endfacet
+  facet normal -0.381274 0.595579 0.707047
+    outer loop
+      vertex 14.8651 -24.2576 0.599999
+      vertex 15.4726 -23.1564 0
+      vertex 14.5516 -23.746 0
+    endloop
+  endfacet
+  facet normal -0.069254 0.703746 0.707069
+    outer loop
+      vertex 2.23216 -28.3623 0.599999
+      vertex 3.27342 -27.657 0
+      vertex 2.18509 -27.7641 0
+    endloop
+  endfacet
+  facet normal -0.357586 0.610095 0.707048
+    outer loop
+      vertex 14.8651 -24.2576 0.599999
+      vertex 14.5516 -23.746 0
+      vertex 13.6081 -24.299 0
+    endloop
+  endfacet
+  facet normal -0.700524 0.0969357 0.707015
+    outer loop
+      vertex 28.2528 -3.34394 0.599999
+      vertex 27.657 -3.27342 0
+      vertex 27.5071 -4.3567 0
+    endloop
+  endfacet
+  facet normal -0.696168 0.124325 0.707032
+    outer loop
+      vertex 27.9033 -5.55032 0.599999
+      vertex 28.0997 -4.45056 0.599999
+      vertex 27.5071 -4.3567 0
+    endloop
+  endfacet
+  facet normal -0.65855 0.257718 0.707031
+    outer loop
+      vertex 26.2844 -10.8873 0.599999
+      vertex 26.6915 -9.84703 0.599999
+      vertex 26.1286 -9.63936 0
+    endloop
+  endfacet
+  facet normal 0.676687 0.205275 0.707076
+    outer loop
+      vertex -27.0576 -8.79153 0.599999
+      vertex -26.4869 -8.60612 0
+      vertex -27.3819 -7.72248 0.599999
+    endloop
+  endfacet
+  facet normal -0.404345 0.580167 0.707044
+    outer loop
+      vertex 16.7225 -23.0165 0.599999
+      vertex 16.3698 -22.5311 0
+      vertex 15.4726 -23.1564 0
+    endloop
+  endfacet
+  facet normal -0.404345 -0.580167 0.707044
+    outer loop
+      vertex 16.3698 22.5311 0
+      vertex 16.7225 23.0165 0.599999
+      vertex 15.4726 23.1564 0
+    endloop
+  endfacet
+  facet normal 0.703793 0.0693171 0.707015
+    outer loop
+      vertex -28.2528 -3.34394 0.599999
+      vertex -27.657 -3.27342 0
+      vertex -28.3623 -2.23216 0.599999
+    endloop
+  endfacet
+  facet normal 0.069254 -0.703746 0.707069
+    outer loop
+      vertex -2.18509 27.7641 0
+      vertex -2.23216 28.3623 0.599999
+      vertex -3.27342 27.657 0
+    endloop
+  endfacet
+  facet normal 0.690751 0.151576 0.707027
+    outer loop
+      vertex -27.0805 -6.50145 0
+      vertex -27.3149 -5.43326 0
+      vertex -27.6639 -6.64152 0.599999
+    endloop
+  endfacet
+  facet normal 0.63626 -0.308656 0.707039
+    outer loop
+      vertex -25.2918 11.6597 0
+      vertex -24.8145 12.6436 0
+      vertex -25.3491 12.916 0.599999
+    endloop
+  endfacet
+  facet normal -0.231682 0.668107 0.707076
+    outer loop
+      vertex 8.79153 -27.0576 0.599999
+      vertex 9.63936 -26.1286 0
+      vertex 8.60612 -26.4869 0
+    endloop
+  endfacet
+  facet normal 0.684277 0.178543 0.707027
+    outer loop
+      vertex -26.8044 -7.55962 0
+      vertex -27.0805 -6.50145 0
+      vertex -27.6639 -6.64152 0.599999
+    endloop
+  endfacet
+  facet normal 0.151576 -0.690751 0.707027
+    outer loop
+      vertex -6.50145 27.0805 0
+      vertex -5.43326 27.3149 0
+      vertex -6.64152 27.6639 0.599999
+    endloop
+  endfacet
+  facet normal 0.469718 0.528627 0.707049
+    outer loop
+      vertex -18.0871 -21.1773 0
+      vertex -18.9046 -20.4509 0
+      vertex -19.3119 -20.8915 0.599999
+    endloop
+  endfacet
+  facet normal 0.690785 0.151552 0.706999
+    outer loop
+      vertex -27.6639 -6.64152 0.599999
+      vertex -27.3149 -5.43326 0
+      vertex -27.9033 -5.55032 0.599999
+    endloop
+  endfacet
+  facet normal -0.684277 -0.178543 0.707027
+    outer loop
+      vertex 27.0805 6.50145 0
+      vertex 27.6639 6.64152 0.599999
+      vertex 26.8044 7.55962 0
+    endloop
+  endfacet
+  facet normal 0.65849 -0.257747 0.707077
+    outer loop
+      vertex -26.1286 9.63936 0
+      vertex -25.73 10.6577 0
+      vertex -26.2844 10.8873 0.599999
+    endloop
+  endfacet
+  facet normal 0.231742 0.668133 0.707031
+    outer loop
+      vertex -8.79153 -27.0576 0.599999
+      vertex -9.63936 -26.1286 0
+      vertex -9.84703 -26.6915 0.599999
+    endloop
+  endfacet
+  facet normal 0.546647 0.448661 0.707022
+    outer loop
+      vertex -21.6335 -18.4768 0.599999
+      vertex -21.8711 -17.2418 0
+      vertex -22.3423 -17.6132 0.599999
+    endloop
+  endfacet
+  facet normal 0.231682 0.668107 0.707076
+    outer loop
+      vertex -8.79153 -27.0576 0.599999
+      vertex -8.60612 -26.4869 0
+      vertex -9.63936 -26.1286 0
+    endloop
+  endfacet
+  facet normal 0.636249 0.308661 0.707047
+    outer loop
+      vertex -25.3491 -12.916 0.599999
+      vertex -25.2918 -11.6597 0
+      vertex -25.8367 -11.9109 0.599999
+    endloop
+  endfacet
+  facet normal -0.151576 0.690751 0.707027
+    outer loop
+      vertex 6.64152 -27.6639 0.599999
+      vertex 6.50145 -27.0805 0
+      vertex 5.43326 -27.3149 0
+    endloop
+  endfacet
+  facet normal 0.509742 0.490119 0.707069
+    outer loop
+      vertex -20.1172 -20.1172 0.599999
+      vertex -19.6929 -19.6929 0
+      vertex -20.8915 -19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0.509741 0.490148 0.70705
+    outer loop
+      vertex -19.6929 -19.6929 0
+      vertex -20.4509 -18.9046 0
+      vertex -20.8915 -19.3119 0.599999
+    endloop
+  endfacet
+  facet normal 0.426799 0.563853 0.707045
+    outer loop
+      vertex -16.7225 -23.0165 0.599999
+      vertex -16.3698 -22.5311 0
+      vertex -17.6132 -22.3423 0.599999
+    endloop
+  endfacet
+  facet normal -0.381246 0.595574 0.707067
+    outer loop
+      vertex 15.806 -23.6553 0.599999
+      vertex 15.4726 -23.1564 0
+      vertex 14.8651 -24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0.333342 -0.623682 0.707039
+    outer loop
+      vertex -12.6436 24.8145 0
+      vertex -12.916 25.3491 0.599999
+      vertex -13.6081 24.299 0
+    endloop
+  endfacet
+  facet normal 0.563853 0.426799 0.707045
+    outer loop
+      vertex -22.3423 -17.6132 0.599999
+      vertex -22.5311 -16.3698 0
+      vertex -23.0165 -16.7225 0.599999
+    endloop
+  endfacet
+  facet normal 0.357587 -0.610094 0.707049
+    outer loop
+      vertex -13.6081 24.299 0
+      vertex -13.9013 24.8225 0.599999
+      vertex -14.8651 24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0.610095 -0.357586 0.707048
+    outer loop
+      vertex -23.746 14.5516 0
+      vertex -24.2576 14.8651 0.599999
+      vertex -24.299 13.6081 0
+    endloop
+  endfacet
+  facet normal 0.308661 -0.636249 0.707047
+    outer loop
+      vertex -11.6597 25.2918 0
+      vertex -11.9109 25.8367 0.599999
+      vertex -12.916 25.3491 0.599999
+    endloop
+  endfacet
+  facet normal -0.178543 -0.684277 0.707027
+    outer loop
+      vertex 7.55962 26.8044 0
+      vertex 6.64152 27.6639 0.599999
+      vertex 6.50145 27.0805 0
+    endloop
+  endfacet
+  facet normal -0.426799 -0.563853 0.707045
+    outer loop
+      vertex 17.6132 22.3423 0.599999
+      vertex 16.7225 23.0165 0.599999
+      vertex 16.3698 22.5311 0
+    endloop
+  endfacet
+  facet normal 0.0969149 -0.700509 0.707032
+    outer loop
+      vertex -4.3567 27.5071 0
+      vertex -3.34394 28.2528 0.599999
+      vertex -4.45056 28.0997 0.599999
+    endloop
+  endfacet
+  facet normal 0.563884 -0.426793 0.707023
+    outer loop
+      vertex -21.8711 17.2418 0
+      vertex -22.3423 17.6132 0.599999
+      vertex -22.5311 16.3698 0
+    endloop
+  endfacet
+  facet normal 0.546647 -0.448661 0.707022
+    outer loop
+      vertex -21.8711 17.2418 0
+      vertex -21.6335 18.4768 0.599999
+      vertex -22.3423 17.6132 0.599999
+    endloop
+  endfacet
+  facet normal 0.0969357 -0.700524 0.707015
+    outer loop
+      vertex -3.27342 27.657 0
+      vertex -3.34394 28.2528 0.599999
+      vertex -4.3567 27.5071 0
+    endloop
+  endfacet
+  facet normal 0.0693171 -0.703793 0.707015
+    outer loop
+      vertex -3.27342 27.657 0
+      vertex -2.23216 28.3623 0.599999
+      vertex -3.34394 28.2528 0.599999
+    endloop
+  endfacet
+  facet normal 0.205306 0.676702 0.707053
+    outer loop
+      vertex -7.72248 -27.3819 0.599999
+      vertex -7.55962 -26.8044 0
+      vertex -8.60612 -26.4869 0
+    endloop
+  endfacet
+  facet normal 0.231682 -0.668107 0.707076
+    outer loop
+      vertex -8.60612 26.4869 0
+      vertex -8.79153 27.0576 0.599999
+      vertex -9.63936 26.1286 0
+    endloop
+  endfacet
+  facet normal 0.124295 0.696207 0.706998
+    outer loop
+      vertex -4.3567 -27.5071 0
+      vertex -5.43326 -27.3149 0
+      vertex -5.55032 -27.9033 0.599999
+    endloop
+  endfacet
+  facet normal 0.595579 0.381274 0.707047
+    outer loop
+      vertex -23.1564 -15.4726 0
+      vertex -23.746 -14.5516 0
+      vertex -24.2576 -14.8651 0.599999
+    endloop
+  endfacet
+  facet normal 0.63626 0.308656 0.707039
+    outer loop
+      vertex -24.8145 -12.6436 0
+      vertex -25.2918 -11.6597 0
+      vertex -25.3491 -12.916 0.599999
+    endloop
+  endfacet
+  facet normal -0.448663 -0.546634 0.707031
+    outer loop
+      vertex 18.0871 21.1773 0
+      vertex 18.4768 21.6335 0.599999
+      vertex 17.2418 21.8711 0
+    endloop
+  endfacet
+  facet normal 0.0416425 -0.705918 0.707068
+    outer loop
+      vertex -2.18509 27.7641 0
+      vertex -1.09339 27.8285 0
+      vertex -2.23216 28.3623 0.599999
+    endloop
+  endfacet
+  facet normal 0.647904 0.283379 0.707048
+    outer loop
+      vertex -25.8367 -11.9109 0.599999
+      vertex -25.2918 -11.6597 0
+      vertex -26.2844 -10.8873 0.599999
+    endloop
+  endfacet
+  facet normal 0.069254 0.703746 0.707069
+    outer loop
+      vertex -2.23216 -28.3623 0.599999
+      vertex -2.18509 -27.7641 0
+      vertex -3.27342 -27.657 0
+    endloop
+  endfacet
+  facet normal 0.308661 0.636249 0.707047
+    outer loop
+      vertex -11.9109 -25.8367 0.599999
+      vertex -11.6597 -25.2918 0
+      vertex -12.916 -25.3491 0.599999
+    endloop
+  endfacet
+  facet normal 0.668107 0.231682 0.707076
+    outer loop
+      vertex -26.1286 -9.63936 0
+      vertex -26.4869 -8.60612 0
+      vertex -27.0576 -8.79153 0.599999
+    endloop
+  endfacet
+  facet normal 0.283339 0.64789 0.707076
+    outer loop
+      vertex -10.8873 -26.2844 0.599999
+      vertex -10.6577 -25.73 0
+      vertex -11.6597 -25.2918 0
+    endloop
+  endfacet
+  facet normal 0.676702 0.205306 0.707053
+    outer loop
+      vertex -26.4869 -8.60612 0
+      vertex -26.8044 -7.55962 0
+      vertex -27.3819 -7.72248 0.599999
+    endloop
+  endfacet
+  facet normal 0.0138623 0.707002 0.707076
+    outer loop
+      vertex 0 -28.45 0.599999
+      vertex -1.09339 -27.8285 0
+      vertex -1.11694 -28.4281 0.599999
+    endloop
+  endfacet
+  facet normal 0.357586 0.610095 0.707048
+    outer loop
+      vertex -13.6081 -24.299 0
+      vertex -14.5516 -23.746 0
+      vertex -14.8651 -24.2576 0.599999
+    endloop
+  endfacet
+  facet normal 0.257747 0.65849 0.707077
+    outer loop
+      vertex -9.63936 -26.1286 0
+      vertex -10.6577 -25.73 0
+      vertex -10.8873 -26.2844 0.599999
+    endloop
+  endfacet
+  facet normal -0.231742 -0.668133 0.707031
+    outer loop
+      vertex 9.63936 26.1286 0
+      vertex 9.84703 26.6915 0.599999
+      vertex 8.79153 27.0576 0.599999
+    endloop
+  endfacet
+  facet normal 0.676687 -0.205275 0.707076
+    outer loop
+      vertex -26.4869 8.60612 0
+      vertex -27.0576 8.79153 0.599999
+      vertex -27.3819 7.72248 0.599999
+    endloop
+  endfacet
+  facet normal 0.668107 -0.231682 0.707076
+    outer loop
+      vertex -26.4869 8.60612 0
+      vertex -26.1286 9.63936 0
+      vertex -27.0576 8.79153 0.599999
+    endloop
+  endfacet
+  facet normal 0.333329 -0.623679 0.707048
+    outer loop
+      vertex -13.6081 24.299 0
+      vertex -12.916 25.3491 0.599999
+      vertex -13.9013 24.8225 0.599999
+    endloop
+  endfacet
+  facet normal -0.357587 0.610094 0.707049
+    outer loop
+      vertex 13.9013 -24.8225 0.599999
+      vertex 14.8651 -24.2576 0.599999
+      vertex 13.6081 -24.299 0
+    endloop
+  endfacet
+  facet normal 0.404345 0.580167 0.707044
+    outer loop
+      vertex -15.4726 -23.1564 0
+      vertex -16.3698 -22.5311 0
+      vertex -16.7225 -23.0165 0.599999
+    endloop
+  endfacet
+  facet normal -0.333329 0.623679 0.707048
+    outer loop
+      vertex 13.9013 -24.8225 0.599999
+      vertex 13.6081 -24.299 0
+      vertex 12.916 -25.3491 0.599999
+    endloop
+  endfacet
+  facet normal 0.205275 0.676687 0.707076
+    outer loop
+      vertex -7.72248 -27.3819 0.599999
+      vertex -8.60612 -26.4869 0
+      vertex -8.79153 -27.0576 0.599999
+    endloop
+  endfacet
+  facet normal 0.404353 -0.580133 0.707067
+    outer loop
+      vertex -15.4726 23.1564 0
+      vertex -15.806 23.6553 0.599999
+      vertex -16.7225 23.0165 0.599999
+    endloop
+  endfacet
+  facet normal 0.124325 0.696168 -0.707031
+    outer loop
+      vertex -4.3567 -27.5071 59
+      vertex -4.45056 -28.0997 58.4
+      vertex -5.55032 -27.9033 58.4
+    endloop
+  endfacet
+  facet normal -0.684259 0.178509 -0.707053
+    outer loop
+      vertex 27.6639 -6.64152 58.4
+      vertex 27.3819 -7.72248 58.4
+      vertex 26.8044 -7.55962 59
+    endloop
+  endfacet
+  facet normal -0.707038 -0.0139029 -0.707038
+    outer loop
+      vertex 28.45 0 58.4
+      vertex 27.85 0 59
+      vertex 27.8285 1.09339 59
+    endloop
+  endfacet
+  facet normal -0.707002 -0.0138623 -0.707075
+    outer loop
+      vertex 28.4281 1.11694 58.4
+      vertex 28.45 0 58.4
+      vertex 27.8285 1.09339 59
+    endloop
+  endfacet
+  facet normal -0.563854 -0.426799 -0.707044
+    outer loop
+      vertex 23.0165 16.7225 58.4
+      vertex 22.5311 16.3698 59
+      vertex 22.3423 17.6132 58.4
+    endloop
+  endfacet
+  facet normal 0.647905 -0.283379 -0.707047
+    outer loop
+      vertex -25.8367 11.9109 58.4
+      vertex -25.2918 11.6597 59
+      vertex -26.2844 10.8873 58.4
+    endloop
+  endfacet
+  facet normal 0.528652 0.469716 -0.707032
+    outer loop
+      vertex -21.1773 -18.0871 59
+      vertex -20.8915 -19.3119 58.4
+      vertex -21.6335 -18.4768 58.4
+    endloop
+  endfacet
+  facet normal -0.70051 -0.096915 -0.707031
+    outer loop
+      vertex 28.0997 4.45056 58.4
+      vertex 28.2528 3.34394 58.4
+      vertex 27.5071 4.3567 59
+    endloop
+  endfacet
+  facet normal -0.178543 0.684277 -0.707027
+    outer loop
+      vertex 7.55962 -26.8044 59
+      vertex 6.64152 -27.6639 58.4
+      vertex 6.50145 -27.0805 59
+    endloop
+  endfacet
+  facet normal 0.70051 0.096915 -0.707031
+    outer loop
+      vertex -27.5071 -4.3567 59
+      vertex -28.0997 -4.45056 58.4
+      vertex -28.2528 -3.34394 58.4
+    endloop
+  endfacet
+  facet normal 0.690786 0.151553 -0.706998
+    outer loop
+      vertex -27.3149 -5.43326 59
+      vertex -27.6639 -6.64152 58.4
+      vertex -27.9033 -5.55032 58.4
+    endloop
+  endfacet
+  facet normal 0.684259 0.178509 -0.707053
+    outer loop
+      vertex -26.8044 -7.55962 59
+      vertex -27.3819 -7.72248 58.4
+      vertex -27.6639 -6.64152 58.4
+    endloop
+  endfacet
+  facet normal -0.0416425 -0.705919 -0.707068
+    outer loop
+      vertex 2.23216 28.3623 58.4
+      vertex 2.18509 27.7641 59
+      vertex 1.09339 27.8285 59
+    endloop
+  endfacet
+  facet normal 0.563885 -0.426794 -0.707023
+    outer loop
+      vertex -22.3423 17.6132 58.4
+      vertex -21.8711 17.2418 59
+      vertex -22.5311 16.3698 59
+    endloop
+  endfacet
+  facet normal -0.469716 0.528652 -0.707032
+    outer loop
+      vertex 19.3119 -20.8915 58.4
+      vertex 18.4768 -21.6335 58.4
+      vertex 18.0871 -21.1773 59
+    endloop
+  endfacet
+  facet normal -0.684277 -0.178543 -0.707027
+    outer loop
+      vertex 27.6639 6.64152 58.4
+      vertex 27.0805 6.50145 59
+      vertex 26.8044 7.55962 59
+    endloop
+  endfacet
+  facet normal 0.283379 0.647905 -0.707047
+    outer loop
+      vertex -11.6597 -25.2918 59
+      vertex -10.8873 -26.2844 58.4
+      vertex -11.9109 -25.8367 58.4
+    endloop
+  endfacet
+  facet normal 0.04165 -0.705911 -0.707075
+    outer loop
+      vertex -1.11694 28.4281 58.4
+      vertex -1.09339 27.8285 59
+      vertex -2.23216 28.3623 58.4
+    endloop
+  endfacet
+  facet normal 0.580134 -0.404353 -0.707067
+    outer loop
+      vertex -23.0165 16.7225 58.4
+      vertex -23.1564 15.4726 59
+      vertex -23.6553 15.806 58.4
+    endloop
+  endfacet
+  facet normal 0.595579 0.381274 -0.707047
+    outer loop
+      vertex -23.746 -14.5516 59
+      vertex -23.1564 -15.4726 59
+      vertex -24.2576 -14.8651 58.4
+    endloop
+  endfacet
+  facet normal -0.0139029 0.707038 -0.707038
+    outer loop
+      vertex 0 -27.85 59
+      vertex 1.09339 -27.8285 59
+      vertex 0 -28.45 58.4
+    endloop
+  endfacet
+  facet normal 0.0139029 0.707038 -0.707038
+    outer loop
+      vertex 0 -27.85 59
+      vertex 0 -28.45 58.4
+      vertex -1.09339 -27.8285 59
+    endloop
+  endfacet
+  facet normal -0.490148 -0.509741 -0.707049
+    outer loop
+      vertex 19.3119 20.8915 58.4
+      vertex 19.6929 19.6929 59
+      vertex 18.9046 20.4509 59
+    endloop
+  endfacet
+  facet normal -0.096915 -0.70051 -0.707031
+    outer loop
+      vertex 4.45056 28.0997 58.4
+      vertex 4.3567 27.5071 59
+      vertex 3.34394 28.2528 58.4
+    endloop
+  endfacet
+  facet normal -0.283379 0.647905 -0.707047
+    outer loop
+      vertex 11.6597 -25.2918 59
+      vertex 11.9109 -25.8367 58.4
+      vertex 10.8873 -26.2844 58.4
+    endloop
+  endfacet
+  facet normal -0.580134 -0.404353 -0.707067
+    outer loop
+      vertex 23.6553 15.806 58.4
+      vertex 23.1564 15.4726 59
+      vertex 23.0165 16.7225 58.4
+    endloop
+  endfacet
+  facet normal 0.231742 -0.668134 -0.707031
+    outer loop
+      vertex -8.79153 27.0576 58.4
+      vertex -9.63936 26.1286 59
+      vertex -9.84703 26.6915 58.4
+    endloop
+  endfacet
+  facet normal -0.696168 -0.124325 -0.707031
+    outer loop
+      vertex 27.9033 5.55032 58.4
+      vertex 28.0997 4.45056 58.4
+      vertex 27.5071 4.3567 59
+    endloop
+  endfacet
+  facet normal -0.703794 -0.0693172 -0.707014
+    outer loop
+      vertex 28.2528 3.34394 58.4
+      vertex 28.3623 2.23216 58.4
+      vertex 27.657 3.27342 59
+    endloop
+  endfacet
+  facet normal 0.690786 -0.151553 -0.706998
+    outer loop
+      vertex -27.6639 6.64152 58.4
+      vertex -27.3149 5.43326 59
+      vertex -27.9033 5.55032 58.4
+    endloop
+  endfacet
+  facet normal 0.509741 0.490148 -0.707049
+    outer loop
+      vertex -20.4509 -18.9046 59
+      vertex -19.6929 -19.6929 59
+      vertex -20.8915 -19.3119 58.4
+    endloop
+  endfacet
+  facet normal 0.703746 0.069254 -0.707068
+    outer loop
+      vertex -27.7641 -2.18509 59
+      vertex -27.657 -3.27342 59
+      vertex -28.3623 -2.23216 58.4
+    endloop
+  endfacet
+  facet normal -0.658551 0.257718 -0.707031
+    outer loop
+      vertex 26.6915 -9.84703 58.4
+      vertex 26.2844 -10.8873 58.4
+      vertex 26.1286 -9.63936 59
+    endloop
+  endfacet
+  facet normal 0.178509 -0.684259 -0.707053
+    outer loop
+      vertex -6.64152 27.6639 58.4
+      vertex -7.55962 26.8044 59
+      vertex -7.72248 27.3819 58.4
+    endloop
+  endfacet
+  facet normal 0.469718 0.528627 -0.707049
+    outer loop
+      vertex -18.9046 -20.4509 59
+      vertex -18.0871 -21.1773 59
+      vertex -19.3119 -20.8915 58.4
+    endloop
+  endfacet
+  facet normal 0.509742 0.490119 -0.707069
+    outer loop
+      vertex -19.6929 -19.6929 59
+      vertex -20.1172 -20.1172 58.4
+      vertex -20.8915 -19.3119 58.4
+    endloop
+  endfacet
+  facet normal 0.580134 0.404353 -0.707067
+    outer loop
+      vertex -23.1564 -15.4726 59
+      vertex -23.0165 -16.7225 58.4
+      vertex -23.6553 -15.806 58.4
+    endloop
+  endfacet
+  facet normal 0.696168 -0.124325 -0.707031
+    outer loop
+      vertex -27.9033 5.55032 58.4
+      vertex -27.5071 4.3567 59
+      vertex -28.0997 4.45056 58.4
+    endloop
+  endfacet
+  facet normal -0.700525 0.0969358 -0.707014
+    outer loop
+      vertex 27.657 -3.27342 59
+      vertex 28.2528 -3.34394 58.4
+      vertex 27.5071 -4.3567 59
+    endloop
+  endfacet
+  facet normal 0.658551 -0.257718 -0.707031
+    outer loop
+      vertex -26.2844 10.8873 58.4
+      vertex -26.1286 9.63936 59
+      vertex -26.6915 9.84703 58.4
+    endloop
+  endfacet
+  facet normal 0.151553 -0.690786 -0.706998
+    outer loop
+      vertex -5.55032 27.9033 58.4
+      vertex -5.43326 27.3149 59
+      vertex -6.64152 27.6639 58.4
+    endloop
+  endfacet
+  facet normal 0.703794 0.0693172 -0.707014
+    outer loop
+      vertex -27.657 -3.27342 59
+      vertex -28.2528 -3.34394 58.4
+      vertex -28.3623 -2.23216 58.4
+    endloop
+  endfacet
+  facet normal -0.703746 -0.069254 -0.707068
+    outer loop
+      vertex 28.3623 2.23216 58.4
+      vertex 27.7641 2.18509 59
+      vertex 27.657 3.27342 59
+    endloop
+  endfacet
+  facet normal 0.0138623 0.707002 -0.707075
+    outer loop
+      vertex -1.09339 -27.8285 59
+      vertex 0 -28.45 58.4
+      vertex -1.11694 -28.4281 58.4
+    endloop
+  endfacet
+  facet normal 0.381246 0.595575 -0.707066
+    outer loop
+      vertex -15.4726 -23.1564 59
+      vertex -14.8651 -24.2576 58.4
+      vertex -15.806 -23.6553 58.4
+    endloop
+  endfacet
+  facet normal -0.647891 -0.283339 -0.707076
+    outer loop
+      vertex 26.2844 10.8873 58.4
+      vertex 25.73 10.6577 59
+      vertex 25.2918 11.6597 59
+    endloop
+  endfacet
+  facet normal -0.546634 0.448663 -0.707031
+    outer loop
+      vertex 21.8711 -17.2418 59
+      vertex 21.6335 -18.4768 58.4
+      vertex 21.1773 -18.0871 59
+    endloop
+  endfacet
+  facet normal -0.690786 0.151553 -0.706998
+    outer loop
+      vertex 27.9033 -5.55032 58.4
+      vertex 27.6639 -6.64152 58.4
+      vertex 27.3149 -5.43326 59
+    endloop
+  endfacet
+  facet normal 0.580168 0.404346 -0.707043
+    outer loop
+      vertex -22.5311 -16.3698 59
+      vertex -23.0165 -16.7225 58.4
+      vertex -23.1564 -15.4726 59
+    endloop
+  endfacet
+  facet normal 0.563854 0.426799 -0.707044
+    outer loop
+      vertex -22.5311 -16.3698 59
+      vertex -22.3423 -17.6132 58.4
+      vertex -23.0165 -16.7225 58.4
+    endloop
+  endfacet
+  facet normal -0.610094 -0.357587 -0.707048
+    outer loop
+      vertex 24.8225 13.9013 58.4
+      vertex 24.299 13.6081 59
+      vertex 24.2576 14.8651 58.4
+    endloop
+  endfacet
+  facet normal -0.151553 0.690786 -0.706998
+    outer loop
+      vertex 6.64152 -27.6639 58.4
+      vertex 5.55032 -27.9033 58.4
+      vertex 5.43326 -27.3149 59
+    endloop
+  endfacet
+  facet normal 0.448663 0.546634 -0.707031
+    outer loop
+      vertex -18.0871 -21.1773 59
+      vertex -17.2418 -21.8711 59
+      vertex -18.4768 -21.6335 58.4
+    endloop
+  endfacet
+  facet normal -0.0969358 0.700525 -0.707014
+    outer loop
+      vertex 4.3567 -27.5071 59
+      vertex 3.34394 -28.2528 58.4
+      vertex 3.27342 -27.657 59
+    endloop
+  endfacet
+  facet normal -0.690752 -0.151576 -0.707027
+    outer loop
+      vertex 27.6639 6.64152 58.4
+      vertex 27.3149 5.43326 59
+      vertex 27.0805 6.50145 59
+    endloop
+  endfacet
+  facet normal -0.700525 -0.0969358 -0.707014
+    outer loop
+      vertex 28.2528 3.34394 58.4
+      vertex 27.657 3.27342 59
+      vertex 27.5071 4.3567 59
+    endloop
+  endfacet
+  facet normal 0.448663 -0.546634 -0.707031
+    outer loop
+      vertex -17.2418 21.8711 59
+      vertex -18.0871 21.1773 59
+      vertex -18.4768 21.6335 58.4
+    endloop
+  endfacet
+  facet normal -0.04165 -0.705911 -0.707075
+    outer loop
+      vertex 1.11694 28.4281 58.4
+      vertex 2.23216 28.3623 58.4
+      vertex 1.09339 27.8285 59
+    endloop
+  endfacet
+  facet normal -0.668108 -0.231682 -0.707075
+    outer loop
+      vertex 27.0576 8.79153 58.4
+      vertex 26.4869 8.60612 59
+      vertex 26.1286 9.63936 59
+    endloop
+  endfacet
+  facet normal -0.469718 -0.528627 -0.707049
+    outer loop
+      vertex 19.3119 20.8915 58.4
+      vertex 18.9046 20.4509 59
+      vertex 18.0871 21.1773 59
+    endloop
+  endfacet
+  facet normal -0.658551 -0.257718 -0.707031
+    outer loop
+      vertex 26.2844 10.8873 58.4
+      vertex 26.6915 9.84703 58.4
+      vertex 26.1286 9.63936 59
+    endloop
+  endfacet
+  facet normal 0.357586 -0.610095 -0.707047
+    outer loop
+      vertex -13.6081 24.299 59
+      vertex -14.5516 23.746 59
+      vertex -14.8651 24.2576 58.4
+    endloop
+  endfacet
+  facet normal -0.257747 0.65849 -0.707076
+    outer loop
+      vertex 10.6577 -25.73 59
+      vertex 10.8873 -26.2844 58.4
+      vertex 9.63936 -26.1286 59
+    endloop
+  endfacet
+  facet normal 0.707038 0.0139029 -0.707038
+    outer loop
+      vertex -27.85 0 59
+      vertex -27.8285 -1.09339 59
+      vertex -28.45 0 58.4
+    endloop
+  endfacet
+  facet normal 0.257747 -0.65849 -0.707076
+    outer loop
+      vertex -9.63936 26.1286 59
+      vertex -10.6577 25.73 59
+      vertex -10.8873 26.2844 58.4
+    endloop
+  endfacet
+  facet normal 0.668134 -0.231742 -0.707031
+    outer loop
+      vertex -26.6915 9.84703 58.4
+      vertex -26.1286 9.63936 59
+      vertex -27.0576 8.79153 58.4
+    endloop
+  endfacet
+  facet normal 0.257747 0.65849 -0.707076
+    outer loop
+      vertex -10.6577 -25.73 59
+      vertex -9.63936 -26.1286 59
+      vertex -10.8873 -26.2844 58.4
+    endloop
+  endfacet
+  facet normal -0.0138623 0.707002 -0.707075
+    outer loop
+      vertex 1.09339 -27.8285 59
+      vertex 1.11694 -28.4281 58.4
+      vertex 0 -28.45 58.4
+    endloop
+  endfacet
+  facet normal 0.151576 0.690752 -0.707027
+    outer loop
+      vertex -6.50145 -27.0805 59
+      vertex -5.43326 -27.3149 59
+      vertex -6.64152 -27.6639 58.4
+    endloop
+  endfacet
+  facet normal -0.469718 0.528627 -0.707049
+    outer loop
+      vertex 18.9046 -20.4509 59
+      vertex 19.3119 -20.8915 58.4
+      vertex 18.0871 -21.1773 59
+    endloop
+  endfacet
+  facet normal -0.448663 0.546634 -0.707031
+    outer loop
+      vertex 18.0871 -21.1773 59
+      vertex 18.4768 -21.6335 58.4
+      vertex 17.2418 -21.8711 59
+    endloop
+  endfacet
+  facet normal 0.124295 0.696208 -0.706998
+    outer loop
+      vertex -5.43326 -27.3149 59
+      vertex -4.3567 -27.5071 59
+      vertex -5.55032 -27.9033 58.4
+    endloop
+  endfacet
+  facet normal -0.705911 -0.04165 -0.707075
+    outer loop
+      vertex 28.3623 2.23216 58.4
+      vertex 28.4281 1.11694 58.4
+      vertex 27.8285 1.09339 59
+    endloop
+  endfacet
+  facet normal 0.404346 -0.580168 -0.707043
+    outer loop
+      vertex -15.4726 23.1564 59
+      vertex -16.3698 22.5311 59
+      vertex -16.7225 23.0165 58.4
+    endloop
+  endfacet
+  facet normal -0.490119 -0.509742 -0.707069
+    outer loop
+      vertex 20.1172 20.1172 58.4
+      vertex 19.6929 19.6929 59
+      vertex 19.3119 20.8915 58.4
+    endloop
+  endfacet
+  facet normal -0.705911 0.04165 -0.707075
+    outer loop
+      vertex 28.4281 -1.11694 58.4
+      vertex 28.3623 -2.23216 58.4
+      vertex 27.8285 -1.09339 59
+    endloop
+  endfacet
+  facet normal -0.333329 -0.623679 -0.707047
+    outer loop
+      vertex 13.9013 24.8225 58.4
+      vertex 13.6081 24.299 59
+      vertex 12.916 25.3491 58.4
+    endloop
+  endfacet
+  facet normal 0.283339 -0.647891 -0.707076
+    outer loop
+      vertex -10.8873 26.2844 58.4
+      vertex -10.6577 25.73 59
+      vertex -11.6597 25.2918 59
+    endloop
+  endfacet
+  facet normal -0.696168 0.124325 -0.707031
+    outer loop
+      vertex 28.0997 -4.45056 58.4
+      vertex 27.9033 -5.55032 58.4
+      vertex 27.5071 -4.3567 59
+    endloop
+  endfacet
+  facet normal -0.684277 0.178543 -0.707027
+    outer loop
+      vertex 27.0805 -6.50145 59
+      vertex 27.6639 -6.64152 58.4
+      vertex 26.8044 -7.55962 59
+    endloop
+  endfacet
+  facet normal 0.65849 0.257747 -0.707076
+    outer loop
+      vertex -26.1286 -9.63936 59
+      vertex -25.73 -10.6577 59
+      vertex -26.2844 -10.8873 58.4
+    endloop
+  endfacet
+  facet normal -0.595575 0.381246 -0.707066
+    outer loop
+      vertex 24.2576 -14.8651 58.4
+      vertex 23.6553 -15.806 58.4
+      vertex 23.1564 -15.4726 59
+    endloop
+  endfacet
+  facet normal 0.0969358 0.700525 -0.707014
+    outer loop
+      vertex -3.27342 -27.657 59
+      vertex -3.34394 -28.2528 58.4
+      vertex -4.3567 -27.5071 59
+    endloop
+  endfacet
+  facet normal -0.580134 0.404353 -0.707067
+    outer loop
+      vertex 23.1564 -15.4726 59
+      vertex 23.6553 -15.806 58.4
+      vertex 23.0165 -16.7225 58.4
+    endloop
+  endfacet
+  facet normal -0.580168 -0.404346 -0.707043
+    outer loop
+      vertex 23.0165 16.7225 58.4
+      vertex 23.1564 15.4726 59
+      vertex 22.5311 16.3698 59
+    endloop
+  endfacet
+  facet normal -0.0139029 -0.707038 -0.707038
+    outer loop
+      vertex 0 28.45 58.4
+      vertex 1.09339 27.8285 59
+      vertex 0 27.85 59
+    endloop
+  endfacet
+  facet normal -0.705919 -0.0416425 -0.707068
+    outer loop
+      vertex 28.3623 2.23216 58.4
+      vertex 27.8285 1.09339 59
+      vertex 27.7641 2.18509 59
+    endloop
+  endfacet
+  facet normal -0.70051 0.096915 -0.707031
+    outer loop
+      vertex 28.2528 -3.34394 58.4
+      vertex 28.0997 -4.45056 58.4
+      vertex 27.5071 -4.3567 59
+    endloop
+  endfacet
+  facet normal -0.563885 -0.426794 -0.707023
+    outer loop
+      vertex 22.3423 17.6132 58.4
+      vertex 22.5311 16.3698 59
+      vertex 21.8711 17.2418 59
+    endloop
+  endfacet
+  facet normal 0.623683 0.333342 -0.707038
+    outer loop
+      vertex -24.8145 -12.6436 59
+      vertex -24.299 -13.6081 59
+      vertex -25.3491 -12.916 58.4
+    endloop
+  endfacet
+  facet normal -0.623679 0.333329 -0.707047
+    outer loop
+      vertex 25.3491 -12.916 58.4
+      vertex 24.8225 -13.9013 58.4
+      vertex 24.299 -13.6081 59
+    endloop
+  endfacet
+  facet normal 0.595579 -0.381274 -0.707047
+    outer loop
+      vertex -23.1564 15.4726 59
+      vertex -23.746 14.5516 59
+      vertex -24.2576 14.8651 58.4
+    endloop
+  endfacet
+  facet normal -0.696208 -0.124295 -0.706998
+    outer loop
+      vertex 27.9033 5.55032 58.4
+      vertex 27.5071 4.3567 59
+      vertex 27.3149 5.43326 59
+    endloop
+  endfacet
+  facet normal 0.528652 -0.469716 -0.707032
+    outer loop
+      vertex -20.8915 19.3119 58.4
+      vertex -21.1773 18.0871 59
+      vertex -21.6335 18.4768 58.4
+    endloop
+  endfacet
+  facet normal -0.528652 0.469716 -0.707032
+    outer loop
+      vertex 21.1773 -18.0871 59
+      vertex 21.6335 -18.4768 58.4
+      vertex 20.8915 -19.3119 58.4
+    endloop
+  endfacet
+  facet normal -0.0693172 -0.703794 -0.707014
+    outer loop
+      vertex 3.34394 28.2528 58.4
+      vertex 3.27342 27.657 59
+      vertex 2.23216 28.3623 58.4
+    endloop
+  endfacet
+  facet normal 0.509742 -0.490119 -0.707069
+    outer loop
+      vertex -20.1172 20.1172 58.4
+      vertex -19.6929 19.6929 59
+      vertex -20.8915 19.3119 58.4
+    endloop
+  endfacet
+  facet normal -0.404353 0.580134 -0.707067
+    outer loop
+      vertex 16.7225 -23.0165 58.4
+      vertex 15.806 -23.6553 58.4
+      vertex 15.4726 -23.1564 59
+    endloop
+  endfacet
+  facet normal 0.707038 -0.0139029 -0.707038
+    outer loop
+      vertex -27.8285 1.09339 59
+      vertex -27.85 0 59
+      vertex -28.45 0 58.4
+    endloop
+  endfacet
+  facet normal 0.490148 -0.509741 -0.707049
+    outer loop
+      vertex -19.3119 20.8915 58.4
+      vertex -18.9046 20.4509 59
+      vertex -19.6929 19.6929 59
+    endloop
+  endfacet
+  facet normal 0.490119 -0.509742 -0.707069
+    outer loop
+      vertex -19.3119 20.8915 58.4
+      vertex -19.6929 19.6929 59
+      vertex -20.1172 20.1172 58.4
+    endloop
+  endfacet
+  facet normal -0.490148 0.509741 -0.707049
+    outer loop
+      vertex 19.6929 -19.6929 59
+      vertex 19.3119 -20.8915 58.4
+      vertex 18.9046 -20.4509 59
+    endloop
+  endfacet
+  facet normal 0.676687 0.205275 -0.707076
+    outer loop
+      vertex -26.4869 -8.60612 59
+      vertex -27.0576 -8.79153 58.4
+      vertex -27.3819 -7.72248 58.4
+    endloop
+  endfacet
+  facet normal -0.490119 0.509742 -0.707069
+    outer loop
+      vertex 19.6929 -19.6929 59
+      vertex 20.1172 -20.1172 58.4
+      vertex 19.3119 -20.8915 58.4
+    endloop
+  endfacet
+  facet normal 0.257718 0.658551 -0.707031
+    outer loop
+      vertex -9.63936 -26.1286 59
+      vertex -9.84703 -26.6915 58.4
+      vertex -10.8873 -26.2844 58.4
+    endloop
+  endfacet
+  facet normal -0.668134 -0.231742 -0.707031
+    outer loop
+      vertex 26.6915 9.84703 58.4
+      vertex 27.0576 8.79153 58.4
+      vertex 26.1286 9.63936 59
+    endloop
+  endfacet
+  facet normal -0.707002 0.0138623 -0.707075
+    outer loop
+      vertex 28.45 0 58.4
+      vertex 28.4281 -1.11694 58.4
+      vertex 27.8285 -1.09339 59
+    endloop
+  endfacet
+  facet normal -0.707038 0.0139029 -0.707038
+    outer loop
+      vertex 27.85 0 59
+      vertex 28.45 0 58.4
+      vertex 27.8285 -1.09339 59
+    endloop
+  endfacet
+  facet normal -0.636249 -0.308661 -0.707047
+    outer loop
+      vertex 25.3491 12.916 58.4
+      vertex 25.8367 11.9109 58.4
+      vertex 25.2918 11.6597 59
+    endloop
+  endfacet
+  facet normal -0.647905 -0.283379 -0.707047
+    outer loop
+      vertex 25.8367 11.9109 58.4
+      vertex 26.2844 10.8873 58.4
+      vertex 25.2918 11.6597 59
+    endloop
+  endfacet
+  facet normal 0.469716 0.528652 -0.707032
+    outer loop
+      vertex -18.0871 -21.1773 59
+      vertex -18.4768 -21.6335 58.4
+      vertex -19.3119 -20.8915 58.4
+    endloop
+  endfacet
+  facet normal -0.696208 0.124295 -0.706998
+    outer loop
+      vertex 27.5071 -4.3567 59
+      vertex 27.9033 -5.55032 58.4
+      vertex 27.3149 -5.43326 59
+    endloop
+  endfacet
+  facet normal 0.668108 -0.231682 -0.707075
+    outer loop
+      vertex -26.1286 9.63936 59
+      vertex -26.4869 8.60612 59
+      vertex -27.0576 8.79153 58.4
+    endloop
+  endfacet
+  facet normal 0.0693172 -0.703794 -0.707014
+    outer loop
+      vertex -2.23216 28.3623 58.4
+      vertex -3.27342 27.657 59
+      vertex -3.34394 28.2528 58.4
+    endloop
+  endfacet
+  facet normal -0.595579 0.381274 -0.707047
+    outer loop
+      vertex 23.746 -14.5516 59
+      vertex 24.2576 -14.8651 58.4
+      vertex 23.1564 -15.4726 59
+    endloop
+  endfacet
+  facet normal -0.528652 -0.469716 -0.707032
+    outer loop
+      vertex 21.6335 18.4768 58.4
+      vertex 21.1773 18.0871 59
+      vertex 20.8915 19.3119 58.4
+    endloop
+  endfacet
+  facet normal -0.426794 0.563885 -0.707023
+    outer loop
+      vertex 17.2418 -21.8711 59
+      vertex 17.6132 -22.3423 58.4
+      vertex 16.3698 -22.5311 59
+    endloop
+  endfacet
+  facet normal -0.257718 -0.658551 -0.707031
+    outer loop
+      vertex 9.84703 26.6915 58.4
+      vertex 10.8873 26.2844 58.4
+      vertex 9.63936 26.1286 59
+    endloop
+  endfacet
+  facet normal 0.205275 0.676687 -0.707076
+    outer loop
+      vertex -8.60612 -26.4869 59
+      vertex -7.72248 -27.3819 58.4
+      vertex -8.79153 -27.0576 58.4
+    endloop
+  endfacet
+  facet normal 0.381274 -0.595579 -0.707047
+    outer loop
+      vertex -14.8651 24.2576 58.4
+      vertex -14.5516 23.746 59
+      vertex -15.4726 23.1564 59
+    endloop
+  endfacet
+  facet normal 0.696208 -0.124295 -0.706998
+    outer loop
+      vertex -27.3149 5.43326 59
+      vertex -27.5071 4.3567 59
+      vertex -27.9033 5.55032 58.4
+    endloop
+  endfacet
+  facet normal 0.546647 0.448661 -0.707022
+    outer loop
+      vertex -21.8711 -17.2418 59
+      vertex -21.6335 -18.4768 58.4
+      vertex -22.3423 -17.6132 58.4
+    endloop
+  endfacet
+  facet normal -0.676702 0.205306 -0.707053
+    outer loop
+      vertex 26.8044 -7.55962 59
+      vertex 27.3819 -7.72248 58.4
+      vertex 26.4869 -8.60612 59
+    endloop
+  endfacet
+  facet normal -0.151576 0.690752 -0.707027
+    outer loop
+      vertex 6.50145 -27.0805 59
+      vertex 6.64152 -27.6639 58.4
+      vertex 5.43326 -27.3149 59
+    endloop
+  endfacet
+  facet normal -0.469716 -0.528652 -0.707032
+    outer loop
+      vertex 18.4768 21.6335 58.4
+      vertex 19.3119 20.8915 58.4
+      vertex 18.0871 21.1773 59
+    endloop
+  endfacet
+  facet normal 0.703746 -0.069254 -0.707068
+    outer loop
+      vertex -27.657 3.27342 59
+      vertex -27.7641 2.18509 59
+      vertex -28.3623 2.23216 58.4
+    endloop
+  endfacet
+  facet normal 0.546634 -0.448663 -0.707031
+    outer loop
+      vertex -21.6335 18.4768 58.4
+      vertex -21.1773 18.0871 59
+      vertex -21.8711 17.2418 59
+    endloop
+  endfacet
+  facet normal 0.205306 -0.676702 -0.707053
+    outer loop
+      vertex -7.72248 27.3819 58.4
+      vertex -7.55962 26.8044 59
+      vertex -8.60612 26.4869 59
+    endloop
+  endfacet
+  facet normal -0.124295 -0.696208 -0.706998
+    outer loop
+      vertex 5.55032 27.9033 58.4
+      vertex 5.43326 27.3149 59
+      vertex 4.3567 27.5071 59
+    endloop
+  endfacet
+  facet normal 0.124295 -0.696208 -0.706998
+    outer loop
+      vertex -4.3567 27.5071 59
+      vertex -5.43326 27.3149 59
+      vertex -5.55032 27.9033 58.4
+    endloop
+  endfacet
+  facet normal 0.668108 0.231682 -0.707075
+    outer loop
+      vertex -26.4869 -8.60612 59
+      vertex -26.1286 -9.63936 59
+      vertex -27.0576 -8.79153 58.4
+    endloop
+  endfacet
+  facet normal 0.684259 -0.178509 -0.707053
+    outer loop
+      vertex -27.3819 7.72248 58.4
+      vertex -26.8044 7.55962 59
+      vertex -27.6639 6.64152 58.4
+    endloop
+  endfacet
+  facet normal 0.178543 0.684277 -0.707027
+    outer loop
+      vertex -6.50145 -27.0805 59
+      vertex -6.64152 -27.6639 58.4
+      vertex -7.55962 -26.8044 59
+    endloop
+  endfacet
+  facet normal -0.0969358 -0.700525 -0.707014
+    outer loop
+      vertex 3.34394 28.2528 58.4
+      vertex 4.3567 27.5071 59
+      vertex 3.27342 27.657 59
+    endloop
+  endfacet
+  facet normal -0.283339 -0.647891 -0.707076
+    outer loop
+      vertex 10.8873 26.2844 58.4
+      vertex 11.6597 25.2918 59
+      vertex 10.6577 25.73 59
+    endloop
+  endfacet
+  facet normal -0.703794 0.0693172 -0.707014
+    outer loop
+      vertex 28.3623 -2.23216 58.4
+      vertex 28.2528 -3.34394 58.4
+      vertex 27.657 -3.27342 59
+    endloop
+  endfacet
+  facet normal 0.610094 0.357587 -0.707048
+    outer loop
+      vertex -24.299 -13.6081 59
+      vertex -24.2576 -14.8651 58.4
+      vertex -24.8225 -13.9013 58.4
+    endloop
+  endfacet
+  facet normal -0.426799 -0.563854 -0.707044
+    outer loop
+      vertex 16.7225 23.0165 58.4
+      vertex 17.6132 22.3423 58.4
+      vertex 16.3698 22.5311 59
+    endloop
+  endfacet
+  facet normal 0.546634 0.448663 -0.707031
+    outer loop
+      vertex -21.1773 -18.0871 59
+      vertex -21.6335 -18.4768 58.4
+      vertex -21.8711 -17.2418 59
+    endloop
+  endfacet
+  facet normal 0.636261 0.308657 -0.707038
+    outer loop
+      vertex -25.2918 -11.6597 59
+      vertex -24.8145 -12.6436 59
+      vertex -25.3491 -12.916 58.4
+    endloop
+  endfacet
+  facet normal 0.124325 -0.696168 -0.707031
+    outer loop
+      vertex -4.45056 28.0997 58.4
+      vertex -4.3567 27.5071 59
+      vertex -5.55032 27.9033 58.4
+    endloop
+  endfacet
+  facet normal 0.205306 0.676702 -0.707053
+    outer loop
+      vertex -7.55962 -26.8044 59
+      vertex -7.72248 -27.3819 58.4
+      vertex -8.60612 -26.4869 59
+    endloop
+  endfacet
+  facet normal -0.308657 -0.636261 -0.707038
+    outer loop
+      vertex 12.916 25.3491 58.4
+      vertex 12.6436 24.8145 59
+      vertex 11.6597 25.2918 59
+    endloop
+  endfacet
+  facet normal 0.178543 -0.684277 -0.707027
+    outer loop
+      vertex -6.64152 27.6639 58.4
+      vertex -6.50145 27.0805 59
+      vertex -7.55962 26.8044 59
+    endloop
+  endfacet
+  facet normal 0.690752 0.151576 -0.707027
+    outer loop
+      vertex -27.3149 -5.43326 59
+      vertex -27.0805 -6.50145 59
+      vertex -27.6639 -6.64152 58.4
+    endloop
+  endfacet
+  facet normal -0.0693172 0.703794 -0.707014
+    outer loop
+      vertex 3.27342 -27.657 59
+      vertex 3.34394 -28.2528 58.4
+      vertex 2.23216 -28.3623 58.4
+    endloop
+  endfacet
+  facet normal -0.381246 0.595575 -0.707066
+    outer loop
+      vertex 15.4726 -23.1564 59
+      vertex 15.806 -23.6553 58.4
+      vertex 14.8651 -24.2576 58.4
+    endloop
+  endfacet
+  facet normal 0.595575 -0.381246 -0.707066
+    outer loop
+      vertex -23.6553 15.806 58.4
+      vertex -23.1564 15.4726 59
+      vertex -24.2576 14.8651 58.4
+    endloop
+  endfacet
+  facet normal 0.707002 0.0138623 -0.707075
+    outer loop
+      vertex -27.8285 -1.09339 59
+      vertex -28.4281 -1.11694 58.4
+      vertex -28.45 0 58.4
+    endloop
+  endfacet
+  facet normal 0.705911 0.04165 -0.707075
+    outer loop
+      vertex -27.8285 -1.09339 59
+      vertex -28.3623 -2.23216 58.4
+      vertex -28.4281 -1.11694 58.4
+    endloop
+  endfacet
+  facet normal -0.610094 0.357587 -0.707048
+    outer loop
+      vertex 24.299 -13.6081 59
+      vertex 24.8225 -13.9013 58.4
+      vertex 24.2576 -14.8651 58.4
+    endloop
+  endfacet
+  facet normal 0.333342 -0.623683 -0.707038
+    outer loop
+      vertex -12.916 25.3491 58.4
+      vertex -12.6436 24.8145 59
+      vertex -13.6081 24.299 59
+    endloop
+  endfacet
+  facet normal -0.636261 0.308657 -0.707038
+    outer loop
+      vertex 25.2918 -11.6597 59
+      vertex 25.3491 -12.916 58.4
+      vertex 24.8145 -12.6436 59
+    endloop
+  endfacet
+  facet normal -0.65849 -0.257747 -0.707076
+    outer loop
+      vertex 26.2844 10.8873 58.4
+      vertex 26.1286 9.63936 59
+      vertex 25.73 10.6577 59
+    endloop
+  endfacet
+  facet normal 0.528627 -0.469718 -0.707049
+    outer loop
+      vertex -20.8915 19.3119 58.4
+      vertex -20.4509 18.9046 59
+      vertex -21.1773 18.0871 59
+    endloop
+  endfacet
+  facet normal -0.205306 0.676702 -0.707053
+    outer loop
+      vertex 8.60612 -26.4869 59
+      vertex 7.72248 -27.3819 58.4
+      vertex 7.55962 -26.8044 59
+    endloop
+  endfacet
+  facet normal -0.65849 0.257747 -0.707076
+    outer loop
+      vertex 26.1286 -9.63936 59
+      vertex 26.2844 -10.8873 58.4
+      vertex 25.73 -10.6577 59
+    endloop
+  endfacet
+  facet normal -0.668108 0.231682 -0.707075
+    outer loop
+      vertex 26.4869 -8.60612 59
+      vertex 27.0576 -8.79153 58.4
+      vertex 26.1286 -9.63936 59
+    endloop
+  endfacet
+  facet normal 0.0139029 -0.707038 -0.707038
+    outer loop
+      vertex 0 28.45 58.4
+      vertex 0 27.85 59
+      vertex -1.09339 27.8285 59
+    endloop
+  endfacet
+  facet normal 0.595575 0.381246 -0.707066
+    outer loop
+      vertex -23.1564 -15.4726 59
+      vertex -23.6553 -15.806 58.4
+      vertex -24.2576 -14.8651 58.4
+    endloop
+  endfacet
+  facet normal 0.04165 0.705911 -0.707075
+    outer loop
+      vertex -1.09339 -27.8285 59
+      vertex -1.11694 -28.4281 58.4
+      vertex -2.23216 -28.3623 58.4
+    endloop
+  endfacet
+  facet normal -0.257718 0.658551 -0.707031
+    outer loop
+      vertex 10.8873 -26.2844 58.4
+      vertex 9.84703 -26.6915 58.4
+      vertex 9.63936 -26.1286 59
+    endloop
+  endfacet
+  facet normal 0.096915 0.70051 -0.707031
+    outer loop
+      vertex -4.3567 -27.5071 59
+      vertex -3.34394 -28.2528 58.4
+      vertex -4.45056 -28.0997 58.4
+    endloop
+  endfacet
+  facet normal -0.647891 0.283339 -0.707076
+    outer loop
+      vertex 25.73 -10.6577 59
+      vertex 26.2844 -10.8873 58.4
+      vertex 25.2918 -11.6597 59
+    endloop
+  endfacet
+  facet normal 0.151553 0.690786 -0.706998
+    outer loop
+      vertex -5.43326 -27.3149 59
+      vertex -5.55032 -27.9033 58.4
+      vertex -6.64152 -27.6639 58.4
+    endloop
+  endfacet
+  facet normal 0.448661 0.546647 -0.707022
+    outer loop
+      vertex -17.2418 -21.8711 59
+      vertex -17.6132 -22.3423 58.4
+      vertex -18.4768 -21.6335 58.4
+    endloop
+  endfacet
+  facet normal 0.151576 -0.690752 -0.707027
+    outer loop
+      vertex -5.43326 27.3149 59
+      vertex -6.50145 27.0805 59
+      vertex -6.64152 27.6639 58.4
+    endloop
+  endfacet
+  facet normal 0.623679 -0.333329 -0.707047
+    outer loop
+      vertex -24.8225 13.9013 58.4
+      vertex -24.299 13.6081 59
+      vertex -25.3491 12.916 58.4
+    endloop
+  endfacet
+  facet normal 0.636249 0.308661 -0.707047
+    outer loop
+      vertex -25.2918 -11.6597 59
+      vertex -25.3491 -12.916 58.4
+      vertex -25.8367 -11.9109 58.4
+    endloop
+  endfacet
+  facet normal 0.528627 0.469718 -0.707049
+    outer loop
+      vertex -20.4509 -18.9046 59
+      vertex -20.8915 -19.3119 58.4
+      vertex -21.1773 -18.0871 59
+    endloop
+  endfacet
+  facet normal -0.124325 0.696168 -0.707031
+    outer loop
+      vertex 5.55032 -27.9033 58.4
+      vertex 4.45056 -28.0997 58.4
+      vertex 4.3567 -27.5071 59
+    endloop
+  endfacet
+  facet normal -0.308657 0.636261 -0.707038
+    outer loop
+      vertex 12.6436 -24.8145 59
+      vertex 12.916 -25.3491 58.4
+      vertex 11.6597 -25.2918 59
+    endloop
+  endfacet
+  facet normal -0.308661 0.636249 -0.707047
+    outer loop
+      vertex 12.916 -25.3491 58.4
+      vertex 11.9109 -25.8367 58.4
+      vertex 11.6597 -25.2918 59
+    endloop
+  endfacet
+  facet normal -0.676687 0.205275 -0.707076
+    outer loop
+      vertex 27.3819 -7.72248 58.4
+      vertex 27.0576 -8.79153 58.4
+      vertex 26.4869 -8.60612 59
+    endloop
+  endfacet
+  facet normal -0.563885 0.426794 -0.707023
+    outer loop
+      vertex 22.5311 -16.3698 59
+      vertex 22.3423 -17.6132 58.4
+      vertex 21.8711 -17.2418 59
+    endloop
+  endfacet
+  facet normal -0.404346 -0.580168 -0.707043
+    outer loop
+      vertex 16.7225 23.0165 58.4
+      vertex 16.3698 22.5311 59
+      vertex 15.4726 23.1564 59
+    endloop
+  endfacet
+  facet normal 0.469716 -0.528652 -0.707032
+    outer loop
+      vertex -18.4768 21.6335 58.4
+      vertex -18.0871 21.1773 59
+      vertex -19.3119 20.8915 58.4
+    endloop
+  endfacet
+  facet normal -0.0416425 0.705919 -0.707068
+    outer loop
+      vertex 2.18509 -27.7641 59
+      vertex 2.23216 -28.3623 58.4
+      vertex 1.09339 -27.8285 59
+    endloop
+  endfacet
+  facet normal 0.333342 0.623683 -0.707038
+    outer loop
+      vertex -12.6436 -24.8145 59
+      vertex -12.916 -25.3491 58.4
+      vertex -13.6081 -24.299 59
+    endloop
+  endfacet
+  facet normal -0.610095 0.357586 -0.707047
+    outer loop
+      vertex 24.299 -13.6081 59
+      vertex 24.2576 -14.8651 58.4
+      vertex 23.746 -14.5516 59
+    endloop
+  endfacet
+  facet normal -0.509741 -0.490148 -0.707049
+    outer loop
+      vertex 20.8915 19.3119 58.4
+      vertex 20.4509 18.9046 59
+      vertex 19.6929 19.6929 59
+    endloop
+  endfacet
+  facet normal -0.546647 0.448661 -0.707022
+    outer loop
+      vertex 21.8711 -17.2418 59
+      vertex 22.3423 -17.6132 58.4
+      vertex 21.6335 -18.4768 58.4
+    endloop
+  endfacet
+  facet normal 0.490148 0.509741 -0.707049
+    outer loop
+      vertex -18.9046 -20.4509 59
+      vertex -19.3119 -20.8915 58.4
+      vertex -19.6929 -19.6929 59
+    endloop
+  endfacet
+  facet normal -0.04165 0.705911 -0.707075
+    outer loop
+      vertex 2.23216 -28.3623 58.4
+      vertex 1.11694 -28.4281 58.4
+      vertex 1.09339 -27.8285 59
+    endloop
+  endfacet
+  facet normal -0.231742 -0.668134 -0.707031
+    outer loop
+      vertex 9.84703 26.6915 58.4
+      vertex 9.63936 26.1286 59
+      vertex 8.79153 27.0576 58.4
+    endloop
+  endfacet
+  facet normal -0.231682 0.668108 -0.707075
+    outer loop
+      vertex 9.63936 -26.1286 59
+      vertex 8.79153 -27.0576 58.4
+      vertex 8.60612 -26.4869 59
+    endloop
+  endfacet
+  facet normal 0.696208 0.124295 -0.706998
+    outer loop
+      vertex -27.5071 -4.3567 59
+      vertex -27.3149 -5.43326 59
+      vertex -27.9033 -5.55032 58.4
+    endloop
+  endfacet
+  facet normal -0.623683 -0.333342 -0.707038
+    outer loop
+      vertex 25.3491 12.916 58.4
+      vertex 24.8145 12.6436 59
+      vertex 24.299 13.6081 59
+    endloop
+  endfacet
+  facet normal 0.0138623 -0.707002 -0.707075
+    outer loop
+      vertex 0 28.45 58.4
+      vertex -1.09339 27.8285 59
+      vertex -1.11694 28.4281 58.4
+    endloop
+  endfacet
+  facet normal -0.448661 -0.546647 -0.707022
+    outer loop
+      vertex 17.6132 22.3423 58.4
+      vertex 18.4768 21.6335 58.4
+      vertex 17.2418 21.8711 59
+    endloop
+  endfacet
+  facet normal -0.124295 0.696208 -0.706998
+    outer loop
+      vertex 5.43326 -27.3149 59
+      vertex 5.55032 -27.9033 58.4
+      vertex 4.3567 -27.5071 59
+    endloop
+  endfacet
+  facet normal 0.509741 -0.490148 -0.707049
+    outer loop
+      vertex -19.6929 19.6929 59
+      vertex -20.4509 18.9046 59
+      vertex -20.8915 19.3119 58.4
+    endloop
+  endfacet
+  facet normal 0.705919 0.0416425 -0.707068
+    outer loop
+      vertex -27.8285 -1.09339 59
+      vertex -27.7641 -2.18509 59
+      vertex -28.3623 -2.23216 58.4
+    endloop
+  endfacet
+  facet normal 0.580168 -0.404346 -0.707043
+    outer loop
+      vertex -23.0165 16.7225 58.4
+      vertex -22.5311 16.3698 59
+      vertex -23.1564 15.4726 59
+    endloop
+  endfacet
+  facet normal -0.357586 -0.610095 -0.707047
+    outer loop
+      vertex 14.8651 24.2576 58.4
+      vertex 14.5516 23.746 59
+      vertex 13.6081 24.299 59
+    endloop
+  endfacet
+  facet normal 0.469718 -0.528627 -0.707049
+    outer loop
+      vertex -18.0871 21.1773 59
+      vertex -18.9046 20.4509 59
+      vertex -19.3119 20.8915 58.4
+    endloop
+  endfacet
+  facet normal -0.231682 -0.668108 -0.707075
+    outer loop
+      vertex 8.79153 27.0576 58.4
+      vertex 9.63936 26.1286 59
+      vertex 8.60612 26.4869 59
+    endloop
+  endfacet
+  facet normal -0.205275 0.676687 -0.707076
+    outer loop
+      vertex 8.60612 -26.4869 59
+      vertex 8.79153 -27.0576 58.4
+      vertex 7.72248 -27.3819 58.4
+    endloop
+  endfacet
+  facet normal 0.231682 -0.668108 -0.707075
+    outer loop
+      vertex -8.79153 27.0576 58.4
+      vertex -8.60612 26.4869 59
+      vertex -9.63936 26.1286 59
+    endloop
+  endfacet
+  facet normal -0.690786 -0.151553 -0.706998
+    outer loop
+      vertex 27.6639 6.64152 58.4
+      vertex 27.9033 5.55032 58.4
+      vertex 27.3149 5.43326 59
+    endloop
+  endfacet
+  facet normal -0.676687 -0.205275 -0.707076
+    outer loop
+      vertex 27.0576 8.79153 58.4
+      vertex 27.3819 7.72248 58.4
+      vertex 26.4869 8.60612 59
+    endloop
+  endfacet
+  facet normal 0.0969358 -0.700525 -0.707014
+    outer loop
+      vertex -3.34394 28.2528 58.4
+      vertex -3.27342 27.657 59
+      vertex -4.3567 27.5071 59
+    endloop
+  endfacet
+  facet normal -0.509742 -0.490119 -0.707069
+    outer loop
+      vertex 20.1172 20.1172 58.4
+      vertex 20.8915 19.3119 58.4
+      vertex 19.6929 19.6929 59
+    endloop
+  endfacet
+  facet normal 0.696168 0.124325 -0.707031
+    outer loop
+      vertex -27.5071 -4.3567 59
+      vertex -27.9033 -5.55032 58.4
+      vertex -28.0997 -4.45056 58.4
+    endloop
+  endfacet
+  facet normal -0.283339 0.647891 -0.707076
+    outer loop
+      vertex 11.6597 -25.2918 59
+      vertex 10.8873 -26.2844 58.4
+      vertex 10.6577 -25.73 59
+    endloop
+  endfacet
+  facet normal -0.636249 0.308661 -0.707047
+    outer loop
+      vertex 25.8367 -11.9109 58.4
+      vertex 25.3491 -12.916 58.4
+      vertex 25.2918 -11.6597 59
+    endloop
+  endfacet
+  facet normal -0.647905 0.283379 -0.707047
+    outer loop
+      vertex 26.2844 -10.8873 58.4
+      vertex 25.8367 -11.9109 58.4
+      vertex 25.2918 -11.6597 59
+    endloop
+  endfacet
+  facet normal -0.069254 -0.703746 -0.707068
+    outer loop
+      vertex 2.23216 28.3623 58.4
+      vertex 3.27342 27.657 59
+      vertex 2.18509 27.7641 59
+    endloop
+  endfacet
+  facet normal 0.700525 0.0969358 -0.707014
+    outer loop
+      vertex -27.657 -3.27342 59
+      vertex -27.5071 -4.3567 59
+      vertex -28.2528 -3.34394 58.4
+    endloop
+  endfacet
+  facet normal 0.703794 -0.0693172 -0.707014
+    outer loop
+      vertex -28.2528 3.34394 58.4
+      vertex -27.657 3.27342 59
+      vertex -28.3623 2.23216 58.4
+    endloop
+  endfacet
+  facet normal 0.705911 -0.04165 -0.707075
+    outer loop
+      vertex -28.3623 2.23216 58.4
+      vertex -27.8285 1.09339 59
+      vertex -28.4281 1.11694 58.4
+    endloop
+  endfacet
+  facet normal 0.707002 -0.0138623 -0.707075
+    outer loop
+      vertex -28.4281 1.11694 58.4
+      vertex -27.8285 1.09339 59
+      vertex -28.45 0 58.4
+    endloop
+  endfacet
+  facet normal -0.668134 0.231742 -0.707031
+    outer loop
+      vertex 27.0576 -8.79153 58.4
+      vertex 26.6915 -9.84703 58.4
+      vertex 26.1286 -9.63936 59
+    endloop
+  endfacet
+  facet normal -0.151576 -0.690752 -0.707027
+    outer loop
+      vertex 6.64152 27.6639 58.4
+      vertex 6.50145 27.0805 59
+      vertex 5.43326 27.3149 59
+    endloop
+  endfacet
+  facet normal 0.668134 0.231742 -0.707031
+    outer loop
+      vertex -26.1286 -9.63936 59
+      vertex -26.6915 -9.84703 58.4
+      vertex -27.0576 -8.79153 58.4
+    endloop
+  endfacet
+  facet normal -0.178509 0.684259 -0.707053
+    outer loop
+      vertex 7.55962 -26.8044 59
+      vertex 7.72248 -27.3819 58.4
+      vertex 6.64152 -27.6639 58.4
+    endloop
+  endfacet
+  facet normal 0.610095 -0.357586 -0.707047
+    outer loop
+      vertex -24.2576 14.8651 58.4
+      vertex -23.746 14.5516 59
+      vertex -24.299 13.6081 59
+    endloop
+  endfacet
+  facet normal 0.205275 -0.676687 -0.707076
+    outer loop
+      vertex -7.72248 27.3819 58.4
+      vertex -8.60612 26.4869 59
+      vertex -8.79153 27.0576 58.4
+    endloop
+  endfacet
+  facet normal 0.178509 0.684259 -0.707053
+    outer loop
+      vertex -7.55962 -26.8044 59
+      vertex -6.64152 -27.6639 58.4
+      vertex -7.72248 -27.3819 58.4
+    endloop
+  endfacet
+  facet normal 0.448661 -0.546647 -0.707022
+    outer loop
+      vertex -17.6132 22.3423 58.4
+      vertex -17.2418 21.8711 59
+      vertex -18.4768 21.6335 58.4
+    endloop
+  endfacet
+  facet normal -0.0138623 -0.707002 -0.707075
+    outer loop
+      vertex 1.11694 28.4281 58.4
+      vertex 1.09339 27.8285 59
+      vertex 0 28.45 58.4
+    endloop
+  endfacet
+  facet normal -0.178509 -0.684259 -0.707053
+    outer loop
+      vertex 7.72248 27.3819 58.4
+      vertex 7.55962 26.8044 59
+      vertex 6.64152 27.6639 58.4
+    endloop
+  endfacet
+  facet normal 0.426799 0.563854 -0.707044
+    outer loop
+      vertex -16.3698 -22.5311 59
+      vertex -16.7225 -23.0165 58.4
+      vertex -17.6132 -22.3423 58.4
+    endloop
+  endfacet
+  facet normal 0.623679 0.333329 -0.707047
+    outer loop
+      vertex -24.299 -13.6081 59
+      vertex -24.8225 -13.9013 58.4
+      vertex -25.3491 -12.916 58.4
+    endloop
+  endfacet
+  facet normal 0.647905 0.283379 -0.707047
+    outer loop
+      vertex -25.2918 -11.6597 59
+      vertex -25.8367 -11.9109 58.4
+      vertex -26.2844 -10.8873 58.4
+    endloop
+  endfacet
+  facet normal 0.623683 -0.333342 -0.707038
+    outer loop
+      vertex -24.299 13.6081 59
+      vertex -24.8145 12.6436 59
+      vertex -25.3491 12.916 58.4
+    endloop
+  endfacet
+  facet normal -0.333342 -0.623683 -0.707038
+    outer loop
+      vertex 12.916 25.3491 58.4
+      vertex 13.6081 24.299 59
+      vertex 12.6436 24.8145 59
+    endloop
+  endfacet
+  facet normal 0.426799 -0.563854 -0.707044
+    outer loop
+      vertex -16.7225 23.0165 58.4
+      vertex -16.3698 22.5311 59
+      vertex -17.6132 22.3423 58.4
+    endloop
+  endfacet
+  facet normal -0.509742 0.490119 -0.707069
+    outer loop
+      vertex 20.8915 -19.3119 58.4
+      vertex 20.1172 -20.1172 58.4
+      vertex 19.6929 -19.6929 59
+    endloop
+  endfacet
+  facet normal 0.426794 -0.563885 -0.707023
+    outer loop
+      vertex -16.3698 22.5311 59
+      vertex -17.2418 21.8711 59
+      vertex -17.6132 22.3423 58.4
+    endloop
+  endfacet
+  facet normal -0.623683 0.333342 -0.707038
+    outer loop
+      vertex 24.8145 -12.6436 59
+      vertex 25.3491 -12.916 58.4
+      vertex 24.299 -13.6081 59
+    endloop
+  endfacet
+  facet normal 0.647891 0.283339 -0.707076
+    outer loop
+      vertex -25.73 -10.6577 59
+      vertex -25.2918 -11.6597 59
+      vertex -26.2844 -10.8873 58.4
+    endloop
+  endfacet
+  facet normal -0.357587 -0.610094 -0.707048
+    outer loop
+      vertex 13.9013 24.8225 58.4
+      vertex 14.8651 24.2576 58.4
+      vertex 13.6081 24.299 59
+    endloop
+  endfacet
+  facet normal -0.595579 -0.381274 -0.707047
+    outer loop
+      vertex 24.2576 14.8651 58.4
+      vertex 23.746 14.5516 59
+      vertex 23.1564 15.4726 59
+    endloop
+  endfacet
+  facet normal 0.257718 -0.658551 -0.707031
+    outer loop
+      vertex -9.84703 26.6915 58.4
+      vertex -9.63936 26.1286 59
+      vertex -10.8873 26.2844 58.4
+    endloop
+  endfacet
+  facet normal 0.676702 0.205306 -0.707053
+    outer loop
+      vertex -26.8044 -7.55962 59
+      vertex -26.4869 -8.60612 59
+      vertex -27.3819 -7.72248 58.4
+    endloop
+  endfacet
+  facet normal -0.333329 0.623679 -0.707047
+    outer loop
+      vertex 13.6081 -24.299 59
+      vertex 13.9013 -24.8225 58.4
+      vertex 12.916 -25.3491 58.4
+    endloop
+  endfacet
+  facet normal -0.151553 -0.690786 -0.706998
+    outer loop
+      vertex 5.55032 27.9033 58.4
+      vertex 6.64152 27.6639 58.4
+      vertex 5.43326 27.3149 59
+    endloop
+  endfacet
+  facet normal 0.426794 0.563885 -0.707023
+    outer loop
+      vertex -17.2418 -21.8711 59
+      vertex -16.3698 -22.5311 59
+      vertex -17.6132 -22.3423 58.4
+    endloop
+  endfacet
+  facet normal 0.069254 -0.703746 -0.707068
+    outer loop
+      vertex -2.23216 28.3623 58.4
+      vertex -2.18509 27.7641 59
+      vertex -3.27342 27.657 59
+    endloop
+  endfacet
+  facet normal 0.0416425 -0.705919 -0.707068
+    outer loop
+      vertex -1.09339 27.8285 59
+      vertex -2.18509 27.7641 59
+      vertex -2.23216 28.3623 58.4
+    endloop
+  endfacet
+  facet normal -0.623679 -0.333329 -0.707047
+    outer loop
+      vertex 24.8225 13.9013 58.4
+      vertex 25.3491 12.916 58.4
+      vertex 24.299 13.6081 59
+    endloop
+  endfacet
+  facet normal 0.283339 0.647891 -0.707076
+    outer loop
+      vertex -10.6577 -25.73 59
+      vertex -10.8873 -26.2844 58.4
+      vertex -11.6597 -25.2918 59
+    endloop
+  endfacet
+  facet normal 0.684277 0.178543 -0.707027
+    outer loop
+      vertex -27.0805 -6.50145 59
+      vertex -26.8044 -7.55962 59
+      vertex -27.6639 -6.64152 58.4
+    endloop
+  endfacet
+  facet normal 0.610094 -0.357587 -0.707048
+    outer loop
+      vertex -24.2576 14.8651 58.4
+      vertex -24.299 13.6081 59
+      vertex -24.8225 13.9013 58.4
+    endloop
+  endfacet
+  facet normal -0.096915 0.70051 -0.707031
+    outer loop
+      vertex 4.3567 -27.5071 59
+      vertex 4.45056 -28.0997 58.4
+      vertex 3.34394 -28.2528 58.4
+    endloop
+  endfacet
+  facet normal -0.205275 -0.676687 -0.707076
+    outer loop
+      vertex 8.79153 27.0576 58.4
+      vertex 8.60612 26.4869 59
+      vertex 7.72248 27.3819 58.4
+    endloop
+  endfacet
+  facet normal -0.178543 -0.684277 -0.707027
+    outer loop
+      vertex 6.64152 27.6639 58.4
+      vertex 7.55962 26.8044 59
+      vertex 6.50145 27.0805 59
+    endloop
+  endfacet
+  facet normal -0.528627 -0.469718 -0.707049
+    outer loop
+      vertex 20.8915 19.3119 58.4
+      vertex 21.1773 18.0871 59
+      vertex 20.4509 18.9046 59
+    endloop
+  endfacet
+  facet normal -0.703746 0.069254 -0.707068
+    outer loop
+      vertex 27.7641 -2.18509 59
+      vertex 28.3623 -2.23216 58.4
+      vertex 27.657 -3.27342 59
+    endloop
+  endfacet
+  facet normal -0.690752 0.151576 -0.707027
+    outer loop
+      vertex 27.3149 -5.43326 59
+      vertex 27.6639 -6.64152 58.4
+      vertex 27.0805 -6.50145 59
+    endloop
+  endfacet
+  facet normal -0.381274 -0.595579 -0.707047
+    outer loop
+      vertex 14.8651 24.2576 58.4
+      vertex 15.4726 23.1564 59
+      vertex 14.5516 23.746 59
+    endloop
+  endfacet
+  facet normal 0.490119 0.509742 -0.707069
+    outer loop
+      vertex -19.6929 -19.6929 59
+      vertex -19.3119 -20.8915 58.4
+      vertex -20.1172 -20.1172 58.4
+    endloop
+  endfacet
+  facet normal 0.563885 0.426794 -0.707023
+    outer loop
+      vertex -21.8711 -17.2418 59
+      vertex -22.3423 -17.6132 58.4
+      vertex -22.5311 -16.3698 59
+    endloop
+  endfacet
+  facet normal 0.0416425 0.705919 -0.707068
+    outer loop
+      vertex -2.18509 -27.7641 59
+      vertex -1.09339 -27.8285 59
+      vertex -2.23216 -28.3623 58.4
+    endloop
+  endfacet
+  facet normal -0.333342 0.623683 -0.707038
+    outer loop
+      vertex 13.6081 -24.299 59
+      vertex 12.916 -25.3491 58.4
+      vertex 12.6436 -24.8145 59
+    endloop
+  endfacet
+  facet normal -0.636261 -0.308657 -0.707038
+    outer loop
+      vertex 25.3491 12.916 58.4
+      vertex 25.2918 11.6597 59
+      vertex 24.8145 12.6436 59
+    endloop
+  endfacet
+  facet normal 0.70051 -0.096915 -0.707031
+    outer loop
+      vertex -28.0997 4.45056 58.4
+      vertex -27.5071 4.3567 59
+      vertex -28.2528 3.34394 58.4
+    endloop
+  endfacet
+  facet normal 0.610095 0.357586 -0.707047
+    outer loop
+      vertex -23.746 -14.5516 59
+      vertex -24.2576 -14.8651 58.4
+      vertex -24.299 -13.6081 59
+    endloop
+  endfacet
+  facet normal 0.404353 -0.580134 -0.707067
+    outer loop
+      vertex -15.806 23.6553 58.4
+      vertex -15.4726 23.1564 59
+      vertex -16.7225 23.0165 58.4
+    endloop
+  endfacet
+  facet normal -0.381246 -0.595575 -0.707066
+    outer loop
+      vertex 15.806 23.6553 58.4
+      vertex 15.4726 23.1564 59
+      vertex 14.8651 24.2576 58.4
+    endloop
+  endfacet
+  facet normal 0.308661 -0.636249 -0.707047
+    outer loop
+      vertex -11.9109 25.8367 58.4
+      vertex -11.6597 25.2918 59
+      vertex -12.916 25.3491 58.4
+    endloop
+  endfacet
+  facet normal 0.333329 -0.623679 -0.707047
+    outer loop
+      vertex -12.916 25.3491 58.4
+      vertex -13.6081 24.299 59
+      vertex -13.9013 24.8225 58.4
+    endloop
+  endfacet
+  facet normal -0.705919 0.0416425 -0.707068
+    outer loop
+      vertex 27.8285 -1.09339 59
+      vertex 28.3623 -2.23216 58.4
+      vertex 27.7641 -2.18509 59
+    endloop
+  endfacet
+  facet normal -0.595575 -0.381246 -0.707066
+    outer loop
+      vertex 23.6553 15.806 58.4
+      vertex 24.2576 14.8651 58.4
+      vertex 23.1564 15.4726 59
+    endloop
+  endfacet
+  facet normal -0.563854 0.426799 -0.707044
+    outer loop
+      vertex 22.5311 -16.3698 59
+      vertex 23.0165 -16.7225 58.4
+      vertex 22.3423 -17.6132 58.4
+    endloop
+  endfacet
+  facet normal -0.580168 0.404346 -0.707043
+    outer loop
+      vertex 23.1564 -15.4726 59
+      vertex 23.0165 -16.7225 58.4
+      vertex 22.5311 -16.3698 59
+    endloop
+  endfacet
+  facet normal -0.546634 -0.448663 -0.707031
+    outer loop
+      vertex 21.6335 18.4768 58.4
+      vertex 21.8711 17.2418 59
+      vertex 21.1773 18.0871 59
+    endloop
+  endfacet
+  facet normal -0.069254 0.703746 -0.707068
+    outer loop
+      vertex 3.27342 -27.657 59
+      vertex 2.23216 -28.3623 58.4
+      vertex 2.18509 -27.7641 59
+    endloop
+  endfacet
+  facet normal -0.124325 -0.696168 -0.707031
+    outer loop
+      vertex 4.45056 28.0997 58.4
+      vertex 5.55032 27.9033 58.4
+      vertex 4.3567 27.5071 59
+    endloop
+  endfacet
+  facet normal -0.676702 -0.205306 -0.707053
+    outer loop
+      vertex 27.3819 7.72248 58.4
+      vertex 26.8044 7.55962 59
+      vertex 26.4869 8.60612 59
+    endloop
+  endfacet
+  facet normal -0.684259 -0.178509 -0.707053
+    outer loop
+      vertex 27.3819 7.72248 58.4
+      vertex 27.6639 6.64152 58.4
+      vertex 26.8044 7.55962 59
+    endloop
+  endfacet
+  facet normal -0.357587 0.610094 -0.707048
+    outer loop
+      vertex 14.8651 -24.2576 58.4
+      vertex 13.9013 -24.8225 58.4
+      vertex 13.6081 -24.299 59
+    endloop
+  endfacet
+  facet normal -0.308661 -0.636249 -0.707047
+    outer loop
+      vertex 11.9109 25.8367 58.4
+      vertex 12.916 25.3491 58.4
+      vertex 11.6597 25.2918 59
+    endloop
+  endfacet
+  facet normal -0.283379 -0.647905 -0.707047
+    outer loop
+      vertex 11.9109 25.8367 58.4
+      vertex 11.6597 25.2918 59
+      vertex 10.8873 26.2844 58.4
+    endloop
+  endfacet
+  facet normal -0.404353 -0.580134 -0.707067
+    outer loop
+      vertex 15.806 23.6553 58.4
+      vertex 16.7225 23.0165 58.4
+      vertex 15.4726 23.1564 59
+    endloop
+  endfacet
+  facet normal 0.563854 -0.426799 -0.707044
+    outer loop
+      vertex -22.3423 17.6132 58.4
+      vertex -22.5311 16.3698 59
+      vertex -23.0165 16.7225 58.4
+    endloop
+  endfacet
+  facet normal -0.448663 -0.546634 -0.707031
+    outer loop
+      vertex 18.4768 21.6335 58.4
+      vertex 18.0871 21.1773 59
+      vertex 17.2418 21.8711 59
+    endloop
+  endfacet
+  facet normal 0.636249 -0.308661 -0.707047
+    outer loop
+      vertex -25.3491 12.916 58.4
+      vertex -25.2918 11.6597 59
+      vertex -25.8367 11.9109 58.4
+    endloop
+  endfacet
+  facet normal -0.257747 -0.65849 -0.707076
+    outer loop
+      vertex 10.8873 26.2844 58.4
+      vertex 10.6577 25.73 59
+      vertex 9.63936 26.1286 59
+    endloop
+  endfacet
+  facet normal -0.231742 0.668134 -0.707031
+    outer loop
+      vertex 9.63936 -26.1286 59
+      vertex 9.84703 -26.6915 58.4
+      vertex 8.79153 -27.0576 58.4
+    endloop
+  endfacet
+  facet normal 0.308657 0.636261 -0.707038
+    outer loop
+      vertex -12.6436 -24.8145 59
+      vertex -11.6597 -25.2918 59
+      vertex -12.916 -25.3491 58.4
+    endloop
+  endfacet
+  facet normal -0.610095 -0.357586 -0.707047
+    outer loop
+      vertex 24.2576 14.8651 58.4
+      vertex 24.299 13.6081 59
+      vertex 23.746 14.5516 59
+    endloop
+  endfacet
+  facet normal 0.65849 -0.257747 -0.707076
+    outer loop
+      vertex -25.73 10.6577 59
+      vertex -26.1286 9.63936 59
+      vertex -26.2844 10.8873 58.4
+    endloop
+  endfacet
+  facet normal 0.647891 -0.283339 -0.707076
+    outer loop
+      vertex -25.2918 11.6597 59
+      vertex -25.73 10.6577 59
+      vertex -26.2844 10.8873 58.4
+    endloop
+  endfacet
+  facet normal 0.096915 -0.70051 -0.707031
+    outer loop
+      vertex -3.34394 28.2528 58.4
+      vertex -4.3567 27.5071 59
+      vertex -4.45056 28.0997 58.4
+    endloop
+  endfacet
+  facet normal -0.357586 0.610095 -0.707047
+    outer loop
+      vertex 14.5516 -23.746 59
+      vertex 14.8651 -24.2576 58.4
+      vertex 13.6081 -24.299 59
+    endloop
+  endfacet
+  facet normal 0.0693172 0.703794 -0.707014
+    outer loop
+      vertex -3.27342 -27.657 59
+      vertex -2.23216 -28.3623 58.4
+      vertex -3.34394 -28.2528 58.4
+    endloop
+  endfacet
+  facet normal 0.700525 -0.0969358 -0.707014
+    outer loop
+      vertex -27.5071 4.3567 59
+      vertex -27.657 3.27342 59
+      vertex -28.2528 3.34394 58.4
+    endloop
+  endfacet
+  facet normal -0.426794 -0.563885 -0.707023
+    outer loop
+      vertex 17.6132 22.3423 58.4
+      vertex 17.2418 21.8711 59
+      vertex 16.3698 22.5311 59
+    endloop
+  endfacet
+  facet normal 0.308661 0.636249 -0.707047
+    outer loop
+      vertex -11.6597 -25.2918 59
+      vertex -11.9109 -25.8367 58.4
+      vertex -12.916 -25.3491 58.4
+    endloop
+  endfacet
+  facet normal 0.658551 0.257718 -0.707031
+    outer loop
+      vertex -26.1286 -9.63936 59
+      vertex -26.2844 -10.8873 58.4
+      vertex -26.6915 -9.84703 58.4
+    endloop
+  endfacet
+  facet normal -0.404346 0.580168 -0.707043
+    outer loop
+      vertex 16.3698 -22.5311 59
+      vertex 16.7225 -23.0165 58.4
+      vertex 15.4726 -23.1564 59
+    endloop
+  endfacet
+  facet normal -0.381274 0.595579 -0.707047
+    outer loop
+      vertex 15.4726 -23.1564 59
+      vertex 14.8651 -24.2576 58.4
+      vertex 14.5516 -23.746 59
+    endloop
+  endfacet
+  facet normal 0.705919 -0.0416425 -0.707068
+    outer loop
+      vertex -27.7641 2.18509 59
+      vertex -27.8285 1.09339 59
+      vertex -28.3623 2.23216 58.4
+    endloop
+  endfacet
+  facet normal 0.231742 0.668134 -0.707031
+    outer loop
+      vertex -9.63936 -26.1286 59
+      vertex -8.79153 -27.0576 58.4
+      vertex -9.84703 -26.6915 58.4
+    endloop
+  endfacet
+  facet normal -0.205306 -0.676702 -0.707053
+    outer loop
+      vertex 7.72248 27.3819 58.4
+      vertex 8.60612 26.4869 59
+      vertex 7.55962 26.8044 59
+    endloop
+  endfacet
+  facet normal -0.448661 0.546647 -0.707022
+    outer loop
+      vertex 18.4768 -21.6335 58.4
+      vertex 17.6132 -22.3423 58.4
+      vertex 17.2418 -21.8711 59
+    endloop
+  endfacet
+  facet normal 0.283379 -0.647905 -0.707047
+    outer loop
+      vertex -10.8873 26.2844 58.4
+      vertex -11.6597 25.2918 59
+      vertex -11.9109 25.8367 58.4
+    endloop
+  endfacet
+  facet normal 0.308657 -0.636261 -0.707038
+    outer loop
+      vertex -11.6597 25.2918 59
+      vertex -12.6436 24.8145 59
+      vertex -12.916 25.3491 58.4
+    endloop
+  endfacet
+  facet normal 0.690752 -0.151576 -0.707027
+    outer loop
+      vertex -27.0805 6.50145 59
+      vertex -27.3149 5.43326 59
+      vertex -27.6639 6.64152 58.4
+    endloop
+  endfacet
+  facet normal 0.676702 -0.205306 -0.707053
+    outer loop
+      vertex -26.4869 8.60612 59
+      vertex -26.8044 7.55962 59
+      vertex -27.3819 7.72248 58.4
+    endloop
+  endfacet
+  facet normal 0.357586 0.610095 -0.707047
+    outer loop
+      vertex -14.5516 -23.746 59
+      vertex -13.6081 -24.299 59
+      vertex -14.8651 -24.2576 58.4
+    endloop
+  endfacet
+  facet normal 0.231682 0.668108 -0.707075
+    outer loop
+      vertex -8.60612 -26.4869 59
+      vertex -8.79153 -27.0576 58.4
+      vertex -9.63936 -26.1286 59
+    endloop
+  endfacet
+  facet normal 0.381274 0.595579 -0.707047
+    outer loop
+      vertex -14.5516 -23.746 59
+      vertex -14.8651 -24.2576 58.4
+      vertex -15.4726 -23.1564 59
+    endloop
+  endfacet
+  facet normal 0.684277 -0.178543 -0.707027
+    outer loop
+      vertex -26.8044 7.55962 59
+      vertex -27.0805 6.50145 59
+      vertex -27.6639 6.64152 58.4
+    endloop
+  endfacet
+  facet normal 0.636261 -0.308657 -0.707038
+    outer loop
+      vertex -24.8145 12.6436 59
+      vertex -25.2918 11.6597 59
+      vertex -25.3491 12.916 58.4
+    endloop
+  endfacet
+  facet normal -0.509741 0.490148 -0.707049
+    outer loop
+      vertex 20.4509 -18.9046 59
+      vertex 20.8915 -19.3119 58.4
+      vertex 19.6929 -19.6929 59
+    endloop
+  endfacet
+  facet normal -0.528627 0.469718 -0.707049
+    outer loop
+      vertex 21.1773 -18.0871 59
+      vertex 20.8915 -19.3119 58.4
+      vertex 20.4509 -18.9046 59
+    endloop
+  endfacet
+  facet normal 0.357587 -0.610094 -0.707048
+    outer loop
+      vertex -13.9013 24.8225 58.4
+      vertex -13.6081 24.299 59
+      vertex -14.8651 24.2576 58.4
+    endloop
+  endfacet
+  facet normal 0.357587 0.610094 -0.707048
+    outer loop
+      vertex -13.6081 -24.299 59
+      vertex -13.9013 -24.8225 58.4
+      vertex -14.8651 -24.2576 58.4
+    endloop
+  endfacet
+  facet normal 0.676687 -0.205275 -0.707076
+    outer loop
+      vertex -27.0576 8.79153 58.4
+      vertex -26.4869 8.60612 59
+      vertex -27.3819 7.72248 58.4
+    endloop
+  endfacet
+  facet normal 0.381246 -0.595575 -0.707066
+    outer loop
+      vertex -14.8651 24.2576 58.4
+      vertex -15.4726 23.1564 59
+      vertex -15.806 23.6553 58.4
+    endloop
+  endfacet
+  facet normal 0.546647 -0.448661 -0.707022
+    outer loop
+      vertex -21.6335 18.4768 58.4
+      vertex -21.8711 17.2418 59
+      vertex -22.3423 17.6132 58.4
+    endloop
+  endfacet
+  facet normal -0.546647 -0.448661 -0.707022
+    outer loop
+      vertex 22.3423 17.6132 58.4
+      vertex 21.8711 17.2418 59
+      vertex 21.6335 18.4768 58.4
+    endloop
+  endfacet
+  facet normal -0.426799 0.563854 -0.707044
+    outer loop
+      vertex 17.6132 -22.3423 58.4
+      vertex 16.7225 -23.0165 58.4
+      vertex 16.3698 -22.5311 59
+    endloop
+  endfacet
+  facet normal 0.069254 0.703746 -0.707068
+    outer loop
+      vertex -2.18509 -27.7641 59
+      vertex -2.23216 -28.3623 58.4
+      vertex -3.27342 -27.657 59
+    endloop
+  endfacet
+  facet normal 0.333329 0.623679 -0.707047
+    outer loop
+      vertex -13.6081 -24.299 59
+      vertex -12.916 -25.3491 58.4
+      vertex -13.9013 -24.8225 58.4
+    endloop
+  endfacet
+  facet normal 0.404346 0.580168 -0.707043
+    outer loop
+      vertex -16.3698 -22.5311 59
+      vertex -15.4726 -23.1564 59
+      vertex -16.7225 -23.0165 58.4
+    endloop
+  endfacet
+  facet normal 0.404353 0.580134 -0.707067
+    outer loop
+      vertex -15.4726 -23.1564 59
+      vertex -15.806 -23.6553 58.4
+      vertex -16.7225 -23.0165 58.4
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
## Summary
- replace `spool_core_sleeve.scad` with anti–z‑fighting AMS Lite sleeve using `$preview` epsilons
- update render script and tests for ID/OD/LEN/TOL interface

## Testing
- `tests/cad/test_spool_core_sleeve.sh`
- `pre-commit run --all-files`
- `pytest -q`
- `npm run lint`
- `npm run test:ci`
- `python -m flywheel.fit`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bbd5713d48832f9ada47c795bc14fa