### PR TITLE
Align linkchecker invocation with prompt docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ bash scripts/checks.sh
 If browser dependencies are missing, run `npm run playwright:install`
 or skip end-to-end tests by prefixing commands with `SKIP_E2E=1`.
 
+The link-checking step runs `linkchecker --no-warnings README.md docs/` to
+surface broken links without flooding CI logs with informational warnings.
+
 ## Contents
 
 - CI workflows for linting, tests, and docs

--- a/docs/flywheel-npx-spin-design.md
+++ b/docs/flywheel-npx-spin-design.md
@@ -331,4 +331,3 @@ impacted files, diff preview, dependencies, and confidence score between 0 and 1
 - Time taken from command start to completion? (minutes)
 - Preferred LLM provider? (token.place/OpenAI/Anthropic/Other)
 - Feature requests or pain points?
-

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -63,4 +63,4 @@ fi
 if command -v pyspelling >/dev/null 2>&1 && [ -f .spellcheck.yaml ]; then
   pyspelling -c .spellcheck.yaml || true
 fi
-linkchecker README.md docs/ || true
+linkchecker --no-warnings README.md docs/ || true

--- a/tests/test_checks_script.py
+++ b/tests/test_checks_script.py
@@ -35,6 +35,13 @@ def test_checks_script_runs_codespell(tmp_path):
         "codespell",
         f'echo codespell "$@" >> "{log_file}"\nexit 0',
     )
+    link_log = tmp_path / "linkchecker.log"
+
+    stub(
+        "linkchecker",
+        f'echo linkchecker "$@" >> "{link_log}"\nexit 0',
+    )
+
     for cmd in [
         "flake8",
         "isort",
@@ -44,7 +51,6 @@ def test_checks_script_runs_codespell(tmp_path):
         "bandit",
         "safety",
         "pyspelling",
-        "linkchecker",
     ]:
         stub(cmd)
 
@@ -65,3 +71,8 @@ def test_checks_script_runs_codespell(tmp_path):
     logged = log_file.read_text().strip()
     assert logged.startswith("codespell ")
     assert "--ignore-words" in logged
+
+    assert link_log.exists()
+    link_logged = link_log.read_text().strip()
+    assert link_logged.startswith("linkchecker ")
+    assert "--no-warnings" in link_logged


### PR DESCRIPTION
## Summary
- call `linkchecker --no-warnings` from `scripts/checks.sh` so it matches the instructions in `docs/prompts/codex/merge-conflicts.md`
- extend the checks script test to assert the new linkchecker arguments and log capture
- document the new behavior in the README and let pre-commit normalize the design doc EOF

## Testing
- pre-commit run --all-files
- pytest -q
- npm run test:ci
- python -m flywheel.fit
- bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68e55f19bdf0832f8b6551fda5843128