### PR TITLE
✅ : – enforce prompt repo manifest parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## 2025-10-06
 - feat: detect mixed uv/pip installers and label workflows without installers as none.
+- test: enforce parity between `docs/repo_list.txt` and `dict/prompt-doc-repos.txt` for prompt propagation.
 
 ## 2025-10-03
 - feat: add CLI entry point for README related-project status updates

--- a/dict/prompt-doc-repos.txt
+++ b/dict/prompt-doc-repos.txt
@@ -9,4 +9,6 @@ futuroptimist/sigma
 futuroptimist/gitshelves
 futuroptimist/wove
 futuroptimist/sugarkube
+futuroptimist/pr-reaper
 futuroptimist/jobbot3000
+futuroptimist/danielsmith.io

--- a/docs/prompts/codex/ci-fix.md
+++ b/docs/prompts/codex/ci-fix.md
@@ -91,6 +91,8 @@ git diff --cached | ./scripts/scan-secrets.py
 ```
 
 Verify `dict/prompt-doc-repos.txt` matches `docs/repo_list.txt`.
+Flywheel now enforces this parity with an automated test, so keep both
+manifests aligned before committing.
 
 Run `npm --prefix docs-site run build` (or your docs generator) to ensure no broken links.
 

--- a/tests/test_repo_lists_alignment.py
+++ b/tests/test_repo_lists_alignment.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+def _read_repo_list(path: str) -> list[str]:
+    """Return non-empty, stripped entries from ``path``."""
+
+    lines = Path(path).read_text().splitlines()
+    return [line.strip() for line in lines if line.strip()]
+
+
+def test_prompt_repo_lists_match():
+    """Ensure prompt-doc and crawl repo manifests stay in sync."""
+
+    repo_list = _read_repo_list("docs/repo_list.txt")
+    prompt_repo_list = _read_repo_list("dict/prompt-doc-repos.txt")
+    assert (
+        repo_list == prompt_repo_list
+    ), "prompt repo manifest must match docs/repo_list.txt"


### PR DESCRIPTION
what: add regression test keeping prompt doc repo manifest synced
why: docs/prompts/codex/ci-fix.md promises repo_list parity
tests: pre-commit run --all-files; pytest -q; npm run lint
       npm run test:ci; python -m flywheel.fit; bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68e3527c74f4832f8fafea5ed12916fe