### PR TITLE
🧹 : wrap prompt docs summary strings for flake8

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -1,10 +1,7 @@
 <!-- spellchecker: disable -->
 # Prompt Docs Summary
 
-This index is auto-generated with
-[scripts/update_prompt_docs_summary.py]
-(../../scripts/update_prompt_docs_summary.py)
-using RepoCrawler to discover prompt documents across repositories.
+This index is auto-generated with [scripts/update_prompt_docs_summary.py](../../scripts/update_prompt_docs_summary.py) using RepoCrawler to discover prompt documents across repositories.
 
 RepoCrawler powers other reports like repo-feature summaries; use it as a model for deep dives.
 

--- a/scripts/update_prompt_docs_summary.py
+++ b/scripts/update_prompt_docs_summary.py
@@ -283,24 +283,31 @@ def main() -> None:
         "<!-- spellchecker: disable -->",
         "# Prompt Docs Summary",
         "",
-        "This index is auto-generated with ",
-        "[scripts/update_prompt_docs_summary.py]",
-        "(../../scripts/update_prompt_docs_summary.py) ",
-        "using RepoCrawler to discover prompt documents across repositories.",
+        (
+            "This index is auto-generated with "
+            "[scripts/update_prompt_docs_summary.py]"
+            "(../../scripts/update_prompt_docs_summary.py) "
+            "using RepoCrawler to discover prompt documents "
+            "across repositories."
+        ),
         "",
-        "RepoCrawler powers other reports like repo-feature summaries; "
-        "use it as a model for deep dives.",
+        (
+            "RepoCrawler powers other reports like repo-feature summaries; "
+            "use it as a model for deep dives."
+        ),
         "",
         (
             "Think of each listed repository as a small flywheel belted "
             "to this codebase. The list in dict/prompt-doc-repos.txt "
-            "mirrors docs/repo_list.txt; if a repo drops from the output, "
+            "mirrors docs/repo_list.txt; if a repo drops from the "
+            "output, "
             "fix that integration rather than deleting it."
         ),
         "",
         (
-            "All prompts are verified with OpenAI Codex. Other coding agents "
-            "like Claude Code, Gemini CLI, and Cursor should work too."
+            "All prompts are verified with OpenAI Codex. Other coding "
+            "agents like Claude Code, Gemini CLI, and Cursor should work "
+            "too."
         ),
         "",
         (
@@ -310,13 +317,13 @@ def main() -> None:
         ),
         "",
         (
-            "One-off prompts are temporary—copy them into issues or PRs, "
-            "implement, and then remove them from source docs."
+            "One-off prompts are temporary—copy them into issues or "
+            "PRs, implement, and then remove them from source docs."
         ),
         "",
         (
-            "All listed prompts are mechanically verified as 1-click ready: "
-            "copy & paste without editing."
+            "All listed prompts are mechanically verified as 1-click "
+            "ready: copy & paste without editing."
         ),
         "",
         "Run this script to regenerate the table:",

--- a/tests/test_prompt_docs_summary.py
+++ b/tests/test_prompt_docs_summary.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 SUMMARY_FILE = Path(__file__).parent.parent / "docs" / "prompt-docs-summary.md"
@@ -6,3 +7,16 @@ SUMMARY_FILE = Path(__file__).parent.parent / "docs" / "prompt-docs-summary.md"
 def test_prompt_docs_summary_has_spellcheck_disabled():
     first_line = SUMMARY_FILE.read_text().splitlines()[0].strip()
     assert first_line == "<!-- spellchecker: disable -->"
+
+
+def test_prompt_docs_summary_has_no_whitespace_broken_links():
+    text = SUMMARY_FILE.read_text()
+    broken_link_match = re.search(
+        r"(?<!!)\[[^\]]+\]\s+\(",
+        text,
+    )
+    error_message = (
+        "prompt-docs-summary.md contains links with whitespace "
+        "between [] and ()"
+    )
+    assert broken_link_match is None, error_message


### PR DESCRIPTION
what:
- rewrap generated summary copy within flake8 line limits
- split regression test assertion to satisfy line length rule

why:
- lint job flagged 80+ char lines after prior change

how to test:
- flake8 scripts/update_prompt_docs_summary.py
- flake8 tests/test_prompt_docs_summary.py
- pytest tests/test_prompt_docs_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68d76b515254832fb01dfc4696bb5c93