### PR TITLE
fix: update Trivy action reference

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
           push: false
           load: true
       - name: Scan with Trivy
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           image-ref: ghcr.io/${{ github.repository }}:${{ github.sha }}
       - name: Push image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
           push: false
           load: true
       - name: Scan with Trivy
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ghcr.io/${{ github.repository }}:${{ github.sha }}
       - name: Push image


### PR DESCRIPTION
### Motivation
- The Docker workflow was failing because GitHub Actions could not resolve `aquasecurity/trivy-action@0.20.0`, preventing jobs from starting.

### Description
- Update `.github/workflows/docker.yml` to use the valid tag `aquasecurity/trivy-action@v0.36.0` and add `.github/dependabot.yml` coverage for `github-actions` with a weekly schedule to keep action pins current.

### Testing
- Ran `git ls-remote --exit-code --tags https://github.com/aquasecurity/trivy-action.git refs/tags/v0.36.0` and it returned the tag (succeeded). 
- Validated YAML by running `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/docker.yml .github/dependabot.yml` (succeeded). 
- Scanned diffs for secrets with `git diff | ./scripts/scan-secrets.py` which reported no secrets (succeeded). 
- Attempted `pre-commit run --files .github/workflows/docker.yml .github/dependabot.yml` but `pre-commit` is not installed in this environment (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e0b5e2228832f9fc43ea2a36821d2)