### PR TITLE
Add docs-lint table checker script and integrate into checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2025-10-08
+- feat: add `docs-lint` table consistency script and tests.
+
 ## 2025-10-07
 - feat: scale `verify_fit` tolerances with the custom `tol` parameter and
   document stricter checks.

--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -65,7 +65,7 @@ immediately actionable.
 
 - One-table-per-PR keeps reviews short and rollbacks easy.
 - Use the CI matrix to test on Node 18 LTS and the latest Node 20.
-- Rerun `npm run docs-lint` after any markdown change to preserve table pipes.
+- Rerun `npm run docs-lint` after any markdown change to preserve table pipes; it validates that each table row keeps the same pipe count.
 - Tip – Codex can `npm i`, run tests and open PRs autonomously; keep your goal sentence tight and your acceptance check explicit.
 
 ## Upgrade Prompt

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "lint": "echo skip",
     "format": "echo skip",
     "format:check": "echo skip",
+    "docs-lint": "node scripts/docs-lint.mjs",
     "jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "coverage": "npm run jest -- --coverage",
     "playwright": "playwright test",

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -48,6 +48,9 @@ pytest -q
 run_security_checks
 
 # docs checks
+if [ -f package.json ]; then
+  npm run docs-lint
+fi
 if command -v codespell >/dev/null 2>&1; then
   codespell \
     --ignore-words dict/allow.txt \

--- a/scripts/docs-lint.mjs
+++ b/scripts/docs-lint.mjs
@@ -1,0 +1,100 @@
+import { readdir, readFile } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+async function collectMarkdown(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'docs-site') {
+        continue;
+      }
+      files.push(...(await collectMarkdown(full)));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function countPipes(line) {
+  return (line.match(/\|/g) || []).length;
+}
+
+function lintLines(lines) {
+  const issues = [];
+  let fence = null;
+  let expectedPipes = null;
+  for (let idx = 0; idx < lines.length; idx += 1) {
+    const raw = lines[idx];
+    const trimmed = raw.trim();
+    if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
+      const marker = trimmed.slice(0, 3);
+      if (!fence) {
+        fence = marker;
+      } else if (trimmed.startsWith(fence)) {
+        fence = null;
+      }
+      continue;
+    }
+    if (fence) {
+      continue;
+    }
+    if (trimmed.startsWith('|')) {
+      const pipes = countPipes(raw);
+      if (expectedPipes === null) {
+        expectedPipes = pipes;
+      } else if (pipes !== expectedPipes) {
+        issues.push({
+          line: idx + 1,
+          message: `Expected ${expectedPipes} pipe characters but found ${pipes}.`,
+        });
+      }
+    } else {
+      expectedPipes = null;
+    }
+  }
+  return issues;
+}
+
+async function lintFile(file) {
+  const text = await readFile(file, 'utf8');
+  const lines = text.split(/\r?\n/);
+  return lintLines(lines).map((issue) => ({ ...issue, file }));
+}
+
+async function main() {
+  const targets = [path.join(ROOT, 'README.md')];
+  const docsDir = path.join(ROOT, 'docs');
+  targets.push(...(await collectMarkdown(docsDir)));
+  targets.sort();
+
+  const problems = [];
+  for (const file of targets) {
+    const issues = await lintFile(file);
+    problems.push(...issues);
+  }
+
+  if (problems.length > 0) {
+    console.error('Docs lint failed: inconsistent table pipes detected.');
+    for (const issue of problems) {
+      console.error(` - ${path.relative(ROOT, issue.file)}:${issue.line} ${issue.message}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log('Docs lint passed: table pipes look consistent.');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/tests/test_ci_script.test.mjs
+++ b/tests/test_ci_script.test.mjs
@@ -11,3 +11,9 @@ test('package.json includes test:ci script', async () => {
   const pkg = await loadPackage();
   expect(pkg.scripts['test:ci']).toBeDefined();
 });
+
+test('package.json provides docs-lint table check', async () => {
+  const pkg = await loadPackage();
+  expect(pkg.scripts['docs-lint']).toBeDefined();
+  expect(pkg.scripts['docs-lint']).toContain('scripts/docs-lint.mjs');
+});


### PR DESCRIPTION
## Summary
- add an npm `docs-lint` script that verifies Markdown table pipe counts to fulfill the guidance in docs/prompts/codex/automation.md
- wire the checker into scripts/checks.sh, document it in the changelog, and note the validation in the prompt docs
- cover the new script with a Jest test so the package manifest always exposes the command

## Testing
- pre-commit run --all-files
- pytest -q
- npm run test:ci
- python -m flywheel.fit
- bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68e3527c74f4832f8fafea5ed12916fe