### PR TITLE
docs: clarify Codex automation prompt

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -228,3 +228,6 @@ lowercasing
 finiteness
 AMS
 Bambu
+jobbot
+UI
+ui

--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -15,18 +15,19 @@ instructions, see [propagate.md](propagate.md).
 
 ```
 SYSTEM:
-You are an automated contributor for the Flywheel repository.
-ASSISTANT: (DEV) Implement code; stop after producing patch.
-ASSISTANT: (CRITIC) Inspect the patch and JSON manifest; reply only "LGTM"
-or a bullet list of fixes needed.
+You are an automated contributor to the Flywheel repository.
+ASSISTANT (DEV): Write code and stop after outputting the patch.
+ASSISTANT (CRITIC): Review the patch and JSON manifest; respond only with "LGTM"
+or a bullet list of required fixes.
 
 PURPOSE:
 Keep the project healthy by making small, well-tested improvements.
 
 CONTEXT:
 - Follow the conventions in AGENTS.md and README.md.
-- Ensure `pre-commit run --all-files`, `pytest -q`, `npm run test:ci`,
-  `python -m flywheel.fit`, and `bash scripts/checks.sh` all succeed.
+- Ensure the following commands succeed:
+  `pre-commit run --all-files`, `pytest -q`, `npm run test:ci`,
+  `python -m flywheel.fit`, and `bash scripts/checks.sh`.
 - Make sure all GitHub Actions workflows pass and keep the README badges green.
 - If browser dependencies are missing, run `npm run playwright:install` or
   prefix tests with `SKIP_E2E=1`.
@@ -44,11 +45,15 @@ OUTPUT_FORMAT:
 The DEV assistant must output the JSON object first, then the diff in a fenced diff block.
 ```
 
-Copy this entire block into Codex when you want the agent to automatically improve Flywheel. This version adds a critic role and machine-readable manifest to streamline review and automation. Update the instructions after each successful run so they stay relevant.
+Copy this entire block into Codex to let the agent automatically improve Flywheel.
+This version adds a critic role and machine-readable manifest to streamline review
+and automation. Update the instructions after each successful run so they stay
+relevant.
 
 ## Implementation prompts
-Copy **one** of the prompts below into Codex when you want the agent to improve `docs/repo-feature-summary.md`.
-Each prompt is file-scoped, single-purpose and immediately actionable.
+Copy **one** of the prompts below into Codex when you want the agent to improve
+`docs/repo-feature-summary.md`. Each prompt is file-scoped, single-purpose and
+immediately actionable.
 
 ### How to choose a prompt
 


### PR DESCRIPTION
## Summary
- clarify role wording and context in Codex automation prompt
- allow missing dictionary terms for jobbot and UI

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c253302c50832f9723a3c6bbe24d2b