### PR TITLE
🛠️ : – add emoji to prompt summary generator

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -67,7 +67,7 @@ python scripts/update_prompt_docs_summary.py --repos-from docs/repo_list.txt --o
 | [docs/prompts/codex/ci-fix.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/ci-fix.md)                                             | [2 – Commit and propagate](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/ci-fix.md#2-commit-and-propagate)                                                  | one-off       | yes          |
 | [docs/prompts/codex/ci-fix.md](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/ci-fix.md)                                             | [4 – Further reading & references](https://github.com/futuroptimist/flywheel/blob/main/docs/prompts/codex/ci-fix.md#4-further-reading-references)                                    | one-off       | yes          |
 
-_Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`, `docs/pms`, `docs/prompts`._
+_❌ Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`, `docs/pms`, `docs/prompts`._
 
 ## [futuroptimist/futuroptimist](https://github.com/futuroptimist/futuroptimist)
 
@@ -172,7 +172,7 @@ _Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`, `docs/pms`
 | **[frontend/src/pages/docs/md/prompts-vitest.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-vitest.md)**                               | **[Vitest test prompts for the _dspace_ repo](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-vitest.md#vitest-test-prompts-for-the-dspace-repo)**                        | **evergreen** | **yes**      |
 | **[frontend/src/pages/docs/md/prompts-vitest.md](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-vitest.md)**                               | **[Upgrader Prompt](https://github.com/democratizedspace/dspace/blob/v3/frontend/src/pages/docs/md/prompts-vitest.md#upgrader-prompt)**                                                                          | **evergreen** | **yes**      |
 
-_Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`, `frontend/src/pages/docs/md`._
+_❌ Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`, `frontend/src/pages/docs/md`._
 
 ## [futuroptimist/token.place](https://github.com/futuroptimist/token.place)
 
@@ -190,7 +190,7 @@ _Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`, `frontend/
 | **[docs/prompts-codex.md](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md)**                   | **[1 Document environment variables in README](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md#1-document-environment-variables-in-readme)** | **one-off**   | **yes**      |
 | **[docs/prompts-codex.md](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md)**                   | **[2 Add API rate limit test](https://github.com/futuroptimist/token.place/blob/main/docs/prompts-codex.md#2-add-api-rate-limit-test)**                                   | **one-off**   | **yes**      |
 
-_Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`._
+_❌ Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`._
 
 ## [futuroptimist/gabriel](https://github.com/futuroptimist/gabriel)
 
@@ -209,7 +209,7 @@ _Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`._
 | [prompts/scan-bright-dark-patterns.md](https://github.com/futuroptimist/gabriel/blob/main/prompts/scan-bright-dark-patterns.md) | [Scan for Bright and Dark Patterns](https://github.com/futuroptimist/gabriel/blob/main/prompts/scan-bright-dark-patterns.md#scan-for-bright-and-dark-patterns)        | unknown       | yes          |
 | [prompts/update-risk-model.md](https://github.com/futuroptimist/gabriel/blob/main/prompts/update-risk-model.md)                 | [Update Flywheel Risk Model](https://github.com/futuroptimist/gabriel/blob/main/prompts/update-risk-model.md#update-flywheel-risk-model)                              | unknown       | yes          |
 
-_Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`, `prompts-repos.md`, `prompts`._
+_❌ Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`, `prompts-repos.md`, `prompts`._
 
 ## [futuroptimist/f2clipboard](https://github.com/futuroptimist/f2clipboard)
 
@@ -223,7 +223,7 @@ _Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`, `prompts-r
 | **[docs/prompts-codex.md](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md)**               | **[Task-specific prompts](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#task-specific-prompts)**                                     | **evergreen** | **yes**      |
 | **[docs/prompts-codex.md](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md)**               | **[2 Emit Markdown to stdout and clipboard](https://github.com/futuroptimist/f2clipboard/blob/main/docs/prompts-codex.md#2-emit-markdown-to-stdout-and-clipboard)** | **one-off**   | **yes**      |
 
-_Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`._
+_❌ Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`._
 
 ## [futuroptimist/axel](https://github.com/futuroptimist/axel)
 
@@ -247,7 +247,7 @@ _Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`._
 | **[docs/prompts/prompts-hillclimb.md](https://github.com/futuroptimist/axel/blob/main/docs/prompts/prompts-hillclimb.md)** | **[add-pipx-install.yml](https://github.com/futuroptimist/axel/blob/main/docs/prompts/prompts-hillclimb.md#add-pipx-installyml)**                               | **unknown**   | **yes**      |
 | **[docs/prompts/prompts-hillclimb.md](https://github.com/futuroptimist/axel/blob/main/docs/prompts/prompts-hillclimb.md)** | **[docker-compose-mock.yml](https://github.com/futuroptimist/axel/blob/main/docs/prompts/prompts-hillclimb.md#docker-compose-mockyml)**                         | **unknown**   | **yes**      |
 
-_Note: Prompt docs also found outside `docs/prompts/codex/`: `.axel/hillclimb/prompts`, `docs/`, `docs/prompts`._
+_❌ Note: Prompt docs also found outside `docs/prompts/codex/`: `.axel/hillclimb/prompts`, `docs/`, `docs/prompts`._
 
 ## [futuroptimist/sigma](https://github.com/futuroptimist/sigma)
 
@@ -260,7 +260,7 @@ _Note: Prompt docs also found outside `docs/prompts/codex/`: `.axel/hillclimb/pr
 | **[docs/prompts-codex-tests.md](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-tests.md)**           | **[Codex Test Addition Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex-tests.md#codex-test-addition-prompt)**    | **evergreen** | **yes**      |
 | **[docs/prompts-codex.md](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex.md)**                       | **[Codex Automation Prompt](https://github.com/futuroptimist/sigma/blob/main/docs/prompts-codex.md#codex-automation-prompt)**                | **evergreen** | **yes**      |
 
-_Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`._
+_❌ Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`._
 
 ## [futuroptimist/gitshelves](https://github.com/futuroptimist/gitshelves)
 
@@ -277,7 +277,7 @@ _Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`._
 | **[docs/prompts-codex.md](https://github.com/futuroptimist/gitshelves/blob/main/docs/prompts-codex.md)**                         | **[1 Document the `--months-per-row` option](https://github.com/futuroptimist/gitshelves/blob/main/docs/prompts-codex.md#1-document-the---months-per-row-option)** | **one-off**   | **yes**      |
 | **[docs/prompts-codex.md](https://github.com/futuroptimist/gitshelves/blob/main/docs/prompts-codex.md)**                         | **[2 Add a spellcheck dictionary](https://github.com/futuroptimist/gitshelves/blob/main/docs/prompts-codex.md#2-add-a-spellcheck-dictionary)**                     | **one-off**   | **yes**      |
 
-_Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`._
+_❌ Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`._
 
 ## [futuroptimist/wove](https://github.com/futuroptimist/wove)
 
@@ -292,7 +292,7 @@ _Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`._
 | **[docs/prompts-docs.md](https://github.com/futuroptimist/wove/blob/main/docs/prompts-docs.md)**           | **[Codex Docs Prompt](https://github.com/futuroptimist/wove/blob/main/docs/prompts-docs.md#codex-docs-prompt)**                                     | **evergreen** | **yes**      |
 | **[docs/prompts-tests.md](https://github.com/futuroptimist/wove/blob/main/docs/prompts-tests.md)**         | **[Codex Test Prompt](https://github.com/futuroptimist/wove/blob/main/docs/prompts-tests.md#codex-test-prompt)**                                    | **evergreen** | **yes**      |
 
-_Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`._
+_❌ Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`._
 
 ## [futuroptimist/sugarkube](https://github.com/futuroptimist/sugarkube)
 
@@ -325,7 +325,7 @@ _Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/`._
 | [docs/prompts/simplification.md](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts/simplification.md)                                                 | [Before you run the prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts/simplification.md#before-you-run-the-prompt)                                                                               | evergreen | yes          |
 | [docs/prompts/simplification.md](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts/simplification.md)                                                 | [Upgrade Prompt](https://github.com/futuroptimist/sugarkube/blob/main/docs/prompts/simplification.md#upgrade-prompt)                                                                                                     | evergreen | yes          |
 
-_Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/archived`, `docs/prompts`._
+_❌ Note: Prompt docs also found outside `docs/prompts/codex/`: `docs/archived`, `docs/prompts`._
 
 ## [futuroptimist/pr-reaper](https://github.com/futuroptimist/pr-reaper)
 

--- a/scripts/update_prompt_docs_summary.py
+++ b/scripts/update_prompt_docs_summary.py
@@ -333,7 +333,7 @@ def main() -> None:
             )
             lines.append(
                 (
-                    "_Note: Prompt docs also found outside "
+                    "_❌ Note: Prompt docs also found outside "
                     "`docs/prompts/codex/`: "
                     f"{locations}._"
                 )


### PR DESCRIPTION
what: emit ❌ marker for noncanonical prompt doc warnings
why: keep the note visible after regenerating summary
how to test: inspect generated markdown


------
https://chatgpt.com/codex/tasks/task_e_68d63f516758832fad6e8c8c1603cf71