### PR TITLE
Clarify final merge-check response categories

### DIFF
--- a/docs/prompts/llm/pr-final-merge-check.md
+++ b/docs/prompts/llm/pr-final-merge-check.md
@@ -32,10 +32,10 @@ A concern is addressed only if at least one of these is clearly true:
 - The comment is purely non-blocking praise, bookkeeping, duplication, or a low-value nit that does not affect merge readiness.
 
 Decision rule:
-Respond with exactly one of these three mutually exclusive categories. Precedence is category 2 > category 3 > category 1:
-- Highest priority, category 2: if code, tests, configuration, generated artifacts, documentation in the repository, or any other repository changes are still needed for merge readiness, return category 2. If the PR description also needs work, defer that assessment until those repository changes are complete and this merge check is rerun; do not create a hybrid response.
-- Next priority, category 3: otherwise, if the PR is technically merge-ready but its description is materially inaccurate, incomplete, stale, misleading, or missing information necessary for a responsible merge record, return category 3.
-- Final fallback, category 1: otherwise, return category 1.
+Respond with exactly one of these three mutually exclusive categories, evaluated in this order:
+- Highest priority: if code, tests, configuration, generated artifacts, documentation in the repository, or any other repository changes are still needed for merge readiness, return category 2. If the PR description also needs work, defer that assessment until those repository changes are complete and this merge check is rerun; do not create a hybrid response.
+- Next: otherwise, if the PR is technically merge-ready but its description is materially inaccurate, incomplete, stale, misleading, or missing information necessary for a responsible merge record, return category 3.
+- Otherwise: return category 1.
 
 Category 1: exact success response
 - If the PR is ready to merge and the PR description is merge-ready, respond with exactly:
@@ -44,7 +44,7 @@ Category 1: exact success response
 - Do not add caveats, summaries, bullets, or extra commentary when the answer is yes.
 
 Category 2: repository changes needed
-- If the PR is not ready to merge because repository changes are still needed, respond only with a single fenced code block containing a copy/paste-ready GitHub PR comment that begins with `@codex` and has no text before or after the fence.
+- If the PR is not ready to merge because repository changes are still needed, respond only with a single outer three-backtick `text` fenced code block containing a copy/paste-ready GitHub PR comment that begins with `@codex` and has no text before or after the fence.
 - Include only work Codex can perform in the repository.
 - Never ask Codex to edit, rewrite, or update the PR title or description.
 - Never ask Codex to click, mark, or otherwise resolve a review thread.
@@ -103,7 +103,7 @@ The category 2 `@codex` comment must:
 - Include verification commands, choosing the narrowest relevant commands first.
 - Avoid broad refactors unless they are required for correctness.
 - Preserve existing conventions and tests.
-- Use triple tildes (`~~~`) instead of triple backticks for any nested code fences inside the comment, because nested triple backticks can break formatting.
+- Use an outer three-backtick `text` fence for the category 2 response, leaving triple tildes (`~~~`) available for any nested code fences inside the comment because nested triple backticks can break formatting.
 - Append `new codex task, not a r/e/v/i/e/w task` as the final line of the generated `@codex` comment, after all other comment text.
 
 Before answering, be strict: category 1 requires repository readiness, addressed or safely non-blocking substantive reviewer concerns, and a materially accurate PR description; category 2 takes precedence over category 3 when both repository work and description work are needed.
@@ -116,18 +116,19 @@ Improve the main PR final merge-check prompt above while preserving its purpose 
 
 Goals:
 - Keep the main prompt copy/paste-ready with a `<PR-URL>` placeholder.
-- Preserve exactly three mutually exclusive output categories with deterministic precedence:
-  1. Exact ready-to-merge success output: `yes, it can be merged`
-  2. One fenced code block containing one actionable `@codex` PR comment for repository changes needed to make the PR merge-ready
-  3. A concise manual instruction followed by one fenced `markdown` block containing the complete replacement PR description
+- Preserve exactly three mutually exclusive output categories with deterministic, unnumbered precedence labels:
+  - Highest priority: repository changes needed to make the PR merge-ready return category 2, one outer three-backtick `text` fenced code block containing one actionable `@codex` PR comment
+  - Next: PR description-only corrections return category 3, a concise manual instruction followed by one fenced `markdown` block containing the complete replacement PR description
+  - Otherwise: ready-to-merge PRs return category 1, the exact success output `yes, it can be merged`
 - Preserve the rule that category 2 takes precedence when both repository changes and PR-description corrections are needed, so description-only assessment is deferred until the merge check is rerun after repository work is complete.
 - Preserve the requirement that the LLM only says yes when every substantive reviewer comment is addressed or safely non-blocking and the PR description does not require a material correction.
 - Preserve the requirement that unresolved GitHub thread UI state alone is not a blocker when the latest code, tests, comments, or discussion adequately address the underlying concern.
 - Preserve strict handling of genuinely unaddressed reviewer concerns and recurring valid AI-review findings.
 - Preserve the requirement that the `@codex` comment concretely maps each remaining substantive concern to a repository change or durable in-code justification, not thread-resolution bookkeeping.
-- Preserve the requirement that category 2 emits no text outside its single fenced `@codex` comment.
+- Preserve the requirement that category 2 emits no text outside its single outer three-backtick `text` fenced `@codex` comment.
 - Preserve the ban on asking Codex to edit the PR title or description or to click, mark, or otherwise resolve review threads.
-- Preserve the requirement to use triple tildes (`~~~`) for nested code fences inside the `@codex` comment or replacement PR description, and to wrap category 3's replacement-description block in a longer outer fence such as `~~~~markdown` so nested fences cannot close it early.
+- Preserve the requirement to use an outer three-backtick `text` fence for the category 2 `@codex` comment, leaving triple tildes (`~~~`) available for nested code fences inside that comment.
+- Preserve the requirement to use triple tildes (`~~~`) for nested code fences inside the replacement PR description, and to wrap category 3's replacement-description block in a longer outer fence such as `~~~~markdown` so nested fences cannot close it early.
 - Preserve the requirement that generated `@codex` comments end with `new codex task, not a r/e/v/i/e/w task`, while ensuring the main prompt itself does not end with that sentinel line.
 - Preserve the requirement that category 3 contains a complete replacement PR description, with no placeholders, TODOs, partial patches, suggested fragments, `@codex`, or Codex sentinel line.
 - Make the prompt better at distinguishing true merge blockers from low-value nits.

--- a/docs/prompts/llm/pr-final-merge-check.md
+++ b/docs/prompts/llm/pr-final-merge-check.md
@@ -23,30 +23,66 @@ Review the PR using the available GitHub context:
 - Any recurring AI review comments, especially from tools such as Greptile, that appear to repeat after prior fixes or after Codex changes.
 
 Core question:
-Can every reviewer concern in the PR now be safely considered addressed?
+Can every reviewer concern in the PR now be safely considered addressed, and is the PR record accurate enough for a responsible merge?
 
 A concern is addressed only if at least one of these is clearly true:
 - The suggested change was implemented correctly.
 - The concern is obsolete because later commits removed or changed the relevant code.
-- The current code intentionally does not follow the suggestion, and the PR now contains enough justification through code structure, tests, comments, PR discussion, or nearby inline/multiline code comments for a maintainer to confidently mark the thread resolved.
+- The current code intentionally does not follow the suggestion, and the PR now contains enough justification through code structure, tests, comments, PR discussion, or nearby inline/multiline code comments for a maintainer to confidently treat the concern as addressed.
 - The comment is purely non-blocking praise, bookkeeping, duplication, or a low-value nit that does not affect merge readiness.
 
 Decision rule:
-- If the PR is ready to merge, respond with exactly:
-  yes, it can be merged
-- Only say `yes, it can be merged` when CI is green, mergeability is acceptable, required approvals are satisfied or no longer needed, and every unresolved or substantive reviewer comment can safely be marked Resolved without further code changes, discussion, or justification.
-- Do not add caveats, summaries, bullets, or extra commentary when the answer is yes.
-- If the PR is not ready to merge, respond only with a single fenced code block containing a copy/paste-ready GitHub PR comment that begins with `@codex`.
+Respond with exactly one of these three mutually exclusive categories, using this precedence:
+1. If code, tests, configuration, generated artifacts, documentation in the repository, or any other repository changes are still needed for merge readiness, return category 2. If the PR description also needs work, defer that assessment until those repository changes are complete and this merge check is rerun; do not create a hybrid response.
+2. Otherwise, if the PR is technically merge-ready but its description is materially inaccurate, incomplete, stale, misleading, or missing information necessary for a responsible merge record, return category 3.
+3. Otherwise, return category 1.
 
-Treat these as merge blockers:
+Category 1: exact success response
+- If the PR is ready to merge and the PR description is merge-ready, respond with exactly:
+  yes, it can be merged
+- Only say `yes, it can be merged` when CI is green, mergeability is acceptable, required approvals are satisfied or no longer needed, every substantive reviewer comment is addressed or safely non-blocking, and the PR description does not require a material correction.
+- Do not add caveats, summaries, bullets, or extra commentary when the answer is yes.
+
+Category 2: repository changes needed
+- If the PR is not ready to merge because repository changes are still needed, respond only with a single fenced code block containing a copy/paste-ready GitHub PR comment that begins with `@codex`.
+- Include only work Codex can perform in the repository.
+- Never ask Codex to edit, rewrite, or update the PR title or description.
+- Never ask Codex to click, mark, or otherwise resolve a review thread.
+- Never include thread-resolution bookkeeping as work in an `@codex` comment.
+
+Category 3: PR description-only correction needed
+- Use this category only when no repository changes remain and the description update is a real merge-readiness requirement rather than optional polish.
+- Respond with a concise manual instruction followed by exactly one fenced `markdown` block containing the entire replacement PR description, for example:
+
+Update the PR description manually to the following:
+
+~~~markdown
+<complete replacement PR description>
+~~~
+
+- Generate the complete description from the PR title, linked issue, current description, final diff, tests, and discussion.
+- Preserve useful and accurate material from the existing description.
+- Correct stale or misleading claims and include the relevant summary, behavior, testing, compatibility, migration, or issue-linking details supported by the PR.
+- Do not emit a partial patch, suggested fragments, placeholders, TODOs, or instructions inside the replacement description.
+- Keep all replacement-description Markdown inside the fence. Use `~~~` for any nested fences required within the generated description.
+- Do not include `@codex` or the Codex sentinel line in category 3.
+
+Treat these as merge blockers that require category 2 when they need repository changes:
 - CI is failing, pending, stale, missing, or ambiguous in a way that matters.
-- There are unresolved review threads, active requested changes, or substantive unaddressed reviewer concerns.
-- Any unresolved thread cannot yet be safely marked Resolved.
+- There are active requested changes or substantive unaddressed reviewer concerns.
 - A reviewer asked a question and the code, tests, comments, or PR discussion do not yet answer it well enough.
 - A reviewer suggested a change and the PR neither implemented it nor explains convincingly why the current approach is better.
 - The diff has likely correctness, regression, security, data-loss, migration, compatibility, or maintainability risks.
 - The PR appears to include unrelated scope creep, broad churn, accidental formatting, generated artifacts, secrets, debug code, or temporary scaffolding.
 - The branch is not mergeable or appears out of date in a way that could invalidate tests or approvals.
+
+Review thread handling:
+- Continue inspecting every substantive human, bot, and AI reviewer comment.
+- Judge the underlying concern against the latest diff, tests, code comments, and discussion.
+- An unresolved GitHub thread is not a blocker merely because its UI state remains unresolved.
+- If the latest code adequately addresses the concern, treat it as addressed and do not mention or dwell on the unresolved thread.
+- If the underlying concern remains valid and requires repository changes, include that work in category 2.
+- Preserve strict handling of genuinely unaddressed reviewer concerns and recurring valid AI-review findings.
 
 Do not block merge for low-value nits. Only produce an `@codex` comment for issues that should be fixed or justified before merge.
 
@@ -57,11 +93,11 @@ When recurring AI review comments are present:
 - Prefer durable explanations in code only when the rationale is not already obvious from names, tests, or surrounding context.
 - Do not ask Codex to blindly placate a bot by weakening correct code.
 
-The `@codex` comment must:
+The category 2 `@codex` comment must:
 - Be concise but complete enough for a fresh Codex task.
 - Start with a brief Scope Lock stating allowed files/areas, do-not-touch areas if known, and that the diff should stay minimal.
-- Include a "Reviewer comment resolution" section that lists each remaining unresolved or substantive reviewer concern and says exactly what must happen for that concern to be safely marked Resolved.
-- For each remaining concern, ask Codex to either implement the reviewer’s suggested change or add enough justification to address the concern and proceed without further changes.
+- Include a "Reviewer comment resolution" section that maps each remaining substantive concern to the concrete repository change or durable in-code justification needed.
+- For each remaining concern, ask Codex to either implement the reviewer’s suggested change or add enough durable justification in the repository to address the concern and proceed without further changes.
 - Name specific reviewers, files, symbols, comments, threads, checks, or quoted snippets when possible.
 - Include concrete implementation steps.
 - Include verification commands, choosing the narrowest relevant commands first.
@@ -70,7 +106,7 @@ The `@codex` comment must:
 - Use triple tildes (`~~~`) instead of triple backticks for any nested code fences inside the comment, because nested triple backticks can break formatting.
 - Append `new codex task, not a r/e/v/i/e/w task` as the final line of the generated `@codex` comment, after all other comment text.
 
-Before answering, be strict: a confident yes means every substantive reviewer concern is resolved, justified, or safely non-blocking.
+Before answering, be strict: category 1 requires repository readiness, addressed or safely non-blocking substantive reviewer concerns, and a materially accurate PR description; category 2 takes precedence over category 3 when both repository work and description work are needed.
 ```
 
 ## Upgrade Prompt
@@ -80,15 +116,22 @@ Improve the main PR final merge-check prompt above while preserving its purpose 
 
 Goals:
 - Keep the main prompt copy/paste-ready with a `<PR-URL>` placeholder.
-- Preserve the exact ready-to-merge success output: `yes, it can be merged`
-- Preserve the requirement that the LLM only says yes when every unresolved or substantive reviewer comment can safely be marked Resolved.
-- Preserve the fallback behavior: one fenced code block containing one `@codex` PR comment.
-- Preserve the requirement that the `@codex` comment concretely maps each remaining reviewer concern to either an implementation change or sufficient justification.
-- Preserve the requirement to use triple tildes (`~~~`) for nested code fences inside the `@codex` comment.
+- Preserve exactly three mutually exclusive output categories with deterministic precedence:
+  1. Exact ready-to-merge success output: `yes, it can be merged`
+  2. One fenced code block containing one actionable `@codex` PR comment for repository changes needed to make the PR merge-ready
+  3. A concise manual instruction followed by one fenced `markdown` block containing the complete replacement PR description
+- Preserve the rule that category 2 takes precedence when both repository changes and PR-description corrections are needed, so description-only assessment is deferred until the merge check is rerun after repository work is complete.
+- Preserve the requirement that the LLM only says yes when every substantive reviewer comment is addressed or safely non-blocking and the PR description does not require a material correction.
+- Preserve the requirement that unresolved GitHub thread UI state alone is not a blocker when the latest code, tests, comments, or discussion adequately address the underlying concern.
+- Preserve strict handling of genuinely unaddressed reviewer concerns and recurring valid AI-review findings.
+- Preserve the requirement that the `@codex` comment concretely maps each remaining substantive concern to a repository change or durable in-code justification, not thread-resolution bookkeeping.
+- Preserve the ban on asking Codex to edit the PR title or description or to click, mark, or otherwise resolve review threads.
+- Preserve the requirement to use triple tildes (`~~~`) for nested code fences inside the `@codex` comment or replacement PR description.
 - Preserve the requirement that generated `@codex` comments end with `new codex task, not a r/e/v/i/e/w task`, while ensuring the main prompt itself does not end with that sentinel line.
+- Preserve the requirement that category 3 contains a complete replacement PR description, with no placeholders, TODOs, partial patches, suggested fragments, `@codex`, or Codex sentinel line.
 - Make the prompt better at distinguishing true merge blockers from low-value nits.
 - Make the prompt better at handling recurring AI review comments without blindly reverting correct code.
-- Make the prompt better at producing followups that let maintainers confidently resolve every remaining review thread.
+- Make the prompt better at producing followups that let maintainers confidently address every remaining substantive concern.
 - Keep the wording compact enough to use as a Streamdeck action.
 
 Return:

--- a/docs/prompts/llm/pr-final-merge-check.md
+++ b/docs/prompts/llm/pr-final-merge-check.md
@@ -32,10 +32,10 @@ A concern is addressed only if at least one of these is clearly true:
 - The comment is purely non-blocking praise, bookkeeping, duplication, or a low-value nit that does not affect merge readiness.
 
 Decision rule:
-Respond with exactly one of these three mutually exclusive categories, using this precedence:
-1. If code, tests, configuration, generated artifacts, documentation in the repository, or any other repository changes are still needed for merge readiness, return category 2. If the PR description also needs work, defer that assessment until those repository changes are complete and this merge check is rerun; do not create a hybrid response.
-2. Otherwise, if the PR is technically merge-ready but its description is materially inaccurate, incomplete, stale, misleading, or missing information necessary for a responsible merge record, return category 3.
-3. Otherwise, return category 1.
+Respond with exactly one of these three mutually exclusive categories. Precedence is category 2 > category 3 > category 1:
+- Highest priority, category 2: if code, tests, configuration, generated artifacts, documentation in the repository, or any other repository changes are still needed for merge readiness, return category 2. If the PR description also needs work, defer that assessment until those repository changes are complete and this merge check is rerun; do not create a hybrid response.
+- Next priority, category 3: otherwise, if the PR is technically merge-ready but its description is materially inaccurate, incomplete, stale, misleading, or missing information necessary for a responsible merge record, return category 3.
+- Final fallback, category 1: otherwise, return category 1.
 
 Category 1: exact success response
 - If the PR is ready to merge and the PR description is merge-ready, respond with exactly:
@@ -56,15 +56,15 @@ Category 3: PR description-only correction needed
 
 Update the PR description manually to the following:
 
-~~~markdown
+~~~~markdown
 <complete replacement PR description>
-~~~
+~~~~
 
 - Generate the complete description from the PR title, linked issue, current description, final diff, tests, and discussion.
 - Preserve useful and accurate material from the existing description.
 - Correct stale or misleading claims and include the relevant summary, behavior, testing, compatibility, migration, or issue-linking details supported by the PR.
 - Do not emit a partial patch, suggested fragments, placeholders, TODOs, or instructions inside the replacement description.
-- Keep all replacement-description Markdown inside the fence. Use `~~~` for any nested fences required within the generated description.
+- Keep all replacement-description Markdown inside the outer fence. Use an outer fence longer than any nested fence, and use `~~~` for any nested fences required within the generated description.
 - Do not include `@codex` or the Codex sentinel line in category 3.
 
 Treat these as merge blockers that require category 2 when they need repository changes:
@@ -127,7 +127,7 @@ Goals:
 - Preserve the requirement that the `@codex` comment concretely maps each remaining substantive concern to a repository change or durable in-code justification, not thread-resolution bookkeeping.
 - Preserve the requirement that category 2 emits no text outside its single fenced `@codex` comment.
 - Preserve the ban on asking Codex to edit the PR title or description or to click, mark, or otherwise resolve review threads.
-- Preserve the requirement to use triple tildes (`~~~`) for nested code fences inside the `@codex` comment or replacement PR description.
+- Preserve the requirement to use triple tildes (`~~~`) for nested code fences inside the `@codex` comment or replacement PR description, and to wrap category 3's replacement-description block in a longer outer fence such as `~~~~markdown` so nested fences cannot close it early.
 - Preserve the requirement that generated `@codex` comments end with `new codex task, not a r/e/v/i/e/w task`, while ensuring the main prompt itself does not end with that sentinel line.
 - Preserve the requirement that category 3 contains a complete replacement PR description, with no placeholders, TODOs, partial patches, suggested fragments, `@codex`, or Codex sentinel line.
 - Make the prompt better at distinguishing true merge blockers from low-value nits.

--- a/docs/prompts/llm/pr-final-merge-check.md
+++ b/docs/prompts/llm/pr-final-merge-check.md
@@ -44,7 +44,7 @@ Category 1: exact success response
 - Do not add caveats, summaries, bullets, or extra commentary when the answer is yes.
 
 Category 2: repository changes needed
-- If the PR is not ready to merge because repository changes are still needed, respond only with a single fenced code block containing a copy/paste-ready GitHub PR comment that begins with `@codex`.
+- If the PR is not ready to merge because repository changes are still needed, respond only with a single fenced code block containing a copy/paste-ready GitHub PR comment that begins with `@codex` and has no text before or after the fence.
 - Include only work Codex can perform in the repository.
 - Never ask Codex to edit, rewrite, or update the PR title or description.
 - Never ask Codex to click, mark, or otherwise resolve a review thread.
@@ -125,6 +125,7 @@ Goals:
 - Preserve the requirement that unresolved GitHub thread UI state alone is not a blocker when the latest code, tests, comments, or discussion adequately address the underlying concern.
 - Preserve strict handling of genuinely unaddressed reviewer concerns and recurring valid AI-review findings.
 - Preserve the requirement that the `@codex` comment concretely maps each remaining substantive concern to a repository change or durable in-code justification, not thread-resolution bookkeeping.
+- Preserve the requirement that category 2 emits no text outside its single fenced `@codex` comment.
 - Preserve the ban on asking Codex to edit the PR title or description or to click, mark, or otherwise resolve review threads.
 - Preserve the requirement to use triple tildes (`~~~`) for nested code fences inside the `@codex` comment or replacement PR description.
 - Preserve the requirement that generated `@codex` comments end with `new codex task, not a r/e/v/i/e/w task`, while ensuring the main prompt itself does not end with that sentinel line.


### PR DESCRIPTION
### Motivation
- Make the final merge-readiness prompt deterministic by defining exactly three mutually exclusive response categories and a clear precedence so the LLM cannot produce hybrid or ambiguous outputs. 
- Ensure the Main Prompt and Upgrade Prompt express the same contract, preserve Streamdeck-friendly shape and frontmatter, and tighten reviewer-thread and `@codex` task rules to avoid asking Codex to edit PR descriptions or resolve threads. 

### Description
- Updated `docs/prompts/llm/pr-final-merge-check.md` Main Prompt to require exactly three output categories with the specified precedence: (1) exact success `yes, it can be merged`, (2) a single fenced `@codex` comment for repository changes, and (3) a manual instruction plus one fenced `markdown` block containing a complete replacement PR description. 
- Revised the Upgrade Prompt to preserve the same three-category contract and to explicitly keep category 2 precedence over description fixes, the triple-tilde nesting rule, and the `new codex task, not a r/e/v/i/e/w task` sentinel placement for generated `@codex` comments. 
- Clarified reviewer-thread handling language so unresolved GitHub UI thread state alone is not a blocker when the latest code, tests, or discussion adequately address the underlying concern, and tightened category 2 wording to map remaining substantive concerns to concrete repository changes or durable in-code justification. 
- Kept overall structure, frontmatter, and unrelated wording intact and limited the diff to the one Markdown file. 

### Testing
- Ran `git diff --check` which produced no trailing-whitespace or similar errors and returned successfully. 
- Ran `pre-commit run --files docs/prompts/llm/pr-final-merge-check.md`, which exercised hooks successfully until the `run project checks` hook failed because `black` would reformat unrelated Python files (`tests/test_patch_coverage.py`, `tests/test_prompt_docs_todos_sorting.py`, `tests/test_runbook_cli.py`, and `flywheel/__main__.py`). 
- Committed the change locally after verification with `git commit`, producing the commit message "Clarify final merge-check response categories".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56fbd311d0832f97090a459b957ff8)