### PR TITLE
Detect uv pip install workflows in RepoCrawler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## 2025-09-27
+- feat: RepoCrawler now treats `uv pip install` workflows as uv installers.
+
 ## 2025-09-05
 - docs: start changelog to track project evolution.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ or skip end-to-end tests by prefixing commands with `SKIP_E2E=1`.
 - Fast Python installs powered by [uv](https://github.com/astral-sh/uv)
 - Example code and templates
 - Python CLI with subcommands `init`, `update`, `audit`, `prompt`, and `crawl` that prompts interactively unless `--yes` is used
-- RepoCrawler detects installers like uv, pipx, pip/pip3, and poetry in workflows
+- RepoCrawler detects installers like uv (including `uv pip install` usage), pipx, pip/pip3, and poetry in workflows
 - [AGENTS.md](AGENTS.md) detailing included LLM assistants
 - [llms.txt](llms.txt) with quick context for AI helpers
 - [CLAUDE.md](CLAUDE.md) summarizing Anthropic guidance

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -55,7 +55,7 @@ class RepoCrawler:
     # so repos with custom workflow names still count.
     CI_KEYWORDS = ("ci", "test", "lint", "build", "docs", "qa")
 
-    _UV = re.compile(r"setup-uv|uv venv", re.I)
+    _UV = re.compile(r"setup-uv|uv\s+venv|uv\s+pip\s+install", re.I)
     _PIP = re.compile(r"\bpip(?:3)?\s+install", re.I)
     _PIPX = re.compile(r"\bpipx\s+install", re.I)
     _POETRY = re.compile(r"poetry\s+install", re.I)
@@ -485,8 +485,9 @@ class RepoCrawler:
     def _detect_installer(self, text: str) -> str:
         """Return installer hint based on workflow snippets.
 
-        Detects ``uv``, ``pipx``, ``pip`` and ``poetry`` keywords and returns
-        ``partial`` when no installer is found.
+        Detects ``uv``, ``pipx``, ``pip`` and ``poetry`` keywords (including
+        workflows that invoke ``uv pip install``) and returns ``partial`` when
+        no installer is found.
         """
         if self._UV.search(text):
             return "uv"

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -178,10 +178,10 @@ def test_has_ci_only_deploy_returns_false():
 @pytest.mark.parametrize(
     "snippet,expected",
     [
-        ("uv pip install -r req.txt", "pip"),
-        ("uv pip install && pip install black", "pip"),
+        ("uv pip install -r req.txt", "uv"),
+        ("uv pip install && pip install black", "uv"),
         ("python -m pip install -r requirements.txt", "pip"),
-        ("RUN pip3 install uv && uv pip install .", "pip"),
+        ("RUN pip3 install uv && uv pip install .", "uv"),
         ("pip3 install -r requirements.txt", "pip"),
     ],
 )


### PR DESCRIPTION
## Summary
- treat `uv pip install` workflow snippets as uv installers in RepoCrawler
- adjust RepoCrawler installer tests and documentation to capture the uv detection promise
- note the change in the changelog

## Testing
- pre-commit run --all-files
- pytest -q
- npm run test:ci
- python -m flywheel.fit
- bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68dcd4b8cdb4832fab09cfc69ded5347