### PR TITLE
ci: add secure owner-only Claude workflow (no-shell, guarded)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,178 @@
+name: Claude Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+  actions: read
+  id-token: write
+
+jobs:
+  claude-response:
+    if: >-
+      github.repository_owner == 'futuroptimist' &&
+      github.actor == 'futuroptimist' &&
+      (
+        (
+          github.event_name == 'issue_comment' &&
+          contains(github.event.comment.body, '@claude') &&
+          !contains(github.event.comment.body, '@claude-exec')
+        ) ||
+        (
+          github.event_name == 'pull_request_review_comment' &&
+          contains(github.event.comment.body, '@claude') &&
+          !contains(github.event.comment.body, '@claude-exec')
+        ) ||
+        (
+          github.event_name == 'pull_request_review' &&
+          contains(github.event.review.body, '@claude') &&
+          !contains(github.event.review.body, '@claude-exec')
+        ) ||
+        (
+          github.event_name == 'issues' &&
+          !github.event.issue.pull_request &&
+          (
+            contains(github.event.issue.title, '@claude') ||
+            contains(github.event.issue.body, '@claude')
+          ) &&
+          !contains(github.event.issue.title, '@claude-exec') &&
+          !contains(github.event.issue.body, '@claude-exec')
+        )
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Reject fork pull requests
+        if: >-
+          github.event.pull_request ||
+          github.event.issue.pull_request
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_API_URL: ${{ github.event.issue.pull_request.url || '' }}
+          EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || '' }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+          import urllib.request
+
+          head_repo = os.environ.get("EVENT_HEAD_REPO")
+          if not head_repo:
+              request = urllib.request.Request(
+                  os.environ["PR_API_URL"],
+                  headers={
+                      "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                      "Accept": "application/vnd.github+json",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              with urllib.request.urlopen(request, timeout=10) as response:
+                  pull_request = json.load(response)
+              head_repo = pull_request.get("head", {}).get("repo", {}).get("full_name")
+
+          if head_repo != os.environ["REPOSITORY"]:
+              print("Claude ordinary workflow does not run on fork pull requests.", file=sys.stderr)
+              sys.exit(1)
+          PY
+
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Claude workspace guard
+        run: |
+          cat > "$RUNNER_TEMP/claude-workspace-guard.py" <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          WORKSPACE = Path(os.environ["GITHUB_WORKSPACE"]).resolve()
+          REPO_TOOLS = {"Read", "Edit", "Write", "Glob", "Grep"}
+          PATH_KEYS = ("file_path", "path", "notebook_path")
+
+          def deny(message: str) -> None:
+              print(message, file=sys.stderr)
+              sys.exit(2)
+
+          try:
+              payload = json.load(sys.stdin)
+          except json.JSONDecodeError as exc:
+              deny(f"Refusing tool use with malformed hook payload: {exc}")
+
+          tool_name = payload.get("tool_name")
+          tool_input = payload.get("tool_input") or {}
+
+          if tool_name == "Bash":
+              deny("Bash is prohibited in this ordinary Claude workflow.")
+
+          if tool_name not in REPO_TOOLS:
+              deny(f"Tool {tool_name!r} is not permitted by the ordinary Claude workflow guard.")
+
+          for key in PATH_KEYS:
+              value = tool_input.get(key)
+              if not value:
+                  continue
+              candidate = Path(value)
+              if not candidate.is_absolute():
+                  candidate = WORKSPACE / candidate
+              resolved = candidate.resolve(strict=False)
+              if resolved != WORKSPACE and WORKSPACE not in resolved.parents:
+                  deny(f"Refusing {tool_name} path outside workspace: {value}")
+
+          pattern = tool_input.get("pattern")
+          if tool_name in {"Glob", "Grep"} and isinstance(pattern, str):
+              pattern_path = Path(pattern)
+              if pattern_path.is_absolute():
+                  resolved = pattern_path.resolve(strict=False)
+                  if resolved != WORKSPACE and WORKSPACE not in resolved.parents:
+                      deny(f"Refusing {tool_name} absolute pattern outside workspace: {pattern}")
+          PY
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608  # v1 reviewed revision
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          include_comments_by_actor: "futuroptimist"
+          additional_permissions: |
+            actions: read
+          use_commit_signing: true
+          settings: |
+            {
+              "hooks": {
+                "PreToolUse": [
+                  {
+                    "matcher": "*",
+                    "hooks": [
+                      {
+                        "type": "command",
+                        "command": "python3 \"$RUNNER_TEMP/claude-workspace-guard.py\""
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          # The action provides its own native GitHub commit/push tools. The
+          # Claude CLI allowedTools list below is intentionally limited to
+          # repository file inspection/edit tools and is not a sandbox by itself.
+          claude_args: >-
+            --setting-sources user
+            --strict-mcp-config
+            --max-turns 120
+            --allowedTools Read,Edit,Write,Glob,Grep
+            --disallowedTools Bash,WebFetch,WebSearch
+            --append-system-prompt "For a request that asks for repository changes, a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early, before lengthy investigation or the final third of the session. Use the action's native signed commit/push mechanism; direct Bash git commands are prohibited. Because the ordinary path intentionally cannot execute repository code, do not withhold a coherent requested change merely because shell-based tests cannot run. Commit it, clearly report which checks were not run, and rely on CI before merge. Perform available non-shell inspection and consistency checks before committing. Reserve the final ten turns for reviewing the diff, checking status, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not create commits for analysis-only requests, empty work, secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit is not evidence that CI is green or that the PR is merge-ready."


### PR DESCRIPTION
### Motivation
- Provide an ordinary owner-triggered `@claude` path that strongly favors making coherent signed checkpoint commits while preventing accidental privileged execution and arbitrary shell/git commands.
- Enforce least-privilege permissions, workspace confinement, and an explicit default-deny PreToolUse guard before allowing any repository file tooling.

### Description
- Added `.github/workflows/claude.yml` to handle `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues` events and restricted activation to the repository owner `futuroptimist`, explicitly excluding `@claude-exec` from matching.
- Enforced least privilege: `permissions` set to `contents: read`, `actions: read`, `id-token: write`; checkout uses full history with `fetch-depth: 0`, `persist-credentials: false`, and `use_commit_signing: true` is enabled for the action.
- Pinned third-party actions to immutable SHAs consistent with repo convention, including `actions/checkout` and `anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608`.
- Added a PreToolUse workspace guard (installed at runtime) that hard-denies the `Bash` tool, restricts allowed Claude repository tools to `Read`, `Edit`, `Write`, `Glob`, and `Grep`, and fails closed if any referenced path or absolute search pattern resolves outside `GITHUB_WORKSPACE`.
- Configured `claude_args` with strict MCP and checkpoint-commit policy and bounded turn count: `--setting-sources user`, `--strict-mcp-config`, `--max-turns 120`, `--allowedTools Read,Edit,Write,Glob,Grep`, `--disallowedTools Bash,WebFetch,WebSearch`, and a single-argument `--append-system-prompt` that requires early checkpoint commits, prohibits direct bash/git commands, and reserves final turns for review and commit.

### Testing
- Workflow assertions: parsed the new YAML and asserted owner-only triggering, `@claude-exec` exclusion, fork-PR rejection, pinned action SHAs, read-only `GITHUB_TOKEN` usage, `persist-credentials: false`, and PreToolUse hook wiring (assertions passed).
- Secret and diff checks: ran `git diff --cached | ./scripts/scan-secrets.py` (no secrets detected) and `git diff --cached --check` (no whitespace/errors reported).
- Targeted JS workflow tests: ran the relevant Jest workflow tests (selected suites passed) and other workflow-focused tests used by the repo (all passed in this environment); `actionlint` was not available locally so it was skipped.
- Result: workflow file added and committed on branch `codex/claude-workflow-no-shell`, Commit SHA `993c60aaad0fd3244a75848922e8ce26129d2252`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60671e1544832fa6582cca17f7db80)