### PR TITLE
🛠️ : repair prompt docs summary link formatting

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -1,10 +1,7 @@
 <!-- spellchecker: disable -->
 # Prompt Docs Summary
 
-This index is auto-generated with
-[scripts/update_prompt_docs_summary.py]
-(../../scripts/update_prompt_docs_summary.py)
-using RepoCrawler to discover prompt documents across repositories.
+This index is auto-generated with [scripts/update_prompt_docs_summary.py](../../scripts/update_prompt_docs_summary.py) using RepoCrawler to discover prompt documents across repositories.
 
 RepoCrawler powers other reports like repo-feature summaries; use it as a model for deep dives.
 

--- a/scripts/update_prompt_docs_summary.py
+++ b/scripts/update_prompt_docs_summary.py
@@ -283,10 +283,12 @@ def main() -> None:
         "<!-- spellchecker: disable -->",
         "# Prompt Docs Summary",
         "",
-        "This index is auto-generated with ",
-        "[scripts/update_prompt_docs_summary.py]",
-        "(../../scripts/update_prompt_docs_summary.py) ",
-        "using RepoCrawler to discover prompt documents across repositories.",
+        (
+            "This index is auto-generated with "
+            "[scripts/update_prompt_docs_summary.py]"
+            "(../../scripts/update_prompt_docs_summary.py)"
+            " using RepoCrawler to discover prompt documents across repositories."
+        ),
         "",
         "RepoCrawler powers other reports like repo-feature summaries; "
         "use it as a model for deep dives.",

--- a/tests/test_prompt_docs_summary.py
+++ b/tests/test_prompt_docs_summary.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 SUMMARY_FILE = Path(__file__).parent.parent / "docs" / "prompt-docs-summary.md"
@@ -6,3 +7,11 @@ SUMMARY_FILE = Path(__file__).parent.parent / "docs" / "prompt-docs-summary.md"
 def test_prompt_docs_summary_has_spellcheck_disabled():
     first_line = SUMMARY_FILE.read_text().splitlines()[0].strip()
     assert first_line == "<!-- spellchecker: disable -->"
+
+
+def test_prompt_docs_summary_has_no_whitespace_broken_links():
+    text = SUMMARY_FILE.read_text()
+    broken_link_match = re.search(r"(?<!!)\[[^\]]+\]\s+\(", text)
+    assert (
+        broken_link_match is None
+    ), "prompt-docs-summary.md contains links with whitespace between [] and ()"


### PR DESCRIPTION
what:
- ensure generator writes inline markdown link
- guard against whitespace between [] and ()

why:
- fix broken repo link on docs/prompt-docs-summary.md

how to test:
- pytest tests/test_prompt_docs_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68d76b515254832fb01dfc4696bb5c93