### PR TITLE
Add secure Claude Code workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,121 @@
+name: Claude Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned, labeled]
+
+permissions:
+  contents: read
+  id-token: write
+  actions: read
+
+jobs:
+  claude:
+    name: Claude ordinary path
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: >-
+      github.actor == 'futuroptimist' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude-exec')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude-exec')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude-exec')) ||
+        (github.event_name == 'issues' && contains(github.event.issue.body, '@claude') && !contains(github.event.issue.body, '@claude-exec'))
+      )
+    steps:
+      - name: Fail closed for fork pull requests
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PATH: ${{ github.event_path }}
+          GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          import urllib.error
+          import urllib.request
+
+          with open(os.environ["EVENT_PATH"], encoding="utf-8") as event_file:
+              event = json.load(event_file)
+
+          pr = event.get("pull_request")
+          if pr is None and event.get("issue", {}).get("pull_request"):
+              issue_number = event["issue"]["number"]
+              url = f"https://api.github.com/repos/{os.environ['REPOSITORY']}/pulls/{issue_number}"
+              request = urllib.request.Request(
+                  url,
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              try:
+                  with urllib.request.urlopen(request, timeout=20) as response:
+                      pr = json.load(response)
+              except urllib.error.HTTPError as error:
+                  print(f"Failed closed: could not inspect pull request fork status: {error}", file=sys.stderr)
+                  sys.exit(1)
+
+          if pr and pr.get("head", {}).get("repo", {}).get("fork"):
+              print("Refusing to run Claude on fork pull request input.", file=sys.stderr)
+              sys.exit(1)
+          PY
+
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608 # v1.0 reviewed for Flywheel/Jobbot
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read
+          include_comments_by_actor: "futuroptimist"
+          use_commit_signing: true
+          # allowedTools is additive and not a sandbox. The action's implicit
+          # native GitHub/session tools remain available; do not invent or
+          # list native commit/push tool names here.
+          claude_args: >-
+            --setting-sources user
+            --strict-mcp-config
+            --max-turns 120
+            --allowedTools Read,Edit,Write,Glob,Grep
+            --disallowedTools Bash,WebFetch,WebSearch
+            --append-system-prompt "For a request that asks for repository changes, a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early, before lengthy investigation or the final third of the session. Use the action's native signed commit/push mechanism; direct Bash git commands are prohibited. Because the ordinary path intentionally cannot execute repository code, do not withhold a coherent requested change merely because shell-based tests cannot run. Commit it, clearly report which checks were not run, and rely on CI before merge. Perform available non-shell inspection and consistency checks before committing. Reserve the final ten turns for reviewing the diff, checking status, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not create commits for analysis-only requests, empty work, secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit is not evidence that CI is green or that the PR is merge-ready."
+          settings: |
+            {
+              "hooks": {
+                "PreToolUse": [
+                  {
+                    "matcher": "Bash",
+                    "hooks": [
+                      {
+                        "type": "command",
+                        "command": "python3 -c 'import sys; print(\"Bash is disabled in this ordinary Claude workflow.\", file=sys.stderr); sys.exit(2)'"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": "Read|Edit|Write|Glob|Grep",
+                    "hooks": [
+                      {
+                        "type": "command",
+                        "command": "python3 -c 'import json, os, pathlib, sys; data=json.load(sys.stdin); workspace=pathlib.Path(os.environ.get(\"GITHUB_WORKSPACE\", os.getcwd())).resolve(); tool_input=data.get(\"tool_input\") or {}; paths=[]\n\ndef walk(value, key=\"\"):\n    if isinstance(value, dict):\n        for child_key, child_value in value.items():\n            walk(child_value, child_key)\n    elif isinstance(value, list):\n        for child_value in value:\n            walk(child_value, key)\n    elif isinstance(value, str) and key in {\"file_path\", \"path\", \"dir\", \"directory\", \"root\", \"cwd\"}:\n        paths.append(value)\n\nwalk(tool_input)\nfor raw_path in paths:\n    candidate = pathlib.Path(raw_path)\n    if not candidate.is_absolute():\n        candidate = workspace / candidate\n    try:\n        resolved = candidate.resolve(strict=False)\n        resolved.relative_to(workspace)\n    except Exception:\n        print(f\"Path escapes GITHUB_WORKSPACE: {raw_path}\", file=sys.stderr)\n        sys.exit(2)\nsys.exit(0)'"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,12 +8,13 @@ on:
   pull_request_review:
     types: [submitted]
   issues:
-    types: [opened, assigned, labeled]
+    types: [opened]
 
 permissions:
   contents: read
   id-token: write
   actions: read
+  pull-requests: read
 
 jobs:
   claude:
@@ -36,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          python - <<'PY'
+          python3 - <<'PY'
           import json
           import os
           import sys
@@ -65,9 +66,11 @@ jobs:
                   print(f"Failed closed: could not inspect pull request fork status: {error}", file=sys.stderr)
                   sys.exit(1)
 
-          if pr and pr.get("head", {}).get("repo", {}).get("fork"):
-              print("Refusing to run Claude on fork pull request input.", file=sys.stderr)
-              sys.exit(1)
+          if pr is not None:
+              head_repo = pr.get("head", {}).get("repo")
+              if head_repo is None or head_repo.get("fork"):
+                  print("Refusing to run Claude on fork pull request input.", file=sys.stderr)
+                  sys.exit(1)
           PY
 
       - name: Checkout repository
@@ -84,9 +87,15 @@ jobs:
             actions: read
           include_comments_by_actor: "futuroptimist"
           use_commit_signing: true
+          # The default Claude GitHub App path exchanges the OIDC token for an
+          # app installation token with write permissions, so the workflow keeps
+          # GITHUB_TOKEN contents read-only and does not pass github_token here.
           # allowedTools is additive and not a sandbox. The action's implicit
           # native GitHub/session tools remain available; do not invent or
           # list native commit/push tool names here.
+          # The pinned action parses claude_args with shell-quote before passing
+          # them to the Claude CLI, so the quoted append-system-prompt remains a
+          # single argument even though YAML folds this block into one line.
           claude_args: >-
             --setting-sources user
             --strict-mcp-config
@@ -108,7 +117,7 @@ jobs:
                     ]
                   },
                   {
-                    "matcher": "Read|Edit|Write|Glob|Grep",
+                    "matcher": "Read|Edit|Write|Glob|Grep|LS",
                     "hooks": [
                       {
                         "type": "command",

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,20 +22,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     if: >-
+      github.repository_owner == 'futuroptimist' &&
       github.actor == 'futuroptimist' &&
       (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude-exec')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude-exec')) ||
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude-exec')) ||
-        (github.event_name == 'issues' && contains(github.event.issue.body, '@claude') && !contains(github.event.issue.body, '@claude-exec'))
+        (github.event_name == 'issues' && (contains(github.event.issue.title, '@claude') || contains(github.event.issue.body, '@claude')) && !contains(github.event.issue.title, '@claude-exec') && !contains(github.event.issue.body, '@claude-exec'))
       )
     steps:
       - name: Fail closed for fork pull requests
         env:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_PATH: ${{ github.event_path }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
         run: |
           python3 - <<'PY'
           import json
@@ -44,13 +45,20 @@ jobs:
           import urllib.error
           import urllib.request
 
-          with open(os.environ["EVENT_PATH"], encoding="utf-8") as event_file:
-              event = json.load(event_file)
+          try:
+              with open(os.environ["EVENT_PATH"], encoding="utf-8") as event_file:
+                  event = json.load(event_file)
+          except Exception as error:
+              print(f"Failed closed: could not parse event payload: {error}", file=sys.stderr)
+              sys.exit(1)
 
           pr = event.get("pull_request")
           if pr is None and event.get("issue", {}).get("pull_request"):
-              issue_number = event["issue"]["number"]
-              url = f"https://api.github.com/repos/{os.environ['REPOSITORY']}/pulls/{issue_number}"
+              issue_number = event["issue"].get("number")
+              if not issue_number:
+                  print("Failed closed: missing pull request issue number.", file=sys.stderr)
+                  sys.exit(1)
+              url = f"https://api.github.com/repos/{os.environ['GITHUB_REPOSITORY']}/pulls/{issue_number}"
               request = urllib.request.Request(
                   url,
                   headers={
@@ -62,19 +70,104 @@ jobs:
               try:
                   with urllib.request.urlopen(request, timeout=20) as response:
                       pr = json.load(response)
-              except urllib.error.HTTPError as error:
+              except (OSError, urllib.error.URLError, urllib.error.HTTPError, TimeoutError, json.JSONDecodeError) as error:
                   print(f"Failed closed: could not inspect pull request fork status: {error}", file=sys.stderr)
                   sys.exit(1)
 
           if pr is not None:
               head_repo = pr.get("head", {}).get("repo")
-              if head_repo is None or head_repo.get("fork"):
-                  print("Refusing to run Claude on fork pull request input.", file=sys.stderr)
+              head_full_name = head_repo.get("full_name") if isinstance(head_repo, dict) else None
+              if head_full_name != os.environ["GITHUB_REPOSITORY"]:
+                  print("Refusing to run Claude on fork or malformed pull request input.", file=sys.stderr)
                   sys.exit(1)
           PY
 
+      - name: Install Claude workspace hook validator
+        run: |
+          cat >"$RUNNER_TEMP/claude_workspace_guard.py" <<'PY'
+          import json
+          import os
+          import pathlib
+          import sys
+
+          GLOB_CHARS = "*?["
+
+          def deny(message):
+              print(message, file=sys.stderr)
+              sys.exit(2)
+
+          try:
+              data = json.load(sys.stdin)
+          except Exception as error:
+              deny(f"Malformed hook JSON: {error}")
+
+          workspace_env = os.environ.get("GITHUB_WORKSPACE")
+          if not workspace_env:
+              deny("Missing GITHUB_WORKSPACE.")
+          workspace = pathlib.Path(workspace_env).resolve(strict=False)
+
+          tool_name = data.get("tool_name") or data.get("tool") or data.get("name")
+          tool_input = data.get("tool_input")
+          if not isinstance(tool_input, dict):
+              deny("Malformed tool input.")
+
+          def require_string(key):
+              value = tool_input.get(key)
+              if not isinstance(value, str) or not value:
+                  deny(f"Missing required {key}.")
+              return value
+
+          def optional_string(key):
+              value = tool_input.get(key)
+              if value is None or value == "":
+                  return None
+              if not isinstance(value, str):
+                  deny(f"Malformed {key}.")
+              return value
+
+          def validate_path(raw_path):
+              candidate = pathlib.Path(raw_path)
+              if not candidate.is_absolute():
+                  candidate = workspace / candidate
+              try:
+                  resolved = candidate.resolve(strict=False)
+                  resolved.relative_to(workspace)
+              except Exception:
+                  deny(f"Path escapes GITHUB_WORKSPACE: {raw_path}")
+
+          def concrete_prefix(glob_pattern):
+              if pathlib.PurePosixPath(glob_pattern).is_absolute() or pathlib.PureWindowsPath(glob_pattern).is_absolute():
+                  deny(f"Absolute glob pattern denied: {glob_pattern}")
+              parts = pathlib.PurePosixPath(glob_pattern.replace("\\", "/")).parts
+              if ".." in parts:
+                  deny(f"Parent traversal in glob pattern denied: {glob_pattern}")
+              first_glob = min((glob_pattern.find(char) for char in GLOB_CHARS if char in glob_pattern), default=len(glob_pattern))
+              prefix = glob_pattern[:first_glob]
+              slash = max(prefix.rfind("/"), prefix.rfind("\\"))
+              return "." if slash < 0 else (prefix[:slash] or ".")
+
+          if tool_name in {"Read", "Edit", "Write"}:
+              validate_path(require_string("file_path"))
+          elif tool_name == "LS":
+              validate_path(require_string("path"))
+          elif tool_name == "Glob":
+              validate_path(concrete_prefix(require_string("pattern")))
+              path = optional_string("path")
+              if path is not None:
+                  validate_path(path)
+          elif tool_name == "Grep":
+              path = optional_string("path")
+              if path is not None:
+                  validate_path(path)
+              glob = optional_string("glob")
+              if glob is not None:
+                  validate_path(concrete_prefix(glob))
+          else:
+              deny(f"Unexpected guarded tool: {tool_name}")
+          PY
+
       - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -121,7 +214,7 @@ jobs:
                     "hooks": [
                       {
                         "type": "command",
-                        "command": "python3 -c 'import json, os, pathlib, sys; data=json.load(sys.stdin); workspace=pathlib.Path(os.environ.get(\"GITHUB_WORKSPACE\", os.getcwd())).resolve(); tool_input=data.get(\"tool_input\") or {}; paths=[]\n\ndef walk(value, key=\"\"):\n    if isinstance(value, dict):\n        for child_key, child_value in value.items():\n            walk(child_value, child_key)\n    elif isinstance(value, list):\n        for child_value in value:\n            walk(child_value, key)\n    elif isinstance(value, str) and key in {\"file_path\", \"path\", \"dir\", \"directory\", \"root\", \"cwd\"}:\n        paths.append(value)\n\nwalk(tool_input)\nfor raw_path in paths:\n    candidate = pathlib.Path(raw_path)\n    if not candidate.is_absolute():\n        candidate = workspace / candidate\n    try:\n        resolved = candidate.resolve(strict=False)\n        resolved.relative_to(workspace)\n    except Exception:\n        print(f\"Path escapes GITHUB_WORKSPACE: {raw_path}\", file=sys.stderr)\n        sys.exit(2)\nsys.exit(0)'"
+                        "command": "python3 \"$RUNNER_TEMP/claude_workspace_guard.py\""
                       }
                     ]
                   }


### PR DESCRIPTION
### Motivation

- Add a secure ordinary `@claude` workflow that favors producing coherent, signed commits for owner-triggered implementation requests.
- Keep the workflow token least-privileged, prevent arbitrary shell/web access, fail closed for fork PRs, and exclude the future privileged `@claude-exec` path.

### Description

- Add `.github/workflows/claude.yml` supporting created issue comments, created PR review comments, submitted PR reviews, and newly opened issues.
- Require both `github.repository_owner == 'futuroptimist'` and `github.actor == 'futuroptimist'`.
- Accept `@claude` in the relevant comment/review text or an opened issue’s title/body, while rejecting the ordinary job if `@claude-exec` appears.
- Run a pre-checkout fork guard that:
  - Uses `python3`.
  - Fetches PR metadata for PR issue comments.
  - Requires `head.repo.full_name == GITHUB_REPOSITORY`.
  - Fails closed on malformed payloads, missing repository data, API errors, timeouts, and parse failures.
- Checkout full history with credentials disabled using immutable pin `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683`.
- Run `anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608` with signed commits and comments limited to `futuroptimist`.
- Install a schema-aware `PreToolUse` validator for `Read`, `Edit`, `Write`, `Glob`, `Grep`, and the action-supplied implicit `LS` tool. It rejects malformed inputs and paths, glob prefixes, parent traversal, or symlinks escaping `GITHUB_WORKSPACE`.
- Hard-deny every Claude `Bash` call. No privileged `@claude-exec` workflow is added.

### Permissions and token model

The workflow `GITHUB_TOKEN` has only:

- `contents: read`
- `actions: read`
- `pull-requests: read`
- `id-token: write`

It does not receive `contents: write` or `workflows: write`. The pinned Claude action exchanges OIDC for a separate short-lived GitHub App installation token used by its native signed commit/push mechanism. Its `additional_permissions` remains limited to `actions: read`.

### Effective Claude arguments

- `--setting-sources user`
- `--strict-mcp-config`
- `--max-turns 120`
- `--allowedTools Read,Edit,Write,Glob,Grep`
- `--disallowedTools Bash,WebFetch,WebSearch`
- One shell-quoted `--append-system-prompt` value establishing the early checkpoint-commit, native signed push, no-shell, unrun-check reporting, final-ten-turn review/commit, and do-not-commit-broken-work contract.

The pinned action parses `claude_args` with `shell-quote`, so the complete appended prompt is passed as one argument. `allowedTools` is additive; the action’s implicit native GitHub/session tools remain available and are not invented or enumerated here.

### Verification

- Parsed `.github/workflows/claude.yml` as YAML.
- Ran `git diff --check`.
- Ran `npm run lint`.
- Ran the repository secret scanner against the workflow diff.
- Exercised the workspace validator with allowed repository-local inputs and denied malformed JSON, missing fields/workspace, absolute and parent-traversing paths/globs, outside paths, and escaping symlinks.
- Verified the complete appended system prompt parses as one argument.
- Verified the targeted hook matcher does not match the action’s native commit, comment, or CI MCP tools.
- Confirmed the diff contains only `.github/workflows/claude.yml`.
- `actionlint` was not installed in the implementation environment.
- Latest-head GitHub checks succeeded: Spelling, Link Check, Lint & Format, Test Suite, and Security scan.

Current branch: `codex/implement-claude-code-github-workflow`  
Current head: `d38582bd52bf7073daf535c2d89a28f6c0c88f4d`

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6066f8ca00832faa7aa22b6ae15bad)