### PR TITLE
Add versioned Bash tag-helper template (rmtag / retag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ contributor.
 | `tests/` | Unit and integration tests for Python and JavaScript modules. |
 | `examples/` | Minimal examples for using the CLI programmatically. |
 | `templates/` | Starter files copied into newly bootstrapped repos. |
+| `templates/dotfiles/` | Versioned shell helper snippets (for example, reusable Bash tag helpers). |
 | `viewer/` | 3D assembly viewer assets built with Three.js. |
 | `cad/` | OpenSCAD source files for printable parts. |
 | `stl/` | Generated models kept in sync with `cad/`. |

--- a/docs/local-environments.md
+++ b/docs/local-environments.md
@@ -16,3 +16,12 @@ The script creates a `.local` folder with two starter files:
 If `.gitignore` is missing the entry, the script appends `.local/` so anything you add stays out of version control. You can extend these files for other projects without affecting the shared repository.
 
 This keeps personal energy flowing into your workflow without leaking private information.
+
+## Reusable Bash helpers
+
+Flywheel also ships a versioned Bash template at `templates/dotfiles/.bashrc` for reusable shell helpers.
+
+- Copy the functions into your personal `~/.bashrc`, or
+- Source the template directly from your local clone.
+
+No automatic install/copy step exists yet; choose the approach that fits your local workflow.

--- a/templates/dotfiles/.bashrc
+++ b/templates/dotfiles/.bashrc
@@ -1,0 +1,22 @@
+rmtag() {
+  local tag="$1"
+  if [[ -z "$tag" ]]; then
+    echo "usage: rmtag <tag-name>"
+    return 1
+  fi
+
+  git tag -d "$tag" &&
+  git push origin --delete "$tag"
+}
+
+retag() {
+  local tag="$1"
+  if [[ -z "$tag" ]]; then
+    echo "usage: retag <tag-name>"
+    return 1
+  fi
+
+  rmtag "$tag" &&
+  git tag "$tag" &&
+  git push origin "$tag"
+}


### PR DESCRIPTION
### Motivation
- Provide a small, versioned, shareable Bash snippet that captures common Git tag helpers so they can be copied into future environments or repos. 
- Make the helpers discoverable in repository documentation without adding installation automation or cross-shell support. 
- Keep the change minimal and focused on reusable dotfiles templates and documentation only.

### Description
- Add `templates/dotfiles/.bashrc` containing `rmtag` and `retag` Bash functions with argument validation, `usage:` messages, and `local tag="$1"` usage. 
- Implement remote deletion with `git push origin --delete "$tag"` for clarity, and make `retag` call `rmtag "$tag"` rather than duplicating deletion logic. 
- Update the README repo map to list `templates/dotfiles/` so the template is discoverable. 
- Add a short `## Reusable Bash helpers` section to `docs/local-environments.md` explaining how to copy or source `templates/dotfiles/.bashrc` and explicitly noting that no automatic install/copy step exists yet.

### Testing
- Sanity-checked the new template file contents with `sed -n '1,160p' templates/dotfiles/.bashrc` and confirmed the functions are present. 
- Verified documentation references with `grep -R "templates/dotfiles" -n README.md docs/local-environments.md` which found the new entries. 
- Ran the repo secret scanner with `git diff --cached | ./scripts/scan-secrets.py` which reported no secrets. 
- Attempted `pre-commit run --files README.md docs/local-environments.md templates/dotfiles/.bashrc || true` but the environment lacked the `pre-commit` binary, so hooks were not executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9e132f518832f91d6c93e25488b3c)