### PR TITLE
📝 : document repo summary regeneration

### DIFF
--- a/docs/repo-feature-summary.md
+++ b/docs/repo-feature-summary.md
@@ -1,6 +1,8 @@
 # Repo Feature Summary
 
 This table tracks which flywheel features each related repository has adopted.
+Regenerate it locally with `flywheel crawl --repos-file docs/repo_list.txt --output \
+docs/repo-feature-summary.md` if the automation run is blocked.
 
 <!-- spellchecker: disable -->
 ## Basics


### PR DESCRIPTION
what: add manual regeneration instructions to docs/repo-feature-summary.md and retain the latest crawl data
why: unblock the nightly summary update after the rebase conflict and document how to refresh it locally
how to test: pre-commit run --all-files; pytest -q; npm run test:ci; python -m flywheel.fit; bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68d4aababf84832f80f56acd19a71aa7