### PR TITLE
feat: enforce codespell in checks script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ responses
 Flask
 trimesh
 tabulate
+codespell
 pygltflib
 assimp_py
 PyYAML

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -48,6 +48,15 @@ pytest -q
 run_security_checks
 
 # docs checks
+if command -v codespell >/dev/null 2>&1; then
+  codespell \
+    --ignore-words dict/allow.txt \
+    --skip ".git,.venv,node_modules,dist,build,docs-site,coverage,*.lock,*.min.js,*.stl,*.obj,*.glb,*.gltf,*.png,*.jpg" \
+    --quiet-level 2
+else
+  echo "codespell not installed; skipping spell check"
+fi
+
 if command -v pyspelling >/dev/null 2>&1 && [ -f .spellcheck.yaml ]; then
   pyspelling -c .spellcheck.yaml || true
 fi

--- a/tests/test_checks_script.py
+++ b/tests/test_checks_script.py
@@ -18,3 +18,50 @@ def test_checks_script_skips_missing_security_tools(tmp_path):
     assert result.returncode == 0
     assert "bandit not installed" in result.stdout
     assert "safety not installed" in result.stdout
+
+
+def test_checks_script_runs_codespell(tmp_path):
+    script = Path(__file__).resolve().parents[1] / "scripts" / "checks.sh"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_file = tmp_path / "codespell.log"
+
+    def stub(name: str, body: str = "exit 0") -> None:
+        path = bin_dir / name
+        path.write_text(f"#!/usr/bin/env bash\n{body}\n")
+        path.chmod(0o755)
+
+    stub(
+        "codespell",
+        f'echo codespell "$@" >> "{log_file}"\nexit 0',
+    )
+    for cmd in [
+        "flake8",
+        "isort",
+        "black",
+        "npm",
+        "pytest",
+        "bandit",
+        "safety",
+        "pyspelling",
+        "linkchecker",
+    ]:
+        stub(cmd)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+    env["SKIP_E2E"] = "1"
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=script.parent.parent,
+    )
+
+    assert result.returncode == 0
+    assert log_file.exists()
+    logged = log_file.read_text().strip()
+    assert logged.startswith("codespell ")
+    assert "--ignore-words" in logged


### PR DESCRIPTION
## Summary
- add codespell to the docs phase of scripts/checks.sh with repo-specific skips
- require codespell as a Python dependency for local environments
- add regression test ensuring the checks script invokes codespell

## Testing
- pre-commit run --all-files
- pytest -q
- npm run test:ci
- python -m flywheel.fit
- bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68dec011c460832fa7f46f5b86e8b183