### PR TITLE
🧰 chore: add reusable Bash tag helper dotfile template

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ contributor.
 | `scripts/` | Shell and Node helpers, including `checks.sh` and docs linters. |
 | `tests/` | Unit and integration tests for Python and JavaScript modules. |
 | `examples/` | Minimal examples for using the CLI programmatically. |
-| `templates/` | Starter files copied into newly bootstrapped repos. |
+| `templates/` | Starter files copied into newly bootstrapped repos (including `templates/dotfiles/` shell helpers). |
 | `viewer/` | 3D assembly viewer assets built with Three.js. |
 | `cad/` | OpenSCAD source files for printable parts. |
 | `stl/` | Generated models kept in sync with `cad/`. |

--- a/docs/local-environments.md
+++ b/docs/local-environments.md
@@ -16,3 +16,9 @@ The script creates a `.local` folder with two starter files:
 If `.gitignore` is missing the entry, the script appends `.local/` so anything you add stays out of version control. You can extend these files for other projects without affecting the shared repository.
 
 This keeps personal energy flowing into your workflow without leaking private information.
+
+## Reusable shell helpers
+
+If you want versioned Bash helpers, copy or source `templates/dotfiles/.bashrc` from this repo in your local shell config (for example, from `~/.bashrc`).
+
+Flywheel does not install this template automatically yet, so choose the approach that fits your local environment.

--- a/templates/dotfiles/.bashrc
+++ b/templates/dotfiles/.bashrc
@@ -1,0 +1,22 @@
+rmtag() {
+  local tag="$1"
+  if [[ -z "$tag" ]]; then
+    echo "usage: rmtag <tag-name>"
+    return 1
+  fi
+
+  git tag -d "$tag" &&
+  git push origin --delete "$tag"
+}
+
+retag() {
+  local tag="$1"
+  if [[ -z "$tag" ]]; then
+    echo "usage: retag <tag-name>"
+    return 1
+  fi
+
+  rmtag "$tag" &&
+  git tag "$tag" &&
+  git push origin "$tag"
+}


### PR DESCRIPTION
### Motivation
- Provide a versioned, shareable Bash dotfile template so simple Git tag helpers can be copied into future environments and repos. 
- Keep personal overrides in `.local/` while committing shareable helpers under `templates/dotfiles/` so they remain discoverable and versioned. 

### Description
- Add `templates/dotfiles/.bashrc` containing `rmtag` and `retag` functions that validate `$1`, print `usage: ...` and return non-zero when missing, use `local tag="$1"`, have `retag` call `rmtag "$tag"`, and use `git push origin --delete "$tag"` for remote deletion. 
- Update the repo map in `README.md` to mention `templates/dotfiles/` so the template is discoverable. 
- Append a concise `## Reusable shell helpers` section to `docs/local-environments.md` explaining how to copy or source `templates/dotfiles/.bashrc` locally and noting no automatic installation is provided. 
- Keep the change minimal and focused to the three files: `templates/dotfiles/.bashrc`, `README.md`, and `docs/local-environments.md`. 

### Testing
- Ran `sed -n '1,160p' templates/dotfiles/.bashrc` to sanity-check the new file and it printed the new functions successfully. 
- Ran `grep -R "templates/dotfiles" -n README.md docs/local-environments.md` to confirm the docs reference and it returned the updated lines. 
- Ran `git diff --cached | ./scripts/scan-secrets.py` which reported `No secrets detected`. 
- Attempted `pre-commit run --files README.md docs/local-environments.md templates/dotfiles/.bashrc || true` but `pre-commit` is not installed in this environment so hooks were not executed (warning reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9e132f518832f91d6c93e25488b3c)