### PR TITLE
Add persistent merge-readiness tally to category 2 of PR final merge-check prompt

### DIFF
--- a/docs/prompts/llm/pr-final-merge-check.md
+++ b/docs/prompts/llm/pr-final-merge-check.md
@@ -33,7 +33,7 @@ A concern is addressed only if at least one of these is clearly true:
 
 Decision rule:
 Respond with exactly one of these three mutually exclusive categories, evaluated in this order:
-- Highest priority: if code, tests, configuration, generated artifacts, documentation in the repository, or any other repository changes are still needed for merge readiness, return category 2. If the PR description also needs work, defer that assessment until those repository changes are complete and this merge check is rerun; do not create a hybrid response.
+- Highest priority: if code, tests, configuration, generated artifacts, documentation in the repository, or any other repository changes are still needed for merge readiness, return category 2. If a material PR-description correction is also already known, track it as the final tally item instead of generating the replacement description yet.
 - Next: otherwise, if the PR is technically merge-ready but its description is materially inaccurate, incomplete, stale, misleading, or missing information necessary for a responsible merge record, return category 3.
 - Otherwise: return category 1.
 
@@ -44,11 +44,14 @@ Category 1: exact success response
 - Do not add caveats, summaries, bullets, or extra commentary when the answer is yes.
 
 Category 2: repository changes needed
-- If the PR is not ready to merge because repository changes are still needed, respond only with a single outer three-backtick `text` fenced code block containing a copy/paste-ready GitHub PR comment that begins with `@codex` and has no text before or after the fence.
-- Include only work Codex can perform in the repository.
+- If the PR is not ready to merge because repository changes are still needed, respond with exactly these two elements, in this order, and no other prose before, between, or after them:
+  1. One copy/paste-ready outer three-backtick `text` fenced code block containing a GitHub PR comment that begins with `@codex`.
+  2. A clearly labeled `Merge-readiness tally:` outside the fence.
+- Include only repository work Codex can perform in the `@codex` comment.
 - Never ask Codex to edit, rewrite, or update the PR title or description.
 - Never ask Codex to click, mark, or otherwise resolve a review thread.
 - Never include thread-resolution bookkeeping as work in an `@codex` comment.
+- Keep the generated `@codex` comment fully self-contained; it must not mention the tally, checkbox states, item numbers, or phrases such as "the item above."
 
 Category 3: PR description-only correction needed
 - Use this category only when no repository changes remain and the description update is a real merge-readiness requirement rather than optional polish.
@@ -86,6 +89,18 @@ Review thread handling:
 
 Do not block merge for low-value nits. Only produce an `@codex` comment for issues that should be fixed or justified before merge.
 
+Merge-readiness tally lifecycle for category 2:
+- On the first category 2 response in this LLM conversation, when no earlier tally exists, construct a comprehensive tally of all current merge blockers with every item initially marked `⬜️`. Do not seed already-resolved historical concerns as completed items.
+- On later invocations, locate the most recent tally in the conversation and reconcile it against the latest PR head, diff, tests, checks, reviews, and discussion. Treat a fully checked tally as supporting evidence, not a substitute for a fresh merge-readiness review of the current PR state.
+- Retain completed and unresolved items so the history remains in context. Preserve item wording and ordering when practical. Never silently remove an earlier item; if it becomes obsolete or proves non-blocking, mark it `✅` with a concise explanation.
+- Every tally item must begin directly with `⬜️` when it remains unresolved or `✅` when the latest PR state verifies it is complete, obsolete, or safely non-blocking under these merge-readiness rules.
+- Mark an item `✅` only after independently verifying the result in the PR. Issuing an `@codex` task or seeing a claimed fix is insufficient. Change a completed item back to `⬜️` if later changes regress it.
+- Add newly discovered blockers as `⬜️`. Consolidate duplicate findings by underlying root cause and exclude optional polish or low-value nits.
+- Select one or a small, coherent, reliably executable group of currently unchecked repository-work items for the current `@codex` comment. Group tightly related items when safe to reduce unnecessary commits, but do not overload one Codex task with unrelated work.
+- Identify every item selected for the current Codex task directly in the tally with the suffix `— targeted by the @codex comment above`. Selected items must remain `⬜️` until a later invocation verifies their implementation.
+- If a material PR-description correction is already known while repository work remains, track it as one distinct `⬜️` item at the end of the tally. Keep it permanently last; insert newly discovered repository blockers before it. Do not include it in the `@codex` task.
+- Emit category 3 only when every repository-work tally item has been verified complete and the PR-description correction is the sole remaining blocker. If the PR description is the only blocker on the first invocation, return category 3 immediately without creating a tally. If the PR is ready immediately, return category 1 immediately without creating a tally.
+
 When recurring AI review comments are present:
 - Determine whether the repeated comment is still valid.
 - If it is valid, ask Codex to fix the underlying issue directly.
@@ -96,8 +111,8 @@ When recurring AI review comments are present:
 The category 2 `@codex` comment must:
 - Be concise but complete enough for a fresh Codex task.
 - Start with a brief Scope Lock stating allowed files/areas, do-not-touch areas if known, and that the diff should stay minimal.
-- Include a "Reviewer comment resolution" section that maps each remaining substantive concern to the concrete repository change or durable in-code justification needed.
-- For each remaining concern, ask Codex to either implement the reviewer’s suggested change or add enough durable justification in the repository to address the concern and proceed without further changes.
+- Include a "Reviewer comment resolution" section that maps each selected substantive concern in the current bounded batch to the concrete repository change or durable in-code justification needed.
+- For each selected concern, ask Codex to either implement the reviewer’s suggested change or add enough durable justification in the repository to address the concern and proceed without further changes.
 - Name specific reviewers, files, symbols, comments, threads, checks, or quoted snippets when possible.
 - Include concrete implementation steps.
 - Include verification commands, choosing the narrowest relevant commands first.
@@ -106,7 +121,7 @@ The category 2 `@codex` comment must:
 - Use an outer three-backtick `text` fence for the category 2 response, leaving triple tildes (`~~~`) available for any nested code fences inside the comment because nested triple backticks can break formatting.
 - Append `new codex task, not a r/e/v/i/e/w task` as the final line of the generated `@codex` comment, after all other comment text.
 
-Before answering, be strict: category 1 requires repository readiness, addressed or safely non-blocking substantive reviewer concerns, and a materially accurate PR description; category 2 takes precedence over category 3 when both repository work and description work are needed.
+Before answering, be strict: category 1 requires repository readiness, addressed or safely non-blocking substantive reviewer concerns, and a materially accurate PR description; category 2 takes precedence over category 3 when both repository work and description work are needed, while known description problems are assessed and tracked in the tally until repository work is complete.
 ```
 
 ## Upgrade Prompt


### PR DESCRIPTION
### Motivation
- Ensure category 2 (repository changes needed) responses persist a merge-readiness tally across repeated invocations in the same LLM conversation so reviewers and Codex tasks can track progress and history.

### Description
- Modified only the first fenced `text` block under `## Main Prompt` in `docs/prompts/llm/pr-final-merge-check.md` to add tally lifecycle behavior and adjust category precedence handling. 
- Updated the Decision rule so a known material PR-description correction is tracked as the final tally item while repository blockers remain. 
- Changed category 2’s output contract to require exactly one outer three-backtick `text` fence containing a copy/paste-ready `@codex` comment followed immediately by a labeled `Merge-readiness tally:` outside the fence, and strengthened rules that keep the generated `@codex` comment self-contained. 
- Added a concise tally lifecycle describing first-invocation all-unchecked capture, later-invocation reconciliation and verification-only completion rules, regression handling, duplicate consolidation, bounded-batch selection with targeted suffixes, and the special final-PR-description-item placement and handling.

### Testing
- Ran `git diff --check` to validate whitespace and patch hygiene and it passed. 
- Verified the change is confined to the intended prompt block with `git diff -- docs/prompts/llm/pr-final-merge-check.md` and inspected the diff. 
- Ran the repository docs linter with `npm run docs-lint` (which runs `node scripts/docs-lint.mjs`) and received `Docs lint passed`. 
- Ran the project secret scan with `git diff | ./scripts/scan-secrets.py` and it reported `No secrets detected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5dd970be64832fa35fc0d2cec35450)