### PR TITLE
docs: persist merge-readiness tally in PR final-merge-check prompt

### DIFF
--- a/docs/prompts/llm/pr-final-merge-check.md
+++ b/docs/prompts/llm/pr-final-merge-check.md
@@ -140,23 +140,23 @@ Improve the main PR final merge-check prompt above while preserving its purpose 
 Goals:
 - Keep the main prompt copy/paste-ready with a `<PR-URL>` placeholder.
 - Preserve exactly three mutually exclusive output categories with deterministic, unnumbered precedence labels:
-  - Highest priority: repository changes needed to make the PR merge-ready return category 2, one outer three-backtick `text` fenced code block containing one actionable `@codex` PR comment followed by a `Merge-readiness tally:` outside the fence
+  - Highest priority: repository changes needed to make the PR merge-ready return category 2, one outer three-backtick `text` fenced code block containing one actionable `@codex` PR comment
   - Next: PR description-only corrections return category 3, a concise manual instruction followed by one fenced `markdown` block containing the complete replacement PR description
   - Otherwise: ready-to-merge PRs return category 1, the exact success output `yes, it can be merged`
-- Preserve the rule that category 2 takes precedence when both repository changes and PR-description corrections are needed: known material PR-description corrections are assessed and tracked as the permanently last tally item, but replacement-description generation is deferred until repository work is complete.
+- Preserve the rule that category 2 takes precedence when both repository changes and PR-description corrections are needed, so description-only assessment is deferred until the merge check is rerun after repository work is complete.
 - Preserve the requirement that the LLM only says yes when every substantive reviewer comment is addressed or safely non-blocking and the PR description does not require a material correction.
 - Preserve the requirement that unresolved GitHub thread UI state alone is not a blocker when the latest code, tests, comments, or discussion adequately address the underlying concern.
 - Preserve strict handling of genuinely unaddressed reviewer concerns and recurring valid AI-review findings.
 - Preserve the requirement that the `@codex` comment concretely maps each remaining substantive concern to a repository change or durable in-code justification, not thread-resolution bookkeeping.
-- Preserve the requirement that category 2 emits only a copy/paste-ready outer three-backtick `text` fenced `@codex` comment followed immediately by a clearly labeled `Merge-readiness tally:` outside the fence, with no other prose.
+- Preserve the requirement that category 2 emits no text outside its single outer three-backtick `text` fenced `@codex` comment.
 - Preserve the ban on asking Codex to edit the PR title or description or to click, mark, or otherwise resolve review threads.
-- Preserve the requirement to use an outer three-backtick `text` fence for the category 2 `@codex` comment, followed by the tally outside that fence, leaving triple tildes (`~~~`) available for nested code fences inside that comment.
+- Preserve the requirement to use an outer three-backtick `text` fence for the category 2 `@codex` comment, leaving triple tildes (`~~~`) available for nested code fences inside that comment.
 - Preserve the requirement to use triple tildes (`~~~`) for nested code fences inside the replacement PR description, and to wrap category 3's replacement-description block in a longer outer fence such as `~~~~markdown` so nested fences cannot close it early.
-- Preserve the requirement that generated `@codex` comments end with `new codex task, not a r/e/v/i/e/w task`, followed by the required tally outside the generated comment fence, while ensuring the main prompt itself does not end with that sentinel line.
+- Preserve the requirement that generated `@codex` comments end with `new codex task, not a r/e/v/i/e/w task`, while ensuring the main prompt itself does not end with that sentinel line.
 - Preserve the requirement that category 3 contains a complete replacement PR description, with no placeholders, TODOs, partial patches, suggested fragments, `@codex`, or Codex sentinel line.
 - Make the prompt better at distinguishing true merge blockers from low-value nits.
 - Make the prompt better at handling recurring AI review comments without blindly reverting correct code.
-- Make the prompt better at producing followups that let maintainers confidently address every remaining substantive concern, including persistent tally reconciliation across repeated invocations, verified completion/regression handling, duplicate consolidation without history loss, and permanently-last tracking for any known PR-description correction while repository work remains.
+- Make the prompt better at producing followups that let maintainers confidently address every remaining substantive concern.
 - Keep the wording compact enough to use as a Streamdeck action.
 
 Return:

--- a/docs/prompts/llm/pr-final-merge-check.md
+++ b/docs/prompts/llm/pr-final-merge-check.md
@@ -64,7 +64,7 @@ Category 2 merge-readiness tally lifecycle:
 - Preserve item wording and ordering when practical.
 - Mark an item `✅` only after independently verifying the result in the PR; issuing an `@codex` task or seeing a claimed fix is insufficient.
 - Change a completed item back to `⬜️` if later changes regress it.
-- Add newly discovered blockers as `⬜️`. Consolidate duplicate findings by underlying root cause and exclude optional polish or low-value nits.
+- Add newly discovered blockers as `⬜️`. Consolidate duplicate findings by underlying root cause and exclude optional polish or low-value nits; when an earlier tally item is a duplicate of a retained consolidated item, keep the earlier item in place and mark it `✅` with a concise duplicate-of explanation rather than deleting it.
 - Identify every item selected for the current Codex task directly in the tally with the suffix `— targeted by the @codex comment above`. Selected items must remain `⬜️` until a later invocation verifies their implementation.
 - Treat a fully checked tally as supporting evidence, not a substitute for a fresh merge-readiness review of the current PR state.
 - If a material PR-description correction is already known while repository work remains, track it as one distinct `⬜️` item at the end of the tally. Keep it permanently last; insert newly discovered repository blockers before it. Do not include it in the `@codex` task. Defer generating the replacement PR description, not assessing or tracking the known description problem.
@@ -140,10 +140,10 @@ Improve the main PR final merge-check prompt above while preserving its purpose 
 Goals:
 - Keep the main prompt copy/paste-ready with a `<PR-URL>` placeholder.
 - Preserve exactly three mutually exclusive output categories with deterministic, unnumbered precedence labels:
-  - Highest priority: repository changes needed to make the PR merge-ready return category 2, one outer three-backtick `text` fenced code block containing one actionable `@codex` PR comment
+  - Highest priority: repository changes needed to make the PR merge-ready return category 2, one outer three-backtick `text` fenced code block containing one actionable `@codex` PR comment followed by a `Merge-readiness tally:` outside the fence
   - Next: PR description-only corrections return category 3, a concise manual instruction followed by one fenced `markdown` block containing the complete replacement PR description
   - Otherwise: ready-to-merge PRs return category 1, the exact success output `yes, it can be merged`
-- Preserve the rule that category 2 takes precedence when both repository changes and PR-description corrections are needed, so description-only assessment is deferred until the merge check is rerun after repository work is complete.
+- Preserve the rule that category 2 takes precedence when both repository changes and PR-description corrections are needed: known material PR-description corrections are assessed and tracked as the permanently last tally item, but replacement-description generation is deferred until repository work is complete.
 - Preserve the requirement that the LLM only says yes when every substantive reviewer comment is addressed or safely non-blocking and the PR description does not require a material correction.
 - Preserve the requirement that unresolved GitHub thread UI state alone is not a blocker when the latest code, tests, comments, or discussion adequately address the underlying concern.
 - Preserve strict handling of genuinely unaddressed reviewer concerns and recurring valid AI-review findings.
@@ -156,7 +156,7 @@ Goals:
 - Preserve the requirement that category 3 contains a complete replacement PR description, with no placeholders, TODOs, partial patches, suggested fragments, `@codex`, or Codex sentinel line.
 - Make the prompt better at distinguishing true merge blockers from low-value nits.
 - Make the prompt better at handling recurring AI review comments without blindly reverting correct code.
-- Make the prompt better at producing followups that let maintainers confidently address every remaining substantive concern, including persistent tally reconciliation across repeated invocations.
+- Make the prompt better at producing followups that let maintainers confidently address every remaining substantive concern, including persistent tally reconciliation across repeated invocations, verified completion/regression handling, duplicate consolidation without history loss, and permanently-last tracking for any known PR-description correction while repository work remains.
 - Keep the wording compact enough to use as a Streamdeck action.
 
 Return:

--- a/docs/prompts/llm/pr-final-merge-check.md
+++ b/docs/prompts/llm/pr-final-merge-check.md
@@ -112,7 +112,7 @@ Do not block merge for low-value nits. Only produce an `@codex` comment for issu
 When recurring AI review comments are present:
 - Determine whether the repeated comment is still valid.
 - If it is valid, ask Codex to fix the underlying issue directly when selecting that concern for the current bounded batch.
-- If the current code is intentional and the AI reviewer is repeatedly asking to revert or change it, ask Codex to add a minimal inline or multiline code comment near the relevant logic explaining the invariant, tradeoff, or rationale, so future reviewers understand why the change should remain.
+- If the current code is intentional and the AI reviewer is repeatedly asking to revert or change it, ask Codex to add a minimal inline or multiline code comment near the relevant logic explaining the invariant, tradeoff, or rationale only when selecting that concern for the current bounded batch, so future reviewers understand why the change should remain.
 - Prefer durable explanations in code only when the rationale is not already obvious from names, tests, or surrounding context.
 - Do not ask Codex to blindly placate a bot by weakening correct code.
 

--- a/docs/prompts/llm/pr-final-merge-check.md
+++ b/docs/prompts/llm/pr-final-merge-check.md
@@ -148,15 +148,15 @@ Goals:
 - Preserve the requirement that unresolved GitHub thread UI state alone is not a blocker when the latest code, tests, comments, or discussion adequately address the underlying concern.
 - Preserve strict handling of genuinely unaddressed reviewer concerns and recurring valid AI-review findings.
 - Preserve the requirement that the `@codex` comment concretely maps each remaining substantive concern to a repository change or durable in-code justification, not thread-resolution bookkeeping.
-- Preserve the requirement that category 2 emits no text outside its single outer three-backtick `text` fenced `@codex` comment.
+- Preserve the requirement that category 2 emits only a copy/paste-ready outer three-backtick `text` fenced `@codex` comment followed immediately by a clearly labeled `Merge-readiness tally:` outside the fence, with no other prose.
 - Preserve the ban on asking Codex to edit the PR title or description or to click, mark, or otherwise resolve review threads.
-- Preserve the requirement to use an outer three-backtick `text` fence for the category 2 `@codex` comment, leaving triple tildes (`~~~`) available for nested code fences inside that comment.
+- Preserve the requirement to use an outer three-backtick `text` fence for the category 2 `@codex` comment, followed by the tally outside that fence, leaving triple tildes (`~~~`) available for nested code fences inside that comment.
 - Preserve the requirement to use triple tildes (`~~~`) for nested code fences inside the replacement PR description, and to wrap category 3's replacement-description block in a longer outer fence such as `~~~~markdown` so nested fences cannot close it early.
-- Preserve the requirement that generated `@codex` comments end with `new codex task, not a r/e/v/i/e/w task`, while ensuring the main prompt itself does not end with that sentinel line.
+- Preserve the requirement that generated `@codex` comments end with `new codex task, not a r/e/v/i/e/w task`, followed by the required tally outside the generated comment fence, while ensuring the main prompt itself does not end with that sentinel line.
 - Preserve the requirement that category 3 contains a complete replacement PR description, with no placeholders, TODOs, partial patches, suggested fragments, `@codex`, or Codex sentinel line.
 - Make the prompt better at distinguishing true merge blockers from low-value nits.
 - Make the prompt better at handling recurring AI review comments without blindly reverting correct code.
-- Make the prompt better at producing followups that let maintainers confidently address every remaining substantive concern.
+- Make the prompt better at producing followups that let maintainers confidently address every remaining substantive concern, including persistent tally reconciliation across repeated invocations.
 - Keep the wording compact enough to use as a Streamdeck action.
 
 Return:

--- a/docs/prompts/llm/pr-final-merge-check.md
+++ b/docs/prompts/llm/pr-final-merge-check.md
@@ -33,7 +33,7 @@ A concern is addressed only if at least one of these is clearly true:
 
 Decision rule:
 Respond with exactly one of these three mutually exclusive categories, evaluated in this order:
-- Highest priority: if code, tests, configuration, generated artifacts, documentation in the repository, or any other repository changes are still needed for merge readiness, return category 2. If the PR description also needs work, defer that assessment until those repository changes are complete and this merge check is rerun; do not create a hybrid response.
+- Highest priority: if code, tests, configuration, generated artifacts, documentation in the repository, or any other repository changes are still needed for merge readiness, return category 2. If a material PR-description correction is also already known, track it in the category 2 tally as described below, but do not ask Codex to perform PR metadata work.
 - Next: otherwise, if the PR is technically merge-ready but its description is materially inaccurate, incomplete, stale, misleading, or missing information necessary for a responsible merge record, return category 3.
 - Otherwise: return category 1.
 
@@ -42,13 +42,35 @@ Category 1: exact success response
   yes, it can be merged
 - Only say `yes, it can be merged` when CI is green, mergeability is acceptable, required approvals are satisfied or no longer needed, every substantive reviewer comment is addressed or safely non-blocking, and the PR description does not require a material correction.
 - Do not add caveats, summaries, bullets, or extra commentary when the answer is yes.
+- Do not include a merge-readiness tally in category 1.
 
 Category 2: repository changes needed
-- If the PR is not ready to merge because repository changes are still needed, respond only with a single outer three-backtick `text` fenced code block containing a copy/paste-ready GitHub PR comment that begins with `@codex` and has no text before or after the fence.
-- Include only work Codex can perform in the repository.
+- If the PR is not ready to merge because repository changes are still needed, respond with only these two elements, in this order, with no other prose before, between, or after them:
+  1. One copy/paste-ready outer three-backtick `text` fenced code block containing a GitHub PR comment that begins with `@codex`.
+  2. A clearly labeled `Merge-readiness tally:` outside the fence.
+- Include only work Codex can perform in the repository in the `@codex` comment.
+- The `@codex` comment should target one or a small, coherent, reliably executable group of currently unchecked repository-work items. Group multiple tightly related items when safe to reduce unnecessary commits, but do not overload one Codex task with unrelated work.
+- The `@codex` comment must map and handle each concern selected for the current bounded batch. The tally remains the authoritative record of all known blockers, including blockers not selected for that task.
 - Never ask Codex to edit, rewrite, or update the PR title or description.
 - Never ask Codex to click, mark, or otherwise resolve a review thread.
 - Never include thread-resolution bookkeeping as work in an `@codex` comment.
+- The generated `@codex` comment must be fully self-contained. It must not mention the tally, checkbox states, item numbers, or phrases such as “the item above.”
+
+Category 2 merge-readiness tally lifecycle:
+- Every tally item must begin directly with `⬜️` when it remains unresolved or `✅` when the latest PR state verifies it is complete, obsolete, or safely non-blocking under these merge-readiness rules.
+- On the first category 2 response when no earlier tally exists in the conversation, construct a comprehensive tally of all current merge blockers with every item initially marked `⬜️`. Do not seed already-resolved historical concerns as completed items.
+- On later invocations, locate and reconcile the most recent tally from this conversation against the latest PR head, diff, tests, checks, reviews, and discussion.
+- Retain completed and unresolved items so the history remains in context. Never silently remove an earlier item. If it becomes obsolete or proves non-blocking, mark it `✅` with a concise explanation.
+- Preserve item wording and ordering when practical.
+- Mark an item `✅` only after independently verifying the result in the PR; issuing an `@codex` task or seeing a claimed fix is insufficient.
+- Change a completed item back to `⬜️` if later changes regress it.
+- Add newly discovered blockers as `⬜️`. Consolidate duplicate findings by underlying root cause and exclude optional polish or low-value nits.
+- Identify every item selected for the current Codex task directly in the tally with the suffix `— targeted by the @codex comment above`. Selected items must remain `⬜️` until a later invocation verifies their implementation.
+- Treat a fully checked tally as supporting evidence, not a substitute for a fresh merge-readiness review of the current PR state.
+- If a material PR-description correction is already known while repository work remains, track it as one distinct `⬜️` item at the end of the tally. Keep it permanently last; insert newly discovered repository blockers before it. Do not include it in the `@codex` task. Defer generating the replacement PR description, not assessing or tracking the known description problem.
+- Emit category 3 only when every repository-work tally item has been verified complete and the PR-description correction is the sole remaining blocker. This should be the final remediation response before category 1 when the user applies the replacement and no new blocker appears.
+- If the PR description is the only blocker on the first invocation, return category 3 immediately without creating a tally.
+- If the PR is ready immediately, return category 1 immediately without creating a tally.
 
 Category 3: PR description-only correction needed
 - Use this category only when no repository changes remain and the description update is a real merge-readiness requirement rather than optional polish.
@@ -66,6 +88,7 @@ Update the PR description manually to the following:
 - Do not emit a partial patch, suggested fragments, placeholders, TODOs, or instructions inside the replacement description.
 - Keep all replacement-description Markdown inside the outer fence. Use an outer fence longer than any nested fence, and use `~~~` for any nested fences required within the generated description.
 - Do not include `@codex` or the Codex sentinel line in category 3.
+- Do not include a merge-readiness tally in category 3.
 
 Treat these as merge blockers that require category 2 when they need repository changes:
 - CI is failing, pending, stale, missing, or ambiguous in a way that matters.
@@ -81,14 +104,14 @@ Review thread handling:
 - Judge the underlying concern against the latest diff, tests, code comments, and discussion.
 - An unresolved GitHub thread is not a blocker merely because its UI state remains unresolved.
 - If the latest code adequately addresses the concern, treat it as addressed and do not mention or dwell on the unresolved thread.
-- If the underlying concern remains valid and requires repository changes, include that work in category 2.
+- If the underlying concern remains valid and requires repository changes, include that work in the category 2 tally and select it for the `@codex` comment only if it belongs in the current bounded batch.
 - Preserve strict handling of genuinely unaddressed reviewer concerns and recurring valid AI-review findings.
 
 Do not block merge for low-value nits. Only produce an `@codex` comment for issues that should be fixed or justified before merge.
 
 When recurring AI review comments are present:
 - Determine whether the repeated comment is still valid.
-- If it is valid, ask Codex to fix the underlying issue directly.
+- If it is valid, ask Codex to fix the underlying issue directly when selecting that concern for the current bounded batch.
 - If the current code is intentional and the AI reviewer is repeatedly asking to revert or change it, ask Codex to add a minimal inline or multiline code comment near the relevant logic explaining the invariant, tradeoff, or rationale, so future reviewers understand why the change should remain.
 - Prefer durable explanations in code only when the rationale is not already obvious from names, tests, or surrounding context.
 - Do not ask Codex to blindly placate a bot by weakening correct code.
@@ -96,8 +119,8 @@ When recurring AI review comments are present:
 The category 2 `@codex` comment must:
 - Be concise but complete enough for a fresh Codex task.
 - Start with a brief Scope Lock stating allowed files/areas, do-not-touch areas if known, and that the diff should stay minimal.
-- Include a "Reviewer comment resolution" section that maps each remaining substantive concern to the concrete repository change or durable in-code justification needed.
-- For each remaining concern, ask Codex to either implement the reviewer’s suggested change or add enough durable justification in the repository to address the concern and proceed without further changes.
+- Include a "Reviewer comment resolution" section that maps each selected substantive concern to the concrete repository change or durable in-code justification needed.
+- For each selected concern, ask Codex to either implement the reviewer’s suggested change or add enough durable justification in the repository to address the concern and proceed without further changes.
 - Name specific reviewers, files, symbols, comments, threads, checks, or quoted snippets when possible.
 - Include concrete implementation steps.
 - Include verification commands, choosing the narrowest relevant commands first.

--- a/docs/prompts/llm/pr-final-merge-check.md
+++ b/docs/prompts/llm/pr-final-merge-check.md
@@ -37,11 +37,16 @@ Respond with exactly one of these three mutually exclusive categories, evaluated
 - Next: otherwise, if the PR is technically merge-ready but its description is materially inaccurate, incomplete, stale, misleading, or missing information necessary for a responsible merge record, return category 3.
 - Otherwise: return category 1.
 
-Category 1: exact success response
-- If the PR is ready to merge and the PR description is merge-ready, respond with exactly:
+Category 1: exact conditional-success response
+- If the PR is ready to merge and the PR description is merge-ready, select exactly one of these two responses.
+- Respond with exactly:
   yes, it can be merged
-- Only say `yes, it can be merged` when CI is green, mergeability is acceptable, required approvals are satisfied or no longer needed, every substantive reviewer comment is addressed or safely non-blocking, and the PR description does not require a material correction.
-- Do not add caveats, summaries, bullets, or extra commentary when the answer is yes.
+  only when all relevant required checks on the latest head have completed successfully, mergeability is acceptable, required approvals are satisfied or no longer needed, every substantive reviewer comment is addressed or safely non-blocking, and the PR description does not require a material correction.
+- Respond with exactly:
+  yes, it can be merged assuming the pending CI checks succeed
+  only when every non-CI readiness condition is satisfied and the only remaining uncertainty is one or more expected, relevant checks on the latest head that are legitimately queued or in progress.
+- Do not use the conditional response when any relevant check failed, was cancelled, timed out, requires action, or otherwise produced an adverse conclusion; when checks are stale, missing, attached only to an older commit, or ambiguous in a way that matters; when the branch is unmergeable or materially out of date; when approvals, substantive reviewer concerns, repository changes, or a material PR-description correction remain; or when there is evidence that pending CI requires repository work rather than merely time to complete.
+- Emit only the selected category 1 sentence, with no tally, caveats, summaries, bullets, or extra commentary.
 - Do not include a merge-readiness tally in category 1.
 
 Category 2: repository changes needed
@@ -91,7 +96,7 @@ Update the PR description manually to the following:
 - Do not include a merge-readiness tally in category 3.
 
 Treat these as merge blockers that require category 2 when they need repository changes:
-- CI is failing, pending, stale, missing, or ambiguous in a way that matters.
+- CI is failing, cancelled, timed out, requires action, stale, missing, attached only to an older commit, ambiguous in a way that matters, or otherwise reveals or requires repository changes; ordinary expected latest-head checks that are merely queued or in progress do not create or continue category 2 by themselves when no repository work is needed.
 - There are active requested changes or substantive unaddressed reviewer concerns.
 - A reviewer asked a question and the code, tests, comments, or PR discussion do not yet answer it well enough.
 - A reviewer suggested a change and the PR neither implemented it nor explains convincingly why the current approach is better.
@@ -129,7 +134,7 @@ The category 2 `@codex` comment must:
 - Use an outer three-backtick `text` fence for the category 2 response, leaving triple tildes (`~~~`) available for any nested code fences inside the comment because nested triple backticks can break formatting.
 - Append `new codex task, not a r/e/v/i/e/w task` as the final line of the generated `@codex` comment, after all other comment text.
 
-Before answering, be strict: category 1 requires repository readiness, addressed or safely non-blocking substantive reviewer concerns, and a materially accurate PR description; category 2 takes precedence over category 3 when both repository work and description work are needed.
+Before answering, be strict: category 1 requires either fully green latest-head CI or conditional readiness under the narrow pending-CI rule above, repository readiness, addressed or safely non-blocking substantive reviewer concerns, and a materially accurate PR description; category 2 takes precedence over category 3 when both repository work and description work are needed.
 ```
 
 ## Upgrade Prompt


### PR DESCRIPTION
### Motivation

- Make category 2 replies carry a persistent, conversation-scoped merge-readiness tally across repeated invocations.
- Distinguish fully green CI from ordinary latest-head checks that are still running, without manufacturing repository work when CI is the only uncertainty.
- Preserve the three mutually exclusive response categories and their precedence.

### Description

- Updated only the first fenced `text` block under `## Main Prompt` in `docs/prompts/llm/pr-final-merge-check.md`.
- Added two deterministic category 1 responses:
  - `yes, it can be merged` when all relevant latest-head checks have succeeded.
  - `yes, it can be merged assuming the pending CI checks succeed` when every non-CI condition is satisfied and expected latest-head checks are merely queued or running.
- Kept failed, cancelled, timed-out, stale, missing, older-head, ambiguous, or repository-work-revealing CI states ineligible for conditional success.
- Changed category 2 responses to emit one copy/paste-ready fenced `@codex` comment followed by an external `Merge-readiness tally:`.
- Added tally lifecycle rules covering initialization, later reconciliation, independently verified completion, regression reopening, retained history, duplicate consolidation, and newly discovered blockers.
- Limited each generated `@codex` task to a coherent selected batch while keeping all known blockers in the tally.
- Required selected items to remain unchecked until independently verified and prohibited generated comments from referring to tally mechanics.
- Required known PR-description corrections to remain the final tally item while repository work is outstanding.
- Preserved category 3 as the description-only remediation response with no tally.
- Kept `## Upgrade Prompt` and all other repository content unchanged.

### Review resolution

- Clarified that earlier duplicate tally entries are retained and marked complete with a duplicate-of explanation instead of being silently removed.
- Qualified recurring-AI guidance so Codex acts only on concerns selected for the current bounded batch.
- Intentionally left `## Upgrade Prompt` unchanged because the original Scope Lock restricted this change to the first Main Prompt block; the related Copilot and Greptile suggestions are therefore non-blocking and out of scope.

### Testing

- `git diff --check`
- `npm run docs-lint`
- `git diff | ./scripts/scan-secrets.py`
- Inspected `git diff -- docs/prompts/llm/pr-final-merge-check.md` and confirmed the final diff is confined to the first Main Prompt fence.
- Confirmed `## Upgrade Prompt` matches the base branch byte-for-byte.
- Latest-head GitHub Actions passed:
  - Test Suite
  - Lint & Format
  - Spelling
  - Link Check
  - Security scan

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5dd960968c832f8d8cd79af2f5e4f8)