### PR TITLE
Update PR merge-check prompt tally behavior

### DIFF
--- a/docs/prompts/llm/pr-final-merge-check.md
+++ b/docs/prompts/llm/pr-final-merge-check.md
@@ -33,7 +33,7 @@ A concern is addressed only if at least one of these is clearly true:
 
 Decision rule:
 Respond with exactly one of these three mutually exclusive categories, evaluated in this order:
-- Highest priority: if code, tests, configuration, generated artifacts, documentation in the repository, or any other repository changes are still needed for merge readiness, return category 2. If the PR description also needs work, defer that assessment until those repository changes are complete and this merge check is rerun; do not create a hybrid response.
+- Highest priority: if code, tests, configuration, generated artifacts, documentation in the repository, or any other repository changes are still needed for merge readiness, return category 2. If the PR description also needs work, assess and track the known description problem in category 2's tally, but do not ask Codex to change PR metadata or generate the replacement description until repository changes are complete and this merge check is rerun.
 - Next: otherwise, if the PR is technically merge-ready but its description is materially inaccurate, incomplete, stale, misleading, or missing information necessary for a responsible merge record, return category 3.
 - Otherwise: return category 1.
 
@@ -44,11 +44,26 @@ Category 1: exact success response
 - Do not add caveats, summaries, bullets, or extra commentary when the answer is yes.
 
 Category 2: repository changes needed
-- If the PR is not ready to merge because repository changes are still needed, respond only with a single outer three-backtick `text` fenced code block containing a copy/paste-ready GitHub PR comment that begins with `@codex` and has no text before or after the fence.
-- Include only work Codex can perform in the repository.
+- If the PR is not ready to merge because repository changes are still needed, respond with exactly two elements in this order and no other prose before, between, or after them:
+  1. One copy/paste-ready outer three-backtick `text` fenced code block containing a GitHub PR comment that begins with `@codex`.
+  2. A clearly labeled `Merge-readiness tally:` outside the fence.
+- Include only work Codex can perform in the repository in the `@codex` comment.
 - Never ask Codex to edit, rewrite, or update the PR title or description.
 - Never ask Codex to click, mark, or otherwise resolve a review thread.
 - Never include thread-resolution bookkeeping as work in an `@codex` comment.
+- Maintain a persistent merge-readiness tally across repeated invocations in the same LLM conversation:
+  - On the first category 2 response when no earlier tally exists in the conversation, construct a comprehensive tally of all current merge blockers with every item initially marked `⬜️`. Do not seed already-resolved historical concerns as completed items.
+  - On later invocations, locate the most recent tally from the conversation and reconcile it against the latest PR head, diff, tests, checks, reviews, and discussion.
+  - Retain completed and unresolved items so the history remains in context, preserving item wording and ordering when practical.
+  - Every tally item must begin directly with `⬜️` when it remains unresolved or `✅` when the latest PR state verifies it is complete, obsolete, or safely non-blocking under these merge-readiness rules.
+  - Mark an item `✅` only after independently verifying the result in the PR; issuing an `@codex` task or seeing a claimed fix is insufficient.
+  - Change a completed item back to `⬜️` if later changes regress it.
+  - Add newly discovered blockers as `⬜️`, consolidate duplicate findings by underlying root cause, and exclude optional polish or low-value nits.
+  - Never silently remove an earlier item. If it becomes obsolete or proves non-blocking, mark it `✅` with a concise explanation.
+  - Treat a fully checked tally as supporting evidence, not a substitute for a fresh merge-readiness review of the current PR state.
+  - If a material PR-description correction is already known while repository work remains, track it as one distinct `⬜️` item at the end of the tally, keep it permanently last, insert newly discovered repository blockers before it, do not include it in the `@codex` task, and defer generating the replacement PR description.
+  - Emit category 3 only when every repository-work tally item has been verified complete and the PR-description correction is the sole remaining blocker. If the PR description is the only blocker on the first invocation, return category 3 immediately without creating a tally. If the PR is ready immediately, return category 1 immediately without creating a tally.
+  - Identify every item selected for the current Codex task directly in the tally with the suffix `— targeted by the @codex comment above`. Selected items must remain `⬜️` until a later invocation verifies their implementation.
 
 Category 3: PR description-only correction needed
 - Use this category only when no repository changes remain and the description update is a real merge-readiness requirement rather than optional polish.
@@ -95,18 +110,20 @@ When recurring AI review comments are present:
 
 The category 2 `@codex` comment must:
 - Be concise but complete enough for a fresh Codex task.
+- Target one or a small, coherent, reliably executable group of currently unchecked repository-work items. Group tightly related items when safe to reduce unnecessary commits, but do not overload one Codex task with unrelated work.
 - Start with a brief Scope Lock stating allowed files/areas, do-not-touch areas if known, and that the diff should stay minimal.
-- Include a "Reviewer comment resolution" section that maps each remaining substantive concern to the concrete repository change or durable in-code justification needed.
-- For each remaining concern, ask Codex to either implement the reviewer’s suggested change or add enough durable justification in the repository to address the concern and proceed without further changes.
+- Include a "Reviewer comment resolution" section that maps each substantive concern selected for the current bounded batch to the concrete repository change or durable in-code justification needed.
+- For each selected concern, ask Codex to either implement the reviewer’s suggested change or add enough durable justification in the repository to address the concern and proceed without further changes. The tally remains the authoritative record of all known blockers, including blockers not selected for the current task.
 - Name specific reviewers, files, symbols, comments, threads, checks, or quoted snippets when possible.
 - Include concrete implementation steps.
 - Include verification commands, choosing the narrowest relevant commands first.
 - Avoid broad refactors unless they are required for correctness.
 - Preserve existing conventions and tests.
 - Use an outer three-backtick `text` fence for the category 2 response, leaving triple tildes (`~~~`) available for any nested code fences inside the comment because nested triple backticks can break formatting.
+- Keep the comment fully self-contained without mentioning the tally, checkbox states, item numbers, or phrases such as "the item above."
 - Append `new codex task, not a r/e/v/i/e/w task` as the final line of the generated `@codex` comment, after all other comment text.
 
-Before answering, be strict: category 1 requires repository readiness, addressed or safely non-blocking substantive reviewer concerns, and a materially accurate PR description; category 2 takes precedence over category 3 when both repository work and description work are needed.
+Before answering, be strict: category 1 requires repository readiness, addressed or safely non-blocking substantive reviewer concerns, and a materially accurate PR description; category 2 takes precedence over category 3 when both repository work and description work are needed, with any known description blocker tracked as the final tally item while repository work remains.
 ```
 
 ## Upgrade Prompt


### PR DESCRIPTION
### Motivation
- Make category 2 merge-readiness checks carry a persistent, conversation-scoped blocker tally so repeated LLM invocations retain history and show verified progress. 
- Preserve the existing three-category precedence and the exact outputs for category 1 and category 3 while removing conflicting wording in the Main Prompt.
- Keep the change minimal and confined to the first fenced `text` block under `## Main Prompt` so the rest of the prompt and repo remain untouched.

### Description
- Edit only the first fenced `text` block in `docs/prompts/llm/pr-final-merge-check.md` to revise category 2’s output contract to emit exactly two elements in order: (1) one outer three-backtick `text` fenced `@codex` PR comment, and (2) a labeled `Merge-readiness tally:` immediately following the fence with no other prose. 
- Add persistent tally lifecycle rules describing initial-tally construction (all items `⬜️`), later-invocation reconciliation, verification semantics for marking `✅`, regression handling, never-silently-removing items, consolidation rules, and explicit handling of a known PR-description blocker (always the final tally item and never included in the `@codex` task). 
- Adjust category 2 batching language so each `@codex` comment targets a bounded, coherent group of selected items and require selected items be annotated in the tally with the suffix `— targeted by the @codex comment above` and remain `⬜️` until independently verified. 
- Preserve all other important constraints (category precedence, exact category 1/3 outputs, Scope Lock, self-contained `@codex` comments, final Codex sentinel line, bans on PR metadata edits and review-thread bookkeeping) and leave the rest of the file and repository unchanged.

### Testing
- Ran `git diff --check` with no reported issues (passed).
- Ran `npm run docs-lint` and confirmed: `Docs lint passed: table pipes look consistent.` (passed).
- Inspected the narrow diff with `git diff -- docs/prompts/llm/pr-final-merge-check.md` to confirm the change is confined to the first fenced Main Prompt block (confirmed).
- Ran the repository secret scan `git diff | ./scripts/scan-secrets.py` which reported `No secrets detected.` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5dd964a920832fa733d8ec8d487380)