### PR TITLE
docs: require full snippet output in merge conflict prompt

### DIFF
--- a/docs/prompts/codex/merge-conflicts.md
+++ b/docs/prompts/codex/merge-conflicts.md
@@ -17,6 +17,8 @@ Resolve the merge conflict in the code snippet below.
 - Do not modify lines outside the conflict.
 - When resolving, prefer the version consistent with naming conventions and other docs in this repo.
 - If both versions are valid, resolve the ambiguity yourself by selecting the option that best fits the surrounding context, incorporating details from prior conversation turns and the memory feature as needed; do not leave manual decision comments in the output.
+- Output the fully resolved snippet exactly once inside a single fenced code block.
+- Include every line that appeared in the original snippet (even if unchanged) so it can be copied without edits.
 - After the code, summarize the differences between the two sides and explain why you resolved them this way.
 
 ```


### PR DESCRIPTION
what: ensure the merge conflict prompt requires returning the full snippet
why: prevent partial snippets so resolutions are copy/paste ready
how to test: pytest -q; GITHUB_TOKEN=testtoken npm run test:ci; python -m flywheel.fit; bash scripts/checks.sh
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68ce567ba5f4832fb67c5c982ba84bb2