### PR TITLE
Add reusable Git shell helpers (rmtag, retag, pokeci)

### DIFF
--- a/docs/local-environments.md
+++ b/docs/local-environments.md
@@ -17,10 +17,28 @@ If `.gitignore` is missing the entry, the script appends `.local/` so anything y
 
 This keeps personal energy flowing into your workflow without leaking private information.
 
-## Reusing Bash tag helpers
+## Reusing Git shell helpers
 
-Flywheel also keeps reusable shell snippets in `templates/dotfiles/`.
-To use the tag helpers, copy `templates/dotfiles/.bashrc` into your local
-shell config or source it from `~/.bashrc`. Flywheel does not install this
-template automatically yet. The helpers accept an optional remote name and
-default to `origin` (`rmtag <tag> [remote]`, `retag <tag> [remote]`).
+Flywheel keeps reusable, repo-versioned shell snippets in
+`templates/dotfiles/.bashrc`. This template is the canonical place for common
+Git shell helpers that can be copied into a local shell config or sourced from
+a checkout of the repository:
+
+```bash
+source /path/to/flywheel/templates/dotfiles/.bashrc
+```
+
+The helpers accept an optional remote name and default to `origin`:
+
+```bash
+rmtag <tag> [remote]
+retag <tag> [remote]
+pokeci <branch-name> [remote]
+```
+
+Use `rmtag` to remove a tag locally and remotely when it exists, and `retag` to
+replace a tag at the current `HEAD` before pushing it. Use `pokeci` to create an
+empty `poke CI` commit on a remote branch. `pokeci` fetches the selected remote
+branch into a temporary detached worktree, commits there, pushes back to the
+same remote branch, and removes the temporary worktree afterward, so it does not
+switch your current checkout or disturb local changes.

--- a/templates/dotfiles/.bashrc
+++ b/templates/dotfiles/.bashrc
@@ -56,15 +56,21 @@ pokeci() {
     return 1
   fi
 
-  local repo_root tmpdir exit_code
+  local repo_root tmpdir exit_code poke_commit
   repo_root="$(git rev-parse --show-toplevel)" || return 1
+
+  if ! git -C "$repo_root" ls-remote --exit-code --heads "$remote" "${branch}" >/dev/null; then
+    echo "pokeci: remote branch '$branch' not found on '$remote'"
+    return 1
+  fi
+
   tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/pokeci.XXXXXX")" || return 1
 
-  git -C "$repo_root" ls-remote --exit-code --heads "$remote" "${branch}" >/dev/null 2>&1 &&
-  git -C "$repo_root" fetch --prune "$remote" "+refs/heads/${branch}:refs/remotes/${remote}/${branch}" &&
+  git -C "$repo_root" fetch "$remote" "+refs/heads/${branch}:refs/remotes/${remote}/${branch}" &&
   git -C "$repo_root" worktree add --detach "$tmpdir" "refs/remotes/${remote}/${branch}" &&
   git -C "$tmpdir" commit --allow-empty -m "poke CI" &&
-  git -C "$tmpdir" push "$remote" "HEAD:refs/heads/${branch}"
+  poke_commit="$(git -C "$tmpdir" rev-parse HEAD)" &&
+  git -C "$repo_root" push "$remote" "${poke_commit}:refs/heads/${branch}"
 
   exit_code=$?
 

--- a/templates/dotfiles/.bashrc
+++ b/templates/dotfiles/.bashrc
@@ -1,10 +1,11 @@
-# templates/dotfiles/.bashrc — Reusable Git tag helpers.
-# Source this file from your ~/.bashrc:
+# Reusable Git helpers.
+# Copy this file into your local shell config or source it from your shell rc file:
 #   source /path/to/flywheel/templates/dotfiles/.bashrc
 
 rmtag() {
   local tag="$1"
   local remote="${2:-origin}"
+
   if [[ -z "$tag" ]]; then
     echo "usage: rmtag <tag-name> [remote]"
     return 1
@@ -22,6 +23,7 @@ rmtag() {
 retag() {
   local tag="$1"
   local remote="${2:-origin}"
+
   if [[ -z "$tag" ]]; then
     echo "usage: retag <tag-name> [remote]"
     return 1
@@ -30,7 +32,43 @@ retag() {
   rmtag "$tag" "$remote" || return 1
   git tag "$tag" || return 1
   git push "$remote" "$tag" || {
-    echo "retag: local tag '$tag' created but push failed — run: git push $remote $tag"
+    echo "retag: local tag '$tag' created but push failed; run: git push $remote $tag"
     return 1
   }
+}
+
+pokeci() {
+  local branch="$1"
+  local remote="${2:-origin}"
+
+  if [[ -z "$branch" ]]; then
+    echo "usage: pokeci <branch-name> [remote]"
+    return 1
+  fi
+
+  if ! git check-ref-format --branch "$branch" >/dev/null 2>&1; then
+    echo "pokeci: invalid branch name: $branch"
+    return 1
+  fi
+
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "pokeci: not inside a git repository"
+    return 1
+  fi
+
+  local repo_root tmpdir exit_code
+  repo_root="$(git rev-parse --show-toplevel)" || return 1
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/pokeci.XXXXXX")" || return 1
+
+  git -C "$repo_root" ls-remote --exit-code --heads "$remote" "${branch}" >/dev/null 2>&1 &&
+  git -C "$repo_root" fetch --prune "$remote" "+refs/heads/${branch}:refs/remotes/${remote}/${branch}" &&
+  git -C "$repo_root" worktree add --detach "$tmpdir" "refs/remotes/${remote}/${branch}" &&
+  git -C "$tmpdir" commit --allow-empty -m "poke CI" &&
+  git -C "$tmpdir" push "$remote" "HEAD:refs/heads/${branch}"
+
+  exit_code=$?
+
+  git -C "$repo_root" worktree remove --force "$tmpdir" >/dev/null 2>&1 || rm -rf "$tmpdir"
+
+  return "$exit_code"
 }

--- a/templates/dotfiles/.bashrc
+++ b/templates/dotfiles/.bashrc
@@ -56,12 +56,20 @@ pokeci() {
     return 1
   fi
 
-  local repo_root tmpdir exit_code poke_commit
+  local repo_root tmpdir exit_code poke_commit ls_remote_exit_code
   repo_root="$(git rev-parse --show-toplevel)" || return 1
 
-  if ! git -C "$repo_root" ls-remote --exit-code --heads "$remote" "${branch}" >/dev/null; then
+  git -C "$repo_root" ls-remote --exit-code --heads "$remote" "${branch}" >/dev/null
+  ls_remote_exit_code=$?
+
+  if [[ "$ls_remote_exit_code" -eq 2 ]]; then
     echo "pokeci: remote branch '$branch' not found on '$remote'"
     return 1
+  fi
+
+  if [[ "$ls_remote_exit_code" -ne 0 ]]; then
+    echo "pokeci: failed to query remote '$remote' for branch '$branch'"
+    return "$ls_remote_exit_code"
   fi
 
   tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/pokeci.XXXXXX")" || return 1


### PR DESCRIPTION
### Motivation
- Provide a small, repo-versioned shell helper template for common Git maintenance tasks (tag replacement and CI pokes) that can be safely copied into a local shell config or sourced from a checkout.
- Ensure the helpers are safe for both `bash` and `zsh`, do not touch the caller's working tree, and do not rely on local machine paths or branch names.

### Description
- Added `templates/dotfiles/.bashrc` containing `rmtag`, `retag`, and `pokeci` helpers that default `remote` to `origin` and validate inputs. 
- Implemented `rmtag` to delete the local tag only if it exists and the remote tag only if it exists, and implemented `retag` to call `rmtag`, recreate the tag at `HEAD`, and push it. 
- Implemented `pokeci` to validate the branch name, verify the remote branch exists, fetch it, create a temporary detached worktree, create an empty `poke CI` commit, push it back to the remote branch, and clean up the temporary worktree without switching the caller's branch. 
- Updated `docs/local-environments.md` to document the template as the canonical repo-versioned location and added concise usage examples (`rmtag`, `retag`, `pokeci`) and behavior notes about the temporary worktree.

### Testing
- `bash -n templates/dotfiles/.bashrc` succeeded (syntax check passed).
- `zsh -n templates/dotfiles/.bashrc` (run when `zsh` is available) succeeded (syntax check passed).
- `grep -n "rmtag\|retag\|pokeci" templates/dotfiles/.bashrc docs/local-environments.md` confirmed the helpers are present in both the template and docs.
- `git diff --check` and `git diff | ./scripts/scan-secrets.py` reported no issues and no secrets detected.
- `bash scripts/checks.sh` was run but failed due to existing Black/formatting differences in unrelated files that would be reformatted (`tests/test_patch_coverage.py`, `tests/test_prompt_docs_todos_sorting.py`, `tests/test_runbook_cli.py`, `flywheel/__main__.py`); these are pre-existing and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b7dcb750c832f86002f9bafc37e92)