### PR TITLE
Add secure owner-only Claude Code workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,127 @@
+name: Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, edited, assigned]
+
+permissions:
+  contents: read
+  actions: read
+  id-token: write
+
+jobs:
+  claude:
+    name: Claude owner request
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: >-
+      ${{
+        github.repository_owner == 'futuroptimist' &&
+        github.actor == 'futuroptimist' &&
+        !contains(github.event.comment.body || github.event.review.body || github.event.issue.body || github.event.issue.title || '', '@claude-exec') &&
+        (
+          (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+          (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+          (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+          (github.event_name == 'issues' && (contains(github.event.issue.body || '', '@claude') || contains(github.event.issue.title, '@claude') || contains(github.event.issue.assignees.*.login, 'claude')))
+        )
+      }}
+    steps:
+      - name: Reject fork pull requests
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PATH: ${{ github.event_path }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          import sys
+          import urllib.request
+
+          with open(os.environ["EVENT_PATH"], encoding="utf-8") as handle:
+              event = json.load(handle)
+
+          pr = event.get("pull_request")
+          issue = event.get("issue") or {}
+          if not pr and issue.get("pull_request"):
+              request = urllib.request.Request(
+                  issue["pull_request"]["url"],
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              with urllib.request.urlopen(request, timeout=15) as response:
+                  pr = json.load(response)
+
+          if not pr:
+              sys.exit(0)
+
+          base_repo = pr.get("base", {}).get("repo", {}).get("full_name")
+          head_repo = pr.get("head", {}).get("repo", {}).get("full_name")
+          expected = os.environ["GITHUB_REPOSITORY"]
+          if base_repo != expected or head_repo != expected:
+              print(
+                  f"Refusing to run Claude on fork PR: base={base_repo!r}, head={head_repo!r}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          PY
+
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608 # v1 reviewed revision
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          additional_permissions: "actions: read"
+          include_comments_by_actor: "futuroptimist"
+          use_commit_signing: true
+          settings: |
+            {
+              "hooks": {
+                "PreToolUse": [
+                  {
+                    "matcher": "Bash",
+                    "hooks": [
+                      {
+                        "type": "command",
+                        "command": "python3 -c 'import sys; print(\"Bash is disabled in this ordinary Claude workflow.\", file=sys.stderr); sys.exit(2)'"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": "Read|Edit|Write|Glob|Grep",
+                    "hooks": [
+                      {
+                        "type": "command",
+                        "command": "python3 - <<'PY'\nimport json, os, pathlib, sys\n\npayload = json.load(sys.stdin)\nworkspace = pathlib.Path(os.environ.get('GITHUB_WORKSPACE', os.getcwd())).resolve()\ntool = payload.get('tool_name', '')\ntool_input = payload.get('tool_input') or {}\nkeys = ('file_path', 'path', 'notebook_path', 'pattern') if tool == 'Glob' else ('file_path', 'path', 'notebook_path')\npaths = [tool_input[k] for k in keys if isinstance(tool_input.get(k), str) and tool_input[k].strip()]\nif not paths and tool in {'Read', 'Edit', 'Write'}:\n    print(f'{tool} requires a repository-confined file path.', file=sys.stderr)\n    sys.exit(2)\nfor raw in paths:\n    candidate = pathlib.Path(raw)\n    if not candidate.is_absolute():\n        candidate = workspace / candidate\n    try:\n        resolved = candidate.resolve(strict=False)\n        resolved.relative_to(workspace)\n    except Exception:\n        print(f'Blocked {tool} path outside repository workspace: {raw}', file=sys.stderr)\n        sys.exit(2)\nsys.exit(0)\nPY"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          # --allowedTools is additive and does not sandbox implicit base tools
+          # supplied by the action, including its native signed commit/push path.
+          # Bash git commands remain prohibited by --disallowedTools and hooks.
+          claude_args: |
+            --setting-sources user
+            --strict-mcp-config
+            --max-turns 120
+            --allowedTools Read,Edit,Write,Glob,Grep
+            --disallowedTools Bash,WebFetch,WebSearch
+            --append-system-prompt "For a request that asks for repository changes, a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early, before lengthy investigation or the final third of the session. Use the action's native signed commit/push mechanism; direct Bash git commands are prohibited. Because the ordinary path intentionally cannot execute repository code, do not withhold a coherent requested change merely because shell-based tests cannot run. Commit it, clearly report which checks were not run, and rely on CI before merge. Perform available non-shell inspection and consistency checks before committing. Reserve the final ten turns for reviewing the diff, checking status, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not create commits for analysis-only requests, empty work, secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit is not evidence that CI is green or that the PR is merge-ready."


### PR DESCRIPTION
### Motivation
- Provide an ordinary owner-triggered Claude Code workflow that enables repository edits while preventing arbitrary shell/git commands and minimizing token permissions. 
- Enforce a default-deny PreToolUse policy and an early checkpoint-commit contract so owner implementation requests produce early, reviewable commits via the action's native signed push mechanism.

### Description
- Added `.github/workflows/claude.yml` that triggers on `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues` and restricts invocation to the repository owner (`futuroptimist`) while explicitly excluding `@claude-exec` matches. 
- Fail-closed fork protection rejects PR contexts where the head/base repo does not match the repository before checking out or running Claude. 
- Enforced least-privilege workflow permissions with `contents: read`, `actions: read`, and `id-token: write`, and avoided `workflows: write`; checkout uses `fetch-depth: 0`, `persist-credentials: false`, and a pinned `actions/checkout` SHA. 
- Pinned `anthropics/claude-code-action` to the reviewed immutable revision `fa7e2f0a29a126f0b81cdcf360561b36e44cf608`, enabled `use_commit_signing: true` and `include_comments_by_actor: "futuroptimist"`, added a default-deny `PreToolUse` policy that hard-denies `Bash` and confines `Read`, `Edit`, `Write`, `Glob`, and `Grep` paths to files resolving inside `GITHUB_WORKSPACE`, and configured `claude_args` with `--setting-sources user`, `--strict-mcp-config`, `--max-turns 120`, `--allowedTools Read,Edit,Write,Glob,Grep`, `--disallowedTools Bash,WebFetch,WebSearch`, and an appended system prompt describing the checkpoint-commit/no-shell contract.

### Testing
- Parsed the workflow as YAML with `python -c 'import yaml; yaml.safe_load(open(".github/workflows/claude.yml"))'` and it succeeded. 
- Ran `git diff --check` and it reported no whitespace/patch errors. 
- Executed policy assertions via a short Python script that validated owner-only triggering, fork rejection logic, immutable action pins, minimal permissions, checkout options, PreToolUse hook contents, `claude_args` flags, and the presence of the appended system prompt, and all assertions passed. 
- Ran the repository secrets scanner with `git diff --cached | python scripts/scan-secrets.py` and it found no secrets. 
- `actionlint` was not available in this environment so the linter was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a606727f580832fb7c373023500af8b)