### PR TITLE
ci: retry summary push on concurrent-update conflict

### DIFF
--- a/.github/workflows/04-update-summary.yml
+++ b/.github/workflows/04-update-summary.yml
@@ -45,10 +45,28 @@ jobs:
         run: cat docs/repo-feature-summary.md >> "$GITHUB_STEP_SUMMARY"
       - name: Commit summary
         if: github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add docs/repo-feature-summary.md
-          git commit -m "📝 : update repo feature summary" || exit 0
-          git pull --rebase origin main
-          git push
+          for attempt in 1 2 3 4 5; do
+            git add docs/repo-feature-summary.md
+            if git diff --cached --quiet; then
+              echo "No changes to commit"
+              exit 0
+            fi
+            git commit -m "📝 : update repo feature summary"
+            if git pull --rebase origin main && git push; then
+              echo "Pushed on attempt $attempt"
+              exit 0
+            fi
+            echo "::warning::Push attempt $attempt failed, likely a concurrent update to the same generated file (e.g. a scheduled run landing at the same time as this push-triggered one); regenerating against the latest main and retrying"
+            git rebase --abort 2>/dev/null || true
+            git fetch origin main
+            git reset --hard origin/main
+            python -m flywheel crawl --repos-file docs/repo_list.txt --output docs/repo-feature-summary.md
+            pre-commit run --files docs/repo-feature-summary.md || true
+          done
+          echo "::error::Failed to push repo feature summary after 5 attempts"
+          exit 1


### PR DESCRIPTION
## Summary
- `04-update-summary.yml` triggers on every push in addition to its daily schedule, so a push landing close to the scheduled run (e.g. merging a PR) can race another invocation of the same workflow to commit and push `docs/repo-feature-summary.md`.
- This just happened for real merging #771: the push-triggered run's `git pull --rebase origin main` hit a genuine content conflict against the scheduled run's already-pushed commit to the same file, and failed outright (https://github.com/futuroptimist/flywheel/actions/runs/31558447380). This is what the companion dashboard fix (futuroptimist/futuroptimist#453) correctly surfaced as a real ❌ instead of masking it as ❓.
- Retry the commit/push a few times: on failure, abort the rebase, reset hard to the fresh `origin/main`, regenerate the summary against that fresh base, and try again. This converges because each retry recomputes the diff against the latest tip instead of replaying a now-stale one.

## Test plan
- [x] `yaml.safe_load` — valid
- [ ] Confirm this workflow runs green (re-triggering after merge, since the current failure needs a fresh run regardless of this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)