### PR TITLE
Treat RepoCrawler CI status API errors as failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## 2025-10-10
 - feat: prompt before injecting dev tooling in `flywheel update` and document
   the `--yes` flag.
+- fix: treat CI status API errors as failures when computing repo summary trunk
+  status.
 ## 2025-10-09
 - fix: mark repo summary trunk status as n/a when CI is pending or missing.
 - fix: allow the repo feature summary CLI to run directly by ensuring the flywheel package is on

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Duplicates are removed automatically so each repository is crawled once.
 Pass `--token YOURTOKEN` or set `GITHUB_TOKEN` to avoid API rate limits.
 Missing parent directories for the output path are created automatically.
 The `Update Repo Feature Summary` workflow runs nightly and after each merge, committing `docs/repo-feature-summary.md` to `main` so the table stays fresh.
-The summary records the short SHA of the latest commit, the name of each repository's default branch, and whether the latest commit passed CI on that branch. If CI metadata is unavailable—because workflows are still running or the GitHub API denies access—the Trunk column shows `n/a` instead of marking the build as failed.
+The summary records the short SHA of the latest commit, the name of each repository's default branch, and whether the latest commit passed CI on that branch. If CI metadata is unavailable because workflows are still running, the Trunk column shows `n/a`. API errors are treated as failures so flaky endpoints surface as `❌` instead of disappearing into the unknown state.
 
 ### Auditing dev tooling
 

--- a/docs/flywheel-npx-spin-design.md
+++ b/docs/flywheel-npx-spin-design.md
@@ -331,4 +331,3 @@ impacted files, diff preview, dependencies, and confidence score between 0 and 1
 - Time taken from command start to completion? (minutes)
 - Preferred LLM provider? (token.place/OpenAI/Anthropic/Other)
 - Feature requests or pain points?
-

--- a/flywheel/repocrawler.py
+++ b/flywheel/repocrawler.py
@@ -367,16 +367,16 @@ class RepoCrawler:
                 timeout=10,
             )
         except RequestException:
-            return None
+            return False
 
         # ----- New, more robust evaluation ---------------------------------
         if resp.status_code != 200:
-            return None
+            return False
 
         try:
             body = resp.json()
         except Exception:
-            return None
+            return False
 
         state = (body.get("state") or "").lower()
         # 1. Fast-path: combined status already success

--- a/tests/test_branch_detection.py
+++ b/tests/test_branch_detection.py
@@ -88,4 +88,4 @@ class DummyMissingStatuses:
 
 def test_branch_green_missing_status_returns_none():
     crawler = RepoCrawler([], session=DummyMissingStatuses())
-    assert crawler._branch_green("demo/repo", "main", "abcdef0") is None
+    assert crawler._branch_green("demo/repo", "main", "abcdef0") is False

--- a/tests/test_repocrawler_extra.py
+++ b/tests/test_repocrawler_extra.py
@@ -708,7 +708,7 @@ def test_branch_green_status_bad_json():
         }
     )
     crawler = RepoCrawler([], session=sess)
-    assert crawler._branch_green("demo/repo", "main", "bad") is None
+    assert crawler._branch_green("demo/repo", "main", "bad") is False
 
 
 def test_branch_green_status_non_200():
@@ -719,7 +719,7 @@ def test_branch_green_status_non_200():
         }
     )
     crawler = RepoCrawler([], session=sess)
-    assert crawler._branch_green("demo/repo", "main", "miss") is None
+    assert crawler._branch_green("demo/repo", "main", "miss") is False
 
 
 def test_branch_green_request_exception():
@@ -731,7 +731,7 @@ def test_branch_green_request_exception():
             raise requests.RequestException("boom")
 
     crawler = RepoCrawler([], session=ErrSession())
-    assert crawler._branch_green("demo/repo", "main", "dead") is None
+    assert crawler._branch_green("demo/repo", "main", "dead") is False
 
 
 def test_branch_green_no_sha():


### PR DESCRIPTION
## Summary
- treat CI status API failures as trunk failures per docs/patch-plan.md and update README/CHANGELOG
- expand RepoCrawler tests to expect failures on status API errors and bad responses

## Testing
- pre-commit run --all-files (run-checks hook skipped; ran bash scripts/checks.sh separately)
- pytest -q
- npm run test:ci
- python -m flywheel.fit
- bash scripts/checks.sh


------
https://chatgpt.com/codex/tasks/task_e_68e55f19bdf0832f8b6551fda5843128