### PR TITLE
docs: add persistent merge-readiness tally to PR final merge-check prompt

### DIFF
--- a/docs/prompts/llm/pr-final-merge-check.md
+++ b/docs/prompts/llm/pr-final-merge-check.md
@@ -33,7 +33,7 @@ A concern is addressed only if at least one of these is clearly true:
 
 Decision rule:
 Respond with exactly one of these three mutually exclusive categories, evaluated in this order:
-- Highest priority: if code, tests, configuration, generated artifacts, documentation in the repository, or any other repository changes are still needed for merge readiness, return category 2. If the PR description also needs work, defer that assessment until those repository changes are complete and this merge check is rerun; do not create a hybrid response.
+- Highest priority: if code, tests, configuration, generated artifacts, documentation in the repository, or any other repository changes are still needed for merge readiness, return category 2. If a material PR-description correction is already known, track it in the category 2 tally but do not include it in the `@codex` task and do not generate the replacement description yet.
 - Next: otherwise, if the PR is technically merge-ready but its description is materially inaccurate, incomplete, stale, misleading, or missing information necessary for a responsible merge record, return category 3.
 - Otherwise: return category 1.
 
@@ -44,7 +44,25 @@ Category 1: exact success response
 - Do not add caveats, summaries, bullets, or extra commentary when the answer is yes.
 
 Category 2: repository changes needed
-- If the PR is not ready to merge because repository changes are still needed, respond only with a single outer three-backtick `text` fenced code block containing a copy/paste-ready GitHub PR comment that begins with `@codex` and has no text before or after the fence.
+- If the PR is not ready to merge because repository changes are still needed, respond with exactly these two elements, in order, and no other prose before, between, or after them:
+  1. One outer three-backtick `text` fenced code block containing a copy/paste-ready GitHub PR comment that begins with `@codex`.
+  2. A clearly labeled `Merge-readiness tally:` outside the fence.
+- Build and maintain the tally across repeated invocations in the same LLM conversation:
+  - On the first category 2 response, when no earlier tally exists in the conversation, construct a comprehensive tally of all current merge blockers with every item initially marked `⬜️`. Do not seed already-resolved historical concerns as completed items.
+  - On later invocations, locate the most recent tally from the conversation and reconcile it against the latest PR head, diff, tests, checks, reviews, and discussion.
+  - Retain completed and unresolved items so the history remains in context. Preserve item wording and ordering when practical.
+  - Mark an item `✅` only after independently verifying from the latest PR state that it is complete, obsolete, or safely non-blocking under these merge-readiness rules. Issuing an `@codex` task or seeing a claimed fix is insufficient.
+  - Change a completed item back to `⬜️` if later changes regress it.
+  - Add newly discovered blockers as `⬜️`.
+  - Never silently remove an earlier item. If it becomes obsolete or proves non-blocking, mark it `✅` with a concise explanation.
+  - Consolidate duplicate findings by underlying root cause and exclude optional polish or low-value nits.
+  - Treat a fully checked tally as supporting evidence, not a substitute for a fresh merge-readiness review of the current PR state.
+- Every tally item must begin directly with `⬜️` when unresolved or `✅` when the latest PR state verifies it is complete, obsolete, or safely non-blocking.
+- Select one or a small, coherent, reliably executable group of currently unchecked repository-work items for the `@codex` comment. Group multiple tightly related items when safe to reduce unnecessary commits, but do not overload one Codex task with unrelated work.
+- Identify every item selected for the current Codex task directly in the tally with the suffix `— targeted by the @codex comment above`. Selected items remain `⬜️` until a later invocation verifies their implementation.
+- Keep the generated `@codex` comment fully self-contained. It must not mention the tally, checkbox states, item numbers, or phrases such as "the item above."
+- If a material PR-description correction is known while repository work remains, track it as one distinct `⬜️` item at the end of the tally. Keep it permanently last; insert newly discovered repository blockers before it. Do not include it in the `@codex` task.
+- Emit category 3 only when every repository-work tally item has been verified complete and the PR-description correction is the sole remaining blocker. If the PR description is the only blocker on the first invocation, return category 3 immediately without creating a tally.
 - Include only work Codex can perform in the repository.
 - Never ask Codex to edit, rewrite, or update the PR title or description.
 - Never ask Codex to click, mark, or otherwise resolve a review thread.
@@ -96,8 +114,8 @@ When recurring AI review comments are present:
 The category 2 `@codex` comment must:
 - Be concise but complete enough for a fresh Codex task.
 - Start with a brief Scope Lock stating allowed files/areas, do-not-touch areas if known, and that the diff should stay minimal.
-- Include a "Reviewer comment resolution" section that maps each remaining substantive concern to the concrete repository change or durable in-code justification needed.
-- For each remaining concern, ask Codex to either implement the reviewer’s suggested change or add enough durable justification in the repository to address the concern and proceed without further changes.
+- Include a "Reviewer comment resolution" section that maps each selected substantive concern for the current bounded batch to the concrete repository change or durable in-code justification needed.
+- For each selected concern, ask Codex to either implement the reviewer’s suggested change or add enough durable justification in the repository to address the concern and proceed without further changes.
 - Name specific reviewers, files, symbols, comments, threads, checks, or quoted snippets when possible.
 - Include concrete implementation steps.
 - Include verification commands, choosing the narrowest relevant commands first.
@@ -106,7 +124,7 @@ The category 2 `@codex` comment must:
 - Use an outer three-backtick `text` fence for the category 2 response, leaving triple tildes (`~~~`) available for any nested code fences inside the comment because nested triple backticks can break formatting.
 - Append `new codex task, not a r/e/v/i/e/w task` as the final line of the generated `@codex` comment, after all other comment text.
 
-Before answering, be strict: category 1 requires repository readiness, addressed or safely non-blocking substantive reviewer concerns, and a materially accurate PR description; category 2 takes precedence over category 3 when both repository work and description work are needed.
+Before answering, be strict: category 1 requires repository readiness, addressed or safely non-blocking substantive reviewer concerns, and a materially accurate PR description; category 2 takes precedence over category 3 when both repository work and description work are needed, while the tally remains the authoritative record of all known blockers including deferred description corrections.
 ```
 
 ## Upgrade Prompt


### PR DESCRIPTION
### Motivation
- Ensure category 2 (repository-work) responses carry a persistent, verifiable merge-readiness checklist across repeated invocations in the same LLM conversation. 
- Make the category 2 output machine-actionable by pairing a copy/paste-ready `@codex` comment with an authoritative tally that documents blockers, verification state, and the subset of items targeted by the current Codex task. 

### Description
- Updated only the first fenced `text` block under `## Main Prompt` in `docs/prompts/llm/pr-final-merge-check.md` to require a single outer three-backtick `text` fence containing an `@codex` PR comment followed immediately by a labeled `Merge-readiness tally:` outside the fence. 
- Added tally lifecycle rules covering the first-category-2 invocation (all items start `⬜️`), reconciliation on later invocations, marking rules (`⬜️`/`✅`), regression handling, never silently removing earlier items, consolidation of duplicates, and that the PR-description correction (if present) is always the final tally item and is not included in the `@codex` task. 
- Revised the category 2 reviewer-resolution mapping so the `@codex` comment implements a bounded, coherent group of selected concerns (each selected item suffixed `— targeted by the @codex comment above`) while the tally remains the authoritative record of all known blockers. 

### Testing
- Ran `git diff --check` with no reported problems. (passed)
- Inspected the narrow diff with `git diff -- docs/prompts/llm/pr-final-merge-check.md` to confirm changes were confined to the Main Prompt block. (confirmed)
- Ran the repository docs lint `npm run docs-lint` and it completed successfully. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5dd978ad34832fbfb2ce83cd031946)