### PR TITLE
Remove DSPACE-specific quest generator from Flywheel

### DIFF
--- a/docs/dspace-integration.md
+++ b/docs/dspace-integration.md
@@ -5,21 +5,18 @@
 ## Why DSPACE Matters
 
 - Demonstrates offline-friendly patterns for storing quest data.
-- Provides a concrete target for the `quest-generator` script included here.
+- Provides a concrete target for Flywheel's generalized quest tooling.
 - Shares the same CI and documentation style as Flywheel for frictionless contributions.
 - Maintains a structured outage catalog under `/outages` so fixes propagate across repositories.
 
 ## Quick start
 
-Clone both repositories side by side and run the quest generator:
+Clone both repositories side by side to share prompts, automation patterns, and
+testing utilities. DSPACE maintains its own quest scaffolding scripts, so refer
+to that repository when you need to author new quests.
 
-```bash
-git clone https://github.com/democratizedspace/dspace
-# assuming flywheel lives next to it
-npm run generate-quest --prefix dspace
-```
-
-Future iterations will tighten the integration so quests can be drafted in Flywheel and consumed directly by DSPACE.
+Future iterations will focus on reusable quest infrastructure inside Flywheel
+rather than shipping DSPACE-specific generators here.
 
 ## Codex Automation
 

--- a/docs/quest-generator.md
+++ b/docs/quest-generator.md
@@ -1,3 +1,10 @@
 # Quest Generator
 
-Run `npm run generate-quest` to scaffold new quests in dspace.
+Flywheel previously tracked a quest generator CLI for DSPACE, but that
+automation now lives in the dedicated `democratizedspace/dspace` repository.
+This guide remains as a pointer so contributors know where to look when they
+need to scaffold new quests.
+
+Visit the DSPACE repository for up-to-date instructions and scripts that create
+quest templates. Flywheel will focus on generalized quest tooling rather than
+shipping game-specific generators here.


### PR DESCRIPTION
## Summary
- remove the DSPACE quest generator CLI and its tests from this repo
- update the DSPACE integration and quest generator docs to point to the
dedicated DSPACE repository

## Testing
- pre-commit run --all-files *(fails: command not found in container)*
- pytest -q
- npm run test:ci
- python -m flywheel.fit
- bash scripts/checks.sh *(bandit, safety, linkchecker unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b6369cdc832fb84fcf50deee1776