### PR TITLE
🛠️ : – Fix prompt docs summary script link

### DIFF
--- a/scripts/update_prompt_docs_summary.py
+++ b/scripts/update_prompt_docs_summary.py
@@ -297,18 +297,18 @@ def main() -> None:
     script_href = Path(
         os.path.relpath(scripts_path, args.out.parent)
     ).as_posix()
+    script_link = f"[{script_display}]({script_href})"
+    generated_line = (
+        "This index is auto-generated with {link} "
+        "using RepoCrawler to discover "
+        "prompt documents across repositories."
+    ).format(link=script_link)
 
     lines = [
         "<!-- spellchecker: disable -->",
         "# Prompt Docs Summary",
         "",
-        (
-            "This index is auto-generated with "
-            "[scripts/update_prompt_docs_summary.py]"
-            "(../../scripts/update_prompt_docs_summary.py) "
-            "using RepoCrawler to discover prompt documents "
-            "across repositories."
-        ),
+        generated_line,
         "",
         (
             "RepoCrawler powers other reports like repo-feature summaries; "


### PR DESCRIPTION
what: reuse computed script link when generating the prompt docs summary.
why: remove unused variables flagged by flake8 and keep generated docs accurate.
how to test: flake8 scripts/update_prompt_docs_summary.py
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68d77bfff3bc832f9232738607e108c1