### PR TITLE
Add versioned Bash tag helper template under templates/dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ contributor.
 | `tests/` | Unit and integration tests for Python and JavaScript modules. |
 | `examples/` | Minimal examples for using the CLI programmatically. |
 | `templates/` | Starter files copied into newly bootstrapped repos. |
+| `templates/dotfiles/` | Reusable shell helpers (for example `.bashrc` tag functions). |
 | `viewer/` | 3D assembly viewer assets built with Three.js. |
 | `cad/` | OpenSCAD source files for printable parts. |
 | `stl/` | Generated models kept in sync with `cad/`. |

--- a/docs/local-environments.md
+++ b/docs/local-environments.md
@@ -16,3 +16,16 @@ The script creates a `.local` folder with two starter files:
 If `.gitignore` is missing the entry, the script appends `.local/` so anything you add stays out of version control. You can extend these files for other projects without affecting the shared repository.
 
 This keeps personal energy flowing into your workflow without leaking private information.
+
+## Reusable dotfile helpers
+
+For shared shell helpers that should stay versioned, use `templates/dotfiles/.bashrc`.
+You can either copy the functions into your `~/.bashrc` (or repo-local Bash config) or
+source the template directly from your shell startup file:
+
+```bash
+source /path/to/repo/templates/dotfiles/.bashrc
+```
+
+Flywheel does not install this template automatically yet, so choose the approach
+that best fits your local setup.

--- a/templates/dotfiles/.bashrc
+++ b/templates/dotfiles/.bashrc
@@ -1,0 +1,22 @@
+rmtag() {
+  local tag="$1"
+  if [[ -z "$tag" ]]; then
+    echo "usage: rmtag <tag-name>"
+    return 1
+  fi
+
+  git tag -d "$tag" &&
+  git push origin --delete "$tag"
+}
+
+retag() {
+  local tag="$1"
+  if [[ -z "$tag" ]]; then
+    echo "usage: retag <tag-name>"
+    return 1
+  fi
+
+  rmtag "$tag" &&
+  git tag "$tag" &&
+  git push origin "$tag"
+}


### PR DESCRIPTION
### Motivation

- Provide a small, versioned, reusable Bash dotfiles template containing two Git tag helper functions so shell helpers can be copied into future environments and repos without living in a personal `.local/` folder.
- Keep the change minimal and focused on a versioned template rather than adding installation automation or cross-shell support. 

### Description

- Add `templates/dotfiles/.bashrc` with two functions: `rmtag` and `retag`, where both validate the argument, print `usage: ...` and return non-zero on missing input, use `local tag="$1"`, and `retag` delegates to `rmtag` rather than duplicating delete logic; remote deletion uses `git push origin --delete "$tag"` for clarity. 
- Update the README repo map to list `templates/dotfiles/` so the new template location is discoverable. 
- Add a concise `## Reusable dotfile helpers` section to `docs/local-environments.md` explaining that users can copy or `source` `templates/dotfiles/.bashrc` into their local shell config and that no automatic installation is provided yet. 

### Testing

- Ran `sed -n '1,160p' templates/dotfiles/.bashrc` to sanity-check the new file contents and it displayed the expected functions. 
- Ran `grep -R "templates/dotfiles" -n README.md docs/local-environments.md` to confirm docs mention the template and it returned matches. 
- Ran `pre-commit run --files README.md docs/local-environments.md templates/dotfiles/.bashrc || true` which did not execute hooks in this environment because `pre-commit` is not installed (environment warning). 
- Ran `git diff --cached | ./scripts/scan-secrets.py` to scan staged changes for secrets and it reported no secrets detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9e132f518832f91d6c93e25488b3c)