### PR TITLE
docs: track aquiloop and fix Related Projects drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,15 +516,18 @@ We aim for a positive-sum, empathetic community. The flywheel embraces regenerat
 - ✅ [sugarkube](https://github.com/futuroptimist/sugarkube) –  \
   k3s platform for off-grid Raspberry Pi clusters.  \
   See `docs/sugarkube-integration.md`.
-- ✅ [jobbot3000](https://github.com/futuroptimist/jobbot3000) –  \\
-  self-hosted job search copilot.
-- ✅ [Prompt Docs Summary][pds] –  \\
+- ✅ [jobbot3000](https://github.com/futuroptimist/jobbot3000) –  \
+  self-hosted, open-source job search copilot.
+- ✅ [pr-reaper](https://github.com/futuroptimist/pr-reaper) –  \
+  GitHub workflow for safely closing stale pull requests in bulk with dry-run support.
+- ✅ [danielsmith.io](https://github.com/futuroptimist/danielsmith.io) –  \
+  Vite + Three.js playground for an orthographic, keyboard-navigable portfolio scene.
+- ✅ [aquiloop](https://github.com/futuroptimist/aquiloop) –  \
+  parametric aquarium tools in OpenSCAD for makers and 3D printing.
+- ✅ [Prompt Docs Summary][pds] –  \
   index of one-click prompts across repos.
 
 [pds]: https://github.com/futuroptimist/flywheel/blob/main/docs/prompt-docs-summary.md
-
-- ✅ [jobbot3000](https://github.com/futuroptimist/jobbot3000) –  \
-  self-hosted, open-source job search copilot.
 
 A summary of flywheel features adopted across repos lives in [docs/repo-feature-summary.md](docs/repo-feature-summary.md).
 

--- a/dict/prompt-doc-repos.txt
+++ b/dict/prompt-doc-repos.txt
@@ -12,3 +12,4 @@ futuroptimist/sugarkube
 futuroptimist/pr-reaper
 futuroptimist/jobbot3000
 futuroptimist/danielsmith.io
+futuroptimist/aquiloop

--- a/docs/repo_list.txt
+++ b/docs/repo_list.txt
@@ -12,3 +12,4 @@ futuroptimist/sugarkube
 futuroptimist/pr-reaper
 futuroptimist/jobbot3000
 futuroptimist/danielsmith.io
+futuroptimist/aquiloop


### PR DESCRIPTION
## Summary
- Add `futuroptimist/aquiloop` to `docs/repo_list.txt` and `dict/prompt-doc-repos.txt` (kept in sync per `tests/test_repo_lists_alignment.py`), and add a corresponding bullet to the README's `## Related Projects` section
- Fix pre-existing drift in the README's Related Projects prose list vs. `docs/repo_list.txt`: it was missing `pr-reaper` and `danielsmith.io` entries, and had a duplicate/malformed `jobbot3000` bullet (stray `\\` line continuation) left over after the `Prompt Docs Summary` link — merged into a single correct entry

This keeps flywheel's repo-tracking manifests in sync with `futuroptimist/futuroptimist`'s README Related Projects dashboard (see futuroptimist/futuroptimist#449).

## Test plan
- [x] `pytest tests/test_repo_lists_alignment.py tests/test_repo_status.py -q` (12 passed)
- [x] `pytest tests/test_repo_feature_summary.py tests/test_repocrawler.py tests/test_repocrawler_extra.py tests/test_update_repo_feature_summary.py -q` (85 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)