### PR TITLE
Fix update_repo_feature_summary CLI path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## 2025-10-09
 - fix: mark repo summary trunk status as n/a when CI is pending or missing.
+- fix: allow the repo feature summary CLI to run directly by ensuring the flywheel package is on
+  `sys.path`.
 
 ## 2025-10-08
 - fix: mask short secrets when reporting scan-secrets findings.

--- a/scripts/update_repo_feature_summary.py
+++ b/scripts/update_repo_feature_summary.py
@@ -4,13 +4,18 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from datetime import date
 from pathlib import Path
 from typing import List
 
 from tabulate import tabulate
 
-from flywheel.repocrawler import RepoCrawler
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from flywheel.repocrawler import RepoCrawler  # noqa: E402
 
 
 def load_repos(path: Path) -> List[str]:

--- a/tests/test_update_repo_feature_summary.py
+++ b/tests/test_update_repo_feature_summary.py
@@ -1,5 +1,7 @@
 import importlib
+import runpy
 import sys
+from pathlib import Path
 
 from flywheel.repocrawler import RepoInfo
 
@@ -61,3 +63,79 @@ def test_repo_feature_summary_has_pattern_table(monkeypatch, tmp_path):
     assert "## Dark & Bright Pattern Scan" in content
     assert "Dark Patterns" in content and "Bright Patterns" in content
     assert "Dark Patterns counts potential UX anti-patterns" in content
+
+
+def test_update_repo_feature_summary_cli_execution(monkeypatch, tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    stripped_path = list(
+        filter(
+            lambda entry: Path(entry).resolve() != root,
+            sys.path,
+        )
+    )
+    monkeypatch.setattr(sys, "path", stripped_path)
+    for name in [
+        "flywheel",
+        "flywheel.repocrawler",
+        "scripts.update_repo_feature_summary",
+    ]:
+        sys.modules.pop(name, None)
+
+    namespace = runpy.run_path(
+        str(root / "scripts" / "update_repo_feature_summary.py"),
+        run_name="not_main",
+    )
+
+    class DummyInfo:
+        def __init__(self):
+            self.name = "owner/repo"
+            self.branch = "main"
+            self.coverage = "100%"
+            self.patch_percent = 95.0
+            self.uses_codecov = True
+            self.has_license = True
+            self.has_ci = True
+            self.has_agents = True
+            self.has_coc = True
+            self.has_contributing = True
+            self.has_precommit = True
+            self.installer = "uv"
+            self.latest_commit = "deadbee"
+            self.workflow_count = 3
+            self.trunk_green = True
+            self.stars = 5
+            self.open_issues = 1
+            self.commit_date = "2024-01-01"
+            self.dark_pattern_count = 0
+            self.bright_pattern_count = 1
+
+    class DummyCrawler:
+        def __init__(self, repos, token=None):
+            self.repos = list(repos)
+
+        def crawl(self):
+            return [DummyInfo()]
+
+    namespace["RepoCrawler"] = DummyCrawler
+
+    repo_file = tmp_path / "repos.txt"
+    repo_file.write_text("owner/repo\n")
+    out_path = tmp_path / "summary.md"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "update_repo_feature_summary.py",
+            "--repos-from",
+            str(repo_file),
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    namespace["main"]()
+
+    assert out_path.exists()
+    content = out_path.read_text()
+    assert "Dark Patterns" in content


### PR DESCRIPTION
what: ensure update_repo_feature_summary extends sys.path, add CLI
regression test, and document the fix in CHANGELOG.md.
why: docs/dark-patterns.md documents running the script directly but it
crashed with ModuleNotFoundError; this unblocks that workflow.
how to test: pre-commit run --all-files && pytest -q && CI=1 npm run
test:ci && python -m flywheel.fit && bash scripts/checks.sh
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68e4c434ec64832f8bc2b07d5908f9fd