### PR TITLE
Add dev tooling scaffolding to flywheel init

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Install the CLI and inject dev tooling. Without `--yes`, the command prompts for
 pipx run flywheel init . --language python --save-dev --yes
 ```
 
+The `--save-dev` flag copies standard workflows, linting configs,
+`.pre-commit-config.yaml`, and `scripts/checks.sh` so new projects inherit the
+full dev tooling out of the box.
+
 ### Updating dev tooling
 
 Refresh CI workflows and config files in an existing repo:

--- a/docs/feature-summary.md
+++ b/docs/feature-summary.md
@@ -182,7 +182,7 @@ feature adoption across repositories.
 **Repo-specific extras**
 - [ ] Mark as **Template** repo
 - [ ] “Use this template” one‑page walkthrough + screenshot/GIF
-- [ ] Option to inject best‑practice scaffolding via `--save-dev`
+- [x] Option to inject best‑practice scaffolding via `--save-dev`
 
 </details>
 

--- a/flywheel/__main__.py
+++ b/flywheel/__main__.py
@@ -19,6 +19,8 @@ OTHER_FILES = [
     ".github/release-drafter.yml",
     ".eslintrc.json",
     ".prettierrc",
+    ".pre-commit-config.yaml",
+    "scripts/checks.sh",
 ]
 
 PY_FILES = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import hashlib
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -34,6 +35,29 @@ def test_init_idempotent(tmp_path):
     assert (target / "pyproject.toml").exists()
     wf = target / ".github" / "workflows" / "01-lint-format.yml"
     assert wf.exists()
+
+
+def test_init_copies_dev_tooling(tmp_path):
+    target = tmp_path / "repo"
+    cmd = [
+        sys.executable,
+        "-m",
+        "flywheel",
+        "init",
+        str(target),
+        "--language",
+        "python",
+        "--save-dev",
+        "--yes",
+    ]
+    subprocess.run(cmd, check=True)
+
+    precommit = target / ".pre-commit-config.yaml"
+    checks = target / "scripts" / "checks.sh"
+
+    assert precommit.exists()
+    assert checks.exists()
+    assert os.access(checks, os.X_OK)
 
 
 def test_prompt(tmp_path):


### PR DESCRIPTION
## Summary
- ensure `flywheel init --save-dev` copies `.pre-commit-config.yaml` and `scripts/checks.sh`
- add a regression test that exercises the new scaffolding behavior
- document the scaffolding update and mark the feature checklist item complete

## Testing
- pre-commit run --all-files
- pytest -q
- npm run test:ci
- python -m flywheel.fit
- bash scripts/checks.sh
- detect-secrets scan /tmp/staged.diff

------
https://chatgpt.com/codex/tasks/task_e_68dcd4b8cdb4832fab09cfc69ded5347