### PR TITLE
⚡️ Speed up JavaScript CI tests

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -38,7 +38,9 @@ jobs:
         run: |
           npm install --no-audit --no-fund
           npx playwright install --with-deps
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f webapp/requirements-playwright.txt ]; then \
+            pip install --no-input -r webapp/requirements-playwright.txt; \
+          fi
           npm test -- --coverage --coverageReporters=lcov
 
       # --- Upload coverage only if the matching report exists ---

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [2025-09-26] - Speed up JavaScript tests
+- install minimal webapp dependencies for Playwright to avoid rebuilding assimp_py in CI
+
 ## [2025-08-27] - Scan root docs for prompt files
 - include `docs/prompts-*.md` in prompt docs crawler
 

--- a/docs/pms/2025-09-26-javascript-tests-runtime.md
+++ b/docs/pms/2025-09-26-javascript-tests-runtime.md
@@ -1,0 +1,25 @@
+# JavaScript tests slowed by Python dependency build
+
+- **Date**: 2025-09-26
+- **Author**: Codex
+- **Status**: resolved
+
+## What went wrong
+The `test (javascript)` GitHub Actions job began running for more than ten minutes, far above the
+normal ~3 minute completion time.
+
+## Root cause
+Commit 2132cb8 (2025-07-19) expanded `requirements.txt` with 3-D tooling such as `assimp_py`. The
+JavaScript workflow installs everything in that file before running Playwright. Because `assimp_py`
+ships source-only wheels, pip rebuilt it from C++ each run, extending the job runtime by several
+minutes.
+
+## Impact
+JavaScript CI checks (e.g. [run 18029996098](https://github.com/futuroptimist/flywheel/actions/runs/18029996098/job/51304258464))
+spent ~10 minutes compiling native dependencies, delaying feedback and burning GitHub Actions
+minutes.
+
+## Actions to take
+- Install only the webapp dependencies needed for Playwright (`Flask`, `trimesh`).
+- Add a regression test that asserts the workflow references the lightweight requirement file.
+- Keep heavy modeling libraries (e.g. `assimp_py`) scoped to build jobs that need them.

--- a/outages/2025-09-26-javascript-tests-runtime.json
+++ b/outages/2025-09-26-javascript-tests-runtime.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-09-26-javascript-tests-runtime",
+  "date": "2025-09-26",
+  "component": "github-actions",
+  "rootCause": "The JavaScript test job installed all of requirements.txt, forcing pip to compile assimp_py from source and adding several minutes to each run.",
+  "resolution": "Install only the lightweight webapp dependencies from webapp/requirements-playwright.txt in the JavaScript workflow and add a regression test.",
+  "references": [
+    "https://github.com/futuroptimist/flywheel/actions/runs/18029996098/job/51304258464"
+  ]
+}

--- a/tests/playwright-deps-workflow.test.mjs
+++ b/tests/playwright-deps-workflow.test.mjs
@@ -1,0 +1,8 @@
+import { readFileSync } from 'node:fs';
+import { test, expect } from '@jest/globals';
+
+const workflow = readFileSync(new URL('../.github/workflows/02-tests.yml', import.meta.url), 'utf8');
+
+test('JS workflow installs lightweight webapp deps', () => {
+  expect(workflow).toMatch(/webapp\/requirements-playwright\.txt/);
+});

--- a/webapp/requirements-playwright.txt
+++ b/webapp/requirements-playwright.txt
@@ -1,0 +1,4 @@
+# Minimal Python dependencies required to run the webapp during Playwright tests.
+# Keep this list lean to avoid expensive installs in CI.
+Flask
+trimesh


### PR DESCRIPTION
## Summary
- install minimal webapp dependencies for the JavaScript workflow so CI skips rebuilding assimp_py
- add a regression test plus outage/postmortem describing the runtime regression
- document the change in the changelog

## Testing
- npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68d637991964832f888005c1be900a3b