### PR TITLE
ci: use github-actions[bot] identity consistently for auto-commits

### DIFF
--- a/.github/workflows/06-prompt-docs.yml
+++ b/.github/workflows/06-prompt-docs.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Commit changes
         if: github.ref == 'refs/heads/main'
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add docs/prompt-docs-summary.md
           if git diff --cached --quiet; then
             echo "No changes to commit"

--- a/.github/workflows/convert-scad.yml
+++ b/.github/workflows/convert-scad.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Commit OBJ models
         if: github.ref == 'refs/heads/main'
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add webapp/static/models/*.obj
           if git diff --cached --quiet; then
             echo "No OBJ changes to commit"

--- a/.github/workflows/export-stl.yml
+++ b/.github/workflows/export-stl.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Commit STL models
         if: github.ref == 'refs/heads/main'
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add stl/**/*.stl || true
           if git diff --cached --quiet; then
             echo "No STL changes to commit"


### PR DESCRIPTION
## Summary
- `06-prompt-docs.yml`, `convert-scad.yml`, and `export-stl.yml` committed as raw git identity name `github-actions` / email `github-actions@github.com`, unlike `04-update-summary.yml` and `update-repo-status.yml` in this same repo, which already use the documented `github-actions[bot]` / `41898282+github-actions[bot]@users.noreply.github.com` identity.
- GitHub can't resolve the plain email to a real account, so its API reports those commits' author as a synthetic `invalid-email-address` user — visible on GitHub's own commit-history UI, and the reason `futuroptimist/futuroptimist`'s Related Projects dashboard showed this repo's status as unknown (❓): its `_should_skip_commit()` heuristic only recognized automated commits by an author/committer login or name ending in `[bot]`, which this identity never did (companion fix: futuroptimist/futuroptimist#453).
- Align all three workflows with this repo's own existing convention.

## Test plan
- [x] `yaml.safe_load` on all three edited workflow files — valid
- [x] Confirmed no other workflow, script, or test in the repo references the old `github-actions@github.com` identity
- [ ] Confirm the next scheduled/triggered run of each workflow commits with the corrected identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)