### PR TITLE
feat: align viewer port with docs default

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ Run the bundled Flask app to explore the CAD models:
 python webapp/app.py
 ```
 
-Visit `http://localhost:42165` and watch the wheel spin in your browser.
+Visit `http://localhost:5000` (or the port set via ``FLYWHEEL_WEBAPP_PORT``)
+and watch the wheel spin in your browser.
 
 Alternatively, open `viewer/threejs.html` for a standalone Three.js demo that loads the STL parts and shows simple ball bearings.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,5 @@ services:
       context: .
       dockerfile: docker/Dockerfile
     ports:
-      - "42165:42165"
+      - "5000:5000"
     command: python webapp/app.py

--- a/docs/web-viewer.md
+++ b/docs/web-viewer.md
@@ -28,7 +28,11 @@ npm run playwright:install
 python webapp/app.py
 ```
 
-Visit [http://localhost:5000](http://localhost:5000) and select a model. Drag the mouse to rotate and scroll to zoom.
+The development server listens on port 5000 by default, matching Flask's
+standard quickstart URL. Set ``FLYWHEEL_WEBAPP_PORT`` to override it, for
+example ``FLYWHEEL_WEBAPP_PORT=8123 python webapp/app.py``. Visit
+[http://localhost:5000](http://localhost:5000) (or your chosen port) and select
+a model. Drag the mouse to rotate and scroll to zoom.
 
 ## Three.js Demo
 

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -16,4 +16,4 @@ spec:
         - name: flywheel
           image: ghcr.io/owner/flywheel:latest
           ports:
-            - containerPort: 42165
+            - containerPort: 5000

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -7,5 +7,5 @@ spec:
     app: flywheel
   ports:
     - port: 80
-      targetPort: 42165
+      targetPort: 5000
   type: ClusterIP

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,11 +3,11 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: 'tests/js',
   use: {
-    baseURL: 'http://localhost:42165',
+    baseURL: 'http://localhost:5000',
   },
   webServer: {
     command: 'python webapp/app.py',
-    port: 42165,
+    port: 5000,
     timeout: 120 * 1000,
     reuseExistingServer: !process.env.CI,
   },

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -226,7 +226,7 @@ def test_main_entry(monkeypatch):
 
     monkeypatch.setattr("flask.app.Flask.run", fake_run)
     runpy.run_module("webapp.app", run_name="__main__")
-    assert called.get("port") == 42165
+    assert called.get("port") == 5000
 
 
 def test_fit_module_main(monkeypatch):

--- a/tests/test_webapp_port.py
+++ b/tests/test_webapp_port.py
@@ -1,0 +1,27 @@
+import importlib
+
+import pytest
+
+from webapp import app as webapp_module
+
+
+@pytest.fixture(autouse=True)
+def _reset_webapp_module():
+    """Reload the webapp module between tests to avoid cached state."""
+    yield
+    importlib.reload(webapp_module)
+
+
+def test_resolve_port_defaults_to_documented_value(monkeypatch):
+    monkeypatch.delenv("FLYWHEEL_WEBAPP_PORT", raising=False)
+    assert webapp_module.resolve_port() == 5000
+
+
+def test_resolve_port_supports_env_override(monkeypatch):
+    monkeypatch.setenv("FLYWHEEL_WEBAPP_PORT", "8123")
+    assert webapp_module.resolve_port() == 8123
+
+
+def test_resolve_port_falls_back_on_invalid_input(monkeypatch):
+    monkeypatch.setenv("FLYWHEEL_WEBAPP_PORT", "not-a-number")
+    assert webapp_module.resolve_port() == 5000

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from flask import Flask, render_template, send_from_directory
@@ -7,6 +8,29 @@ app = Flask(__name__)
 
 MODEL_DIR = Path(__file__).resolve().parent / "static" / "models"
 SCAD_DIR = Path(__file__).resolve().parent.parent / "cad"
+
+DEFAULT_PORT = 5000
+PORT_ENV_VAR = "FLYWHEEL_WEBAPP_PORT"
+
+
+def resolve_port(default: int = DEFAULT_PORT) -> int:
+    """Return the port the development server should bind to.
+
+    The default matches the documented quickstart (`http://localhost:5000`).
+    Set ``FLYWHEEL_WEBAPP_PORT`` to override the port. Invalid values fall back
+    to ``default`` so a mistyped environment variable does not crash the app.
+    """
+
+    raw = os.environ.get(PORT_ENV_VAR)
+    if raw:
+        try:
+            port = int(raw)
+        except ValueError:
+            port = None
+        else:
+            if 0 < port < 65536:
+                return port
+    return default
 
 
 def ensure_obj_models():
@@ -89,7 +113,6 @@ def models(filename):
 
 
 if __name__ == "__main__":
-    # Hard-coded port chosen arbitrarily within the dynamic/private range.
-    port = 42165
+    port = resolve_port()
     print(f"Starting Flask development server on port {port}…")
     app.run(debug=True, port=port)


### PR DESCRIPTION
## Summary
- honor docs/web-viewer.md guidance that the Flask app runs on port 5000
- add resolve_port with FLYWHEEL_WEBAPP_PORT override and cover it with tests
- update automation configs (Playwright, docker, k8s) and docs for the new default

## Testing
- pre-commit run --all-files
- pytest -q
- npm run test:ci
- python -m flywheel.fit
- bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68e1b6369cdc832fb84fcf50deee1776