### PR TITLE
fix: treat missing trunk CI data as n/a

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Append `@branch` to any repo to crawl a non-default branch, e.g. `owner/name@dev
 Pass `--token YOURTOKEN` or set `GITHUB_TOKEN` to avoid API rate limits.
 Missing parent directories for the output path are created automatically.
 The `Update Repo Feature Summary` workflow runs nightly and after each merge, committing `docs/repo-feature-summary.md` to `main` so the table stays fresh.
-The summary records the short SHA of the latest commit, the name of each repository's default branch, and whether the latest commit passed CI on that branch.
+The summary records the short SHA of the latest commit, the name of each repository's default branch, and whether the latest commit passed CI on that branch. If CI metadata is unavailable—because workflows are still running or the GitHub API denies access—the Trunk column shows `n/a` instead of marking the build as failed.
 
 ### Auditing dev tooling
 

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -367,16 +367,16 @@ class RepoCrawler:
                 timeout=10,
             )
         except RequestException:
-            return False
+            return None
 
         # ----- New, more robust evaluation ---------------------------------
         if resp.status_code != 200:
-            return False
+            return None
 
         try:
             body = resp.json()
         except Exception:
-            return False
+            return None
 
         state = (body.get("state") or "").lower()
         # 1. Fast-path: combined status already success

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -708,7 +708,7 @@ def test_branch_green_status_bad_json():
         }
     )
     crawler = RepoCrawler([], session=sess)
-    assert crawler._branch_green("demo/repo", "main", "bad") is False
+    assert crawler._branch_green("demo/repo", "main", "bad") is None
 
 
 def test_branch_green_status_non_200():
@@ -719,7 +719,7 @@ def test_branch_green_status_non_200():
         }
     )
     crawler = RepoCrawler([], session=sess)
-    assert crawler._branch_green("demo/repo", "main", "miss") is False
+    assert crawler._branch_green("demo/repo", "main", "miss") is None
 
 
 def test_branch_green_request_exception():
@@ -731,7 +731,7 @@ def test_branch_green_request_exception():
             raise requests.RequestException("boom")
 
     crawler = RepoCrawler([], session=ErrSession())
-    assert crawler._branch_green("demo/repo", "main", "dead") is False
+    assert crawler._branch_green("demo/repo", "main", "dead") is None
 
 
 def test_branch_green_no_sha():


### PR DESCRIPTION
## Summary
- return `None` from `_branch_green` when CI APIs error so crawl summary reports `n/a`
- cover missing-status scenarios in branch detection tests and adjust existing expectations
- document that the README promise about the Trunk column now handles API denials gracefully

## Testing
- pre-commit run --all-files
- pytest -q
- npm run test:ci
- python -m flywheel.fit
- bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68e4c434ec64832f8bc2b07d5908f9fd