### PR TITLE
Fix unused script link variables in prompt summary generator

### DIFF
--- a/scripts/update_prompt_docs_summary.py
+++ b/scripts/update_prompt_docs_summary.py
@@ -304,8 +304,8 @@ def main() -> None:
         "",
         (
             "This index is auto-generated with "
-            "[scripts/update_prompt_docs_summary.py]"
-            "(../../scripts/update_prompt_docs_summary.py) "
+            f"[{script_display}]"
+            f"({script_href}) "
             "using RepoCrawler to discover prompt documents "
             "across repositories."
         ),


### PR DESCRIPTION
what: replace hard-coded script link with computed path values
why: satisfy flake8 by using script_display and script_href
how to test: python -m compileall scripts/update_prompt_docs_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68d77c33583c832f929ab39b142b7783