### PR TITLE
📝 : – document Upgrade Prompt standard

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -12,6 +12,10 @@ Think of each listed repository as a small flywheel belted to this codebase. The
 
 All prompts are verified with OpenAI Codex. Other coding agents like Claude Code, Gemini CLI, and Cursor should work too.
 
+Each prompt document ends with a bespoke **Upgrade Prompt** section that guides future edits.
+Place this upgrade prompt at the bottom of the file.
+Downstream repos already use this pattern; it's now standard for Flywheel prompt docs.
+
 **206 one-click prompts verified across 13 repos (45 evergreen, 2 one-off, 7 unknown).**
 
 One-off prompts are temporary—copy them into issues or PRs, implement, and then remove them from source docs.


### PR DESCRIPTION
what: document requirement for bespoke upgrade prompt in prompt docs
why: align flywheel with downstream repos using upgrade prompts
how to test:
- pytest -q
- npm run lint
- npm run test:ci
- python -m flywheel.fit
- RUN_SECURITY_ONLY=1 bash scripts/checks.sh
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bf4f75c2f0832fa6444d9e6ca2f142