### PR TITLE
Add CLI prompt example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ or skip end-to-end tests by prefixing commands with `SKIP_E2E=1`.
 - Secret scanning helper `scripts/scan-secrets.py` that blocks common tokens in staged diffs
 - README status helper (`python -m src.repo_status`) that handles mixed-case workflow conclusions and validates attempt counts
 - Fast Python installs powered by [uv](https://github.com/astral-sh/uv)
-- Example code and templates
+- Example code and templates, including `examples/basic.py` for calling the CLI
+  programmatically
 - Python CLI with subcommands `init`, `update`, `audit`, `prompt`, `crawl`, and `runbook` that prompts interactively unless `--yes` is used
 - RepoCrawler detects installers like uv (including `uv pip install` usage), pipx, pip/pip3, and poetry in workflows
 - [AGENTS.md](AGENTS.md) detailing included LLM assistants

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Minimal example showing how to call the flywheel CLI from Python."""
+
+import io
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def generate_prompt(argv: Sequence[str] | None = None) -> str:
+    """Return the Codex automation prompt for the target repository."""
+
+    from flywheel.__main__ import build_parser
+
+    parser = build_parser()
+    cli_args = list(argv) if argv is not None else ["prompt", "."]
+    parsed = parser.parse_args(cli_args)
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        parsed.func(parsed)
+    return buffer.getvalue()
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Print the automation prompt for ``repo`` (defaults to repo root)."""
+
+    args = list(argv) if argv is not None else sys.argv[1:]
+    if args:
+        repo_path = Path(args[0]).resolve()
+    else:
+        repo_path = REPO_ROOT
+    prompt = generate_prompt(["prompt", str(repo_path)])
+    # ``prompt`` already ends with a newline; avoid double spacing when
+    # printing the result.
+    print(prompt, end="" if prompt.endswith("\n") else "\n")
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via tests
+    main()

--- a/tests/test_examples_basic.py
+++ b/tests/test_examples_basic.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_basic_example_script_outputs_prompt(tmp_path):
+    script = Path(__file__).resolve().parents[1] / "examples" / "basic.py"
+    assert script.exists(), "examples/basic.py is required by llms.txt"
+
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    output = result.stdout
+    assert "# Purpose" in output
+    assert "# Context" in output
+    assert "# Request" in output
+    assert output.strip(), "Script should emit non-empty prompt text"


### PR DESCRIPTION
## Summary
- add the CLI usage example promised in `llms.txt` by introducing `examples/basic.py`
- cover the script with an automated test and mention it in the README contents list

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `SKIP_E2E=1 npm run test:ci` *(output truncated by container log limits after Playwright warnings)*
- `python -m flywheel.fit`
- `SKIP_E2E=1 bash scripts/checks.sh` *(output truncated by container log limits during Jest console warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68e40c0c37bc832fb7a433a7203fa059