### PR TITLE
📝: fix broken link in prompt docs summary

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -2,8 +2,7 @@
 # Prompt Docs Summary
 
 This index is auto-generated with
-[scripts/update_prompt_docs_summary.py]
-(../../scripts/update_prompt_docs_summary.py)
+[scripts/update_prompt_docs_summary.py](../../scripts/update_prompt_docs_summary.py)
 using RepoCrawler to discover prompt documents across repositories.
 
 RepoCrawler powers other reports like repo-feature summaries; use it as a model for deep dives.


### PR DESCRIPTION
Fix markdown link in docs/prompt-docs-summary.md.

what: repair link syntax in intro paragraph
why: make script link render properly
how to test:
 - pre-commit run --all-files
 - npm run lint
 - npm run test:ci
 - pytest -q
 - python -m flywheel.fit
 - bash scripts/checks.sh
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68c5d7013898832fa51492b43076eecf