### PR TITLE
🛡️ Mask short secret tokens in scan-secrets output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 2025-10-08
+- fix: mask short secrets when reporting scan-secrets findings.
 ## 2025-10-07
 - feat: scale `verify_fit` tolerances with the custom `tol` parameter and
   document stricter checks.

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -64,8 +64,13 @@ class Finding:
     @property
     def masked(self) -> str:
         token = self.match.strip()
-        if len(token) <= 8:
-            return token
+        length = len(token)
+        if length == 0:
+            return ""
+        if length <= 2:
+            return "…" * length
+        if length <= 8:
+            return f"{token[0]}…{token[-1]}"
         return f"{token[:4]}…{token[-4:]}"
 
 

--- a/tests/test_scan_secrets.py
+++ b/tests/test_scan_secrets.py
@@ -36,6 +36,18 @@ def test_detects_github_token():
     assert "…" in finding.masked
 
 
+def test_masks_short_token_without_leaking():
+    desc = "Potential token"
+    finding = scan_secrets.Finding("demo.txt", 1, "ghp_abcd", desc)
+    assert finding.masked == "g…d"
+    assert finding.masked != finding.match
+
+
+def test_masks_very_short_token():
+    finding = scan_secrets.Finding("demo.txt", 1, "sk", "Potential token")
+    assert finding.masked == "……"
+
+
 def test_ignores_removed_lines():
     removal = "ghp_" + "abcd" * 9
     diff = (


### PR DESCRIPTION
## Summary
- ensure `scripts/scan-secrets.py` masks short matches so it delivers on the doc note that "Matches are masked in the output" and avoid leaking secrets
- extend unit coverage with tests for short and very short tokens
- document the fix in `CHANGELOG.md`

## Testing
- pre-commit run --all-files
- pytest -q
- npm run test:ci
- python -m flywheel.fit
- bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68e3527c74f4832f8fafea5ed12916fe