### PR TITLE
📝 : clarify merge conflict upgrade prompt

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -42,6 +42,7 @@ io
 isort
 json
 js
+jobbot
 macOS
 md
 npm
@@ -52,6 +53,8 @@ release-drafter
 repo
 repo_manager
 repos
+UI
+ui
 roadmap
 subcommands
 subprocess

--- a/docs/prompts/codex/merge-conflicts.md
+++ b/docs/prompts/codex/merge-conflicts.md
@@ -27,21 +27,20 @@ Type: evergreen
 Use this prompt to refine the merge conflict instructions.
 
 ```text
-Review the following code snippet or prompt, refine its clarity and accuracy, then output:
+Review the snippet or prompt below and improve its clarity and correctness.
 
-1. The improved version of the snippet or prompt (in a fenced block).
-2. A bullet-point summary of your changes and reasoning.
+1. Provide the revised snippet inside a fenced block.
+2. List bullet points summarizing your changes and rationale.
 
-After updating, run these lightweight checks:
+After editing, run:
 
 - `pre-commit run --all-files`
 - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
 - `linkchecker --no-warnings README.md docs/`
 - `git diff --cached | ./scripts/scan-secrets.py`
 
-If everything passes, output:
-`“All lightweight checks passed. Ready for CI.”`
-Otherwise, list the failing steps with concise explanations.
+If all commands succeed, reply with `All lightweight checks passed. Ready for CI.`
+Otherwise, report the failing step(s) with a brief explanation.
 
-_*Note: Full test suites (`pytest`, `npm test`, `python -m flywheel.fit`) should be run separately in CI, not here.*_
+_Run full test suites (`pytest`, `npm test`, `python -m flywheel.fit`) separately in CI._
 ```


### PR DESCRIPTION
## Summary
- refine merge-conflict upgrade prompt wording
- allow `jobbot` and UI terms in spellcheck dictionary

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c253302c50832f9723a3c6bbe24d2b