### PR TITLE
Require category‑2 @codex comment to contain the full Merge‑readiness tally and tighten tally lifecycle & reviewer‑resolution

### DIFF
--- a/docs/prompts/llm/pr-final-merge-check.md
+++ b/docs/prompts/llm/pr-final-merge-check.md
@@ -50,19 +50,27 @@ Category 1: exact conditional-success response
 - Do not include a merge-readiness tally in category 1.
 
 Category 2: repository changes needed
-- If the PR is not ready to merge because repository changes are still needed, respond with only these two elements, in this order, with no other prose before, between, or after them:
-  1. One copy/paste-ready outer three-backtick `text` fenced code block containing a GitHub PR comment that begins with `@codex`.
-  2. A clearly labeled `Merge-readiness tally:` outside the fence.
-- Include only work Codex can perform in the repository in the `@codex` comment.
-- The `@codex` comment should target one or a small, coherent, reliably executable group of currently unchecked repository-work items. Group multiple tightly related items when safe to reduce unnecessary commits, but do not overload one Codex task with unrelated work.
-- The `@codex` comment must map and handle each concern selected for the current bounded batch. The tally remains the authoritative record of all known blockers, including blockers not selected for that task.
+- If the PR is not ready to merge because repository changes are still needed, respond with exactly one element and no other prose before or after it: one copy/paste-ready outer three-backtick `text` fenced code block containing the complete generated GitHub PR comment.
+- The fenced comment must begin with `@codex` and include the complete `Merge-readiness tally:` inside the generated comment.
+- Within each generated category 2 comment, use this order:
+  1. `@codex`
+  2. Scope Lock
+  3. Task-selection warning
+  4. Complete merge-readiness tally
+  5. Reviewer comment resolution
+  6. Concrete implementation instructions
+  7. Verification commands
+  8. `new codex task, not a r/e/v/i/e/w task` as the final line
+- Include only work Codex can perform in the repository as current implementation instructions.
+- Target one or a small, coherent, reliably executable group of currently unchecked repository-work items. Group multiple tightly related items when safe to reduce unnecessary commits, but do not overload one Codex task with unrelated work.
+- The generated comment must map and handle each concern selected for the current bounded batch. The in-comment tally remains the authoritative record of all known blockers, including blockers not selected for that task.
 - Never ask Codex to edit, rewrite, or update the PR title or description.
 - Never ask Codex to click, mark, or otherwise resolve a review thread.
 - Never include thread-resolution bookkeeping as work in an `@codex` comment.
-- The generated `@codex` comment must be fully self-contained. It must not mention the tally, checkbox states, item numbers, or phrases such as “the item above.”
 
 Category 2 merge-readiness tally lifecycle:
 - Every tally item must begin directly with `⬜️` when it remains unresolved or `✅` when the latest PR state verifies it is complete, obsolete, or safely non-blocking under these merge-readiness rules.
+- When known, each tally entry should concisely identify the relevant reviewer, check, run, file, or symbol; the observed behavior or failed contract; why it blocks merging; and the condition that would prove it complete. Avoid vague entries that contain only a proposed solution.
 - On the first category 2 response when no earlier tally exists in the conversation, construct a comprehensive tally of all current merge blockers with every item initially marked `⬜️`. Do not seed already-resolved historical concerns as completed items.
 - On later invocations, locate and reconcile the most recent tally from this conversation against the latest PR head, diff, tests, checks, reviews, and discussion.
 - Retain completed and unresolved items so the history remains in context. Never silently remove an earlier item. If it becomes obsolete or proves non-blocking, mark it `✅` with a concise explanation.
@@ -70,7 +78,9 @@ Category 2 merge-readiness tally lifecycle:
 - Mark an item `✅` only after independently verifying the result in the PR; issuing an `@codex` task or seeing a claimed fix is insufficient.
 - Change a completed item back to `⬜️` if later changes regress it.
 - Add newly discovered blockers as `⬜️`. Consolidate duplicate findings by underlying root cause and exclude optional polish or low-value nits; when an earlier tally item is a duplicate of a retained consolidated item, keep the earlier item in place and mark it `✅` with a concise duplicate-of explanation rather than deleting it.
-- Identify every item selected for the current Codex task directly in the tally with the suffix `— targeted by the @codex comment above`. Selected items must remain `⬜️` until a later invocation verifies their implementation.
+- Identify every unresolved item selected for the current Codex task directly in the tally with the suffix `— targeted by this Codex task`. Mark unresolved items not selected for the current task with `— context only; not targeted by this Codex task`. Completed `✅` entries need no suffix unless helpful for clarity.
+- Selected items must remain `⬜️` until a later invocation independently verifies their implementation.
+- On subsequent invocations, retain every prior tally entry, reconcile its status, and apply the targeted suffix only to the current bounded batch. Previously targeted but still unresolved entries become context-only unless selected again.
 - Treat a fully checked tally as supporting evidence, not a substitute for a fresh merge-readiness review of the current PR state.
 - If a material PR-description correction is already known while repository work remains, track it as one distinct `⬜️` item at the end of the tally. Keep it permanently last; insert newly discovered repository blockers before it. Do not include it in the `@codex` task. Defer generating the replacement PR description, not assessing or tracking the known description problem.
 - Emit category 3 only when every repository-work tally item has been verified complete and the PR-description correction is the sole remaining blocker. This should be the final remediation response before category 1 when the user applies the replacement and no new blocker appears.
@@ -124,11 +134,13 @@ When recurring AI review comments are present:
 The category 2 `@codex` comment must:
 - Be concise but complete enough for a fresh Codex task.
 - Start with a brief Scope Lock stating allowed files/areas, do-not-touch areas if known, and that the diff should stay minimal.
-- Include a "Reviewer comment resolution" section that maps each selected substantive concern to the concrete repository change or durable in-code justification needed.
-- For each selected concern, ask Codex to either implement the reviewer’s suggested change or add enough durable justification in the repository to address the concern and proceed without further changes.
+- Include a Task-selection warning that says: Implement only unresolved entries marked `— targeted by this Codex task`. Unresolved entries marked `— context only; not targeted by this Codex task` are supplied solely for diagnosis and must not expand the Scope Lock. Completed `✅` entries are history, not work requests. PR-description corrections are manual maintainer actions and must never be implemented by Codex.
+- Include the complete `Merge-readiness tally:` after the Task-selection warning.
+- Include a "Reviewer comment resolution" section covering only currently targeted entries. For each targeted concern, require evidence from the current PR state; the underlying contract, risk, or user-visible failure; the required outcome; a suggested implementation only when supported by the evidence; and verification that directly proves the outcome.
+- Require Codex to inspect the current code before applying a reviewer’s suggested patch. If a smaller or different change correctly satisfies the underlying contract, it should prefer that over blindly implementing a stale or speculative suggestion.
 - Name specific reviewers, files, symbols, comments, threads, checks, or quoted snippets when possible.
-- Include concrete implementation steps.
-- Include verification commands, choosing the narrowest relevant commands first.
+- Include concrete implementation steps covering only currently targeted entries.
+- Include verification commands that directly prove the targeted outcomes, choosing the narrowest relevant commands first.
 - Avoid broad refactors unless they are required for correctness.
 - Preserve existing conventions and tests.
 - Use an outer three-backtick `text` fence for the category 2 response, leaving triple tildes (`~~~`) available for any nested code fences inside the comment because nested triple backticks can break formatting.
@@ -152,7 +164,10 @@ Goals:
 - Preserve the requirement that the LLM only says yes when every substantive reviewer comment is addressed or safely non-blocking and the PR description does not require a material correction.
 - Preserve the requirement that unresolved GitHub thread UI state alone is not a blocker when the latest code, tests, comments, or discussion adequately address the underlying concern.
 - Preserve strict handling of genuinely unaddressed reviewer concerns and recurring valid AI-review findings.
-- Preserve the requirement that the `@codex` comment concretely maps each remaining substantive concern to a repository change or durable in-code justification, not thread-resolution bookkeeping.
+- Preserve the requirement that the `@codex` comment concretely maps each currently targeted substantive concern to a repository change or durable in-code justification, not thread-resolution bookkeeping.
+- Preserve the self-contained in-comment tally as the authoritative record of all known blockers, including current-target versus context-only labeling, tally lifecycle, reconciliation, and history retention across invocations.
+- Preserve root-cause-oriented reviewer-resolution instructions that require current evidence, underlying contract/risk/failure, required outcome, evidence-supported implementation suggestions, and direct verification rather than blind application of stale or speculative patches.
+- Preserve bounded task scope: only one small coherent current batch is targeted, untargeted unresolved tally entries are context only, completed entries are history, and PR-description corrections remain manual maintainer actions.
 - Preserve the requirement that category 2 emits no text outside its single outer three-backtick `text` fenced `@codex` comment.
 - Preserve the ban on asking Codex to edit the PR title or description or to click, mark, or otherwise resolve review threads.
 - Preserve the requirement to use an outer three-backtick `text` fence for the category 2 `@codex` comment, leaving triple tildes (`~~~`) available for nested code fences inside that comment.


### PR DESCRIPTION
### Motivation
- Make category 2 outputs self-contained so an executing Codex agent has the complete evidence and context it needs without expanding the bounded task.
- Avoid ambiguous or split instructions (tally outside the comment, multi-element category‑2 output) that led to inconsistent agent behavior.
- Strengthen reviewer-resolution guidance so fixes target root causes, not speculative patches, and to reduce blind application of stale suggestions.

### Description
- Updated `docs/prompts/llm/pr-final-merge-check.md` so category 2 emits exactly one outer three-backtick `text` fenced block containing the complete generated `@codex` PR comment and moved the full `Merge-readiness tally:` inside that comment.
- Added an explicit required order inside each generated category 2 comment: `@codex`, Scope Lock, the task-selection warning (exact wording required), complete merge-readiness tally, reviewer comment resolution, concrete implementation instructions, verification commands, and `new codex task, not a r/e/v/i/e/w task` as the final line.
- Introduced current-target versus context-only tally labeling and reinforced tally lifecycle rules to retain history, reconcile prior entries on subsequent invocations, and mark only the current bounded batch as targeted (`— targeted by this Codex task` vs `— context only; not targeted by this Codex task`).
- Strengthened the “Reviewer comment resolution” requirements to demand evidence from the current PR state, the underlying contract/risk, required outcomes, evidence-backed implementation suggestions only when justified, and direct verification steps; and required Codex to inspect current code before applying reviewer suggestions.
- Removed conflicting/obsolete language that required the tally be outside the fence, described category 2 as two elements, or implied untargeted tally entries were implementation instructions; updated the Upgrade Prompt so future edits must preserve the single-fence, self-contained tally and bounded-task safeguards.
- Manually traced sample first-and-later category 2 flow to confirm the first response creates a comprehensive in-comment tally and later invocations retain history while only the current batch is targeted.

### Testing
- Ran `rg -n "Merge-readiness tally|targeted by this Codex task|context only|outside the fence|must not mention the tally|targeted by the @codex comment above" docs/prompts/llm/pr-final-merge-check.md` and confirmed the file contains the updated phrases and no obsolete two-element/outside‑the‑fence rules (passed).
- Ran `npm run docs-lint` and confirmed documentation linting passed (passed).
- Ran `pre-commit run --files docs/prompts/llm/pr-final-merge-check.md` which failed in the repository’s broader `run project checks` hook because four unrelated Python files would be reformatted by Black (`tests/test_patch_coverage.py`, `tests/test_prompt_docs_todos_sorting.py`, `tests/test_runbook_cli.py`, and `flywheel/__main__.py`) and so the pre-commit step exited non-zero (failed due to unrelated formatting in other files).
- Ran `git diff --check` and `git diff --stat` to confirm only `docs/prompts/llm/pr-final-merge-check.md` is modified and there are no whitespace/errors from the edit (passed).

Notes: the change touches only `docs/prompts/llm/pr-final-merge-check.md`; the pre-commit failure is caused by existing repository formatting issues unrelated to this prompt edit and should be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6046c7af68832fb03a8a859c1fa59e)