### PR TITLE
Require category 2 to emit a single fenced @codex comment with in‑comment Merge‑readiness tally

### DIFF
--- a/docs/prompts/llm/pr-final-merge-check.md
+++ b/docs/prompts/llm/pr-final-merge-check.md
@@ -50,32 +50,55 @@ Category 1: exact conditional-success response
 - Do not include a merge-readiness tally in category 1.
 
 Category 2: repository changes needed
-- If the PR is not ready to merge because repository changes are still needed, respond with only these two elements, in this order, with no other prose before, between, or after them:
-  1. One copy/paste-ready outer three-backtick `text` fenced code block containing a GitHub PR comment that begins with `@codex`.
-  2. A clearly labeled `Merge-readiness tally:` outside the fence.
-- Include only work Codex can perform in the repository in the `@codex` comment.
+- If the PR is not ready to merge because repository changes are still needed, respond with exactly one element and no other prose before or after it:
+  - One copy/paste-ready outer three-backtick `text` fenced code block containing the complete generated GitHub PR comment that begins with `@codex`.
+- The complete `Merge-readiness tally:` must be inside the generated `@codex` comment.
+- Include only work Codex can perform in the repository as implementation instructions. Tally entries not targeted by the current task are diagnostic context only, not work requests.
 - The `@codex` comment should target one or a small, coherent, reliably executable group of currently unchecked repository-work items. Group multiple tightly related items when safe to reduce unnecessary commits, but do not overload one Codex task with unrelated work.
-- The `@codex` comment must map and handle each concern selected for the current bounded batch. The tally remains the authoritative record of all known blockers, including blockers not selected for that task.
+- The in-comment tally remains the authoritative record of all known blockers, including blockers not selected for that task.
 - Never ask Codex to edit, rewrite, or update the PR title or description.
 - Never ask Codex to click, mark, or otherwise resolve a review thread.
 - Never include thread-resolution bookkeeping as work in an `@codex` comment.
-- The generated `@codex` comment must be fully self-contained. It must not mention the tally, checkbox states, item numbers, or phrases such as “the item above.”
+
+Each generated category 2 comment must use this order:
+1. `@codex`
+2. Scope Lock
+3. Task-selection warning
+4. Complete merge-readiness tally
+5. Reviewer comment resolution
+6. Concrete implementation instructions
+7. Verification commands
+8. `new codex task, not a r/e/v/i/e/w task` as the final line
+
+The task-selection warning must say:
+- Implement only unresolved entries marked `— targeted by this Codex task`.
+- Unresolved entries marked `— context only; not targeted by this Codex task` are supplied solely for diagnosis and must not expand the Scope Lock.
+- Completed `✅` entries are history, not work requests.
+- PR-description corrections are manual maintainer actions and must never be implemented by Codex.
 
 Category 2 merge-readiness tally lifecycle:
 - Every tally item must begin directly with `⬜️` when it remains unresolved or `✅` when the latest PR state verifies it is complete, obsolete, or safely non-blocking under these merge-readiness rules.
 - On the first category 2 response when no earlier tally exists in the conversation, construct a comprehensive tally of all current merge blockers with every item initially marked `⬜️`. Do not seed already-resolved historical concerns as completed items.
 - On later invocations, locate and reconcile the most recent tally from this conversation against the latest PR head, diff, tests, checks, reviews, and discussion.
-- Retain completed and unresolved items so the history remains in context. Never silently remove an earlier item. If it becomes obsolete or proves non-blocking, mark it `✅` with a concise explanation.
+- Retain every prior completed and unresolved item so the history remains in context. Never silently remove an earlier item. If it becomes obsolete or proves non-blocking, mark it `✅` with a concise explanation.
 - Preserve item wording and ordering when practical.
 - Mark an item `✅` only after independently verifying the result in the PR; issuing an `@codex` task or seeing a claimed fix is insufficient.
 - Change a completed item back to `⬜️` if later changes regress it.
 - Add newly discovered blockers as `⬜️`. Consolidate duplicate findings by underlying root cause and exclude optional polish or low-value nits; when an earlier tally item is a duplicate of a retained consolidated item, keep the earlier item in place and mark it `✅` with a concise duplicate-of explanation rather than deleting it.
-- Identify every item selected for the current Codex task directly in the tally with the suffix `— targeted by the @codex comment above`. Selected items must remain `⬜️` until a later invocation verifies their implementation.
+- Identify every unresolved item as either `— targeted by this Codex task` for the current bounded batch or `— context only; not targeted by this Codex task` for non-selected blockers. Selected items must remain `⬜️` until a later invocation verifies their implementation.
+- On subsequent invocations, retain every prior tally entry, reconcile its status, and apply the targeted suffix only to the current batch. Previously targeted but still unresolved entries become context-only unless selected again.
 - Treat a fully checked tally as supporting evidence, not a substitute for a fresh merge-readiness review of the current PR state.
-- If a material PR-description correction is already known while repository work remains, track it as one distinct `⬜️` item at the end of the tally. Keep it permanently last; insert newly discovered repository blockers before it. Do not include it in the `@codex` task. Defer generating the replacement PR description, not assessing or tracking the known description problem.
+- If a material PR-description correction is already known while repository work remains, track it as one distinct `⬜️` item at the end of the tally with `— context only; not targeted by this Codex task`. Keep it permanently last; insert newly discovered repository blockers before it. Do not include it in the `@codex` task. Defer generating the replacement PR description, not assessing or tracking the known description problem.
 - Emit category 3 only when every repository-work tally item has been verified complete and the PR-description correction is the sole remaining blocker. This should be the final remediation response before category 1 when the user applies the replacement and no new blocker appears.
 - If the PR description is the only blocker on the first invocation, return category 3 immediately without creating a tally.
 - If the PR is ready immediately, return category 1 immediately without creating a tally.
+
+Tally entries should be useful diagnostic context. When known, each entry must concisely identify:
+- The relevant reviewer, check, run, file, or symbol.
+- The observed behavior or failed contract.
+- Why it blocks merging.
+- The condition that would prove it complete.
+Avoid vague entries that contain only a proposed solution.
 
 Category 3: PR description-only correction needed
 - Use this category only when no repository changes remain and the description update is a real merge-readiness requirement rather than optional polish.
@@ -124,11 +147,13 @@ When recurring AI review comments are present:
 The category 2 `@codex` comment must:
 - Be concise but complete enough for a fresh Codex task.
 - Start with a brief Scope Lock stating allowed files/areas, do-not-touch areas if known, and that the diff should stay minimal.
-- Include a "Reviewer comment resolution" section that maps each selected substantive concern to the concrete repository change or durable in-code justification needed.
-- For each selected concern, ask Codex to either implement the reviewer’s suggested change or add enough durable justification in the repository to address the concern and proceed without further changes.
+- Include the required task-selection warning before the tally.
+- Include the complete `Merge-readiness tally:` inside the comment, after the warning and before reviewer-resolution instructions.
+- Include a "Reviewer comment resolution" section covering only currently targeted entries. For each targeted concern, require evidence from the current PR state; the underlying contract, risk, or user-visible failure; the required outcome; a suggested implementation only when supported by the evidence; and verification that directly proves the outcome.
+- Require Codex to inspect the current code before applying a reviewer’s suggested patch. If a smaller or different change correctly satisfies the underlying contract, Codex should prefer that over blindly implementing a stale or speculative suggestion.
 - Name specific reviewers, files, symbols, comments, threads, checks, or quoted snippets when possible.
-- Include concrete implementation steps.
-- Include verification commands, choosing the narrowest relevant commands first.
+- Include concrete implementation steps covering only currently targeted entries.
+- Include verification commands, choosing the narrowest relevant commands first and ensuring they directly prove the targeted outcomes.
 - Avoid broad refactors unless they are required for correctness.
 - Preserve existing conventions and tests.
 - Use an outer three-backtick `text` fence for the category 2 response, leaving triple tildes (`~~~`) available for any nested code fences inside the comment because nested triple backticks can break formatting.
@@ -152,8 +177,8 @@ Goals:
 - Preserve the requirement that the LLM only says yes when every substantive reviewer comment is addressed or safely non-blocking and the PR description does not require a material correction.
 - Preserve the requirement that unresolved GitHub thread UI state alone is not a blocker when the latest code, tests, comments, or discussion adequately address the underlying concern.
 - Preserve strict handling of genuinely unaddressed reviewer concerns and recurring valid AI-review findings.
-- Preserve the requirement that the `@codex` comment concretely maps each remaining substantive concern to a repository change or durable in-code justification, not thread-resolution bookkeeping.
-- Preserve the requirement that category 2 emits no text outside its single outer three-backtick `text` fenced `@codex` comment.
+- Preserve the requirement that the `@codex` comment includes a self-contained `Merge-readiness tally:` with current-target versus context-only labeling, then maps only currently targeted concerns to repository changes or durable in-code justification, not thread-resolution bookkeeping.
+- Preserve the single-fence category 2 output: exactly one outer three-backtick `text` fenced `@codex` comment, with the complete tally inside the comment and no prose outside the fence.
 - Preserve the ban on asking Codex to edit the PR title or description or to click, mark, or otherwise resolve review threads.
 - Preserve the requirement to use an outer three-backtick `text` fence for the category 2 `@codex` comment, leaving triple tildes (`~~~`) available for nested code fences inside that comment.
 - Preserve the requirement to use triple tildes (`~~~`) for nested code fences inside the replacement PR description, and to wrap category 3's replacement-description block in a longer outer fence such as `~~~~markdown` so nested fences cannot close it early.
@@ -161,7 +186,10 @@ Goals:
 - Preserve the requirement that category 3 contains a complete replacement PR description, with no placeholders, TODOs, partial patches, suggested fragments, `@codex`, or Codex sentinel line.
 - Make the prompt better at distinguishing true merge blockers from low-value nits.
 - Make the prompt better at handling recurring AI review comments without blindly reverting correct code.
-- Make the prompt better at producing followups that let maintainers confidently address every remaining substantive concern.
+- Preserve tally lifecycle and history retention: later invocations retain every prior tally entry, reconcile status from the current PR, target only the current bounded batch, and move unresolved previously targeted entries back to context-only unless selected again.
+- Preserve root-cause-oriented reviewer-resolution instructions that require current evidence, underlying contract/risk/user-visible failure, required outcome, evidence-supported implementation suggestions, and verification that directly proves the outcome.
+- Preserve bounded task scope: only one small coherent group may be targeted, untargeted blockers remain diagnostic context only, completed items are history, and PR-description corrections remain manual maintainer actions.
+- Make the prompt better at producing followups that let maintainers confidently address every remaining substantive concern without expanding the current Codex task.
 - Keep the wording compact enough to use as a Streamdeck action.
 
 Return:


### PR DESCRIPTION
### Motivation
- Make category 2 outputs self-contained so the executing agent receives the complete merge-readiness evidence and instructions without expanding the task scope. 
- Keep the same three-category decision order and existing safeguards while removing conflicting phrasing that allowed the tally to live outside the generated comment. 

### Description
- Update `docs/prompts/llm/pr-final-merge-check.md` (Main Prompt and Upgrade Prompt) so category 2 emits exactly one outer three-backtick `text` fenced `@codex` comment containing the complete `Merge-readiness tally:` and no prose outside the fence. 
- Require a strict in-comment order: `@codex`, Scope Lock, Task-selection warning, Complete merge-readiness tally, Reviewer comment resolution, Concrete implementation instructions, Verification commands, and the final sentinel `new codex task, not a r/e/v/i/e/w task`. 
- Add current-target versus context-only labeling and lifecycle/history rules so tallies are retained, reconciled on later invocations, and only the current bounded batch is targeted. 
- Strengthen reviewer-resolution rules to require evidence from the current PR state, the underlying contract/risk, the required outcome, evidence-supported implementation suggestions, and direct verification commands; update the Upgrade Prompt to preserve these constraints. 

### Testing
- Ran `rg -n "Merge-readiness tally|targeted by this Codex task|context only|outside the fence|must not mention the tally|targeted by the @codex comment above" docs/prompts/llm/pr-final-merge-check.md` and confirmed the updated phrases and single-fence requirement are present. 
- Ran `npm run docs-lint` and it passed: "Docs lint passed". 
- Ran `pre-commit run --files docs/prompts/llm/pr-final-merge-check.md`; the pre-commit tool was initially missing, was installed, and the hook run failed because the repository’s `run project checks` hook would reformat unrelated Python files (Black would reformat 4 existing files), so the pre-commit check did not pass. 
- Ran `git diff --check` which reported no whitespace/patch errors, and `git diff --stat` which shows only `docs/prompts/llm/pr-final-merge-check.md` changed. 
- Manually traced example category 2 flows and confirmed the first category 2 response now produces a single fenced `@codex` comment holding the full tally and that later invocations retain and reconcile prior tally entries while targeting only the current bounded batch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6046b84424832f84d8759f19e2bcea)